### PR TITLE
Flatten HTTP handler config

### DIFF
--- a/modules/caddyhttp/encode/encode.go
+++ b/modules/caddyhttp/encode/encode.go
@@ -36,7 +36,7 @@ import (
 
 func init() {
 	caddy.RegisterModule(caddy.Module{
-		Name: "http.middleware.encode",
+		Name: "http.handlers.encode",
 		New:  func() interface{} { return new(Encode) },
 	})
 }

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -35,7 +35,7 @@ func init() {
 	weakrand.Seed(time.Now().UnixNano())
 
 	caddy.RegisterModule(caddy.Module{
-		Name: "http.responders.file_server",
+		Name: "http.handlers.file_server",
 		New:  func() interface{} { return new(FileServer) },
 	})
 }
@@ -108,7 +108,7 @@ func (fsrv *FileServer) Validate() error {
 	return nil
 }
 
-func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, _ caddyhttp.Handler) error {
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(caddy.Replacer)
 
 	filesToHide := fsrv.transformHidePaths(repl)
@@ -119,7 +119,7 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request) error 
 	if filename == "" {
 		// no files worked, so resort to fallback
 		if fsrv.Fallback != nil {
-			fallback, w := fsrv.Fallback.BuildCompositeRoute(w, r)
+			fallback := fsrv.Fallback.BuildCompositeRoute(w, r)
 			return fallback.ServeHTTP(w, r)
 		}
 		return caddyhttp.Error(http.StatusNotFound, nil)
@@ -452,7 +452,7 @@ const minBackoff, maxBackoff = 2, 5
 
 // Interface guards
 var (
-	_ caddy.Provisioner = (*FileServer)(nil)
-	_ caddy.Validator   = (*FileServer)(nil)
-	_ caddyhttp.Handler = (*FileServer)(nil)
+	_ caddy.Provisioner           = (*FileServer)(nil)
+	_ caddy.Validator             = (*FileServer)(nil)
+	_ caddyhttp.MiddlewareHandler = (*FileServer)(nil)
 )

--- a/modules/caddyhttp/rewrite/rewrite.go
+++ b/modules/caddyhttp/rewrite/rewrite.go
@@ -25,7 +25,7 @@ import (
 
 func init() {
 	caddy.RegisterModule(caddy.Module{
-		Name: "http.middleware.rewrite",
+		Name: "http.handlers.rewrite",
 		New:  func() interface{} { return new(Rewrite) },
 	})
 }

--- a/modules/caddyhttp/staticresp_test.go
+++ b/modules/caddyhttp/staticresp_test.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/caddyserver/caddy/v2"
@@ -29,7 +30,7 @@ func TestStaticResponseHandler(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	s := Static{
-		StatusCode: http.StatusNotFound,
+		StatusCode: strconv.Itoa(http.StatusNotFound),
 		Headers: http.Header{
 			"X-Test": []string{"Testing"},
 		},
@@ -37,7 +38,7 @@ func TestStaticResponseHandler(t *testing.T) {
 		Close: true,
 	}
 
-	err := s.ServeHTTP(w, r)
+	err := s.ServeHTTP(w, r, nil)
 	if err != nil {
 		t.Errorf("did not expect an error, but got: %v", err)
 	}

--- a/modules/caddyhttp/templates/templates.go
+++ b/modules/caddyhttp/templates/templates.go
@@ -28,7 +28,7 @@ import (
 
 func init() {
 	caddy.RegisterModule(caddy.Module{
-		Name: "http.middleware.templates",
+		Name: "http.handlers.templates",
 		New:  func() interface{} { return new(Templates) },
 	})
 }


### PR DESCRIPTION
## 1. What does this change do, exactly?
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

Makes v2's handler config linear, as opposed to nested.

Differentiating middleware and responders has one benefit, namely that
it's clear which module provides the response, but even then it's not
a great advantage. Linear handler config makes a little more sense,
giving greater flexibility and simplifying the core a bit, even though
it's slightly awkward that handlers which are responders may not use
the 'next' handler that is passed in at all.

## 2. Please link to the relevant issues.
<!-- This adds crucial context to your change. -->

#2662


## 3. Which documentation changes (if any) need to be made because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->

Update the wiki to show the flattened config structure for handlers.