### PR TITLE
fix the package import path by adhering to gomod semantic when major version is > 1

### DIFF
--- a/caddyconfig/httpcaddyfile/addresses.go
+++ b/caddyconfig/httpcaddyfile/addresses.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/caddyserver/caddy/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/mholt/certmagic"
 )

--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -21,8 +21,8 @@ import (
 	"net/http"
 	"reflect"
 
-	"github.com/caddyserver/caddy/caddyconfig"
-	"github.com/caddyserver/caddy/modules/caddyhttp"
+	"github.com/caddyserver/caddy/v2/caddyconfig"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
 )
 

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -17,7 +17,7 @@ package fileserver
 import (
 	"encoding/json"
 
-	"github.com/caddyserver/caddy/modules/caddyhttp/rewrite"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp/rewrite"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 )


### PR DESCRIPTION
## 1. What does this change do, exactly?
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

The wrong import path slipped in during the last refactor for the Caddyfile adapter. This PR corrects the import path.


## 2. Please link to the relevant issues.
<!-- This adds crucial context to your change. -->

None.


## 3. Which documentation changes (if any) need to be made because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->

None


## 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
