### PR TITLE
caddyhttp: Add new directive alias

### DIFF
--- a/caddyhttp/alias/alias.go
+++ b/caddyhttp/alias/alias.go
@@ -1,0 +1,70 @@
+// Copyright 2019 Light Code Labs, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alias
+
+import (
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/mholt/caddy/caddyhttp/staticfiles"
+)
+
+// AliasHandler is a handler to which changes the root folder.
+type AliasHandler struct {
+	url     string
+	handler httpserver.Handler
+
+	Next httpserver.Handler
+}
+
+// NewAliasHandler creates a new AlaisHandler with the provided options.
+func NewAliasHandler(url, path string, cfg *httpserver.SiteConfig, next httpserver.Handler) *AliasHandler {
+	h := &AliasHandler{
+		url: url,
+
+		Next: next,
+	}
+
+	if path != "" {
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(cfg.Root, path)
+		}
+		h.handler = &staticfiles.FileServer{
+			Root:       http.Dir(path),
+			Hide:       cfg.HiddenFiles,
+			IndexPages: cfg.IndexPages,
+		}
+	}
+
+	return h
+}
+
+func (h *AliasHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
+	if strings.HasPrefix(r.RequestURI, h.url) {
+		r.URL.Path = strings.TrimPrefix(r.URL.Path, h.url)
+		if r.URL.Opaque != "" {
+			r.URL.Opaque = strings.TrimPrefix(r.URL.Opaque, h.url)
+		}
+		if r.URL.RawPath != "" {
+			r.URL.RawPath = strings.TrimPrefix(r.URL.RawPath, h.url)
+		}
+
+		return h.handler.ServeHTTP(w, r)
+	}
+
+	return h.Next.ServeHTTP(w, r)
+}

--- a/caddyhttp/alias/init.go
+++ b/caddyhttp/alias/init.go
@@ -1,0 +1,64 @@
+// Copyright 2019 Light Code Labs, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package alias has Middleware that provides a static file server for files in
+// folders outside of the global root.
+package alias
+
+import (
+	"github.com/mholt/caddy"
+	"github.com/mholt/caddy/caddyhttp/httpserver"
+)
+
+func init() {
+	caddy.RegisterPlugin("alias", caddy.Plugin{
+		ServerType: "http",
+		Action:     setup,
+	})
+}
+
+func setup(c *caddy.Controller) error {
+	for c.Next() {
+		// First param is the URL prefix.
+		if !c.NextArg() {
+			return c.ArgErr()
+		}
+		url := c.Val()
+
+		// Second parm is a path to use as root when this alias is accessed.
+		if !c.NextArg() {
+			return c.ArgErr()
+		}
+		path := c.Val()
+
+		if c.NextArg() {
+			// only two arguments allowed.
+			return c.ArgErr()
+		}
+
+		// Inject our middle ware.
+		cfg := httpserver.GetConfig(c)
+		mid := func(next httpserver.Handler) httpserver.Handler {
+			return NewAliasHandler(
+				url,
+				path,
+				cfg,
+				next,
+			)
+		}
+		cfg.AddMiddleware(mid)
+	}
+
+	return nil
+}

--- a/caddyhttp/caddyhttp.go
+++ b/caddyhttp/caddyhttp.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/mholt/caddy/caddyhttp/httpserver"
 
 	// plug in the standard directives
+	_ "github.com/mholt/caddy/caddyhttp/alias"
 	_ "github.com/mholt/caddy/caddyhttp/basicauth"
 	_ "github.com/mholt/caddy/caddyhttp/bind"
 	_ "github.com/mholt/caddy/caddyhttp/browse"


### PR DESCRIPTION
Sometimes it is useful to allow serving of files outside of the normal
site root. This change adds the new directive 'alias' which allows just
that.

```
alias path directory
```

- *path* is the base path to match for this alias.
- *directory* is the directory to use as root for matched paths. If
  directory is relative, it will be relative to the site root. Files
  are looked up below that directory by their path given, reduced by
  the alias path prefix.

Serves files from blog on /blog/.

```
alias /blog/ /srv/my-blog/www/
```

An request to `/blog/index.html` will serve the file
`/srv/my-blog/www/index.html`.