### PR TITLE
Removed X-Forwarded-For for transparent directive

### DIFF
--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -433,7 +433,6 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream, hasSrv bool) error {
 	case "transparent":
 		u.upstreamHeaders.Add("Host", "{host}")
 		u.upstreamHeaders.Add("X-Real-IP", "{remote}")
-		u.upstreamHeaders.Add("X-Forwarded-For", "{remote}")
 		u.upstreamHeaders.Add("X-Forwarded-Proto", "{scheme}")
 	case "websocket":
 		u.upstreamHeaders.Add("Connection", "{>Connection}")


### PR DESCRIPTION
See #1960.

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
Removes `X-Forwarded-For` for `transparent` directive in `proxy` block.

### 2. Please link to the relevant issues.
#1960

### 3. Which documentation changes (if any) need to be made because of this PR?
Need to document that you don't need to manually add `X-Forwarded-For` header, and that `transparent` doesn't add it anymore.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I am willing to help maintain this change if there are issues with it later

This change is way too small.
