### PR TITLE
feature: Add pledge for OpenBSD

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -469,6 +469,9 @@ func (i *Instance) Caddyfile() Input {
 //
 // This function blocks until all the servers are listening.
 func Start(cdyfile Input) (*Instance, error) {
+	// This restricts system operations on OpenBSD and is a no-op on all other operating systems.
+	pledge()
+
 	inst := &Instance{serverType: cdyfile.ServerType(), wg: new(sync.WaitGroup), Storage: make(map[interface{}]interface{})}
 	err := startWithListenerFds(cdyfile, inst, nil)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/naoina/toml v0.1.1
 	github.com/russross/blackfriday v0.0.0-20170610170232-067529f716f4
 	golang.org/x/net v0.0.0-20190328230028-74de082e2cca
+	golang.org/x/sys v0.0.0-20191023151326-f89234f9a2c2 // indirect
 	gopkg.in/mcuadros/go-syslog.v2 v2.2.1
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190228124157-a34e9553db1e h1:ZytStCyV048ZqDsWHiYDdoI2Vd4msMcrDECFxS+tL9c=
 golang.org/x/sys v0.0.0-20190228124157-a34e9553db1e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191023151326-f89234f9a2c2 h1:I7efaDQAsIQmkTF+WSdcydwVWzK07Yuz8IFF8rNkDe0=
+golang.org/x/sys v0.0.0-20191023151326-f89234f9a2c2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/pledge_nonopenbsd.go
+++ b/pledge_nonopenbsd.go
@@ -1,0 +1,7 @@
+// +build !openbsd
+
+package caddy
+
+// pledge is a no-op on any operating system that isn't OpenBSD.
+func pledge() {
+}

--- a/pledge_openbsd.go
+++ b/pledge_openbsd.go
@@ -1,3 +1,5 @@
+// +build openbsd
+
 package caddy
 
 import (

--- a/pledge_openbsd.go
+++ b/pledge_openbsd.go
@@ -1,0 +1,27 @@
+package caddy
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// pledge invokes the pledge system call with the associated promises. It passes `NULL` to the
+// `execpromises` argument.
+func pledge() {
+	const (
+		// Allows things such as read, write, and socket operations.
+		io = "stdio"
+		// Allows setting up a socket to listen.
+		net = "inet"
+		// Allows calling `setrlimit`.
+		limit = "proc"
+	)
+
+	promises := strings.Join([]string{io, net, limit}, " ")
+	err := unix.PledgePromises(promises)
+	if err != nil {
+		fmt.Printf("WARNING: Error calling pledge: %s", err)
+	}
+}


### PR DESCRIPTION
This patch adds a pledge system call for OpenBSD builds to better
protect caddy on this operating system.

Signed-off-by: Garrett Squire <garrettsquire@gmail.com>

## 1. What does this change do, exactly?
It adds a call to `pledge` for OpenBSD builds.

## 2. Please link to the relevant issues.
Closes #2817 

## 3. Which documentation changes (if any) need to be made because of this PR?
It may be worth noting this somewhere but I am not sure yet.

## 4. Checklist
- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
