### PR TITLE
caddy: remove unused code.

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -41,7 +41,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/mholt/caddy/caddyfile"
 	"github.com/mholt/caddy/telemetry"
@@ -60,9 +59,6 @@ var (
 
 	// PidFile is the path to the pidfile to create.
 	PidFile string
-
-	// GracefulTimeout is the maximum duration of a graceful shutdown.
-	GracefulTimeout time.Duration
 
 	// isUpgrade will be set to true if this process
 	// was started as part of an upgrade, where a parent


### PR DESCRIPTION
there are two same definations:

https://github.com/mholt/caddy/blob/04789a24467cbf47a6e9adfc270df01b57295230/caddy.go#L64-L65

https://github.com/mholt/caddy/blob/04789a24467cbf47a6e9adfc270df01b57295230/caddyhttp/httpserver/plugin.go#L716-L717

the first is unused, whether it is legacy code?