### PR TITLE
tls/acme: Ability to customize trusted roots for ACME servers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/klauspost/compress v1.7.1-0.20190613161414-0b31f265a57b
 	github.com/klauspost/cpuid v1.2.1
 	github.com/lucas-clemente/quic-go v0.7.1-0.20190908032346-fc962d18373a
-	github.com/mholt/certmagic v0.7.2
+	github.com/mholt/certmagic v0.7.3-0.20190917224939-65d418add14f
 	github.com/muhammadmuzzammil1998/jsonc v0.0.0-20190902132743-e4903c4dea48
 	github.com/rs/cors v1.6.0
 	github.com/russross/blackfriday/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-tty v0.0.0-20180219170247-931426f7535a/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/mholt/certmagic v0.7.2 h1:i4FRZyM33Ke6UdTrq69hLSRq1xvqS83JQTkzzUWtuF4=
-github.com/mholt/certmagic v0.7.2/go.mod h1:hqHzDsY32TwZpj/KswVylheSISjquF/eOVOaJTYV15w=
+github.com/mholt/certmagic v0.7.3-0.20190917224939-65d418add14f h1:IocLraK7JNMvVbuZShaLJMsWMPgdElPNwmPPWPb0XMI=
+github.com/mholt/certmagic v0.7.3-0.20190917224939-65d418add14f/go.mod h1:hqHzDsY32TwZpj/KswVylheSISjquF/eOVOaJTYV15w=
 github.com/miekg/dns v1.1.15 h1:CSSIDtllwGLMoA6zjdKnaE6Tx6eVUxQ29LUgGetiDCI=
 github.com/miekg/dns v1.1.15/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=


### PR DESCRIPTION
## 1. What does this change do, exactly?
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

Adds the ability to customize trusted root CAs for ACME servers. Makes integrations with things like Smallstep CA a lot easier and more secure.

/cc @mmalone


## 2. Please link to the relevant issues.
<!-- This adds crucial context to your change. -->

Closes #2702


## 3. Which documentation changes (if any) need to be made because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->

Add `trusted_roots_pem_files` to docs.