### PR TITLE
Support relative unix socket file path

### DIFF
--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -26,6 +26,7 @@ import (
 	"net/textproto"
 	"net/url"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -271,7 +272,12 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 
 func parseUpstream(u string) ([]string, error) {
 	if strings.HasPrefix(u, "unix:") {
-		return []string{u}, nil
+		relativePath := u[len("unix:"):]
+		absolutePath, err := filepath.Abs(relativePath)
+		if err != nil {
+			return nil, err
+		}
+		return []string{"unix:" + absolutePath}, nil
 	}
 
 	isSrv := strings.HasPrefix(u, "srv://") || strings.HasPrefix(u, "srv+https://")


### PR DESCRIPTION
Hi there,

I like to provide a Caddyfile that is portable, and that does not consume a port. Socket files are perfect for this, but I could not figure out a way to make a relative path work.

Here's the Caddyfile that I would like to add to my [github-activity](https://github.com/stefansundin/github-activity) project:

```
http://github-activity.localhost {
  on startup bundle exec puma -b unix://tmp/puma.sock
  proxy / unix:tmp/puma.sock {
    transparent
  }
}
```

Let me know if you want me to change anything. Thanks!