### PR TITLE
Part 1: Optimize using compiler's inliner

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -209,7 +209,15 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 // value will still be returned, but with an
 // unknown version.
 func GoModule() *debug.Module {
-	mod := &debug.Module{Version: "unknown"}
+	var mod debug.Module
+	return goModule(&mod)
+}
+
+// goModule holds the actual implementation of GoModule.
+// Allocating debug.Module in GoModule() and passing a
+// reference to goModule enables mid-stack inlining.
+func goModule(mod *debug.Module) *debug.Module {
+	mod.Version = "unknown"
 	bi, ok := debug.ReadBuildInfo()
 	if ok {
 		mod.Path = bi.Main.Path

--- a/modules/caddyhttp/encode/encode.go
+++ b/modules/caddyhttp/encode/encode.go
@@ -103,6 +103,7 @@ func (enc *Encode) initResponseWriter(rw *responseWriter, encodingName string, w
 	buf := bufPool.Get().(*bytes.Buffer)
 	buf.Reset()
 
+	// The allocation of ResponseWriterWrapper might be optimized as well.
 	rw.ResponseWriterWrapper = &caddyhttp.ResponseWriterWrapper{ResponseWriter: wrappedRW}
 	rw.encodingName = encodingName
 	rw.buf = buf

--- a/modules/caddyhttp/encode/encode_test.go
+++ b/modules/caddyhttp/encode/encode_test.go
@@ -1,53 +1,12 @@
 package encode
 
 import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-	"sync"
 	"testing"
-
-	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 )
 
-// The following benchmarks represent a comparison between some
-// optimized methods and their previous implementation.
-//
-// Benchmark the old openResponseWriter implementation.
-func BenchmarkOldOpenResponseWriter(b *testing.B) {
-	oEnc := new(oldEncode)
-	for n := 0; n < b.N; n++ {
-		oEnc.openResponseWriter("test", nil)
-	}
-}
-
-// Benchmark the new openResponseWriter implementation.
-func BenchmarkNewOpenResponseWriter(b *testing.B) {
+func BenchmarkOpenResponseWriter(b *testing.B) {
 	enc := new(Encode)
 	for n := 0; n < b.N; n++ {
 		enc.openResponseWriter("test", nil)
-	}
-}
-
-// oldEncode is a copy of Encode that implements the older version
-// of the benchmarked methods, while the 'real' Encode holds the
-// newer methods. This should ensure a fair comparison.
-type oldEncode struct {
-	EncodingsRaw map[string]json.RawMessage `json:"encodings,omitempty"`
-	Prefer       []string                   `json:"prefer,omitempty"`
-	MinLength    int                        `json:"minimum_length,omitempty"`
-
-	writerPools map[string]*sync.Pool
-}
-
-// The old openResponseWriter version.
-func (oenc *oldEncode) openResponseWriter(encodingName string, w http.ResponseWriter) *responseWriter {
-	buf := bufPool.Get().(*bytes.Buffer)
-	buf.Reset()
-	return &responseWriter{
-		ResponseWriterWrapper: &caddyhttp.ResponseWriterWrapper{ResponseWriter: w},
-		encodingName:          encodingName,
-		buf:                   buf,
-		config:                nil,
 	}
 }

--- a/modules/caddyhttp/encode/encode_test.go
+++ b/modules/caddyhttp/encode/encode_test.go
@@ -1,0 +1,53 @@
+package encode
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+// The following benchmarks represent a comparison between some
+// optimized methods and their previous implementation.
+//
+// Benchmark the old openResponseWriter implementation.
+func BenchmarkOldOpenResponseWriter(b *testing.B) {
+	oEnc := new(oldEncode)
+	for n := 0; n < b.N; n++ {
+		oEnc.openResponseWriter("test", nil)
+	}
+}
+
+// Benchmark the new openResponseWriter implementation.
+func BenchmarkNewOpenResponseWriter(b *testing.B) {
+	enc := new(Encode)
+	for n := 0; n < b.N; n++ {
+		enc.openResponseWriter("test", nil)
+	}
+}
+
+// oldEncode is a copy of Encode that implements the older version
+// of the benchmarked methods, while the 'real' Encode holds the
+// newer methods. This should ensure a fair comparison.
+type oldEncode struct {
+	EncodingsRaw map[string]json.RawMessage `json:"encodings,omitempty"`
+	Prefer       []string                   `json:"prefer,omitempty"`
+	MinLength    int                        `json:"minimum_length,omitempty"`
+
+	writerPools map[string]*sync.Pool
+}
+
+// The old openResponseWriter version.
+func (oenc *oldEncode) openResponseWriter(encodingName string, w http.ResponseWriter) *responseWriter {
+	buf := bufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	return &responseWriter{
+		ResponseWriterWrapper: &caddyhttp.ResponseWriterWrapper{ResponseWriter: w},
+		encodingName:          encodingName,
+		buf:                   buf,
+		config:                nil,
+	}
+}

--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -133,16 +133,16 @@ func (fsrv *FileServer) browseApplyQueryParams(w http.ResponseWriter, r *http.Re
 }
 
 func (fsrv *FileServer) browseWriteJSON(listing browseListing) (*bytes.Buffer, error) {
-	buf := fsrv.bufPools["json"].Get().(*bytes.Buffer)
+	buf := bufPool.Get().(*bytes.Buffer)
 	err := json.NewEncoder(buf).Encode(listing.Items)
-	fsrv.bufPools["json"].Put(buf)
+	bufPool.Put(buf)
 	return buf, err
 }
 
 func (fsrv *FileServer) browseWriteHTML(listing browseListing) (*bytes.Buffer, error) {
-	buf := fsrv.bufPools["html"].Get().(*bytes.Buffer)
+	buf := bufPool.Get().(*bytes.Buffer)
 	err := fsrv.Browse.template.Execute(buf, listing)
-	fsrv.bufPools["html"].Put(buf)
+	bufPool.Put(buf)
 	return buf, err
 }
 

--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -133,13 +133,21 @@ func (fsrv *FileServer) browseApplyQueryParams(w http.ResponseWriter, r *http.Re
 }
 
 func (fsrv *FileServer) browseWriteJSON(listing browseListing) (*bytes.Buffer, error) {
-	buf := new(bytes.Buffer)
+	var buf bytes.Buffer
+	return fsrv.initJSONBuffer(&buf, listing)
+}
+
+func (fsrv *FileServer) initJSONBuffer(buf *bytes.Buffer, listing browseListing) (*bytes.Buffer, error) {
 	err := json.NewEncoder(buf).Encode(listing.Items)
 	return buf, err
 }
 
 func (fsrv *FileServer) browseWriteHTML(listing browseListing) (*bytes.Buffer, error) {
-	buf := new(bytes.Buffer)
+	var buf bytes.Buffer
+	return fsrv.initHTMLBuffer(&buf, listing)
+}
+
+func (fsrv *FileServer) initHTMLBuffer(buf *bytes.Buffer, listing browseListing) (*bytes.Buffer, error) {
 	err := fsrv.Browse.template.Execute(buf, listing)
 	return buf, err
 }

--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -133,22 +133,16 @@ func (fsrv *FileServer) browseApplyQueryParams(w http.ResponseWriter, r *http.Re
 }
 
 func (fsrv *FileServer) browseWriteJSON(listing browseListing) (*bytes.Buffer, error) {
-	var buf bytes.Buffer
-	return fsrv.initJSONBuffer(&buf, listing)
-}
-
-func (fsrv *FileServer) initJSONBuffer(buf *bytes.Buffer, listing browseListing) (*bytes.Buffer, error) {
+	buf := fsrv.bufPools["json"].Get().(*bytes.Buffer)
 	err := json.NewEncoder(buf).Encode(listing.Items)
+	fsrv.bufPools["json"].Put(buf)
 	return buf, err
 }
 
 func (fsrv *FileServer) browseWriteHTML(listing browseListing) (*bytes.Buffer, error) {
-	var buf bytes.Buffer
-	return fsrv.initHTMLBuffer(&buf, listing)
-}
-
-func (fsrv *FileServer) initHTMLBuffer(buf *bytes.Buffer, listing browseListing) (*bytes.Buffer, error) {
+	buf := fsrv.bufPools["html"].Get().(*bytes.Buffer)
 	err := fsrv.Browse.template.Execute(buf, listing)
+	fsrv.bufPools["html"].Put(buf)
 	return buf, err
 }
 

--- a/modules/caddyhttp/fileserver/browse_test.go
+++ b/modules/caddyhttp/fileserver/browse_test.go
@@ -59,10 +59,21 @@ func BenchmarkOldBrowseWriteHTML(b *testing.B) {
 		TemplateFile: "",
 		template:     template.New("test"),
 	}
+	listing := browseListing{
+		Name:           "test",
+		Path:           "test",
+		CanGoUp:        false,
+		Items:          make([]fileInfo, 100),
+		NumDirs:        42,
+		NumFiles:       420,
+		Sort:           "",
+		Order:          "",
+		ItemsLimitedTo: 42,
+	}
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		ofsrv.browseWriteHTML(browseListing{})
+		ofsrv.browseWriteHTML(listing)
 	}
 }
 
@@ -73,10 +84,21 @@ func BenchmarkNewBrowseWriteHTML(b *testing.B) {
 		TemplateFile: "",
 		template:     template.New("test"),
 	}
+	listing := browseListing{
+		Name:           "test",
+		Path:           "test",
+		CanGoUp:        false,
+		Items:          make([]fileInfo, 100),
+		NumDirs:        42,
+		NumFiles:       420,
+		Sort:           "",
+		Order:          "",
+		ItemsLimitedTo: 42,
+	}
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		fsrv.browseWriteHTML(browseListing{})
+		fsrv.browseWriteHTML(listing)
 	}
 }
 

--- a/modules/caddyhttp/fileserver/browse_test.go
+++ b/modules/caddyhttp/fileserver/browse_test.go
@@ -3,10 +3,13 @@ package fileserver
 import (
 	"html/template"
 	"testing"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 func BenchmarkBrowseWriteJSON(b *testing.B) {
 	fsrv := new(FileServer)
+	fsrv.Provision(caddy.Context{})
 	listing := browseListing{
 		Name:           "test",
 		Path:           "test",
@@ -27,6 +30,7 @@ func BenchmarkBrowseWriteJSON(b *testing.B) {
 
 func BenchmarkBrowseWriteHTML(b *testing.B) {
 	fsrv := new(FileServer)
+	fsrv.Provision(caddy.Context{})
 	fsrv.Browse = &Browse{
 		TemplateFile: "",
 		template:     template.New("test"),

--- a/modules/caddyhttp/fileserver/browse_test.go
+++ b/modules/caddyhttp/fileserver/browse_test.go
@@ -1,38 +1,11 @@
 package fileserver
 
 import (
-	"bytes"
-	"encoding/json"
 	"html/template"
 	"testing"
 )
 
-// The following benchmarks represent a comparison between some
-// optimized methods and their previous implementation.
-//
-// Benchmark the old BrowseWriteJSON implementation.
-func BenchmarkOldBrowseWriteJSON(b *testing.B) {
-	ofsrv := new(oldFileServer)
-	listing := browseListing{
-		Name:           "test",
-		Path:           "test",
-		CanGoUp:        false,
-		Items:          make([]fileInfo, 100),
-		NumDirs:        42,
-		NumFiles:       420,
-		Sort:           "",
-		Order:          "",
-		ItemsLimitedTo: 42,
-	}
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
-		ofsrv.browseWriteJSON(listing)
-	}
-}
-
-// Benchmark the new BrowseWriteJSON implementation.
-func BenchmarkNewBrowseWriteJSON(b *testing.B) {
+func BenchmarkBrowseWriteJSON(b *testing.B) {
 	fsrv := new(FileServer)
 	listing := browseListing{
 		Name:           "test",
@@ -52,33 +25,7 @@ func BenchmarkNewBrowseWriteJSON(b *testing.B) {
 	}
 }
 
-// Benchmark the old BrowseWriteHTML implementation.
-func BenchmarkOldBrowseWriteHTML(b *testing.B) {
-	ofsrv := new(oldFileServer)
-	ofsrv.Browse = &Browse{
-		TemplateFile: "",
-		template:     template.New("test"),
-	}
-	listing := browseListing{
-		Name:           "test",
-		Path:           "test",
-		CanGoUp:        false,
-		Items:          make([]fileInfo, 100),
-		NumDirs:        42,
-		NumFiles:       420,
-		Sort:           "",
-		Order:          "",
-		ItemsLimitedTo: 42,
-	}
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
-		ofsrv.browseWriteHTML(listing)
-	}
-}
-
-// Benchmark the new BrowseWriteHTML implementation.
-func BenchmarkNewBrowseWriteHTML(b *testing.B) {
+func BenchmarkBrowseWriteHTML(b *testing.B) {
 	fsrv := new(FileServer)
 	fsrv.Browse = &Browse{
 		TemplateFile: "",
@@ -100,28 +47,4 @@ func BenchmarkNewBrowseWriteHTML(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		fsrv.browseWriteHTML(listing)
 	}
-}
-
-// oldFileServer is a copy of FileServer that implements the older
-// version of the benchmarked methods, while the 'real' FileServer
-// holds the newer methods. This should ensure a fair comparison.
-type oldFileServer struct {
-	Root       string   `json:"root,omitempty"`
-	Hide       []string `json:"hide,omitempty"`
-	IndexNames []string `json:"index_names,omitempty"`
-	Browse     *Browse  `json:"browse,omitempty"`
-}
-
-// The old browseWriteJSON version.
-func (ofsrv *oldFileServer) browseWriteJSON(listing browseListing) (*bytes.Buffer, error) {
-	buf := new(bytes.Buffer)
-	err := json.NewEncoder(buf).Encode(listing.Items)
-	return buf, err
-}
-
-// The old browseWriteHTML version.
-func (ofsrv *oldFileServer) browseWriteHTML(listing browseListing) (*bytes.Buffer, error) {
-	buf := new(bytes.Buffer)
-	err := ofsrv.Browse.template.Execute(buf, listing)
-	return buf, err
 }

--- a/modules/caddyhttp/fileserver/browse_test.go
+++ b/modules/caddyhttp/fileserver/browse_test.go
@@ -1,0 +1,105 @@
+package fileserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"html/template"
+	"testing"
+)
+
+// The following benchmarks represent a comparison between some
+// optimized methods and their previous implementation.
+//
+// Benchmark the old BrowseWriteJSON implementation.
+func BenchmarkOldBrowseWriteJSON(b *testing.B) {
+	ofsrv := new(oldFileServer)
+	listing := browseListing{
+		Name:           "test",
+		Path:           "test",
+		CanGoUp:        false,
+		Items:          make([]fileInfo, 100),
+		NumDirs:        42,
+		NumFiles:       420,
+		Sort:           "",
+		Order:          "",
+		ItemsLimitedTo: 42,
+	}
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		ofsrv.browseWriteJSON(listing)
+	}
+}
+
+// Benchmark the new BrowseWriteJSON implementation.
+func BenchmarkNewBrowseWriteJSON(b *testing.B) {
+	fsrv := new(FileServer)
+	listing := browseListing{
+		Name:           "test",
+		Path:           "test",
+		CanGoUp:        false,
+		Items:          make([]fileInfo, 100),
+		NumDirs:        42,
+		NumFiles:       420,
+		Sort:           "",
+		Order:          "",
+		ItemsLimitedTo: 42,
+	}
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		fsrv.browseWriteJSON(listing)
+	}
+}
+
+// Benchmark the old BrowseWriteHTML implementation.
+func BenchmarkOldBrowseWriteHTML(b *testing.B) {
+	ofsrv := new(oldFileServer)
+	ofsrv.Browse = &Browse{
+		TemplateFile: "",
+		template:     template.New("test"),
+	}
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		ofsrv.browseWriteHTML(browseListing{})
+	}
+}
+
+// Benchmark the new BrowseWriteHTML implementation.
+func BenchmarkNewBrowseWriteHTML(b *testing.B) {
+	fsrv := new(FileServer)
+	fsrv.Browse = &Browse{
+		TemplateFile: "",
+		template:     template.New("test"),
+	}
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		fsrv.browseWriteHTML(browseListing{})
+	}
+}
+
+// oldFileServer is a copy of FileServer that implements the older
+// version of the benchmarked methods, while the 'real' FileServer
+// holds the newer methods. This should ensure a fair comparison.
+type oldFileServer struct {
+	Root       string   `json:"root,omitempty"`
+	Hide       []string `json:"hide,omitempty"`
+	IndexNames []string `json:"index_names,omitempty"`
+	Browse     *Browse  `json:"browse,omitempty"`
+}
+
+// The old browseWriteJSON version.
+func (ofsrv *oldFileServer) browseWriteJSON(listing browseListing) (*bytes.Buffer, error) {
+	buf := new(bytes.Buffer)
+	err := json.NewEncoder(buf).Encode(listing.Items)
+	return buf, err
+}
+
+// The old browseWriteHTML version.
+func (ofsrv *oldFileServer) browseWriteHTML(listing browseListing) (*bytes.Buffer, error) {
+	buf := new(bytes.Buffer)
+	err := ofsrv.Browse.template.Execute(buf, listing)
+	return buf, err
+}

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -49,7 +49,6 @@ type FileServer struct {
 	IndexNames []string `json:"index_names,omitempty"`
 	Browse     *Browse  `json:"browse,omitempty"`
 
-	bufPools map[string]*sync.Pool
 	// TODO: Content negotiation
 }
 
@@ -57,19 +56,6 @@ type FileServer struct {
 func (fsrv *FileServer) Provision(ctx caddy.Context) error {
 	if fsrv.IndexNames == nil {
 		fsrv.IndexNames = defaultIndexNames
-	}
-
-	fsrv.bufPools = map[string]*sync.Pool{
-		"json": &sync.Pool{
-			New: func() interface{} {
-				return new(bytes.Buffer)
-			},
-		},
-		"html": &sync.Pool{
-			New: func() interface{} {
-				return new(bytes.Buffer)
-			},
-		},
 	}
 
 	if fsrv.Browse != nil {
@@ -317,6 +303,12 @@ func calculateEtag(d os.FileInfo) string {
 }
 
 var defaultIndexNames = []string{"index.html"}
+
+var bufPool = sync.Pool{
+	New: func() interface{} {
+		return new(bytes.Buffer)
+	},
+}
 
 const minBackoff, maxBackoff = 2, 5
 


### PR DESCRIPTION
 ## 1. What does this change do, exactly?
Allocating a value and returning a reference to it in a single function causes the Go compiler to escape the value to the heap, since it has to outlive the function's lifetime. Optimizing the function calls (as shown in the first commit) can enable mid-stack inlining of the function and avoiding a heap allocation.




## 2. Please link to the relevant issues.
https://github.com/caddyserver/caddy/issues/2681




## 3. Which documentation changes (if any) need to be made because of this PR?
This is an internal change.




## 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
