### PR TITLE
replace XDG Directory configuration to standard os.UserConfigDir

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -17,7 +17,6 @@ package caddy
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/mholt/certmagic"
 )
@@ -31,34 +30,15 @@ type StorageConverter interface {
 	CertMagicStorage() (certmagic.Storage, error)
 }
 
-// homeDir returns the best guess of the current user's home
-// directory from environment variables. If unknown, "." (the
-// current directory) is returned instead.
-func homeDir() string {
-	home := os.Getenv("HOME")
-	if home == "" && runtime.GOOS == "windows" {
-		drive := os.Getenv("HOMEDRIVE")
-		path := os.Getenv("HOMEPATH")
-		home = drive + path
-		if drive == "" || path == "" {
-			home = os.Getenv("USERPROFILE")
-		}
-	}
-	if home == "" {
-		home = "."
-	}
-	return home
-}
-
 // dataDir returns a directory path that is suitable for storage.
-// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables
+// If the location cannot be determined, use current directory.
 func dataDir() string {
-	baseDir := filepath.Join(homeDir(), ".local", "share")
-	if xdgData := os.Getenv("XDG_DATA_HOME"); xdgData != "" {
-		baseDir = xdgData
+	baseDir, err := os.UserConfigDir()
+	if err != nil {
+		baseDir, err = os.Getwd()
+		if err != nil {
+			panic("failed to locate current directory")
+		}
 	}
 	return filepath.Join(baseDir, "caddy")
 }
-
-// TODO: Consider using Go 1.13's os.UserConfigDir() (https://golang.org/pkg/os/#UserConfigDir)
-// if we are going to store the last-loaded config anywhere


### PR DESCRIPTION
## 1. Which version of Caddy are you using (`caddy -version`)?
v2

## 2. What are you trying to do?
Remove xdg config directory for universal support.

v2 introduces XDG specification. 
While it is popular in linux, It's only for linux. 
I don't think we need non-standard, complex third party packages for this.
But as go 1.13 now has os.UserConfigDir I think we should use it.
If we simply use os.UserConfigDir, we can also just remove homedir.(#2770)

os.UserConfigDir uses XDG_CONFIG_HOME instead of XDG_CONFIG_DATA for linux. 
But it seems quite common. https://github.com/golang/go/issues/29960#issue-403761007

And getting current directory using "." is too fragile process. Replaced it with proper function.

## 3. Which documentation changes (if any) need to be made because of this PR?
cancel xdg configuration

## 4. Checklist

- [o] I have written tests and verified that they fail without my change
- [o] I have squashed any insignificant commits
- [o] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [o] I am willing to help maintain this change if there are issues with it later
