### PR TITLE
Move certmagic import out of caddy package

### DIFF
--- a/caddy/caddymain/run.go
+++ b/caddy/caddymain/run.go
@@ -83,6 +83,7 @@ func Run() {
 
 	caddy.AppName = appName
 	caddy.AppVersion = module.Version
+	caddy.OnProcessExit = append(caddy.OnProcessExit, certmagic.CleanUpOwnLocks)
 	certmagic.UserAgent = appName + "/" + cleanModVersion
 
 	// Set up process log before anything bad happens

--- a/sigtrap.go
+++ b/sigtrap.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"github.com/caddyserver/caddy/telemetry"
-	"github.com/mholt/certmagic"
 )
 
 // TrapSignals create signal handlers for all applicable signals for this
@@ -50,7 +49,6 @@ func trapSignalsCrossPlatform() {
 				for _, f := range OnProcessExit {
 					f() // important cleanup actions only
 				}
-				certmagic.CleanUpOwnLocks()
 				os.Exit(2)
 			}
 
@@ -65,7 +63,6 @@ func trapSignalsCrossPlatform() {
 			}
 
 			go func() {
-				certmagic.CleanUpOwnLocks()
 				os.Exit(executeShutdownCallbacks("SIGINT"))
 			}()
 		}

--- a/sigtrap_posix.go
+++ b/sigtrap_posix.go
@@ -23,7 +23,6 @@ import (
 	"syscall"
 
 	"github.com/caddyserver/caddy/telemetry"
-	"github.com/mholt/certmagic"
 )
 
 // trapSignalsPosix captures POSIX-only signals.
@@ -39,7 +38,6 @@ func trapSignalsPosix() {
 				for _, f := range OnProcessExit {
 					f() // only perform important cleanup actions
 				}
-				certmagic.CleanUpOwnLocks()
 				os.Exit(0)
 
 			case syscall.SIGTERM:
@@ -57,7 +55,6 @@ func trapSignalsPosix() {
 				telemetry.AppendUnique("sigtrap", "SIGTERM")
 				go telemetry.StopEmitting() // won't finish in time, but that's OK - just don't block
 
-				certmagic.CleanUpOwnLocks()
 				os.Exit(exitCode)
 
 			case syscall.SIGUSR1:


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## What does this change do, exactly?
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

Moves the `certmagic` import out of the core `caddy` package. The only use of certmagic is calling a shutdown hook. The reason behind this change is reducing the import graph for projects that use Caddy's core packages but not certmagic, for example [nextdhcp](https://github.com/nextdhcp/nextdhcp).

Ideally the telemetry import would be eliminated too (perhaps using an interface variable that is populated by an init func in the telemetry package), but I thought I'd start here.

## Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [ ] I am willing to help maintain this change if there are issues with it later
