### PR TITLE
Replace placeholders in host matcher

### DIFF
--- a/modules/caddyhttp/caddyhttp.go
+++ b/modules/caddyhttp/caddyhttp.go
@@ -273,6 +273,8 @@ func (app *App) automaticHTTPS() error {
 	// addresses to the routes that do HTTP->HTTPS redirects
 	lnAddrRedirRoutes := make(map[string]Route)
 
+	repl := caddy.NewReplacer()
+
 	for srvName, srv := range app.Servers {
 		srv.tlsApp = tlsApp
 
@@ -294,6 +296,7 @@ func (app *App) automaticHTTPS() error {
 				for _, m := range matcherSet {
 					if hm, ok := m.(*MatchHost); ok {
 						for _, d := range *hm {
+							d = repl.ReplaceAll(d, "")
 							if certmagic.HostQualifies(d) &&
 								!srv.AutoHTTPS.Skipped(d, srv.AutoHTTPS.Skip) {
 								domainSet[d] = struct{}{}

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -118,8 +118,11 @@ func (m MatchHost) Match(r *http.Request) bool {
 		reqHost = strings.TrimSuffix(reqHost, "]")
 	}
 
+	repl := r.Context().Value(caddy.ReplacerCtxKey).(caddy.Replacer)
+
 outer:
 	for _, host := range m {
+		host = repl.ReplaceAll(host, "")
 		if strings.Contains(host, "*") {
 			patternParts := strings.Split(host, ".")
 			incomingParts := strings.Split(reqHost, ".")

--- a/modules/caddyhttp/matchers_test.go
+++ b/modules/caddyhttp/matchers_test.go
@@ -539,22 +539,32 @@ func TestResponseMatcher(t *testing.T) {
 	}
 }
 
-func BenchmarkHostMatcherWithoutPlaceholders(b *testing.B) {
+func BenchmarkHostMatcherWithoutPlaceholder(b *testing.B) {
 	req := &http.Request{Host: "localhost"}
+	repl := caddy.NewReplacer()
+	ctx := context.WithValue(req.Context(), caddy.ReplacerCtxKey, repl)
+	req = req.WithContext(ctx)
+
 	match := MatchHost{"localhost"}
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		match.Match(req)
 	}
 }
 
-func BenchmarkHostMatcherWithPlaceholders(b *testing.B) {
+func BenchmarkHostMatcherWithPlaceholder(b *testing.B) {
 	err := os.Setenv("GO_BENCHMARK_DOMAIN", "localhost")
 	if err != nil {
 		b.Errorf("error while setting up environment: %v", err)
 	}
+
 	req := &http.Request{Host: "localhost"}
+	repl := caddy.NewReplacer()
+	ctx := context.WithValue(req.Context(), caddy.ReplacerCtxKey, repl)
+	req = req.WithContext(ctx)
 	match := MatchHost{"{env.GO_BENCHMARK_DOMAIN}"}
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		match.Match(req)

--- a/modules/caddyhttp/matchers_test.go
+++ b/modules/caddyhttp/matchers_test.go
@@ -20,12 +20,18 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/caddyserver/caddy/v2"
 )
 
 func TestHostMatcher(t *testing.T) {
+	err := os.Setenv("GO_BENCHMARK_DOMAIN", "localhost")
+	if err != nil {
+		t.Errorf("error while setting up environment: %v", err)
+	}
+
 	for i, tc := range []struct {
 		match  MatchHost
 		input  string
@@ -106,8 +112,22 @@ func TestHostMatcher(t *testing.T) {
 			input:  "example.com:5555",
 			expect: true,
 		},
+		{
+			match:  MatchHost{"{env.GO_BENCHMARK_DOMAIN}"},
+			input:  "localhost",
+			expect: true,
+		},
+		{
+			match:  MatchHost{"{env.GO_NONEXISTENT}"},
+			input:  "localhost",
+			expect: false,
+		},
 	} {
 		req := &http.Request{Host: tc.input}
+		repl := caddy.NewReplacer()
+		ctx := context.WithValue(req.Context(), caddy.ReplacerCtxKey, repl)
+		req = req.WithContext(ctx)
+
 		actual := tc.match.Match(req)
 		if actual != tc.expect {
 			t.Errorf("Test %d %v: Expected %t, got %t for '%s'", i, tc.match, tc.expect, actual, tc.input)
@@ -516,5 +536,27 @@ func TestResponseMatcher(t *testing.T) {
 			t.Errorf("Test %d %v: Expected %t, got %t for HTTP %d %v", i, tc.require, tc.expect, actual, tc.status, tc.hdr)
 			continue
 		}
+	}
+}
+
+func BenchmarkHostMatcherWithoutPlaceholders(b *testing.B) {
+	req := &http.Request{Host: "localhost"}
+	match := MatchHost{"localhost"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		match.Match(req)
+	}
+}
+
+func BenchmarkHostMatcherWithPlaceholders(b *testing.B) {
+	err := os.Setenv("GO_BENCHMARK_DOMAIN", "localhost")
+	if err != nil {
+		b.Errorf("error while setting up environment: %v", err)
+	}
+	req := &http.Request{Host: "localhost"}
+	match := MatchHost{"{env.GO_BENCHMARK_DOMAIN}"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		match.Match(req)
 	}
 }


### PR DESCRIPTION
## 1. What does this change do, exactly?

Allow environment placeholders in the `match` part:

```json
          "routes": [
            {
              "match": [
                {
                  "host": ["{env.DOMAIN_NAME}"]
                }
              ]
```

## 2. Please link to the relevant issues.

#2802

## 3. Which documentation changes (if any) need to be made because of this PR?

In the `routes.match` section, the `host` part supports the following placeholders:

- `system.hostname`
- `system.os`
- `system.arch`

In addition, environment placeholders are supported, in the form `env.ENV_NAME`.

This allows to use configurations like this:

```json
"routes": [
  {
    "match": [{ "host": ["{system.hostname}"] }]
  }
]
```
(match the hostname that's assigned to the OS caddy is running on)

```json
"routes": [
  {
    "match": [{ "host": ["{env.ENVIRONMENT}.example.com"] }]
  }
]
```
(given the environment variable `ENVIRONMENT` set to `staging`, this will match the hostname `staging.example.com`)

## 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
