### PR TITLE
Use syslog to manage caddy std{out,err} on FreeBSD

### DIFF
--- a/dist/init/freebsd/README.md
+++ b/dist/init/freebsd/README.md
@@ -1,0 +1,34 @@
+# Logging the caddy process's output:
+
+Caddy's FreeBSD `rc.d` script uses `daemon` to run `caddy`; by default
+it sends the process's standard output and error to syslog with the
+`caddy` tag, the `local7` facility and the `notice` level.
+
+The stock FreeBSD `/etc/syslog.conf` has a line near the top that
+captures nearly anything logged at the `notice` level or higher and
+sends it to `/var/log/messages`.  That line will send the caddy
+process's output to `/var/log/messages`.
+
+The simplest way to send `caddy` output to a separate file is:
+
+- to log the messages at a lower level so that they slip past that
+  early rule, e.g. add an `/etc/rc.conf` entry like
+
+  ``` shell
+  caddy_syslog_level="info"
+  ```
+
+- and then add a rule that catches them, e.g. by creating a
+  `/usr/local/etc/syslog.d/caddy.conf` file that contains:
+
+  ```
+  # Capture all messages tagged with "caddy" and send them to /var/log/caddy.log
+  !caddy
+  *.*      /var/log/caddy.log
+  ```
+
+  Heads up, if you specify a file that does not already exist, you'll
+  need to create it.
+
+There are many other ways to do it, read the `syslogd.conf` man page
+for additional information.

--- a/dist/init/freebsd/README.md
+++ b/dist/init/freebsd/README.md
@@ -11,14 +11,14 @@ process's output to `/var/log/messages`.
 
 The simplest way to send `caddy` output to a separate file is:
 
-- to log the messages at a lower level so that they slip past that
-  early rule, e.g. add an `/etc/rc.conf` entry like
+- Arrange to log the messages at a lower level so that they slip past
+  that early rule, e.g. add an `/etc/rc.conf` entry like
 
   ``` shell
   caddy_syslog_level="info"
   ```
 
-- and then add a rule that catches them, e.g. by creating a
+- Add a rule that catches them, e.g. by creating a
   `/usr/local/etc/syslog.d/caddy.conf` file that contains:
 
   ```
@@ -30,5 +30,15 @@ The simplest way to send `caddy` output to a separate file is:
   Heads up, if you specify a file that does not already exist, you'll
   need to create it.
 
-There are many other ways to do it, read the `syslogd.conf` man page
-for additional information.
+-  Rotate `/var/log/caddy.log` with `newsyslog` by creating a
+  `/usr/local/etc/newsyslog.conf/caddy.conf` file that contains:
+
+  ```
+  # See newsyslog.conf(5) for details.  Logs written by syslog,
+  # no need for a pidfile or signal, the defaults workg.
+  # logfilename         [owner:group]  mode count size when  flags [/pid_file] [sig_num]
+  /var/log/caddy.log        www:www       664  7     *    @T00  J
+  ```
+
+There are many other ways to do it, read the `syslogd.conf` and
+`newsyslog.conf` man pages for additional information.

--- a/dist/init/freebsd/caddy
+++ b/dist/init/freebsd/caddy
@@ -29,8 +29,13 @@
 # caddy_group (str):  	      Set to "wheel" by default.
 #                             Defines the group that caddy files will be attached to
 #
-# caddy_logfile (str)	      Set to "/var/log/caddy.log" by default.
-#			      Defines where the process log file is written, this is not a web access log
+# caddy_syslog_facility (str) Set to "local7" by default.
+#                             Defines the syslog facility used to log output from the caddy process.
+#                             This is NOT the web access log.
+#
+# caddy_syslog_level (str)    Set to "notice" by default.
+#                             Defines the syslog level used to log output from the caddy process.
+#                             This is NOT the web access log.
 #
 # caddy_env (str)	      Set to "" by default.
 #			      This allows environment variable to be set that may be required, for example when using "DNS Challenge" account credentials are required.
@@ -49,7 +54,8 @@ load_rc_config ${name}
 : ${caddy_bin_path="/usr/local/bin/caddy"}
 : ${caddy_cpu="99%"} # was a bug for me that caused a crash within jails
 : ${caddy_config_path="/usr/local/www/Caddyfile"}
-: ${caddy_logfile="/var/log/caddy.log"}
+: ${caddy_syslog_facility="local7"}
+: ${caddy_syslog_level="notice"}
 : ${caddy_user="root"}
 : ${caddy_group="wheel"}
 
@@ -62,7 +68,7 @@ fi
 pidfile="/var/run/${name}.pid"
 procname="${caddy_bin_path}" #enabled builtin pid checking for start / stop
 command="/usr/sbin/daemon"
-command_args="-p ${pidfile} /usr/bin/env ${caddy_env} ${procname} -cpu ${caddy_cpu} -log stdout -conf ${caddy_config_path} -agree -email ${caddy_cert_email} < /dev/null >> ${caddy_logfile} 2>&1"
+command_args="-p ${pidfile} -T ${name} -l ${caddy_syslog_facility} -s ${caddy_syslog_level} /usr/bin/env ${caddy_env} ${procname} -cpu ${caddy_cpu} -log stdout -conf ${caddy_config_path} -agree -email ${caddy_cert_email} < /dev/null"
 
 start_precmd="caddy_startprecmd"
 
@@ -70,10 +76,6 @@ caddy_startprecmd()
 {
 	if [ ! -e "${pidfile}" ]; then
 		install -o "${caddy_user}" -g "${caddy_group}" "/dev/null" "${pidfile}"
-	fi
-
-	if [ ! -e "${caddy_logfile}" ]; then
-		install -o "${caddy_user}" -g "${caddy_group}" "/dev/null" "${caddy_logfile}"
 	fi
 }
 


### PR DESCRIPTION
## 1. What does this change do, exactly?
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

There is no good way to rotate the logfile created by the previous FreeBSD rc.d script (logging uses redirection to send the output the file and the file is held open by the shell).

This solves the problem by sending caddy's std{out,err} stream to syslog.  

Because the script uses the `daemon` utility to run the `caddy` process, this change simply uses the `daemon` command's builtin syslog functionality.

The old `caddy_logfile` rc.conf variable is replaced by `caddy_syslog_facility` (which defaults to 'local7') and `caddy_syslog_level` (which defaults to 'notice').

By default, these messages will end up in `/var/log/messages`, but all of syslog's power can be used to manage them.  The README.md documents a simple way to send the output to `/var/log/caddy.log`.

## 2. Please link to the relevant issues.
<!-- This adds crucial context to your change. -->

None.

## 3. Which documentation changes (if any) need to be made because of this PR?

This PR adds a `dist/init/freebsd/README.md` file that discusses using caddy with syslog.

I'm open to suggests for how to call attention to this information.  I'd like to refer to it from the script itself too if there's a clean way to do so.

## 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
