### PR TITLE
Add raw markdown text for templates' metadata.

### DIFF
--- a/caddyhttp/markdown/process.go
+++ b/caddyhttp/markdown/process.go
@@ -67,6 +67,9 @@ func (c *Config) Markdown(title string, r io.Reader, dirents []os.FileInfo, ctx 
 	markdown := parser.Markdown()
 	mdata := parser.Metadata()
 
+	// set it as the raw markdown text data for template
+	mdata.Variables["raw"] = string(markdown)
+
 	// process markdown
 	extns := 0
 	extns |= blackfriday.EXTENSION_TABLES


### PR DESCRIPTION
---
name: Pull request
about: Add raw markdown text for templates' metadata.
title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. What does this change do, exactly?
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

Add an attribute `.raw` to markdown template's `.Doc` that contain the raw markdown text of a .md file, then the use of front(browser) rendering will be possible.

Example: [https://github.com/mholt/caddy/issues/2632](https://github.com/mholt/caddy/issues/2632)



## 2. Please link to the relevant issues.
<!-- This adds crucial context to your change. -->

[Add raw markdown data to template's metadata, to support frontend markdown rendering.](https://github.com/mholt/caddy/issues/2632)




## 3. Which documentation changes (if any) need to be made because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->


In Chapter "http.markdown", Section "Markdown Templates", add

```
The variable `.Doc.raw` holds the raw text data of the markdown file body.
```

## 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
