### PR TITLE
Use gopkg.in/russross/blackfriday.v1 import path

### DIFF
--- a/caddyhttp/httpserver/tplcontext.go
+++ b/caddyhttp/httpserver/tplcontext.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/caddyserver/caddy/caddytls"
 	"github.com/mholt/certmagic"
-	"github.com/russross/blackfriday"
+	"gopkg.in/russross/blackfriday.v1"
 )
 
 // This file contains the context and functions available for

--- a/caddyhttp/markdown/markdown.go
+++ b/caddyhttp/markdown/markdown.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/caddyserver/caddy/caddyhttp/httpserver"
-	"github.com/russross/blackfriday"
+	"gopkg.in/russross/blackfriday.v1"
 )
 
 // Markdown implements a layer of middleware that serves

--- a/caddyhttp/markdown/markdown_test.go
+++ b/caddyhttp/markdown/markdown_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/caddyserver/caddy"
 	"github.com/caddyserver/caddy/caddyhttp/httpserver"
-	"github.com/russross/blackfriday"
+	"gopkg.in/russross/blackfriday.v1"
 )
 
 func TestMarkdown(t *testing.T) {

--- a/caddyhttp/markdown/process.go
+++ b/caddyhttp/markdown/process.go
@@ -22,7 +22,7 @@ import (
 	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 	"github.com/caddyserver/caddy/caddyhttp/markdown/metadata"
 	"github.com/caddyserver/caddy/caddyhttp/markdown/summary"
-	"github.com/russross/blackfriday"
+	"gopkg.in/russross/blackfriday.v1"
 )
 
 // FileInfo represents a file in a particular server context. It wraps the os.FileInfo struct.

--- a/caddyhttp/markdown/setup.go
+++ b/caddyhttp/markdown/setup.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/caddyserver/caddy"
 	"github.com/caddyserver/caddy/caddyhttp/httpserver"
-	"github.com/russross/blackfriday"
+	"gopkg.in/russross/blackfriday.v1"
 )
 
 func init() {

--- a/caddyhttp/markdown/summary/render.go
+++ b/caddyhttp/markdown/summary/render.go
@@ -17,7 +17,7 @@ package summary
 import (
 	"bytes"
 
-	"github.com/russross/blackfriday"
+	"gopkg.in/russross/blackfriday.v1"
 )
 
 // Ensure we implement the Blackfriday Markdown Renderer interface

--- a/caddyhttp/markdown/summary/summary.go
+++ b/caddyhttp/markdown/summary/summary.go
@@ -17,7 +17,7 @@ package summary
 import (
 	"bytes"
 
-	"github.com/russross/blackfriday"
+	"gopkg.in/russross/blackfriday.v1"
 )
 
 // Markdown formats input using a plain-text renderer, and

--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,9 @@ require (
 	github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
 	github.com/naoina/go-stringutil v0.1.0 // indirect
 	github.com/naoina/toml v0.1.1
-	github.com/russross/blackfriday v0.0.0-20170610170232-067529f716f4
 	golang.org/x/net v0.0.0-20190328230028-74de082e2cca
 	gopkg.in/mcuadros/go-syslog.v2 v2.2.1
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
+	gopkg.in/russross/blackfriday.v1 v1.5
 	gopkg.in/yaml.v2 v2.2.2
 )


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to the code
title: ''
labels: ''
assignees: ''
---

## 1. What does this change do, exactly?

This changes blackfriday's import path to `gopkg.in/russross/blackfriday.v1` everywhere.  That is recommended by blackfriday's README.  My main motivation for this is to help with RPM packaging in Fedora.  The unversioned `github.com/russross/blackfriday` import path belongs to the v2 RPM package, so I need to ensure I'm referencing the v1 RPM package.

[`go.mod`](https://github.com/caddyserver/caddy/blob/a23f707268b9f6a3613356ab426155969bb2320b/go.mod) currently references [commit 067529f716f4](https://github.com/russross/blackfriday/commit/067529f716f4) of blackfriday.
The earliest tag that includes that is [v1.5](https://github.com/russross/blackfriday/commits/v1.5), so I went ahead and just used that in this change.

There is [some debate](https://github.com/russross/blackfriday/issues/491) upstream about that import path not matching what is listed in their `go.mod`.  In the RPM package it works fine to replace `github.com/russross/blackfriday` with `gopkg.in/russross/blackfriday.v1`, but that build environment explicitly sets `GO111MODULE=off`.  I'm new to golang, and especially go modules, so I'm not sure if this is actually the correct way to handle this.  I'm curious to see if this passes your CI or not.  If it's no good, feel free to close this.

## 2. Please link to the relevant issues.

This was a small enough change I didn't create a separate issue first.

## 3. Which documentation changes (if any) need to be made because of this PR?

I don't believe there is any.

## 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
