### PR TITLE
Add tls_client_provided_cert placeholder

### DIFF
--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -446,6 +446,12 @@ func (r *replacer) getSubstitution(key string) string {
 			}
 		}
 		return r.emptyValue
+	case "{tls_client_provided_cert}":
+		if r.getPeerCert() != nil {
+			return "true"
+		} else {
+			return "false"
+		}
 	case "{tls_client_escaped_cert}":
 		cert := r.getPeerCert()
 		if cert != nil {


### PR DESCRIPTION
### 1. What does this change do, exactly?
Adds a placeholder that resolves to true if the client offered a cert to authenticate themselves, and false otherwise

### 2. Please link to the relevant issues.
None

### 3. Which documentation changes (if any) need to be made because of this PR?
https://caddyserver.com/docs/placeholders needs to list the new placeholder

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later
