### PR TITLE
V2: Implement taskkill /f to force quit on windows when caddy stop

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -194,7 +194,7 @@ func cmdStop() (int, error) {
 	if err != nil {
 		return caddy.ExitCodeFailedStartup, fmt.Errorf("listing processes: %v", err)
 	}
-	thisProcName := getAppName()
+	thisProcName := getProcessName()
 	var found bool
 	for _, p := range processList {
 		// the process we're looking for should have the same name but different PID

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -27,7 +27,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
+
 	"strings"
 
 	"github.com/caddyserver/caddy/v2"
@@ -194,11 +194,11 @@ func cmdStop() (int, error) {
 	if err != nil {
 		return caddy.ExitCodeFailedStartup, fmt.Errorf("listing processes: %v", err)
 	}
-	thisProcName := filepath.Base(os.Args[0])
+	thisProcName := getAppName()
 	var found bool
 	for _, p := range processList {
 		// the process we're looking for should have the same name but different PID
-		if matchProcess(p.Executable(), thisProcName) && p.Pid() != os.Getpid() {
+		if p.Executable() == thisProcName && p.Pid() != os.Getpid() {
 			found = true
 			fmt.Printf("pid=%d\n", p.Pid())
 

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -15,285 +15,285 @@
 package caddycmd
 
 import (
-    "bytes"
-    "crypto/rand"
-    "encoding/json"
-    "flag"
-    "fmt"
-    "io"
-    "io/ioutil"
-    "log"
-    "net"
-    "net/http"
-    "os"
-    "os/exec"
-    "path/filepath"
-    "strings"
+	"bytes"
+	"crypto/rand"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 
-    "github.com/caddyserver/caddy/v2"
-    "github.com/mholt/certmagic"
-    "github.com/mitchellh/go-ps"
+	"github.com/caddyserver/caddy/v2"
+	"github.com/mholt/certmagic"
+	"github.com/mitchellh/go-ps"
 )
 
 func cmdStart() (int, error) {
-    startCmd := flag.NewFlagSet("start", flag.ExitOnError)
-    startCmdConfigFlag := startCmd.String("config", "", "Configuration file")
-    startCmd.Parse(os.Args[2:])
+	startCmd := flag.NewFlagSet("start", flag.ExitOnError)
+	startCmdConfigFlag := startCmd.String("config", "", "Configuration file")
+	startCmd.Parse(os.Args[2:])
 
-    // open a listener to which the child process will connect when
-    // it is ready to confirm that it has successfully started
-    ln, err := net.Listen("tcp", "127.0.0.1:0")
-    if err != nil {
-        return caddy.ExitCodeFailedStartup,
-            fmt.Errorf("opening listener for success confirmation: %v", err)
-    }
-    defer ln.Close()
+	// open a listener to which the child process will connect when
+	// it is ready to confirm that it has successfully started
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return caddy.ExitCodeFailedStartup,
+			fmt.Errorf("opening listener for success confirmation: %v", err)
+	}
+	defer ln.Close()
 
-    // craft the command with a pingback address and with a
-    // pipe for its stdin, so we can tell it our confirmation
-    // code that we expect so that some random port scan at
-    // the most unfortunate time won't fool us into thinking
-    // the child succeeded (i.e. the alternative is to just
-    // wait for any connection on our listener, but better to
-    // ensure it's the process we're expecting - we can be
-    // sure by giving it some random bytes and having it echo
-    // them back to us)
-    cmd := exec.Command(os.Args[0], "run", "--pingback", ln.Addr().String())
-    if *startCmdConfigFlag != "" {
-        cmd.Args = append(cmd.Args, "--config", *startCmdConfigFlag)
-    }
-    stdinpipe, err := cmd.StdinPipe()
-    if err != nil {
-        return caddy.ExitCodeFailedStartup,
-            fmt.Errorf("creating stdin pipe: %v", err)
-    }
-    cmd.Stdout = os.Stdout
-    cmd.Stderr = os.Stderr
+	// craft the command with a pingback address and with a
+	// pipe for its stdin, so we can tell it our confirmation
+	// code that we expect so that some random port scan at
+	// the most unfortunate time won't fool us into thinking
+	// the child succeeded (i.e. the alternative is to just
+	// wait for any connection on our listener, but better to
+	// ensure it's the process we're expecting - we can be
+	// sure by giving it some random bytes and having it echo
+	// them back to us)
+	cmd := exec.Command(os.Args[0], "run", "--pingback", ln.Addr().String())
+	if *startCmdConfigFlag != "" {
+		cmd.Args = append(cmd.Args, "--config", *startCmdConfigFlag)
+	}
+	stdinpipe, err := cmd.StdinPipe()
+	if err != nil {
+		return caddy.ExitCodeFailedStartup,
+			fmt.Errorf("creating stdin pipe: %v", err)
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
-    // generate the random bytes we'll send to the child process
-    expect := make([]byte, 32)
-    _, err = rand.Read(expect)
-    if err != nil {
-        return caddy.ExitCodeFailedStartup, fmt.Errorf("generating random confirmation bytes: %v", err)
-    }
+	// generate the random bytes we'll send to the child process
+	expect := make([]byte, 32)
+	_, err = rand.Read(expect)
+	if err != nil {
+		return caddy.ExitCodeFailedStartup, fmt.Errorf("generating random confirmation bytes: %v", err)
+	}
 
-    // begin writing the confirmation bytes to the child's
-    // stdin; use a goroutine since the child hasn't been
-    // started yet, and writing sychronously would result
-    // in a deadlock
-    go func() {
-        stdinpipe.Write(expect)
-        stdinpipe.Close()
-    }()
+	// begin writing the confirmation bytes to the child's
+	// stdin; use a goroutine since the child hasn't been
+	// started yet, and writing sychronously would result
+	// in a deadlock
+	go func() {
+		stdinpipe.Write(expect)
+		stdinpipe.Close()
+	}()
 
-    // start the process
-    err = cmd.Start()
-    if err != nil {
-        return caddy.ExitCodeFailedStartup, fmt.Errorf("starting caddy process: %v", err)
-    }
+	// start the process
+	err = cmd.Start()
+	if err != nil {
+		return caddy.ExitCodeFailedStartup, fmt.Errorf("starting caddy process: %v", err)
+	}
 
-    // there are two ways we know we're done: either
-    // the process will connect to our listener, or
-    // it will exit with an error
-    success, exit := make(chan struct{}), make(chan error)
+	// there are two ways we know we're done: either
+	// the process will connect to our listener, or
+	// it will exit with an error
+	success, exit := make(chan struct{}), make(chan error)
 
-    // in one goroutine, we await the success of the child process
-    go func() {
-        for {
-            conn, err := ln.Accept()
-            if err != nil {
-                if !strings.Contains(err.Error(), "use of closed network connection") {
-                    log.Println(err)
-                }
-                break
-            }
-            err = handlePingbackConn(conn, expect)
-            if err == nil {
-                close(success)
-                break
-            }
-            log.Println(err)
-        }
-    }()
+	// in one goroutine, we await the success of the child process
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				if !strings.Contains(err.Error(), "use of closed network connection") {
+					log.Println(err)
+				}
+				break
+			}
+			err = handlePingbackConn(conn, expect)
+			if err == nil {
+				close(success)
+				break
+			}
+			log.Println(err)
+		}
+	}()
 
-    // in another goroutine, we await the failure of the child process
-    go func() {
-        err := cmd.Wait() // don't send on this line! Wait blocks, but send starts before it unblocks
-        exit <- err       // sending on separate line ensures select won't trigger until after Wait unblocks
-    }()
+	// in another goroutine, we await the failure of the child process
+	go func() {
+		err := cmd.Wait() // don't send on this line! Wait blocks, but send starts before it unblocks
+		exit <- err       // sending on separate line ensures select won't trigger until after Wait unblocks
+	}()
 
-    // when one of the goroutines unblocks, we're done and can exit
-    select {
-    case <-success:
-        fmt.Println("Successfully started Caddy")
-    case err := <-exit:
-        return caddy.ExitCodeFailedStartup,
-            fmt.Errorf("caddy process exited with error: %v", err)
-    }
+	// when one of the goroutines unblocks, we're done and can exit
+	select {
+	case <-success:
+		fmt.Println("Successfully started Caddy")
+	case err := <-exit:
+		return caddy.ExitCodeFailedStartup,
+			fmt.Errorf("caddy process exited with error: %v", err)
+	}
 
-    return caddy.ExitCodeSuccess, nil
+	return caddy.ExitCodeSuccess, nil
 }
 
 func cmdRun() (int, error) {
-    runCmd := flag.NewFlagSet("run", flag.ExitOnError)
-    runCmdConfigFlag := runCmd.String("config", "", "Configuration file")
-    runCmdPingbackFlag := runCmd.String("pingback", "", "Echo confirmation bytes to this address on success")
-    runCmd.Parse(os.Args[2:])
+	runCmd := flag.NewFlagSet("run", flag.ExitOnError)
+	runCmdConfigFlag := runCmd.String("config", "", "Configuration file")
+	runCmdPingbackFlag := runCmd.String("pingback", "", "Echo confirmation bytes to this address on success")
+	runCmd.Parse(os.Args[2:])
 
-    // if a config file was specified for bootstrapping
-    // the server instance, load it now
-    var config []byte
-    if *runCmdConfigFlag != "" {
-        var err error
-        config, err = ioutil.ReadFile(*runCmdConfigFlag)
-        if err != nil {
-            return caddy.ExitCodeFailedStartup,
-                fmt.Errorf("reading config file: %v", err)
-        }
-    }
+	// if a config file was specified for bootstrapping
+	// the server instance, load it now
+	var config []byte
+	if *runCmdConfigFlag != "" {
+		var err error
+		config, err = ioutil.ReadFile(*runCmdConfigFlag)
+		if err != nil {
+			return caddy.ExitCodeFailedStartup,
+				fmt.Errorf("reading config file: %v", err)
+		}
+	}
 
-    // set a fitting User-Agent for ACME requests
-    goModule := caddy.GoModule()
-    cleanModVersion := strings.TrimPrefix(goModule.Version, "v")
-    certmagic.UserAgent = "Caddy/" + cleanModVersion
+	// set a fitting User-Agent for ACME requests
+	goModule := caddy.GoModule()
+	cleanModVersion := strings.TrimPrefix(goModule.Version, "v")
+	certmagic.UserAgent = "Caddy/" + cleanModVersion
 
-    // start the admin endpoint along with any initial config
-    err := caddy.StartAdmin(config)
-    if err != nil {
-        return caddy.ExitCodeFailedStartup,
-            fmt.Errorf("starting caddy administration endpoint: %v", err)
-    }
-    defer caddy.StopAdmin()
+	// start the admin endpoint along with any initial config
+	err := caddy.StartAdmin(config)
+	if err != nil {
+		return caddy.ExitCodeFailedStartup,
+			fmt.Errorf("starting caddy administration endpoint: %v", err)
+	}
+	defer caddy.StopAdmin()
 
-    // if we are to report to another process the successful start
-    // of the server, do so now by echoing back contents of stdin
-    if *runCmdPingbackFlag != "" {
-        confirmationBytes, err := ioutil.ReadAll(os.Stdin)
-        if err != nil {
-            return caddy.ExitCodeFailedStartup,
-                fmt.Errorf("reading confirmation bytes from stdin: %v", err)
-        }
-        conn, err := net.Dial("tcp", *runCmdPingbackFlag)
-        if err != nil {
-            return caddy.ExitCodeFailedStartup,
-                fmt.Errorf("dialing confirmation address: %v", err)
-        }
-        defer conn.Close()
-        _, err = conn.Write(confirmationBytes)
-        if err != nil {
-            return caddy.ExitCodeFailedStartup,
-                fmt.Errorf("writing confirmation bytes to %s: %v", *runCmdPingbackFlag, err)
-        }
-    }
+	// if we are to report to another process the successful start
+	// of the server, do so now by echoing back contents of stdin
+	if *runCmdPingbackFlag != "" {
+		confirmationBytes, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return caddy.ExitCodeFailedStartup,
+				fmt.Errorf("reading confirmation bytes from stdin: %v", err)
+		}
+		conn, err := net.Dial("tcp", *runCmdPingbackFlag)
+		if err != nil {
+			return caddy.ExitCodeFailedStartup,
+				fmt.Errorf("dialing confirmation address: %v", err)
+		}
+		defer conn.Close()
+		_, err = conn.Write(confirmationBytes)
+		if err != nil {
+			return caddy.ExitCodeFailedStartup,
+				fmt.Errorf("writing confirmation bytes to %s: %v", *runCmdPingbackFlag, err)
+		}
+	}
 
-    select {}
+	select {}
 }
 
 func cmdStop() (int, error) {
-    processList, err := ps.Processes()
-    if err != nil {
-        return caddy.ExitCodeFailedStartup, fmt.Errorf("listing processes: %v", err)
-    }
-    thisProcName := filepath.Base(os.Args[0])
-    var found bool
-    for _, p := range processList {
-        // the process we're looking for should have the same name but different PID
-        if matchProcess(p.Executable() ,thisProcName) && p.Pid() != os.Getpid() {
-            found = true
-            fmt.Printf("pid=%d\n", p.Pid())
-            
-            if err := gracefullyStopProcess(p.Pid()); err != nil {
-                return caddy.ExitCodeFailedStartup, err
-            }
-        }
-    }
-    if !found {
-        return caddy.ExitCodeFailedStartup, fmt.Errorf("Caddy is not running")
-    }
-    fmt.Println(" success")
-    return caddy.ExitCodeSuccess, nil
+	processList, err := ps.Processes()
+	if err != nil {
+		return caddy.ExitCodeFailedStartup, fmt.Errorf("listing processes: %v", err)
+	}
+	thisProcName := filepath.Base(os.Args[0])
+	var found bool
+	for _, p := range processList {
+		// the process we're looking for should have the same name but different PID
+		if matchProcess(p.Executable(), thisProcName) && p.Pid() != os.Getpid() {
+			found = true
+			fmt.Printf("pid=%d\n", p.Pid())
+
+			if err := gracefullyStopProcess(p.Pid()); err != nil {
+				return caddy.ExitCodeFailedStartup, err
+			}
+		}
+	}
+	if !found {
+		return caddy.ExitCodeFailedStartup, fmt.Errorf("Caddy is not running")
+	}
+	fmt.Println(" success")
+	return caddy.ExitCodeSuccess, nil
 }
 
 func cmdReload() (int, error) {
-    reloadCmd := flag.NewFlagSet("load", flag.ExitOnError)
-    reloadCmdConfigFlag := reloadCmd.String("config", "", "Configuration file")
-    reloadCmdAddrFlag := reloadCmd.String("address", "", "Address of the administration listener, if different from config")
-    reloadCmd.Parse(os.Args[2:])
+	reloadCmd := flag.NewFlagSet("load", flag.ExitOnError)
+	reloadCmdConfigFlag := reloadCmd.String("config", "", "Configuration file")
+	reloadCmdAddrFlag := reloadCmd.String("address", "", "Address of the administration listener, if different from config")
+	reloadCmd.Parse(os.Args[2:])
 
-    // a configuration is required
-    if *reloadCmdConfigFlag == "" {
-        return caddy.ExitCodeFailedStartup,
-            fmt.Errorf("no configuration to load (use --config)")
-    }
+	// a configuration is required
+	if *reloadCmdConfigFlag == "" {
+		return caddy.ExitCodeFailedStartup,
+			fmt.Errorf("no configuration to load (use --config)")
+	}
 
-    // load the configuration file
-    config, err := ioutil.ReadFile(*reloadCmdConfigFlag)
-    if err != nil {
-        return caddy.ExitCodeFailedStartup,
-            fmt.Errorf("reading config file: %v", err)
-    }
+	// load the configuration file
+	config, err := ioutil.ReadFile(*reloadCmdConfigFlag)
+	if err != nil {
+		return caddy.ExitCodeFailedStartup,
+			fmt.Errorf("reading config file: %v", err)
+	}
 
-    // get the address of the admin listener and craft endpoint URL
-    adminAddr := *reloadCmdAddrFlag
-    if adminAddr == "" {
-        var tmpStruct struct {
-            Admin caddy.AdminConfig `json:"admin"`
-        }
-        err = json.Unmarshal(config, &tmpStruct)
-        if err != nil {
-            return caddy.ExitCodeFailedStartup,
-                fmt.Errorf("unmarshaling admin listener address from config: %v", err)
-        }
-        adminAddr = tmpStruct.Admin.Listen
-    }
-    if adminAddr == "" {
-        adminAddr = caddy.DefaultAdminListen
-    }
-    adminEndpoint := fmt.Sprintf("http://%s/load", adminAddr)
+	// get the address of the admin listener and craft endpoint URL
+	adminAddr := *reloadCmdAddrFlag
+	if adminAddr == "" {
+		var tmpStruct struct {
+			Admin caddy.AdminConfig `json:"admin"`
+		}
+		err = json.Unmarshal(config, &tmpStruct)
+		if err != nil {
+			return caddy.ExitCodeFailedStartup,
+				fmt.Errorf("unmarshaling admin listener address from config: %v", err)
+		}
+		adminAddr = tmpStruct.Admin.Listen
+	}
+	if adminAddr == "" {
+		adminAddr = caddy.DefaultAdminListen
+	}
+	adminEndpoint := fmt.Sprintf("http://%s/load", adminAddr)
 
-    // send the configuration to the instance
-    resp, err := http.Post(adminEndpoint, "application/json", bytes.NewReader(config))
-    if err != nil {
-        return caddy.ExitCodeFailedStartup,
-            fmt.Errorf("sending configuration to instance: %v", err)
-    }
-    defer resp.Body.Close()
+	// send the configuration to the instance
+	resp, err := http.Post(adminEndpoint, "application/json", bytes.NewReader(config))
+	if err != nil {
+		return caddy.ExitCodeFailedStartup,
+			fmt.Errorf("sending configuration to instance: %v", err)
+	}
+	defer resp.Body.Close()
 
-    // if it didn't work, let the user know
-    if resp.StatusCode >= 400 {
-        respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1024*10))
-        if err != nil {
-            return caddy.ExitCodeFailedStartup,
-                fmt.Errorf("HTTP %d: reading error message: %v", resp.StatusCode, err)
-        }
-        return caddy.ExitCodeFailedStartup,
-            fmt.Errorf("caddy responded with error: HTTP %d: %s", resp.StatusCode, respBody)
-    }
+	// if it didn't work, let the user know
+	if resp.StatusCode >= 400 {
+		respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1024*10))
+		if err != nil {
+			return caddy.ExitCodeFailedStartup,
+				fmt.Errorf("HTTP %d: reading error message: %v", resp.StatusCode, err)
+		}
+		return caddy.ExitCodeFailedStartup,
+			fmt.Errorf("caddy responded with error: HTTP %d: %s", resp.StatusCode, respBody)
+	}
 
-    return caddy.ExitCodeSuccess, nil
+	return caddy.ExitCodeSuccess, nil
 }
 
 func cmdVersion() (int, error) {
-    goModule := caddy.GoModule()
-    if goModule.Sum != "" {
-        // a build with a known version will also have a checksum
-        fmt.Printf("%s %s\n", goModule.Version, goModule.Sum)
-    } else {
-        fmt.Println(goModule.Version)
-    }
-    return caddy.ExitCodeSuccess, nil
+	goModule := caddy.GoModule()
+	if goModule.Sum != "" {
+		// a build with a known version will also have a checksum
+		fmt.Printf("%s %s\n", goModule.Version, goModule.Sum)
+	} else {
+		fmt.Println(goModule.Version)
+	}
+	return caddy.ExitCodeSuccess, nil
 }
 
 func cmdListModules() (int, error) {
-    for _, m := range caddy.Modules() {
-        fmt.Println(m)
-    }
-    return caddy.ExitCodeSuccess, nil
+	for _, m := range caddy.Modules() {
+		fmt.Println(m)
+	}
+	return caddy.ExitCodeSuccess, nil
 }
 
 func cmdEnviron() (int, error) {
-    for _, v := range os.Environ() {
-        fmt.Println(v)
-    }
-    return caddy.ExitCodeSuccess, nil
+	for _, v := range os.Environ() {
+		fmt.Println(v)
+	}
+	return caddy.ExitCodeSuccess, nil
 }

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -15,285 +15,285 @@
 package caddycmd
 
 import (
-	"bytes"
-	"crypto/rand"
-	"encoding/json"
-	"flag"
-	"fmt"
-	"io"
-	"io/ioutil"
-	"log"
-	"net"
-	"net/http"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
+    "bytes"
+    "crypto/rand"
+    "encoding/json"
+    "flag"
+    "fmt"
+    "io"
+    "io/ioutil"
+    "log"
+    "net"
+    "net/http"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "strings"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/mholt/certmagic"
-	"github.com/mitchellh/go-ps"
+    "github.com/caddyserver/caddy/v2"
+    "github.com/mholt/certmagic"
+    "github.com/mitchellh/go-ps"
 )
 
 func cmdStart() (int, error) {
-	startCmd := flag.NewFlagSet("start", flag.ExitOnError)
-	startCmdConfigFlag := startCmd.String("config", "", "Configuration file")
-	startCmd.Parse(os.Args[2:])
+    startCmd := flag.NewFlagSet("start", flag.ExitOnError)
+    startCmdConfigFlag := startCmd.String("config", "", "Configuration file")
+    startCmd.Parse(os.Args[2:])
 
-	// open a listener to which the child process will connect when
-	// it is ready to confirm that it has successfully started
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return caddy.ExitCodeFailedStartup,
-			fmt.Errorf("opening listener for success confirmation: %v", err)
-	}
-	defer ln.Close()
+    // open a listener to which the child process will connect when
+    // it is ready to confirm that it has successfully started
+    ln, err := net.Listen("tcp", "127.0.0.1:0")
+    if err != nil {
+        return caddy.ExitCodeFailedStartup,
+            fmt.Errorf("opening listener for success confirmation: %v", err)
+    }
+    defer ln.Close()
 
-	// craft the command with a pingback address and with a
-	// pipe for its stdin, so we can tell it our confirmation
-	// code that we expect so that some random port scan at
-	// the most unfortunate time won't fool us into thinking
-	// the child succeeded (i.e. the alternative is to just
-	// wait for any connection on our listener, but better to
-	// ensure it's the process we're expecting - we can be
-	// sure by giving it some random bytes and having it echo
-	// them back to us)
-	cmd := exec.Command(os.Args[0], "run", "--pingback", ln.Addr().String())
-	if *startCmdConfigFlag != "" {
-		cmd.Args = append(cmd.Args, "--config", *startCmdConfigFlag)
-	}
-	stdinpipe, err := cmd.StdinPipe()
-	if err != nil {
-		return caddy.ExitCodeFailedStartup,
-			fmt.Errorf("creating stdin pipe: %v", err)
-	}
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+    // craft the command with a pingback address and with a
+    // pipe for its stdin, so we can tell it our confirmation
+    // code that we expect so that some random port scan at
+    // the most unfortunate time won't fool us into thinking
+    // the child succeeded (i.e. the alternative is to just
+    // wait for any connection on our listener, but better to
+    // ensure it's the process we're expecting - we can be
+    // sure by giving it some random bytes and having it echo
+    // them back to us)
+    cmd := exec.Command(os.Args[0], "run", "--pingback", ln.Addr().String())
+    if *startCmdConfigFlag != "" {
+        cmd.Args = append(cmd.Args, "--config", *startCmdConfigFlag)
+    }
+    stdinpipe, err := cmd.StdinPipe()
+    if err != nil {
+        return caddy.ExitCodeFailedStartup,
+            fmt.Errorf("creating stdin pipe: %v", err)
+    }
+    cmd.Stdout = os.Stdout
+    cmd.Stderr = os.Stderr
 
-	// generate the random bytes we'll send to the child process
-	expect := make([]byte, 32)
-	_, err = rand.Read(expect)
-	if err != nil {
-		return caddy.ExitCodeFailedStartup, fmt.Errorf("generating random confirmation bytes: %v", err)
-	}
+    // generate the random bytes we'll send to the child process
+    expect := make([]byte, 32)
+    _, err = rand.Read(expect)
+    if err != nil {
+        return caddy.ExitCodeFailedStartup, fmt.Errorf("generating random confirmation bytes: %v", err)
+    }
 
-	// begin writing the confirmation bytes to the child's
-	// stdin; use a goroutine since the child hasn't been
-	// started yet, and writing sychronously would result
-	// in a deadlock
-	go func() {
-		stdinpipe.Write(expect)
-		stdinpipe.Close()
-	}()
+    // begin writing the confirmation bytes to the child's
+    // stdin; use a goroutine since the child hasn't been
+    // started yet, and writing sychronously would result
+    // in a deadlock
+    go func() {
+        stdinpipe.Write(expect)
+        stdinpipe.Close()
+    }()
 
-	// start the process
-	err = cmd.Start()
-	if err != nil {
-		return caddy.ExitCodeFailedStartup, fmt.Errorf("starting caddy process: %v", err)
-	}
+    // start the process
+    err = cmd.Start()
+    if err != nil {
+        return caddy.ExitCodeFailedStartup, fmt.Errorf("starting caddy process: %v", err)
+    }
 
-	// there are two ways we know we're done: either
-	// the process will connect to our listener, or
-	// it will exit with an error
-	success, exit := make(chan struct{}), make(chan error)
+    // there are two ways we know we're done: either
+    // the process will connect to our listener, or
+    // it will exit with an error
+    success, exit := make(chan struct{}), make(chan error)
 
-	// in one goroutine, we await the success of the child process
-	go func() {
-		for {
-			conn, err := ln.Accept()
-			if err != nil {
-				if !strings.Contains(err.Error(), "use of closed network connection") {
-					log.Println(err)
-				}
-				break
-			}
-			err = handlePingbackConn(conn, expect)
-			if err == nil {
-				close(success)
-				break
-			}
-			log.Println(err)
-		}
-	}()
+    // in one goroutine, we await the success of the child process
+    go func() {
+        for {
+            conn, err := ln.Accept()
+            if err != nil {
+                if !strings.Contains(err.Error(), "use of closed network connection") {
+                    log.Println(err)
+                }
+                break
+            }
+            err = handlePingbackConn(conn, expect)
+            if err == nil {
+                close(success)
+                break
+            }
+            log.Println(err)
+        }
+    }()
 
-	// in another goroutine, we await the failure of the child process
-	go func() {
-		err := cmd.Wait() // don't send on this line! Wait blocks, but send starts before it unblocks
-		exit <- err       // sending on separate line ensures select won't trigger until after Wait unblocks
-	}()
+    // in another goroutine, we await the failure of the child process
+    go func() {
+        err := cmd.Wait() // don't send on this line! Wait blocks, but send starts before it unblocks
+        exit <- err       // sending on separate line ensures select won't trigger until after Wait unblocks
+    }()
 
-	// when one of the goroutines unblocks, we're done and can exit
-	select {
-	case <-success:
-		fmt.Println("Successfully started Caddy")
-	case err := <-exit:
-		return caddy.ExitCodeFailedStartup,
-			fmt.Errorf("caddy process exited with error: %v", err)
-	}
+    // when one of the goroutines unblocks, we're done and can exit
+    select {
+    case <-success:
+        fmt.Println("Successfully started Caddy")
+    case err := <-exit:
+        return caddy.ExitCodeFailedStartup,
+            fmt.Errorf("caddy process exited with error: %v", err)
+    }
 
-	return caddy.ExitCodeSuccess, nil
+    return caddy.ExitCodeSuccess, nil
 }
 
 func cmdRun() (int, error) {
-	runCmd := flag.NewFlagSet("run", flag.ExitOnError)
-	runCmdConfigFlag := runCmd.String("config", "", "Configuration file")
-	runCmdPingbackFlag := runCmd.String("pingback", "", "Echo confirmation bytes to this address on success")
-	runCmd.Parse(os.Args[2:])
+    runCmd := flag.NewFlagSet("run", flag.ExitOnError)
+    runCmdConfigFlag := runCmd.String("config", "", "Configuration file")
+    runCmdPingbackFlag := runCmd.String("pingback", "", "Echo confirmation bytes to this address on success")
+    runCmd.Parse(os.Args[2:])
 
-	// if a config file was specified for bootstrapping
-	// the server instance, load it now
-	var config []byte
-	if *runCmdConfigFlag != "" {
-		var err error
-		config, err = ioutil.ReadFile(*runCmdConfigFlag)
-		if err != nil {
-			return caddy.ExitCodeFailedStartup,
-				fmt.Errorf("reading config file: %v", err)
-		}
-	}
+    // if a config file was specified for bootstrapping
+    // the server instance, load it now
+    var config []byte
+    if *runCmdConfigFlag != "" {
+        var err error
+        config, err = ioutil.ReadFile(*runCmdConfigFlag)
+        if err != nil {
+            return caddy.ExitCodeFailedStartup,
+                fmt.Errorf("reading config file: %v", err)
+        }
+    }
 
-	// set a fitting User-Agent for ACME requests
-	goModule := caddy.GoModule()
-	cleanModVersion := strings.TrimPrefix(goModule.Version, "v")
-	certmagic.UserAgent = "Caddy/" + cleanModVersion
+    // set a fitting User-Agent for ACME requests
+    goModule := caddy.GoModule()
+    cleanModVersion := strings.TrimPrefix(goModule.Version, "v")
+    certmagic.UserAgent = "Caddy/" + cleanModVersion
 
-	// start the admin endpoint along with any initial config
-	err := caddy.StartAdmin(config)
-	if err != nil {
-		return caddy.ExitCodeFailedStartup,
-			fmt.Errorf("starting caddy administration endpoint: %v", err)
-	}
-	defer caddy.StopAdmin()
+    // start the admin endpoint along with any initial config
+    err := caddy.StartAdmin(config)
+    if err != nil {
+        return caddy.ExitCodeFailedStartup,
+            fmt.Errorf("starting caddy administration endpoint: %v", err)
+    }
+    defer caddy.StopAdmin()
 
-	// if we are to report to another process the successful start
-	// of the server, do so now by echoing back contents of stdin
-	if *runCmdPingbackFlag != "" {
-		confirmationBytes, err := ioutil.ReadAll(os.Stdin)
-		if err != nil {
-			return caddy.ExitCodeFailedStartup,
-				fmt.Errorf("reading confirmation bytes from stdin: %v", err)
-		}
-		conn, err := net.Dial("tcp", *runCmdPingbackFlag)
-		if err != nil {
-			return caddy.ExitCodeFailedStartup,
-				fmt.Errorf("dialing confirmation address: %v", err)
-		}
-		defer conn.Close()
-		_, err = conn.Write(confirmationBytes)
-		if err != nil {
-			return caddy.ExitCodeFailedStartup,
-				fmt.Errorf("writing confirmation bytes to %s: %v", *runCmdPingbackFlag, err)
-		}
-	}
+    // if we are to report to another process the successful start
+    // of the server, do so now by echoing back contents of stdin
+    if *runCmdPingbackFlag != "" {
+        confirmationBytes, err := ioutil.ReadAll(os.Stdin)
+        if err != nil {
+            return caddy.ExitCodeFailedStartup,
+                fmt.Errorf("reading confirmation bytes from stdin: %v", err)
+        }
+        conn, err := net.Dial("tcp", *runCmdPingbackFlag)
+        if err != nil {
+            return caddy.ExitCodeFailedStartup,
+                fmt.Errorf("dialing confirmation address: %v", err)
+        }
+        defer conn.Close()
+        _, err = conn.Write(confirmationBytes)
+        if err != nil {
+            return caddy.ExitCodeFailedStartup,
+                fmt.Errorf("writing confirmation bytes to %s: %v", *runCmdPingbackFlag, err)
+        }
+    }
 
-	select {}
+    select {}
 }
 
 func cmdStop() (int, error) {
-	processList, err := ps.Processes()
-	if err != nil {
-		return caddy.ExitCodeFailedStartup, fmt.Errorf("listing processes: %v", err)
-	}
-	thisProcName := filepath.Base(os.Args[0])
-	var found bool
-	for _, p := range processList {
-		// the process we're looking for should have the same name but different PID
-		if p.Executable() == thisProcName && p.Pid() != os.Getpid() {
-			found = true
-			fmt.Printf("pid=%d\n", p.Pid())
-			fmt.Printf("Graceful stop...")
-			if err := gracefullyStopProcess(p.Pid()); err != nil {
-				return caddy.ExitCodeFailedStartup, err
-			}
-		}
-	}
-	if !found {
-		return caddy.ExitCodeFailedStartup, fmt.Errorf("Caddy is not running")
-	}
-	fmt.Println(" success")
-	return caddy.ExitCodeSuccess, nil
+    processList, err := ps.Processes()
+    if err != nil {
+        return caddy.ExitCodeFailedStartup, fmt.Errorf("listing processes: %v", err)
+    }
+    thisProcName := filepath.Base(os.Args[0])
+    var found bool
+    for _, p := range processList {
+        // the process we're looking for should have the same name but different PID
+        if matchProcess(p.Executable() ,thisProcName) && p.Pid() != os.Getpid() {
+            found = true
+            fmt.Printf("pid=%d\n", p.Pid())
+            
+            if err := gracefullyStopProcess(p.Pid()); err != nil {
+                return caddy.ExitCodeFailedStartup, err
+            }
+        }
+    }
+    if !found {
+        return caddy.ExitCodeFailedStartup, fmt.Errorf("Caddy is not running")
+    }
+    fmt.Println(" success")
+    return caddy.ExitCodeSuccess, nil
 }
 
 func cmdReload() (int, error) {
-	reloadCmd := flag.NewFlagSet("load", flag.ExitOnError)
-	reloadCmdConfigFlag := reloadCmd.String("config", "", "Configuration file")
-	reloadCmdAddrFlag := reloadCmd.String("address", "", "Address of the administration listener, if different from config")
-	reloadCmd.Parse(os.Args[2:])
+    reloadCmd := flag.NewFlagSet("load", flag.ExitOnError)
+    reloadCmdConfigFlag := reloadCmd.String("config", "", "Configuration file")
+    reloadCmdAddrFlag := reloadCmd.String("address", "", "Address of the administration listener, if different from config")
+    reloadCmd.Parse(os.Args[2:])
 
-	// a configuration is required
-	if *reloadCmdConfigFlag == "" {
-		return caddy.ExitCodeFailedStartup,
-			fmt.Errorf("no configuration to load (use --config)")
-	}
+    // a configuration is required
+    if *reloadCmdConfigFlag == "" {
+        return caddy.ExitCodeFailedStartup,
+            fmt.Errorf("no configuration to load (use --config)")
+    }
 
-	// load the configuration file
-	config, err := ioutil.ReadFile(*reloadCmdConfigFlag)
-	if err != nil {
-		return caddy.ExitCodeFailedStartup,
-			fmt.Errorf("reading config file: %v", err)
-	}
+    // load the configuration file
+    config, err := ioutil.ReadFile(*reloadCmdConfigFlag)
+    if err != nil {
+        return caddy.ExitCodeFailedStartup,
+            fmt.Errorf("reading config file: %v", err)
+    }
 
-	// get the address of the admin listener and craft endpoint URL
-	adminAddr := *reloadCmdAddrFlag
-	if adminAddr == "" {
-		var tmpStruct struct {
-			Admin caddy.AdminConfig `json:"admin"`
-		}
-		err = json.Unmarshal(config, &tmpStruct)
-		if err != nil {
-			return caddy.ExitCodeFailedStartup,
-				fmt.Errorf("unmarshaling admin listener address from config: %v", err)
-		}
-		adminAddr = tmpStruct.Admin.Listen
-	}
-	if adminAddr == "" {
-		adminAddr = caddy.DefaultAdminListen
-	}
-	adminEndpoint := fmt.Sprintf("http://%s/load", adminAddr)
+    // get the address of the admin listener and craft endpoint URL
+    adminAddr := *reloadCmdAddrFlag
+    if adminAddr == "" {
+        var tmpStruct struct {
+            Admin caddy.AdminConfig `json:"admin"`
+        }
+        err = json.Unmarshal(config, &tmpStruct)
+        if err != nil {
+            return caddy.ExitCodeFailedStartup,
+                fmt.Errorf("unmarshaling admin listener address from config: %v", err)
+        }
+        adminAddr = tmpStruct.Admin.Listen
+    }
+    if adminAddr == "" {
+        adminAddr = caddy.DefaultAdminListen
+    }
+    adminEndpoint := fmt.Sprintf("http://%s/load", adminAddr)
 
-	// send the configuration to the instance
-	resp, err := http.Post(adminEndpoint, "application/json", bytes.NewReader(config))
-	if err != nil {
-		return caddy.ExitCodeFailedStartup,
-			fmt.Errorf("sending configuration to instance: %v", err)
-	}
-	defer resp.Body.Close()
+    // send the configuration to the instance
+    resp, err := http.Post(adminEndpoint, "application/json", bytes.NewReader(config))
+    if err != nil {
+        return caddy.ExitCodeFailedStartup,
+            fmt.Errorf("sending configuration to instance: %v", err)
+    }
+    defer resp.Body.Close()
 
-	// if it didn't work, let the user know
-	if resp.StatusCode >= 400 {
-		respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1024*10))
-		if err != nil {
-			return caddy.ExitCodeFailedStartup,
-				fmt.Errorf("HTTP %d: reading error message: %v", resp.StatusCode, err)
-		}
-		return caddy.ExitCodeFailedStartup,
-			fmt.Errorf("caddy responded with error: HTTP %d: %s", resp.StatusCode, respBody)
-	}
+    // if it didn't work, let the user know
+    if resp.StatusCode >= 400 {
+        respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1024*10))
+        if err != nil {
+            return caddy.ExitCodeFailedStartup,
+                fmt.Errorf("HTTP %d: reading error message: %v", resp.StatusCode, err)
+        }
+        return caddy.ExitCodeFailedStartup,
+            fmt.Errorf("caddy responded with error: HTTP %d: %s", resp.StatusCode, respBody)
+    }
 
-	return caddy.ExitCodeSuccess, nil
+    return caddy.ExitCodeSuccess, nil
 }
 
 func cmdVersion() (int, error) {
-	goModule := caddy.GoModule()
-	if goModule.Sum != "" {
-		// a build with a known version will also have a checksum
-		fmt.Printf("%s %s\n", goModule.Version, goModule.Sum)
-	} else {
-		fmt.Println(goModule.Version)
-	}
-	return caddy.ExitCodeSuccess, nil
+    goModule := caddy.GoModule()
+    if goModule.Sum != "" {
+        // a build with a known version will also have a checksum
+        fmt.Printf("%s %s\n", goModule.Version, goModule.Sum)
+    } else {
+        fmt.Println(goModule.Version)
+    }
+    return caddy.ExitCodeSuccess, nil
 }
 
 func cmdListModules() (int, error) {
-	for _, m := range caddy.Modules() {
-		fmt.Println(m)
-	}
-	return caddy.ExitCodeSuccess, nil
+    for _, m := range caddy.Modules() {
+        fmt.Println(m)
+    }
+    return caddy.ExitCodeSuccess, nil
 }
 
 func cmdEnviron() (int, error) {
-	for _, v := range os.Environ() {
-		fmt.Println(v)
-	}
-	return caddy.ExitCodeSuccess, nil
+    for _, v := range os.Environ() {
+        fmt.Println(v)
+    }
+    return caddy.ExitCodeSuccess, nil
 }

--- a/cmd/proc_posix.go
+++ b/cmd/proc_posix.go
@@ -30,6 +30,6 @@ func gracefullyStopProcess(pid int) error {
 	return nil
 }
 
-func getAppName() string {
+func getProcessName() string {
 	return filepath.Base(os.Args[0])
 }

--- a/cmd/proc_posix.go
+++ b/cmd/proc_posix.go
@@ -17,19 +17,19 @@
 package caddycmd
 
 import (
-    "fmt"
-    "syscall"
+	"fmt"
+	"syscall"
 )
 
 func gracefullyStopProcess(pid int) error {
-    fmt.Printf("Graceful stop...")
-    err := syscall.Kill(pid, syscall.SIGINT)
-    if err != nil {
-        return fmt.Errorf("kill: %v", err)
-    }
-    return nil
+	fmt.Printf("Graceful stop...")
+	err := syscall.Kill(pid, syscall.SIGINT)
+	if err != nil {
+		return fmt.Errorf("kill: %v", err)
+	}
+	return nil
 }
 
-func matchProcess(appname string, processname string ) bool {    
-    return  appname == processname 
+func matchProcess(appname string, processname string) bool {
+	return appname == processname
 }

--- a/cmd/proc_posix.go
+++ b/cmd/proc_posix.go
@@ -17,14 +17,19 @@
 package caddycmd
 
 import (
-	"fmt"
-	"syscall"
+    "fmt"
+    "syscall"
 )
 
 func gracefullyStopProcess(pid int) error {
-	err := syscall.Kill(pid, syscall.SIGINT)
-	if err != nil {
-		return fmt.Errorf("kill: %v", err)
-	}
-	return nil
+    fmt.Printf("Graceful stop...")
+    err := syscall.Kill(pid, syscall.SIGINT)
+    if err != nil {
+        return fmt.Errorf("kill: %v", err)
+    }
+    return nil
+}
+
+func matchProcess(appname string, processname string ) bool {    
+    return  appname == processname 
 }

--- a/cmd/proc_posix.go
+++ b/cmd/proc_posix.go
@@ -30,6 +30,6 @@ func gracefullyStopProcess(pid int) error {
 	return nil
 }
 
-func matchProcess(appname string, processname string) bool {
-	return appname == processname
+func getAppName() string {
+	return filepath.Base(os.Args[0])
 }

--- a/cmd/proc_windows.go
+++ b/cmd/proc_windows.go
@@ -15,15 +15,24 @@
 package caddycmd
 
 import (
-	"fmt"
-	"os/exec"
-	"strconv"
+    "fmt"
+    "os/exec"
+    "strconv"
 )
 
 func gracefullyStopProcess(pid int) error {
-	cmd := exec.Command("taskkill", "/pid", strconv.Itoa(pid))
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("taskkill: %v", err)
-	}
-	return nil
+    fmt.Printf("Stop...")
+    // process on windows will not stop unless forced with /f
+    cmd := exec.Command("taskkill", "/pid", strconv.Itoa(pid),"/f")
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("taskkill: %v", err)
+    }
+    return nil
+}
+
+func matchProcess(appname string, processname string ) bool {
+
+    // on Windows the process name will include the extension
+    return  appname == processname + ".exe"
+
 }

--- a/cmd/proc_windows.go
+++ b/cmd/proc_windows.go
@@ -31,8 +31,6 @@ func gracefullyStopProcess(pid int) error {
 }
 
 func matchProcess(appname string, processname string ) bool {
-
     // on Windows the process name will include the extension
     return  appname == processname + ".exe"
-
 }

--- a/cmd/proc_windows.go
+++ b/cmd/proc_windows.go
@@ -23,7 +23,7 @@ import (
 )
 
 func gracefullyStopProcess(pid int) error {
-	fmt.Printf("Stop...")
+	fmt.Printf("Forceful Stop...")
 	// process on windows will not stop unless forced with /f
 	cmd := exec.Command("taskkill", "/pid", strconv.Itoa(pid), "/f")
 	if err := cmd.Run(); err != nil {
@@ -35,7 +35,7 @@ func gracefullyStopProcess(pid int) error {
 // On Windows the app name passed in os.Args[0] will match how
 // caddy was started eg will match caddy or caddy.exe.
 // So return appname with .exe for consistency
-func getAppName() string {
+func getProcessName() string {
 	base := filepath.Base(os.Args[0])
 	if filepath.Ext(base) == "" {
 		return base + ".exe"

--- a/cmd/proc_windows.go
+++ b/cmd/proc_windows.go
@@ -16,7 +16,9 @@ package caddycmd
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 )
 
@@ -30,7 +32,13 @@ func gracefullyStopProcess(pid int) error {
 	return nil
 }
 
-func matchProcess(appname string, processname string) bool {
-	// on Windows the process name will include the extension
-	return appname == processname+".exe"
+// On Windows the app name passed in os.Args[0] will match how
+// caddy was started eg will match caddy or caddy.exe.
+// So return appname with .exe for consistency
+func getAppName() string {
+	base := filepath.Base(os.Args[0])
+	if filepath.Ext(base) == "" {
+		return base + ".exe"
+	}
+	return base
 }

--- a/cmd/proc_windows.go
+++ b/cmd/proc_windows.go
@@ -15,22 +15,22 @@
 package caddycmd
 
 import (
-    "fmt"
-    "os/exec"
-    "strconv"
+	"fmt"
+	"os/exec"
+	"strconv"
 )
 
 func gracefullyStopProcess(pid int) error {
-    fmt.Printf("Stop...")
-    // process on windows will not stop unless forced with /f
-    cmd := exec.Command("taskkill", "/pid", strconv.Itoa(pid),"/f")
-    if err := cmd.Run(); err != nil {
-        return fmt.Errorf("taskkill: %v", err)
-    }
-    return nil
+	fmt.Printf("Stop...")
+	// process on windows will not stop unless forced with /f
+	cmd := exec.Command("taskkill", "/pid", strconv.Itoa(pid), "/f")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("taskkill: %v", err)
+	}
+	return nil
 }
 
-func matchProcess(appname string, processname string ) bool {
-    // on Windows the process name will include the extension
-    return  appname == processname + ".exe"
+func matchProcess(appname string, processname string) bool {
+	// on Windows the process name will include the extension
+	return appname == processname+".exe"
 }


### PR DESCRIPTION
---
name: Implement taskkill /f to force quit on windows when caddy stop
about: Gracefull shutdown on windows
title: ''
labels: ''
assignees: ''
---

As discussed this is the first iteration of forced shutdown on windows.

The current code wont shutdown caddy on windows.  taskkill /f is required. 

## 1. What does this change do, exactly?

Shutsdown a running instance of caddy by using `taskkill /f` to force shutdown of the process.  Also ensure process is found on windows systems

## 2. Please link to the relevant issues.

#2657 



## 3. Which documentation changes (if any) need to be made because of this PR?

Important to tell windows users that shutdown is not graceful on windows.  Ideally recommend they call stop on admin interface before calling `caddy stop`

I will make a change to 
## 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
