### PR TITLE
fastcgi: Implement / redirect for index.php with php_fastcgi directive

### DIFF
--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -403,6 +403,11 @@ func (m *MatchNegate) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &m.MatchersRaw)
 }
 
+// MarshalJSON marshals m's matchers.
+func (m MatchNegate) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.MatchersRaw)
+}
+
 // UnmarshalCaddyfile implements caddyfile.Unmarshaler.
 func (m *MatchNegate) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	// TODO: figure out how this will work
@@ -686,4 +691,7 @@ var (
 	_ caddyfile.Unmarshaler = (*MatchHeaderRE)(nil)
 	_ caddyfile.Unmarshaler = (*MatchProtocol)(nil)
 	_ caddyfile.Unmarshaler = (*MatchRemoteIP)(nil)
+
+	_ json.Marshaler   = (*MatchNegate)(nil)
+	_ json.Unmarshaler = (*MatchNegate)(nil)
 )

--- a/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
@@ -138,7 +138,7 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 	// route to rewrite to PHP index file
 	rewriteMatcherSet := map[string]json.RawMessage{
 		"file": h.JSON(fileserver.MatchFile{
-			TryFiles: []string{"{http.request.uri.path}", "index.php"},
+			TryFiles: []string{"{http.request.uri.path}", "{http.request.uri.path}/index.php", "index.php"},
 		}, nil),
 	}
 	rewriteHandler := rewrite.Rewrite{

--- a/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
@@ -16,6 +16,7 @@ package fastcgi
 
 import (
 	"encoding/json"
+	"net/http"
 
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -114,6 +115,26 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 		return nil, h.ArgErr()
 	}
 
+	// route to redirect to canonical path if index PHP file
+	redirMatcherSet := map[string]json.RawMessage{
+		"file": h.JSON(fileserver.MatchFile{
+			TryFiles: []string{"{http.request.uri.path}/index.php"},
+		}, nil),
+		"not": h.JSON(caddyhttp.MatchNegate{
+			MatchersRaw: map[string]json.RawMessage{
+				"path": h.JSON(caddyhttp.MatchPath{"*/"}, nil),
+			},
+		}, nil),
+	}
+	redirHandler := caddyhttp.StaticResponse{
+		StatusCode: caddyhttp.WeakString("307"),
+		Headers:    http.Header{"Location": []string{"{http.request.uri.path}/"}},
+	}
+	redirRoute := caddyhttp.Route{
+		MatcherSetsRaw: []map[string]json.RawMessage{redirMatcherSet},
+		HandlersRaw:    []json.RawMessage{caddyconfig.JSONModuleObject(redirHandler, "handler", "static_response", nil)},
+	}
+
 	// route to rewrite to PHP index file
 	rewriteMatcherSet := map[string]json.RawMessage{
 		"file": h.JSON(fileserver.MatchFile{
@@ -175,7 +196,7 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 	// wrap ours in a subroute and return that
 	if hasUserMatcher {
 		subroute := caddyhttp.Subroute{
-			Routes: caddyhttp.RouteList{rewriteRoute, rpRoute},
+			Routes: caddyhttp.RouteList{redirRoute, rewriteRoute, rpRoute},
 		}
 		return []httpcaddyfile.ConfigValue{
 			{
@@ -191,6 +212,10 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 	// if the user did not specify a matcher, then
 	// we can just use our own matchers
 	return []httpcaddyfile.ConfigValue{
+		{
+			Class: "route",
+			Value: redirRoute,
+		},
 		{
 			Class: "route",
 			Value: rewriteRoute,

--- a/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
@@ -127,7 +127,7 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 		}, nil),
 	}
 	redirHandler := caddyhttp.StaticResponse{
-		StatusCode: caddyhttp.WeakString("307"),
+		StatusCode: caddyhttp.WeakString("308"),
 		Headers:    http.Header{"Location": []string{"{http.request.uri.path}/"}},
 	}
 	redirRoute := caddyhttp.Route{


### PR DESCRIPTION
## 1. What does this change do, exactly?
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

When using the `php_fastcgi` directive, should redirect requests from `/foo` to `/foo/` if there is a `/foo/index.php` file.


## 2. Please link to the relevant issues.
<!-- This adds crucial context to your change. -->

See #2752 and https://caddy.community/t/v2-redirect-path-to-path-index-php-with-assets/6196?u=matt



## 3. Which documentation changes (if any) need to be made because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->

Update php_fastcgi docs.