### PR TITLE
v2 CI: cache the GOCACHE directory

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ steps:
     $ProgressPreference = 'SilentlyContinue'
     Write-Host "Downloading Go..."
     (New-Object System.Net.WebClient).DownloadFile("https://dl.google.com/go/$(LATEST_GO).windows-amd64.zip", "$(LATEST_GO).windows-amd64.zip")
-    Write-Host "Extracting Go... (I'm slow too)"
+    Write-Host "Extracting Go... (I'm slow)"
     7z x "$(LATEST_GO).windows-amd64.zip" -o"$(gorootDir)"
   condition: eq( variables['Agent.OS'], 'Windows_NT' )
   displayName: Install Go on Windows
@@ -79,11 +79,21 @@ steps:
 - bash: |
     printf "Using go at: $(which go)\n"
     printf "Go version: $(go version)\n"
+    echo "##vso[task.setvariable variable=GO_CACHE]$(go env GOCACHE)"
     printf "\n\nGo environment:\n\n"
     go env
     printf "\n\nSystem environment:\n\n"
     env
   displayName: Print Go version and environment
+
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops
+- task: CacheBeta@0
+  inputs:
+    # Non-absolute paths are resolved against $(System.DefaultWorkingDirectory), which is the root of the project.
+    # TODO: include go.sum as part of the key.
+    key: '"gocache" | "$(Agent.OS)"'
+    path: $(GO_CACHE)
+  displayName: Cache Go packages
 
 - script: |
     go get -v -t -d ./...

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,6 +67,15 @@ steps:
   condition: eq( variables['Agent.OS'], 'Windows_NT' )
   displayName: Install Go on Windows
 
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops
+- task: CacheBeta@0
+  inputs:
+    # Non-absolute paths are resolved against $(System.DefaultWorkingDirectory), which is the root of the project.
+    # TODO: include go.sum as part of the key.
+    key: '"gocache" | "$(Agent.OS)"'
+    path: $(GO_CACHE)
+  displayName: Cache Go packages
+
 - bash: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.19.1
   displayName: Install golangci-lint
 
@@ -85,15 +94,6 @@ steps:
     printf "\n\nSystem environment:\n\n"
     env
   displayName: Print Go version and environment
-
-# https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops
-- task: CacheBeta@0
-  inputs:
-    # Non-absolute paths are resolved against $(System.DefaultWorkingDirectory), which is the root of the project.
-    # TODO: include go.sum as part of the key.
-    key: '"gocache" | "$(Agent.OS)"'
-    path: $(GO_CACHE)
-  displayName: Cache Go packages
 
 - script: |
     go get -v -t -d ./...


### PR DESCRIPTION
## 1. What does this change do, exactly?
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

Use CacheBeta to cache the contents of GOCACHE directory so builds don't need to re-download previously downloaded deps that haven't changed. This should speed up the builds.

Let's see how this works for us.

## 2. Please link to the relevant issues.
<!-- This adds crucial context to your change. -->

N/A


## 3. Which documentation changes (if any) need to be made because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->

N/A


## 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
