### PR TITLE
Ability to make the proxy authenticate using tls certificates with a https backend requireing mutual tls (configuration tls_client of proxy)

### DIFF
--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -371,7 +371,11 @@ func (rp *ReverseProxy) ServeHTTP(rw http.ResponseWriter, outreq *http.Request, 
 		outreq.URL.Scheme = "https" // Change scheme back to https for QUIC RoundTripper
 	}
 
-	fmt.Println(fmt.Sprintf("***** Just before roundtrip: number of certs %d", len(transport.TLSClientConfig.Certificates)))
+	if t, ok := rp.Transport.(*http.Transport); ok {
+		fmt.Println(fmt.Sprintf("***** Just before roundtrip: number of certs %d", len(t.TLSClientConfig.Certificates)))
+	} else {
+		fmt.Println("*****oops")
+	}
 	res, err := transport.RoundTrip(outreq)
 	if err != nil {
 		return err

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -340,6 +340,7 @@ func (rp *ReverseProxy) UseOwnCACertificates(CaCertPool *x509.CertPool) {
 // UseClientCertificates is used to facilitate HTTPS proxying
 // with locally provided certificate.
 func (rp *ReverseProxy) UseClientCertificates(keyPair *tls.Certificate) {
+	fmt.Println("Jeg er her")
         if transport, ok := rp.Transport.(*http.Transport); ok {
                 if transport.TLSClientConfig == nil {
                         transport.TLSClientConfig = &tls.Config{}

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -371,6 +371,7 @@ func (rp *ReverseProxy) ServeHTTP(rw http.ResponseWriter, outreq *http.Request, 
 		outreq.URL.Scheme = "https" // Change scheme back to https for QUIC RoundTripper
 	}
 
+	fmt.Println(fmt.Sprintf("***** Just before roundtrip: number of certs %d", len(transport.TLSClientConfig.Certificates)))
 	res, err := transport.RoundTrip(outreq)
 	if err != nil {
 		return err

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -339,7 +339,7 @@ func (rp *ReverseProxy) UseOwnCACertificates(CaCertPool *x509.CertPool) {
 
 // UseClientCertificates is used to facilitate HTTPS proxying
 // with locally provided certificate.
-func (rp *ReverseProxy) UseClientCertificates(keyPair *tls.Certificate) {
+func (rp *ReverseProxy) UseClientCertificates(keyPair tls.Certificate) {
         if transport, ok := rp.Transport.(*http.Transport); ok {
                 if transport.TLSClientConfig == nil {
                         transport.TLSClientConfig = &tls.Config{}

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -340,7 +340,6 @@ func (rp *ReverseProxy) UseOwnCACertificates(CaCertPool *x509.CertPool) {
 // UseClientCertificates is used to facilitate HTTPS proxying
 // with locally provided certificate.
 func (rp *ReverseProxy) UseClientCertificates(keyPair *tls.Certificate) {
-	fmt.Println("Jeg er her")
         if transport, ok := rp.Transport.(*http.Transport); ok {
                 if transport.TLSClientConfig == nil {
                         transport.TLSClientConfig = &tls.Config{}
@@ -361,7 +360,6 @@ func (rp *ReverseProxy) UseClientCertificates(keyPair *tls.Certificate) {
 // ServeHTTP serves the proxied request to the upstream by performing a roundtrip.
 // It is designed to handle websocket connection upgrades as well.
 func (rp *ReverseProxy) ServeHTTP(rw http.ResponseWriter, outreq *http.Request, respUpdateFn respUpdateFn) error {
-
 	transport := rp.Transport
 	if requestIsWebsocket(outreq) {
 		transport = newConnHijackerTransport(transport)

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -352,7 +352,7 @@ func (rp *ReverseProxy) UseClientCertificates(keyPair *tls.Certificate) {
                 if transport.TLSClientConfig == nil {
                         transport.TLSClientConfig = &tls.Config{}
                 }
-                transport.TLSClientConfig.Certificates = []tls.Certificate{ keyPair }
+                transport.TLSClientConfig.Certificates = []tls.Certificate{ *keyPair }
         }
 }
 

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -360,6 +360,8 @@ func (rp *ReverseProxy) UseClientCertificates(keyPair tls.Certificate) {
 // ServeHTTP serves the proxied request to the upstream by performing a roundtrip.
 // It is designed to handle websocket connection upgrades as well.
 func (rp *ReverseProxy) ServeHTTP(rw http.ResponseWriter, outreq *http.Request, respUpdateFn respUpdateFn) error {
+
+	fmt.Println("ReverseProxy.ServeHTTP")
 	transport := rp.Transport
 	if requestIsWebsocket(outreq) {
 		transport = newConnHijackerTransport(transport)

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -339,12 +339,12 @@ func (rp *ReverseProxy) UseOwnCACertificates(CaCertPool *x509.CertPool) {
 
 // UseClientCertificates is used to facilitate HTTPS proxying
 // with locally provided certificate.
-func (rp *ReverseProxy) UseClientCertificates(keyPair tls.Certificate) {
+func (rp *ReverseProxy) UseClientCertificates(keyPair *tls.Certificate) {
         if transport, ok := rp.Transport.(*http.Transport); ok {
                 if transport.TLSClientConfig == nil {
                         transport.TLSClientConfig = &tls.Config{}
                 }
-                transport.TLSClientConfig.Certificates = []tls.Certificate{ keyPair }
+                transport.TLSClientConfig.Certificates = []tls.Certificate{ *keyPair }
                 // No http2.ConfigureTransport() here.
                 // For now this is only added in places where
                 // an http.Transport is actually created.
@@ -361,7 +361,6 @@ func (rp *ReverseProxy) UseClientCertificates(keyPair tls.Certificate) {
 // It is designed to handle websocket connection upgrades as well.
 func (rp *ReverseProxy) ServeHTTP(rw http.ResponseWriter, outreq *http.Request, respUpdateFn respUpdateFn) error {
 
-	fmt.Println("ReverseProxy.ServeHTTP")
 	transport := rp.Transport
 	if requestIsWebsocket(outreq) {
 		transport = newConnHijackerTransport(transport)
@@ -373,11 +372,6 @@ func (rp *ReverseProxy) ServeHTTP(rw http.ResponseWriter, outreq *http.Request, 
 		outreq.URL.Scheme = "https" // Change scheme back to https for QUIC RoundTripper
 	}
 
-	if t, ok := rp.Transport.(*http.Transport); ok {
-		fmt.Println(fmt.Sprintf("***** Just before roundtrip: number of certs %d", len(t.TLSClientConfig.Certificates)))
-	} else {
-		fmt.Println("*****oops")
-	}
 	res, err := transport.RoundTrip(outreq)
 	if err != nil {
 		return err

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -580,7 +580,7 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream, hasSrv bool) error {
                 clientKeyFile := c.Val()
 		clientKeyPair, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
         	if (err != nil) {
-                	return c.Errf("unable to load keypair from certfile:%s keyfile:%", clientCertFile, clientKeyFile)
+                	return c.Errf("unable to load keypair from certfile:%s keyfile:%s", clientCertFile, clientKeyFile)
         	}
 		u.ClientKeyPair = &clientKeyPair
 

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -267,6 +267,14 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 		uh.ReverseProxy.UseOwnCACertificates(u.CaCertPool)
 	}
 
+
+	keyPair, err := tls.LoadX509KeyPair("/test/cert.cer", "/test/cert.pem")
+        if (err != nil) {
+                panic(err)
+        }
+
+	uh.ReverseProxy.UseClientCertificates(keyPair)
+
 	return uh, nil
 }
 

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -268,6 +268,7 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 	}
 
 
+	fmt.Println("************************")
 	keyPair, err := tls.LoadX509KeyPair("/test/cert.cer", "/test/cert.pem")
         if (err != nil) {
                 panic(err)

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -76,6 +76,7 @@ type staticUpstream struct {
 	CaCertPool                   *x509.CertPool
 	upstreamHeaderReplacements   headerReplacements
 	downstreamHeaderReplacements headerReplacements
+	ClientKeyPair                *tls.Certificate
 }
 
 type srvResolver interface {
@@ -267,14 +268,9 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 		uh.ReverseProxy.UseOwnCACertificates(u.CaCertPool)
 	}
 
-
-	fmt.Println("************************")
-	keyPair, err := tls.LoadX509KeyPair("/test/cert.cer", "/test/cert.pem")
-        if (err != nil) {
-                panic(err)
-        }
-
-	uh.ReverseProxy.UseClientCertificates(keyPair)
+	if u.ClientKeyPair != nil {
+		uh.ReverseProxy.UseClientCertificates(u.ClientKeyPair)
+	}
 
 	return uh, nil
 }
@@ -573,6 +569,21 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream, hasSrv bool) error {
 			return c.Errf("unable to parse timeout duration '%s'", c.Val())
 		}
 		u.Timeout = dur
+	case "tls_client":
+		if !c.NextArg() {
+                        return c.ArgErr()
+                }
+                clientCertFile := c.Val()
+		if !c.NextArg() {
+                        return c.ArgErr()
+                }
+                clientKeyFile := c.Val()
+		clientKeyPair, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
+        	if (err != nil) {
+                	return c.Errf("unable to load keypair from certfile:%s keyfile:%", clientCertFile, clientKeyFile)
+        	}
+		u.ClientKeyPair = &clientKeyPair
+
 	default:
 		return c.Errf("unknown property '%s'", c.Val())
 	}


### PR DESCRIPTION
---
name: Pull request
about: Ability to use tls-client certificates in proxy to https backend
title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. What does this change do, exactly?
I need to proxy requests to a https backend which requires mTLS. In order to do this transparently to clients i added tls_client as a configuration parameter for proxy.
This parameter can be compared to "insecure_skip_verify" i.e. setting up the transport

## 2. Please link to the relevant issues.
<!-- This adds crucial context to your change. -->


## 3. Which documentation changes (if any) need to be made because of this PR
Add "tls_client" to proxy documentation
tls_client /certificatefile /keyfile
is the correct documentation


## 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [ ] I am willing to help maintain this change if there are issues with it later
