### PR TITLE
Add RemoteAddr placeholders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ Caddyfile
 *.prof
 *.test
 
+# build artifacts
+cmd/caddy/caddy
+cmd/caddy/caddy.exe
+
 # mac specific
 .DS_Store
 

--- a/modules/caddyhttp/replacer.go
+++ b/modules/caddyhttp/replacer.go
@@ -65,13 +65,24 @@ func addHTTPVarsToReplacer(repl caddy.Replacer, req *http.Request, w http.Respon
 					return req.Host, true // OK; there probably was no port
 				}
 				return host, true
-			case "http.request.hostport":
-				return req.Host, true
-			case "http.request.method":
-				return req.Method, true
 			case "http.request.port":
 				_, port, _ := net.SplitHostPort(req.Host)
 				return port, true
+			case "http.request.hostport":
+				return req.Host, true
+			case "http.request.remote":
+				return req.RemoteAddr, true
+			case "http.request.remote.host":
+				host, _, err := net.SplitHostPort(req.RemoteAddr)
+				if err != nil {
+					return req.RemoteAddr, true
+				}
+				return host, true
+			case "http.request.remote.port":
+				_, port, _ := net.SplitHostPort(req.RemoteAddr)
+				return port, true
+			case "http.request.method":
+				return req.Method, true
 			case "http.request.scheme":
 				if req.TLS != nil {
 					return "https", true

--- a/modules/caddyhttp/replacer_test.go
+++ b/modules/caddyhttp/replacer_test.go
@@ -1,0 +1,71 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddyhttp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+)
+
+func TestHTTPVarReplacement(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/", nil)
+	repl := caddy.NewReplacer()
+	ctx := context.WithValue(req.Context(), caddy.ReplacerCtxKey, repl)
+	req = req.WithContext(ctx)
+	req.Host = "example.com:80"
+	req.RemoteAddr = "localhost:1234"
+	res := httptest.NewRecorder()
+	addHTTPVarsToReplacer(repl, req, res)
+
+	for i, tc := range []struct {
+		input      string
+		expect     string
+	}{
+		{
+			input:  "{http.request.scheme}",
+			expect: "http",
+		},
+		{
+			input:  "{http.request.host}",
+			expect: "example.com",
+		},
+		{
+			input:  "{http.request.port}",
+			expect: "80",
+		},
+		{
+			input:  "{http.request.hostport}",
+			expect: "example.com:80",
+		},
+		{
+			input:  "{http.request.remote.host}",
+			expect: "localhost",
+		},
+		{
+			input:  "{http.request.remote.port}",
+			expect: "1234",
+		},
+	} {
+		actual := repl.ReplaceAll(tc.input, "<empty>")
+		if actual != tc.expect {
+			t.Errorf("Test %d: Expected placeholder %s to be '%s' but got '%s'",
+				i, tc.input, tc.expect, actual)
+		}
+	}
+}


### PR DESCRIPTION
## 1. What does this change do, exactly?

Add additional placeholders for RemoteAddr (the IP + port of the client)

- `http.request.remote`, e.g. "70.116.186.215:34231"
- `http.request.remote.host`, e.g. "70.116.186.215"
- `http.request.remote.port`, e.g. "34231"

## 2. Please link to the relevant issues.

No issue created as this PR is so small. It's fine to close it if it doesn't fit!

## 3. Which documentation changes (if any) need to be made because of this PR?

List of placeholders needs to be expanded!

## 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
