### PR TITLE
Re-add ReadWriteDirectories.

### DIFF
--- a/dist/init/linux-systemd/caddy.service
+++ b/dist/init/linux-systemd/caddy.service
@@ -39,6 +39,7 @@ ProtectSystem=full
 ; … except /etc/ssl/caddy, because we want Letsencrypt-certificates there.
 ;   This merely retains r/w access rights, it does not add any new. Must still be writable on the host!
 ReadWritePaths=/etc/ssl/caddy
+ReadWriteDirectories=/etc/ssl/caddy
 
 ; The following additional security directives only work with systemd v229 or later.
 ; They further restrict privileges that can be gained by caddy. Uncomment if you like.


### PR DESCRIPTION
In systemd 231
(https://github.com/systemd/systemd/blob/4f10b80786e8baa1399b6de6111d5b3a16bf99ba/NEWS#L3558-L3565),
ReadWriteDirectories was renamed ReadWritePaths.

In https://github.com/caddyserver/caddy/pull/2620/files, @aspeteRakete
renamed the directive in Caddy's example systemd unit.

However, this means that if anyone runs this sytemd unit on a version of
systemd older than 231, Caddy will go into a crash loop that hammers
Let's Encrypt's servers. That's because the ProtectSystem=full directive
prevents writes to all paths that aren't explicitly permitted, and older
systemd doesn't see any paths being permitted.

To maximize compatibility, I re-add the original ReadWriteDirectories
directive. Older systemd will read that; newer systemd will read the
newer directive. Both should ignore the directive they do not recognize.

Another approach to solve this problem would be to remove
ProtectSystem=true, originally introduced in da8ae9e5. That would reduce
the risk of similar breakages in the future. It would make for a slightly
less "exemplary" systemd unit, but I think it would still be adequate,
given that this unit runs caddy as "www-data", a user the presumably has
low privileges.

This issue was also discussed at https://community.letsencrypt.org/t/need-unblock-ip/103584/1.

Related to #2698 