### PR TITLE
If an encoding has a qvalue strip it

### DIFF
--- a/caddyhttp/staticfiles/fileserver_test.go
+++ b/caddyhttp/staticfiles/fileserver_test.go
@@ -264,6 +264,28 @@ func TestServeHTTP(t *testing.T) {
 			expectedLocation:    "https://foo/example.com/../",
 			expectedBodyContent: movedPermanently,
 		},
+		// Test 30 - Accept-Encoding does not fail when a qvalue is present
+		{
+			url:                   "https://foo/sub/gzipped.html",
+			acceptEncoding:        "gzip;q=0.9,bz",
+			expectedStatus:        http.StatusOK,
+			expectedBodyContent:   testFiles[webrootSubGzippedHTMLGz],
+			expectedEtag:          `"2n9ch"`,
+			expectedVary:          "Accept-Encoding",
+			expectedEncoding:      "gzip",
+			expectedContentLength: strconv.Itoa(len(testFiles[webrootSubGzippedHTMLGz])),
+		},
+		// Test 31 - Accept-Encoding ignore qvalue of zero
+		{
+			url:                   "https://foo/sub/gzipped.html",
+			acceptEncoding:        "bz;q=0,gzip;q=0.9",
+			expectedStatus:        http.StatusOK,
+			expectedBodyContent:   testFiles[webrootSubGzippedHTMLGz],
+			expectedEtag:          `"2n9ch"`,
+			expectedVary:          "Accept-Encoding",
+			expectedEncoding:      "gzip",
+			expectedContentLength: strconv.Itoa(len(testFiles[webrootSubGzippedHTMLGz])),
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
---
name: Pull request
about: Take in consideration the the qvalue when matching Accept-Encoding
title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. What does this change do, exactly?
Take in consideration the the qvalue when matching Accept-Encoding.
https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3

## 2. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
