### PR TITLE
reverseproxy: avoid panic if failed to parse url

### DIFF
--- a/modules/caddyhttp/reverseproxy/command.go
+++ b/modules/caddyhttp/reverseproxy/command.go
@@ -69,12 +69,12 @@ func cmdReverseProxy(fs caddycmd.Flags) (int, error) {
 
 	fromURL, err := url.Parse(from)
 	if err != nil {
-		fromURL.Host = from
+		return 0, err
 	}
 
 	toURL, err := url.Parse(to)
 	if err != nil {
-		toURL.Host = to
+		return 0, err
 	}
 
 	ht := HTTPTransport{}


### PR DESCRIPTION
## 1. What does this change do, exactly?
```
caddy reverse-proxy -from ':30000' -to '127.0.0.1:8384'
```
this commands panics when failed to parse error as it tries to write to nil pointer.


## 2. Please link to the relevant issues.
none



## 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
