### PR TITLE
admin listener as optin for initial config

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -148,7 +148,7 @@ func StartAdmin(initialConfigJSON []byte) error {
 
 	go cfgEndptSrv.Serve(ln)
 
-	fmt.Println("Caddy 2 admin endpoint listening on", adminConfig.Listen)
+	Log().Named("admin").Info("Caddy 2 admin endpoint started.", zap.String("listenAddress", adminConfig.Listen))
 
 	return nil
 }

--- a/admin.go
+++ b/admin.go
@@ -150,14 +150,6 @@ func StartAdmin(initialConfigJSON []byte) error {
 
 	fmt.Println("Caddy 2 admin endpoint listening on", adminConfig.Listen)
 
-	if len(initialConfigJSON) > 0 {
-		err := Load(bytes.NewReader(initialConfigJSON))
-		if err != nil {
-			return fmt.Errorf("loading initial config: %v", err)
-		}
-		fmt.Println("Caddy 2 serving initial configuration")
-	}
-
 	return nil
 }
 

--- a/admin.go
+++ b/admin.go
@@ -64,6 +64,15 @@ func StartAdmin(initialConfigJSON []byte) error {
 	cfgEndptSrvMu.Lock()
 	defer cfgEndptSrvMu.Unlock()
 
+	if cfgEndptSrv != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		err := cfgEndptSrv.Shutdown(ctx)
+		if err != nil {
+			return fmt.Errorf("shutting down old admin endpoint: %v", err)
+		}
+	}
+
 	adminConfig := DefaultAdminConfig
 	if len(initialConfigJSON) > 0 {
 		var config *Config
@@ -73,14 +82,6 @@ func StartAdmin(initialConfigJSON []byte) error {
 		}
 		if config != nil && config.Admin != nil {
 			adminConfig = config.Admin
-		}
-		if cfgEndptSrv != nil {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			err := cfgEndptSrv.Shutdown(ctx)
-			if err != nil {
-				return fmt.Errorf("shutting down old admin endpoint: %v", err)
-			}
 		}
 	}
 

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -74,6 +74,8 @@ func (st ServerType) Setup(originalServerBlocks []caddyfile.ServerBlock,
 				val, err = parseOptACMECA(disp)
 			case "email":
 				val, err = parseOptEmail(disp)
+			case "admin":
+				val, err = parseOptAdmin(disp)
 			default:
 				return nil, warnings, fmt.Errorf("unrecognized parameter name: %s", dir)
 			}
@@ -253,6 +255,9 @@ func (st ServerType) Setup(originalServerBlocks []caddyfile.ServerBlock,
 			"module",
 			storageCvtr.(caddy.Module).CaddyModule().ID(),
 			&warnings)
+	}
+	if adminConfig, ok := options["admin"].(string); ok && adminConfig != "" {
+		cfg.Admin = &caddy.AdminConfig{Listen: adminConfig}
 	}
 
 	return cfg, warnings, nil

--- a/caddyconfig/httpcaddyfile/options.go
+++ b/caddyconfig/httpcaddyfile/options.go
@@ -132,3 +132,17 @@ func parseOptEmail(d *caddyfile.Dispenser) (string, error) {
 	}
 	return val, nil
 }
+
+func parseOptAdmin(d *caddyfile.Dispenser) (string, error) {
+	if d.Next() {
+		var listenAddress string
+		d.AllArgs(&listenAddress)
+
+		if listenAddress == "" {
+			listenAddress = caddy.DefaultAdminListen
+		}
+
+		return listenAddress, nil
+	}
+	return "", nil
+}

--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -161,12 +161,15 @@ func cmdRun(fl Flags) (int, error) {
 	certmagic.UserAgent = "Caddy/" + cleanModVersion
 
 	// start the admin endpoint along with any initial config
+	// a configuration without admin config is considered fine
+	// but does not enable the admin endpoint at all.
 	err = caddy.StartAdmin(config)
-	if err != nil {
+	if err == nil {
+		defer caddy.StopAdmin()
+	} else if err != caddy.ErrAdminInterfaceNotConfigured {
 		return caddy.ExitCodeFailedStartup,
 			fmt.Errorf("starting caddy administration endpoint: %v", err)
 	}
-	defer caddy.StopAdmin()
 
 	// if we are to report to another process the successful start
 	// of the server, do so now by echoing back contents of stdin

--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -162,13 +162,22 @@ func cmdRun(fl Flags) (int, error) {
 
 	// start the admin endpoint along with any initial config
 	// a configuration without admin config is considered fine
-	// but does not enable the admin endpoint at all.
+	// but does not enable the admin endpoint at all
 	err = caddy.StartAdmin(config)
 	if err == nil {
 		defer caddy.StopAdmin()
 	} else if err != caddy.ErrAdminInterfaceNotConfigured {
 		return caddy.ExitCodeFailedStartup,
 			fmt.Errorf("starting caddy administration endpoint: %v", err)
+	}
+
+	// if a config has been supplied, load it as initial config
+	if len(config) > 0 {
+		err := caddy.Load(bytes.NewReader(config))
+		if err != nil {
+			return caddy.ExitCodeFailedStartup, fmt.Errorf("loading initial config: %v", err)
+		}
+		caddy.Log().Named("admin").Info("Caddy 2 serving initial configuration")
 	}
 
 	// if we are to report to another process the successful start


### PR DESCRIPTION
## 1. What does this change do, exactly?

After these changes, the admin endpoint is no longer enabled by default if a configuration file is specified. Instead, the admin listener needs to be configured explicitly.

For the `Caddyfile` this has been simplified with the "admin" option. Without parameters, it will use the (current) default listen address. If a parameter is given, it is treated as listener address.

Example:

```
{
    admin
}
```

Example 2:

```
{
    admin 0.0.0.0:1234
}
```

## 2. Please link to the relevant issues.

Closes #2833




## 3. Which documentation changes (if any) need to be made because of this PR?

* It needs to be stated that `run` only initializes the admin listener if no config file is given.
* The admin endpoint documentation needs to mention that if a config file is given, the listen address has to be specified for the admin endpoint to be available.
* The `Caddyfile` documentation needs to be enhanced to mention the new `admin [listen address]` option (see examples above).
