### PR TITLE
Add support for client TLS authentication Caddy V2

### DIFF
--- a/modules/caddyhttp/caddyhttp.go
+++ b/modules/caddyhttp/caddyhttp.go
@@ -75,6 +75,10 @@ func (app *App) Provision(ctx caddy.Context) error {
 			srv.AutoHTTPS = new(AutoHTTPSConfig)
 		}
 
+		if len(srv.TLSConnPolicies) != 0 {
+			srv.StrictSNIHost = true
+		}
+
 		// TODO: Test this function to ensure these replacements are performed
 		for i := range srv.Listen {
 			srv.Listen[i] = repl.ReplaceAll(srv.Listen[i], "")

--- a/modules/caddyhttp/caddyhttp.go
+++ b/modules/caddyhttp/caddyhttp.go
@@ -297,8 +297,16 @@ func (app *App) automaticHTTPS() error {
 			// tell the server to use TLS by specifying a TLS
 			// connection policy (which supports HTTP/2 and the
 			// TLS-ALPN ACME challenge as well)
-			srv.TLSConnPolicies = caddytls.ConnectionPolicies{
-				{ALPN: defaultALPN},
+			if srv.TLSConnPolicies == nil {
+				// build a new TLSConnPolicies if it does not exist
+				srv.TLSConnPolicies = caddytls.ConnectionPolicies{
+					&caddytls.ConnectionPolicy{ALPN: defaultALPN},
+				}
+			} else {
+				// append the default policy at the end of the existing policies
+				srv.TLSConnPolicies = append(srv.TLSConnPolicies,
+					&caddytls.ConnectionPolicy{ALPN: defaultALPN},
+				)
 			}
 
 			if srv.AutoHTTPS.DisableRedir {

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -49,6 +49,10 @@ type Server struct {
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Server", "Caddy")
 
+	if len(s.TLSConnPolicies) != 0 {
+		s.StrictSNIHost = true
+	}
+
 	if s.tlsApp.HandleHTTPChallenge(w, r) {
 		return
 	}

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -49,10 +49,6 @@ type Server struct {
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Server", "Caddy")
 
-	if len(s.TLSConnPolicies) != 0 {
-		s.StrictSNIHost = true
-	}
-
 	if s.tlsApp.HandleHTTPChallenge(w, r) {
 		return
 	}

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -40,7 +40,7 @@ type Server struct {
 	TLSConnPolicies   caddytls.ConnectionPolicies `json:"tls_connection_policies,omitempty"`
 	AutoHTTPS         *AutoHTTPSConfig            `json:"automatic_https,omitempty"`
 	MaxRehandles      *int                        `json:"max_rehandles,omitempty"`
-	StrictSNIHost     bool                        `json:"strict_sni_host,omitempty"` // TODO: see if we can turn this on by default when clientauth is configured
+	StrictSNIHost     bool                        `json:"strict_sni_host,omitempty"`
 
 	tlsApp *caddytls.TLS
 }
@@ -176,6 +176,15 @@ func (s *Server) listenersUseAnyPortOtherThan(otherPort int) bool {
 					return true
 				}
 			}
+		}
+	}
+	return false
+}
+
+func (s *Server) hasTLSClientAuth() bool {
+	for _, cp := range s.TLSConnPolicies {
+		if cp.Active() {
+			return true
 		}
 	}
 	return false

--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -236,8 +236,7 @@ func (p *ConnectionPolicy) buildStandardTLSConfig(ctx caddy.Context) error {
 			for _, clientCAString := range p.ClientAuthentication.TrustedCACerts {
 				clientCA, err := parseCertFromBase64Func(clientCAString)
 				if err != nil {
-					// TODO log error
-					continue
+					return fmt.Errorf("parsing certificate: %v", err)
 				}
 
 				// add the certificate to cliCertPool
@@ -245,7 +244,7 @@ func (p *ConnectionPolicy) buildStandardTLSConfig(ctx caddy.Context) error {
 			}
 
 			verifyPeerCertificateFunc := func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-				if rawCerts == nil {
+				if len(rawCerts) == 0 {
 					return fmt.Errorf("no certificate provided")
 				}
 
@@ -287,8 +286,7 @@ func (p *ConnectionPolicy) buildStandardTLSConfig(ctx caddy.Context) error {
 			for _, clientCertString := range p.ClientAuthentication.TrustedLeafCerts {
 				clientCert, err := parseCertFromBase64Func(clientCertString)
 				if err != nil {
-					// TODO log error
-					continue
+					return fmt.Errorf("parsing certificate: %v", err)
 				}
 
 				trustedLeafCerts = append(trustedLeafCerts, clientCert)
@@ -304,7 +302,7 @@ func (p *ConnectionPolicy) buildStandardTLSConfig(ctx caddy.Context) error {
 					}
 				}
 
-				if rawCerts == nil {
+				if len(rawCerts) == 0 {
 					return fmt.Errorf("no certificate provided")
 				}
 
@@ -337,9 +335,14 @@ func (p *ConnectionPolicy) buildStandardTLSConfig(ctx caddy.Context) error {
 
 // ClientAuthentication defines client authentication solutions
 type ClientAuthentication struct {
+	// TrustedCACerts contains a list of CA to verify the peer certificates.
+	// TrustedLeafCerts contains a list of accepted certificates.
+	// For both certificates are base64 DER encoded.
 	TrustedCACerts   []string `json:"trusted_ca_certs,omitempty"`
 	TrustedLeafCerts []string `json:"trusted_leaf_certs,omitempty"`
-	AskURL           string   `json:"ask_url,omitempty"`
+
+	// TODO
+	AskURL string `json:"ask_url,omitempty"`
 }
 
 // setDefaultTLSParams sets the default TLS cipher suites, protocol versions,

--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -340,9 +340,6 @@ type ClientAuthentication struct {
 	// For both certificates are base64 DER encoded.
 	TrustedCACerts   []string `json:"trusted_ca_certs,omitempty"`
 	TrustedLeafCerts []string `json:"trusted_leaf_certs,omitempty"`
-
-	// TODO
-	AskURL string `json:"ask_url,omitempty"`
 }
 
 // setDefaultTLSParams sets the default TLS cipher suites, protocol versions,


### PR DESCRIPTION

---
name: Add support for client TLS authentication Caddy V2
about: Adding support for client TLS authentication for the next Caddy release
title: 'Add support for client TLS authentication :smile:'
labels: 'V2'
assignees: '@alexandrestein'
---

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. What does this change do, exactly?
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->
The thing is pretty obvious and it was available in **Caddy 1**.



## 2. Please link to the relevant issues.
<!-- This adds crucial context to your change. -->
[An issue](https://github.com/caddyserver/caddy/issues/2680) is open about this.

I'm really new to the project and I don't know if this is the best way to this.
To test this update I used a similar configuration:
```json
{
    "apps": {
        "http": {
            "http_port": 80,
            "https_port": 443,
            "grace_period": "2s",
            "servers": {
                "mainServices": {
                    "listen": [
                        ":443"
                    ],
                    "tls_connection_policies": [
                        {
                            "match": {
                                "sni": [
                                    "0.dom.com",
                                    "dom.com"
                                ]
                            },
                            "client_cas": [
                                "MIIDSzCCAjOgAwIBAgIUfIRObjWNUA4jxQ/0x8BOCvE2Vw4wDQYJKoZIhvcNAQELBQAwFjEUMBIGA1UEAwwLRWFzeS1SU0EgQ0EwHhcNMTkwODI4MTYyNTU5WhcNMjkwODI1MTYyNTU5WjAWMRQwEgYDVQQDDAtFYXN5LVJTQSBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK5m5elxhQfMp/3aVJ4JnpN9PUSz6LlP6LePAPFU7gqohVVFVtDkChJAG3FNkNQNlieVTja/bgH9IcC6oKbROwdY1h0MvNV8AHHigvl03WuJD8g2ReVFXXwsnrPmKXCFzQyMI6TYk3m2gYrXsZOU1GLnfMRC3KAMRgE2F45twOs9hqG169YJ6mM2eQjzjCHWI6S2/iUYvYxRkCOlYUbLsMD/AhgAf1plzg6LPqNxtdlwxZnA0ytgkmhK67HtzJu0+ovUCsMv0RwcMhsEo9T8nyFAGt9XLZ63X5WpBCTUApaAUhnG0XnerjmUWb6eUWw4zev54sEfY5F3x002iQaW6cECAwEAAaOBkDCBjTAdBgNVHQ4EFgQU4CBUbZsS2GaNIkGRz/cBsD5ivjswUQYDVR0jBEowSIAU4CBUbZsS2GaNIkGRz/cBsD5ivjuhGqQYMBYxFDASBgNVBAMMC0Vhc3ktUlNBIENBghR8hE5uNY1QDiPFD/THwE4K8TZXDjAMBgNVHRMEBTADAQH/MAsGA1UdDwQEAwIBBjANBgkqhkiG9w0BAQsFAAOCAQEAKB3V4HIzoiO/Ch6WMj9bLJ2FGbpkMrcb/Eq01hT5zcfKD66lVS1MlK+cRL446Z2b2KDP1oFyVs+qmrmtdwrWgD+nfe2sBmmIHo9m9KygMkEOfG3MghGTEcS+0cTKEcoHYWYyOqQh6jnedXY8Cdm4GM1hAc9MiL3/sqV8YCVSLNnkoNysmr06/rZ0MCUZPGUtRmfd0heWhrfzAKw2HLgX+RAmpOE2MZqWcjvqKGyaRiaZks4nJkP6521aC2Lgp0HhCz1j8/uQ5ldoDszCnu/iro0NAsNtudTMD+YoLQxLqdleIh6CW+illc2VdXwj7mn6J04yns9jfE2jRjW/yTLFuQ=="
                            ]
                        }
                    ],
                    "routes": [
                        {
                            "match": [
                                {
                                    "host": [
                                        "0.dom.com",
                                        "dom.com"
                                    ]
                                }
                            ],
                            "handle": [
                                {
                                    "handler": "file_server",
                                    "browse": {}
                                }
                            ]
                        },
                        {
                            "match": [
                                {
                                    "host": [
                                        "1.dom.com"
                                    ]
                                }
                            ],
                            "handle": [
                                {
                                    "handler": "file_server",
                                    "browse": {}
                                }
                            ]
                        }
                    ]
                }
            }
        }
    },
    "tls": {
        "management": {
            "module": "acme",
            "ca": "https://acme-staging-v02.api.letsencrypt.org/directory",
            "email": "astein58@gmail.com",
            "on_demand": false
        }
    }
}
```
[Here](https://github.com/caddyserver/caddy/files/3552078/caddyTestingClient.zip) is a client certificate you can use to try. The password is "caddy".
And [here](https://github.com/caddyserver/caddy/files/3552081/ca.zip) the CA certificate.

I didn't notice any side effect and it was asking for certificate.

Let me know what change would you like to see. :smile: 

## 3. Which documentation changes (if any) need to be made because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->

The part related to the **tls_connection_policies** in the Wiki V2.


## 4. Checklist

- [ ] I have written tests and verified that they fail without my change
**No but I'm ready to do it. I don't see where you are managing the CI**
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
