### PR TITLE
v2: speed up some of powershell's processes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,7 @@ steps:
     Write-Host "Downloading Go..."
     (New-Object System.Net.WebClient).DownloadFile("https://dl.google.com/go/$(LATEST_GO).windows-amd64.zip", "$(LATEST_GO).windows-amd64.zip")
     Write-Host "Extracting Go... (I'm slow too)"
-    Expand-Archive "$(LATEST_GO).windows-amd64.zip" -DestinationPath "$(gorootDir)"
+    7z x "$(LATEST_GO).windows-amd64.zip" -o"$(gorootDir)"
   condition: eq( variables['Agent.OS'], 'Windows_NT' )
   displayName: Install Go on Windows
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,10 @@ steps:
   condition: eq( variables['Agent.OS'], 'Darwin' )
   displayName: Install Go on macOS
 
+# The low performance is partly due to PowerShell's attempt to update the progress bar. Disabling it speeds up the process.
+# Reference: https://github.com/PowerShell/PowerShell/issues/2138
 - powershell: |
+    $ProgressPreference = 'SilentlyContinue'
     Write-Host "Downloading Go... (please be patient, I am very slow)"
     (New-Object System.Net.WebClient).DownloadFile("https://dl.google.com/go/$(LATEST_GO).windows-amd64.zip", "$(LATEST_GO).windows-amd64.zip")
     Write-Host "Extracting Go... (I'm slow too)"
@@ -88,8 +91,8 @@ steps:
   workingDirectory: '$(modulePath)'
   displayName: Get dependencies
 
+# its behavior is governed by .golangci.yml
 - script: |
-    # its behavior is governed by .golangci.yml
     (golangci-lint run --out-format junit-xml) > test-results/lint-result.xml
     exit 0
   workingDirectory: '$(modulePath)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ steps:
 # Reference: https://github.com/PowerShell/PowerShell/issues/2138
 - powershell: |
     $ProgressPreference = 'SilentlyContinue'
-    Write-Host "Downloading Go... (please be patient, I am very slow)"
+    Write-Host "Downloading Go..."
     (New-Object System.Net.WebClient).DownloadFile("https://dl.google.com/go/$(LATEST_GO).windows-amd64.zip", "$(LATEST_GO).windows-amd64.zip")
     Write-Host "Extracting Go... (I'm slow too)"
     Expand-Archive "$(LATEST_GO).windows-amd64.zip" -DestinationPath "$(gorootDir)"


### PR DESCRIPTION
## 1. What does this change do, exactly?
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

Downloading the latest Go and extracting the archive is slow on Windows. According to PowerShell/PowerShell#2138 this is due to PowerShell attempting to update the progress. Since this is running on CI, the progress isn't important.


## 2. Please link to the relevant issues.
<!-- This adds crucial context to your change. -->

PowerShell/PowerShell#2138


## 3. Which documentation changes (if any) need to be made because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->

N/A


## 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
