### PR TITLE
V2:Add stop command to admin.  

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -176,14 +176,14 @@ func handleStop(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.Println("[ADMIN] Initiating shutdown")
-	if err := stopandCleanup(); err != nil {
+	if err := stopAndCleanup(); err != nil {
 		log.Printf("[ADMIN][ERROR] stopping: %v \n", err)
 	}
 	log.Println("[ADMIN] Exiting")
 	os.Exit(0)
 }
 
-func stopandCleanup() error {
+func stopAndCleanup() error {
 	if err := Stop(); err != nil {
 		return err
 	}

--- a/admin.go
+++ b/admin.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"os"
 	"net/http"
 	"net/http/pprof"
 	"strings"
@@ -83,6 +84,8 @@ func StartAdmin(initialConfigJSON []byte) error {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/load", handleLoadConfig)
+	mux.HandleFunc("/stop", handleStop)
+
 
 	///// BEGIN PPROF STUFF (TODO: Temporary) /////
 	mux.HandleFunc("/debug/pprof/", pprof.Index)
@@ -149,7 +152,7 @@ type AdminRoute struct {
 
 func handleLoadConfig(w http.ResponseWriter, r *http.Request) {
 	r.Close = true
-	if r.Method != "POST" {
+	if r.Method != http.MethodPost {
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 		return
 	}
@@ -165,6 +168,16 @@ func handleLoadConfig(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+}
+
+func handleStop(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodPost {
+		log.Println("Shutting down...")
+		Stop()		
+		log.Println("Shut down.")
+		os.Exit(0)
+	}
+	return
 }
 
 // Load loads and starts a configuration.

--- a/sigtrap.go
+++ b/sigtrap.go
@@ -18,8 +18,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-
-	"github.com/mholt/certmagic"
 )
 
 // TrapSignals create signal/interrupt handlers as best it can for the
@@ -57,15 +55,11 @@ func trapSignalsCrossPlatform() {
 func gracefulStop(sigName string) {
 	exitCode := ExitCodeSuccess
 
-	// first stop all the apps
-	err := Stop()
+	err := stopAndCleanup()
 	if err != nil {
 		log.Printf("[ERROR] %s stop: %v", sigName, err)
 		exitCode = ExitCodeFailedQuit
 	}
-
-	// always, always, always try to clean up locks
-	certmagic.CleanUpOwnLocks()
 
 	log.Printf("[INFO] %s: Shutdown done", sigName)
 	os.Exit(exitCode)


### PR DESCRIPTION
## 1. What does this change do, exactly?

Add a stop command to  admin  website.

This gracefully stops all servers and exits the go process.

This enables graceful shutdown on Windows.

Gives the following output on windows 

````
D:\godev\src\github.com\caddyserver\caddy\cmd\caddy>caddy start
2019/07/14 22:50:14 Caddy 2 admin endpoint listening on localhost:2019
Successfully started Caddy

D:\godev\src\github.com\caddyserver\caddy\cmd\caddy>2019/07/14 22:50:20 [INFO][cache:0xc0000a8780] Started certificate maintenance routine
2019/07/14 22:50:24 Shutting down...

2019/07/14 22:50:24 [INFO][cache:0xc0000a8780] Stopped certificate maintenance routine
2019/07/14 22:50:24 Shut down.
````

## 2. Please link to the relevant issues.
<!-- This adds crucial context to your change. -->
#2670 
#2657 



## 3. Which documentation changes (if any) need to be made because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->

Add `stop` command to admin website


## 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
