### PR TITLE
no SetKeepAlivePeriod in openbsd

### DIFF
--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -554,18 +554,19 @@ type tcpKeepAliveListener struct {
 }
 
 // Accept accepts the connection with a keep-alive enabled.
-func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
+func (ln tcpKeepAliveListener) Accept() (net.Conn, error) {
 	tc, err := ln.AcceptTCP()
 	if err != nil {
-		return
+		return nil, err
 	}
 	if err = tc.SetKeepAlive(true); err != nil {
-		return
+		return nil, err
 	}
 	// OpenBSD has no user-settable per-socket TCP keepalive
+	// https://github.com/caddyserver/caddy/pull/2787
 	if runtime.GOOS != "openbsd" {
 		if err = tc.SetKeepAlivePeriod(3 * time.Minute); err != nil {
-			return
+			return nil, err
 		}
 	}
 	return tc, nil

--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -562,8 +562,11 @@ func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
 	if err = tc.SetKeepAlive(true); err != nil {
 		return
 	}
-	if err = tc.SetKeepAlivePeriod(3 * time.Minute); err != nil {
-		return
+	// OpenBSD has no user-settable per-socket TCP keepalive
+	if runtime.GOOS != "openbsd" {
+		if err = tc.SetKeepAlivePeriod(3 * time.Minute); err != nil {
+			return
+		}
 	}
 	return tc, nil
 }


### PR DESCRIPTION

 I played a bit with this issue https://github.com/caddyserver/caddy/issues/2694 and I was able to reproduce it. The logs don't show anything because the function calls in this function do not return errors https://github.com/caddyserver/caddy/blob/master/caddyhttp/httpserver/server.go#L557
After restoring the errors temporarily to debug I could see the error was:  
````set tcp 127.0.0.1:xxxx->127.0.0.1:yyyy : protocol not available````
After digging around a bit I found out that openbsd has not user-settable per-socket keepalive times http://golang.ir/src/net/tcpsockopt_openbsd.go

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. What does this change do, exactly?
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->
Adds a runtime check to skip the call to tc.SetKeepAlivePeriod for openbsd


## 2. Please link to the relevant issues.
<!-- This adds crucial context to your change. -->
https://github.com/caddyserver/caddy/issues/2694



## 3. Which documentation changes (if any) need to be made because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->
None



## 4. Checklist

- [ ] I have written tests and verified that they fail without my change
 (*Can't figure out which tests that would be in this case*)
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
