### PR TITLE
Add flag to disable timestamps for process log

### DIFF
--- a/caddy/caddymain/run.go
+++ b/caddy/caddymain/run.go
@@ -60,6 +60,7 @@ func init() {
 	flag.StringVar(&certmagic.Default.Email, "email", "", "Default ACME CA account email address")
 	flag.DurationVar(&certmagic.HTTPTimeout, "catimeout", certmagic.HTTPTimeout, "Default ACME CA HTTP timeout")
 	flag.StringVar(&logfile, "log", "", "Process log file")
+	flag.BoolVar(&logTimestamps, "log-timestamps", true, "Enable timestamps for the process log")
 	flag.IntVar(&logRollMB, "log-roll-mb", 100, "Roll process log when it reaches this many megabytes (0 to disable rolling)")
 	flag.BoolVar(&logRollCompress, "log-roll-compress", true, "Gzip-compress rolled process log files")
 	flag.StringVar(&caddy.PidFile, "pidfile", "", "Path to write pid file")
@@ -85,6 +86,11 @@ func Run() {
 	caddy.AppVersion = module.Version
 	caddy.OnProcessExit = append(caddy.OnProcessExit, certmagic.CleanUpOwnLocks)
 	certmagic.UserAgent = appName + "/" + cleanModVersion
+
+	if !logTimestamps {
+		// Disable timestamps for logging
+		log.SetFlags(0)
+	}
 
 	// Set up process log before anything bad happens
 	switch logfile {
@@ -590,6 +596,7 @@ var (
 	envFile         string
 	fromJSON        bool
 	logfile         string
+	logTimestamps   bool
 	logRollMB       int
 	logRollCompress bool
 	revoke          string

--- a/caddyhttp/errors/errors.go
+++ b/caddyhttp/errors/errors.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/caddyserver/caddy"
 	"github.com/caddyserver/caddy/caddyhttp/httpserver"
@@ -50,7 +49,7 @@ func (h ErrorHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, er
 	status, err := h.Next.ServeHTTP(w, r)
 
 	if err != nil {
-		errMsg := fmt.Sprintf("%s [ERROR %d %s] %v", time.Now().Format(timeFormat), status, r.URL.Path, err)
+		errMsg := fmt.Sprintf("[ERROR %d %s] %v", status, r.URL.Path, err)
 		if h.Debug {
 			// Write error to response instead of to log
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -79,8 +78,7 @@ func (h ErrorHandler) errorPage(w http.ResponseWriter, r *http.Request, code int
 		errorPage, err := os.Open(pagePath)
 		if err != nil {
 			// An additional error handling an error... <insert grumpy cat here>
-			h.Log.Printf("%s [NOTICE %d %s] could not load error page: %v",
-				time.Now().Format(timeFormat), code, r.URL.String(), err)
+			h.Log.Printf("[NOTICE %d %s] could not load error page: %v", code, r.URL.String(), err)
 			httpserver.DefaultErrorFunc(w, r, code)
 			return
 		}
@@ -93,8 +91,7 @@ func (h ErrorHandler) errorPage(w http.ResponseWriter, r *http.Request, code int
 
 		if err != nil {
 			// Epic fail... sigh.
-			h.Log.Printf("%s [NOTICE %d %s] could not respond with %s: %v",
-				time.Now().Format(timeFormat), code, r.URL.String(), pagePath, err)
+			h.Log.Printf("[NOTICE %d %s] could not respond with %s: %v", code, r.URL.String(), pagePath, err)
 			httpserver.DefaultErrorFunc(w, r, code)
 		}
 
@@ -148,7 +145,7 @@ func (h ErrorHandler) recovery(w http.ResponseWriter, r *http.Request) {
 		file = file[pkgPathPos+len(delim):]
 	}
 
-	panicMsg := fmt.Sprintf("%s [PANIC %s] %s:%d - %v", time.Now().Format(timeFormat), r.URL.String(), file, line, rec)
+	panicMsg := fmt.Sprintf("[PANIC %s] %s:%d - %v", r.URL.String(), file, line, rec)
 	if h.Debug {
 		// Write error and stack trace to the response rather than to a log
 		var stackBuf [4096]byte
@@ -160,5 +157,3 @@ func (h ErrorHandler) recovery(w http.ResponseWriter, r *http.Request) {
 		h.errorPage(w, r, http.StatusInternalServerError)
 	}
 }
-
-const timeFormat = "02/Jan/2006:15:04:05 -0700"

--- a/caddyhttp/httpserver/logger.go
+++ b/caddyhttp/httpserver/logger.go
@@ -171,7 +171,7 @@ selectwriter:
 		}
 	}
 
-	l.Logger = log.New(l.writer, "", 0)
+	l.Logger = log.New(l.writer, "", log.Flags())
 
 	return nil
 

--- a/dist/init/linux-systemd/caddy.service
+++ b/dist/init/linux-systemd/caddy.service
@@ -20,7 +20,7 @@ Group=www-data
 Environment=CADDYPATH=/etc/ssl/caddy
 
 ; Always set "-root" to something safe in case it gets forgotten in the Caddyfile.
-ExecStart=/usr/local/bin/caddy -log stdout -log-timestamps false -agree=true -conf=/etc/caddy/Caddyfile -root=/var/tmp
+ExecStart=/usr/local/bin/caddy -log stdout -log-timestamps=false -agree=true -conf=/etc/caddy/Caddyfile -root=/var/tmp
 ExecReload=/bin/kill -USR1 $MAINPID
 
 ; Use graceful shutdown with a reasonable timeout

--- a/dist/init/linux-systemd/caddy.service
+++ b/dist/init/linux-systemd/caddy.service
@@ -20,7 +20,7 @@ Group=www-data
 Environment=CADDYPATH=/etc/ssl/caddy
 
 ; Always set "-root" to something safe in case it gets forgotten in the Caddyfile.
-ExecStart=/usr/local/bin/caddy -log stdout -agree=true -conf=/etc/caddy/Caddyfile -root=/var/tmp
+ExecStart=/usr/local/bin/caddy -log stdout -log-timestamps false -agree=true -conf=/etc/caddy/Caddyfile -root=/var/tmp
 ExecReload=/bin/kill -USR1 $MAINPID
 
 ; Use graceful shutdown with a reasonable timeout


### PR DESCRIPTION
solves #2615

---
name: Pull request
about: Propose changes to the code
title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. What does this change do, exactly?

This change adds a flag to enable/disable timestamps for the process log. It also unifies the timestamp format for the log entries. Until this change there were two different formats:

```
Okt 01 00:37:30 example.com caddy[2548]: 01/Oct/2019:00:37:30 +0200 [ERROR 499 /api/update] context canceled
Okt 01 00:38:33 example.com caddy[2548]: 01/Oct/2019:00:38:33 +0200 [ERROR 499 /api/update] context canceled
Okt 01 00:38:48 example.com caddy[2548]: 2019/10/01 00:38:48 http: TLS handshake error from 109.192.194.xxx:22799: tls: unsupported SSLv2 handshake received
Okt 01 00:38:49 example.com caddy[2548]: 2019/10/01 00:38:49 http: TLS handshake error from 109.192.194.xxx:22837: tls: unsupported SSLv2 handshake received
```

## 2. Please link to the relevant issues.

https://github.com/caddyserver/caddy/issues/2615

## 3. Which documentation changes (if any) need to be made because of this PR?

The documentation for the CLI parameters has to be adjusted.


## 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
