### PR TITLE
v2: Lint v2 Linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,52 @@
+linters-settings:
+  errcheck:
+    ignore: fmt:.*,io/ioutil:^Read.*,github.com/caddyserver/caddy/v2/caddyconfig:RegisterAdapter,github.com/caddyserver/caddy/v2:RegisterModule
+    ignoretests: true
+  misspell:
+    locale: US
+  goimports:
+    local-prefixes: github.com/golangci/golangci-lint
+
+linters:
+  enable:
+    - bodyclose
+    - errcheck
+    - gofmt
+    - goimports
+    - gosec
+    - ineffassign
+    - misspell
+
+run:
+  # default concurrency is a available CPU number.
+  # concurrency: 4 # explicitly omit this value to fully utilize available resources.
+  deadline: 5m
+  issues-exit-code: 1
+  tests: false
+
+# output configuration options
+output:
+  # for local hacking, comment the following line or change value to 'colored-line-number'
+  #format: colored-line-number # junit-xml
+  print-issued-lines: true
+  print-linter-name: true
+
+issues:
+  exclude-rules:
+    # we aren't calling unknown URL
+    - text: "G107" # G107: Url provided to HTTP request as taint input
+      linters:
+        - gosec
+    # as a web server that's expected to handle any template, this is totally in the hands of the user.
+    - text: "G203" # G203: Use of unescaped data in HTML templates
+      linters:
+        - gosec
+    # we're shelling out to known commands, not relying on user-defined input.
+    - text: "G204" # G204: Audit use of command execution
+      linters:
+        - gosec
+    # the choice of weakrand is deliberate, hence the named import "weakrand"
+    - path: modules/caddyhttp/reverseproxy/selectionpolicies.go
+      text: "G404" # G404: Insecure random number source (rand)
+      linters:
+        - gosec

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,8 +26,7 @@ run:
 
 # output configuration options
 output:
-  # for local hacking, comment the following line or change value to 'colored-line-number'
-  format: junit-xml
+  format: 'colored-line-number'
   print-issued-lines: true
   print-linter-name: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,8 +4,6 @@ linters-settings:
     ignoretests: true
   misspell:
     locale: US
-  goimports:
-    local-prefixes: github.com/golangci/golangci-lint
 
 linters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,7 @@ run:
 # output configuration options
 output:
   # for local hacking, comment the following line or change value to 'colored-line-number'
-  #format: colored-line-number # junit-xml
+  format: junit-xml
   print-issued-lines: true
   print-linter-name: true
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,7 +90,7 @@ steps:
 
 - script: |
     # its behavior is governed by .golangci.yml
-    (golangci-lint run) > test-results/lint-result.xml
+    (golangci-lint run --out-format junit-xml) > test-results/lint-result.xml
     exit 0
   workingDirectory: '$(modulePath)'
   continueOnError: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,8 @@ steps:
   displayName: Get dependencies
 
 - script: |
-    (golangci-lint run --out-format junit-xml -E gofmt -E goimports -E misspell) > test-results/lint-result.xml
+    # its behavior is governed by .golangci.yml
+    (golangci-lint run) > test-results/lint-result.xml
     exit 0
   workingDirectory: '$(modulePath)'
   continueOnError: true

--- a/caddyconfig/caddyfile/lexer.go
+++ b/caddyconfig/caddyfile/lexer.go
@@ -107,7 +107,6 @@ func (l *lexer) next() bool {
 				escaped = false
 			} else {
 				if ch == '"' {
-					quoted = false
 					return makeToken()
 				}
 			}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -118,7 +118,6 @@ func loadConfig(configFile, adapterName string) ([]byte, error) {
 			if os.IsNotExist(err) {
 				// okay, no default Caddyfile; pretend like this never happened
 				cfgAdapter = nil
-				err = nil
 			} else if err != nil {
 				// default Caddyfile exists, but error reading it
 				return nil, fmt.Errorf("reading default Caddyfile: %v", err)

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -169,7 +169,7 @@ func (s *Server) enforcementHandler(w http.ResponseWriter, r *http.Request, next
 		if err != nil {
 			hostname = r.Host // OK; probably lacked port
 		}
-		if strings.ToLower(r.TLS.ServerName) != strings.ToLower(hostname) {
+		if !strings.EqualFold(r.TLS.ServerName, hostname) {
 			err := fmt.Errorf("strict host matching: TLS ServerName (%s) and HTTP Host (%s) values differ",
 				r.TLS.ServerName, hostname)
 			r.Close = true


### PR DESCRIPTION
## 1. What does this change do, exactly?

The enabled preferred linters of `golangci-lint` were inlined as part of the invocation in `azure-pipelines.yml`. This prevents the code editors (e.g. VSCode) from enforcing the project's linting preferences due to the preferences being embedded in `azure-pipelines.yml`. Our linter of choice, `golangci-lint`, supports having a configuration file named `.golangci.yml` at the module root to enforce project-wide standard of linting.


## 2. Please link to the relevant issues.
<!-- This adds crucial context to your change. -->

N/A


## 3. Which documentation changes (if any) need to be made because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->


None.

## 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
