### PR TITLE
go.mod, go.sum always eol=lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,8 @@
 
 # go fmt will enforce this, but in case a user has not called "go fmt" allow GIT to catch this:
 *.go      text eol=lf core.whitespace whitespace=indent-with-non-tab,trailing-space,tabwidth=4
+go.mod    text eol=lf
+go.sum    text eol=lf
 
 *.txt     text eol=lf core.whitespace whitespace=tab-in-indent,trailing-space,tabwidth=2
 *.tpl     text eol=lf core.whitespace whitespace=tab-in-indent,trailing-space,tabwidth=2


### PR DESCRIPTION
---
name: Pull request
about: go.mod, go.sum always eol=lf
title: 'go.mod, go.sum always eol=lf'
labels: ''
assignees: ''
---

## 1. What does this change do, exactly?
For Windows users, go.mod, go.sum should always use eol=lf


