### PR TITLE
New config option tls.dump_cert

### DIFF
--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -79,6 +79,9 @@ type Config struct {
 	// that we generated in memory for convenience
 	SelfSigned bool
 
+	// Dump the self-signed certificate to a path
+	DumpSelfSignedCert string
+
 	// The email address to use when creating or
 	// using an ACME account (fun fact: if this
 	// is set to "off" then this config will not


### PR DESCRIPTION
This option adds support for dumping auto generated, self-signed certificate into a file in specified path.

Please let me know if I should improve variable/conf naming, or any part of the code at all.
