### PR TITLE
Modifying Lexer to remove tailing { if not quoted

### DIFF
--- a/caddyfile/lexer.go
+++ b/caddyfile/lexer.go
@@ -124,6 +124,9 @@ func (l *lexer) next() bool {
 				comment = false
 			}
 			if len(val) > 0 {
+				if len(val) > 1 && val[len(val)-1] == '{' {
+					val = val[:len(val)-1]
+				}
 				return makeToken()
 			}
 			continue

--- a/caddyfile/lexer.go
+++ b/caddyfile/lexer.go
@@ -124,9 +124,6 @@ func (l *lexer) next() bool {
 				comment = false
 			}
 			if len(val) > 0 {
-				if len(val) > 1 && val[len(val)-1] == '{' {
-					val = val[:len(val)-1]
-				}
 				return makeToken()
 			}
 			continue

--- a/caddyfile/parse.go
+++ b/caddyfile/parse.go
@@ -177,7 +177,7 @@ func (p *parser) blockContents() error {
 		p.cursor--
 	}
 
-	err := p.directives()
+	err := p.directives(errOpenCurlyBrace == nil)
 	if err != nil {
 		return err
 	}
@@ -197,11 +197,15 @@ func (p *parser) blockContents() error {
 // and it expects the next token to be the first
 // directive. It goes until EOF or closing curly brace
 // which ends the server block.
-func (p *parser) directives() error {
+func (p *parser) directives(serverIsBlock bool) error {
 	for p.Next() {
 		// end of server block
 		if p.Val() == "}" {
-			break
+			if serverIsBlock {
+				break
+			} else {
+				return p.Errf("'}' closing curly brace without '{' open curly brace")
+			}
 		}
 
 		// special case: import directive replaces tokens during parse-time

--- a/caddyfile/parse_test.go
+++ b/caddyfile/parse_test.go
@@ -217,8 +217,8 @@ func TestParseOneAndImport(t *testing.T) {
 		{`localhost:1234{
 		    dir1 foo bar
 		    dir2
-		  }`, false, []string{
-			"localhost:1234",
+		  }`, true, []string{
+			"localhost:1234{",
 		}, map[string]int{
 			"dir1": 3,
 			"dir2": 1,

--- a/caddyfile/parse_test.go
+++ b/caddyfile/parse_test.go
@@ -214,6 +214,36 @@ func TestParseOneAndImport(t *testing.T) {
 			"dir3": 1,
 		}},
 
+		{`localhost:1234{
+		    dir1 foo bar
+		    dir2
+		  }`, false, []string{
+			"localhost:1234",
+		}, map[string]int{
+			"dir1": 3,
+			"dir2": 1,
+		}},
+
+		{`"localhost:1234"{
+		    dir1 foo bar
+		    dir2
+		  }`, false, []string{
+			"localhost:1234",
+		}, map[string]int{
+			"dir1": 3,
+			"dir2": 1,
+		}},
+
+		{`"localhost:1234{"
+		    dir1 foo bar
+		    dir2
+		  `, false, []string{
+			"localhost:1234{",
+		}, map[string]int{
+			"dir1": 3,
+			"dir2": 1,
+		}},
+
 		{`import testdata/import_test2.txt`, false, []string{
 			"host1",
 		}, map[string]int{


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. What does this change do, exactly?
When a address ends with a `{` and is not quoted, it discard the `{` in the address name.

This is meant to avoid this 

```
localhost:1234{
    dir1 foo bar
    dir2
}
```
parsed as `localhost:1234` and not `localhost:1234{`

but 

```
"localhost:1234{"
    dir1 foo bar
    dir2
```
parsed as `localhost:1234{`



## 2. Please link to the relevant issues.
https://github.com/caddyserver/caddy/issues/2719



## 3. Which documentation changes (if any) need to be made because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->




## 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
