### PR TITLE
fix OOM issue caught by fuzzing

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"mime"
-	"net"
 	"net/http"
 	"net/http/pprof"
 	"net/url"
@@ -49,7 +48,7 @@ type AdminConfig struct {
 
 // listenAddr extracts a singular listen address from ac.Listen,
 // returning the network and the address of the listener.
-func (admin AdminConfig) listenAddr() (netw string, addr string, err error) {
+func (admin AdminConfig) listenAddr() (string, string, error) {
 	input := admin.Listen
 	if input == "" {
 		input = DefaultAdminListen
@@ -57,14 +56,13 @@ func (admin AdminConfig) listenAddr() (netw string, addr string, err error) {
 	listenAddr, err := ParseNetworkAddress(input)
 	if err != nil {
 		err = fmt.Errorf("parsing admin listener address: %v", err)
-		return
+		return "", "", err
 	}
 	if listenAddr.PortSpanSize() != 1 {
 		err = fmt.Errorf("admin endpoint must have exactly one address; cannot listen on %v", listenAddr)
-		return
+		return "", "", err
 	}
-	addr = net.JoinHostPort(listenAddr.Host, fmt.Sprintf("%d", listenAddr.FromPort))
-	return listenAddr.Network, addr, nil
+	return listenAddr.Network, listenAddr.HostPort(0), nil
 }
 
 // newAdminHandler reads admin's config and returns an http.Handler suitable

--- a/admin.go
+++ b/admin.go
@@ -55,14 +55,12 @@ func (admin AdminConfig) listenAddr() (string, string, error) {
 	}
 	listenAddr, err := ParseNetworkAddress(input)
 	if err != nil {
-		err = fmt.Errorf("parsing admin listener address: %v", err)
-		return "", "", err
+		return "", "", fmt.Errorf("parsing admin listener address: %v", err)
 	}
-	if listenAddr.PortSpanSize() != 1 {
-		err = fmt.Errorf("admin endpoint must have exactly one address; cannot listen on %v", listenAddr)
-		return "", "", err
+	if listenAddr.PortRangeSize() != 1 {
+		return "", "", fmt.Errorf("admin endpoint must have exactly one address; cannot listen on %v", listenAddr)
 	}
-	return listenAddr.Network, listenAddr.HostPort(0), nil
+	return listenAddr.Network, listenAddr.JoinHostPort(0), nil
 }
 
 // newAdminHandler reads admin's config and returns an http.Handler suitable

--- a/listeners_fuzz.go
+++ b/listeners_fuzz.go
@@ -17,15 +17,10 @@
 
 package caddy
 
-import "fmt"
-
 func FuzzParseNetworkAddress(data []byte) int {
-	l, err := ParseNetworkAddress(string(data))
+	_, err := ParseNetworkAddress(string(data))
 	if err != nil {
 		return 0
-	}
-	if l == nil {
-		panic(fmt.Sprintf("received nil listener with nil err: %s", string(data)))
 	}
 	return 1
 }

--- a/listeners_fuzz.go
+++ b/listeners_fuzz.go
@@ -17,10 +17,15 @@
 
 package caddy
 
+import "fmt"
+
 func FuzzParseNetworkAddress(data []byte) int {
-	_, _, err := ParseNetworkAddress(string(data))
+	l, err := ParseNetworkAddress(string(data))
 	if err != nil {
 		return 0
+	}
+	if l == nil {
+		panic(fmt.Sprintf("received nil listener with nil err: %s", string(data)))
 	}
 	return 1
 }

--- a/listeners_test.go
+++ b/listeners_test.go
@@ -229,6 +229,10 @@ func TestParseNetworkAddress(t *testing.T) {
 				EndPort:   0,
 			},
 		},
+		{
+			input:     "localhost:1-999999999999",
+			expectErr: true,
+		},
 	} {
 		actualAddr, err := ParseNetworkAddress(tc.input)
 		if tc.expectErr && err == nil {

--- a/listeners_test.go
+++ b/listeners_test.go
@@ -152,9 +152,9 @@ func TestJoinNetworkAddress(t *testing.T) {
 
 func TestParseNetworkAddress(t *testing.T) {
 	for i, tc := range []struct {
-		input          string
-		expectListener *Listener
-		expectErr      bool
+		input      string
+		expectAddr ParsedAddress
+		expectErr  bool
 	}{
 		{
 			input:     "",
@@ -166,54 +166,54 @@ func TestParseNetworkAddress(t *testing.T) {
 		},
 		{
 			input: ":1234",
-			expectListener: &Listener{
-				Network:  "tcp",
-				Host:     "",
-				FromPort: 1234,
-				ToPort:   1234,
+			expectAddr: ParsedAddress{
+				Network:   "tcp",
+				Host:      "",
+				StartPort: 1234,
+				EndPort:   1234,
 			},
 		},
 		{
 			input: "tcp/:1234",
-			expectListener: &Listener{
-				Network:  "tcp",
-				Host:     "",
-				FromPort: 1234,
-				ToPort:   1234,
+			expectAddr: ParsedAddress{
+				Network:   "tcp",
+				Host:      "",
+				StartPort: 1234,
+				EndPort:   1234,
 			},
 		},
 		{
 			input: "tcp6/:1234",
-			expectListener: &Listener{
-				Network:  "tcp6",
-				Host:     "",
-				FromPort: 1234,
-				ToPort:   1234,
+			expectAddr: ParsedAddress{
+				Network:   "tcp6",
+				Host:      "",
+				StartPort: 1234,
+				EndPort:   1234,
 			},
 		},
 		{
 			input: "tcp4/localhost:1234",
-			expectListener: &Listener{
-				Network:  "tcp4",
-				Host:     "localhost",
-				FromPort: 1234,
-				ToPort:   1234,
+			expectAddr: ParsedAddress{
+				Network:   "tcp4",
+				Host:      "localhost",
+				StartPort: 1234,
+				EndPort:   1234,
 			},
 		},
 		{
 			input: "unix//foo/bar",
-			expectListener: &Listener{
+			expectAddr: ParsedAddress{
 				Network: "unix",
 				Host:    "/foo/bar",
 			},
 		},
 		{
 			input: "localhost:1234-1234",
-			expectListener: &Listener{
-				Network:  "tcp",
-				Host:     "localhost",
-				FromPort: 1234,
-				ToPort:   1234,
+			expectAddr: ParsedAddress{
+				Network:   "tcp",
+				Host:      "localhost",
+				StartPort: 1234,
+				EndPort:   1234,
 			},
 		},
 		{
@@ -222,11 +222,11 @@ func TestParseNetworkAddress(t *testing.T) {
 		},
 		{
 			input: "localhost:0",
-			expectListener: &Listener{
-				Network:  "tcp",
-				Host:     "localhost",
-				FromPort: 0,
-				ToPort:   0,
+			expectAddr: ParsedAddress{
+				Network:   "tcp",
+				Host:      "localhost",
+				StartPort: 0,
+				EndPort:   0,
 			},
 		},
 	} {
@@ -237,18 +237,12 @@ func TestParseNetworkAddress(t *testing.T) {
 		if !tc.expectErr && err != nil {
 			t.Errorf("Test %d: Expected no error but got: %v", i, err)
 		}
-		if (tc.expectListener == nil && actualAddr != nil) || (tc.expectListener != nil && actualAddr == nil) {
-			t.Errorf("Test %d: Listener expectation not matching actual. Expected: %v  but got %v", i, tc.expectListener, actualAddr)
+
+		if actualAddr.Network != tc.expectAddr.Network {
+			t.Errorf("Test %d: Expected network '%v' but got '%v'", i, tc.expectAddr, actualAddr)
 		}
-		// expectation of nil listener are cleared, proceed to next if the expected listener is nil.
-		if tc.expectListener == nil {
-			continue
-		}
-		if actualAddr.Network != tc.expectListener.Network {
-			t.Errorf("Test %d: Expected network '%v' but got '%v'", i, tc.expectListener, actualAddr)
-		}
-		if !reflect.DeepEqual(tc.expectListener, actualAddr) {
-			t.Errorf("Test %d: Expected addresses %v but got %v", i, tc.expectListener, actualAddr)
+		if !reflect.DeepEqual(tc.expectAddr, actualAddr) {
+			t.Errorf("Test %d: Expected addresses %v but got %v", i, tc.expectAddr, actualAddr)
 		}
 	}
 }

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -110,13 +110,13 @@ func (h *Handler) doActiveHealthChecksForAllHosts() {
 				)
 				return
 			}
-			if addr.PortSpanSize() != 1 {
+			if addr.PortRangeSize() != 1 {
 				h.HealthChecks.Active.logger.Error("multiple addresses (upstream must map to only one address)",
 					zap.String("address", networkAddr),
 				)
 				return
 			}
-			hostAddr := addr.HostPort(0)
+			hostAddr := addr.JoinHostPort(0)
 			if addr.Network == "unix" || addr.Network == "unixgram" || addr.Network == "unixpacket" {
 				// this will be used as the Host portion of a http.Request URL, and
 				// paths to socket files would produce an error when creating URL,

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -116,7 +116,7 @@ func (h *Handler) doActiveHealthChecksForAllHosts() {
 				)
 				return
 			}
-			hostAddr := net.JoinHostPort(addr.Host, fmt.Sprintf("%d", addr.FromPort))
+			hostAddr := addr.HostPort(0)
 			if addr.Network == "unix" || addr.Network == "unixgram" || addr.Network == "unixpacket" {
 				// this will be used as the Host portion of a http.Request URL, and
 				// paths to socket files would produce an error when creating URL,

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -16,7 +16,7 @@ package reverseproxy
 
 import (
 	"fmt"
-	"net"
+	"strconv"
 	"sync/atomic"
 
 	"github.com/caddyserver/caddy/v2"
@@ -203,9 +203,9 @@ func fillDialInfo(upstream *Upstream, repl caddy.Replacer) (DialInfo, error) {
 	return DialInfo{
 		Upstream: upstream,
 		Network:  addr.Network,
-		Address:  net.JoinHostPort(addr.Host, fmt.Sprintf("%d", addr.FromPort)),
+		Address:  addr.HostPort(0),
 		Host:     addr.Host,
-		Port:     fmt.Sprintf("%d", addr.FromPort),
+		Port:     strconv.Itoa(int(addr.StartPort)),
 	}, nil
 }
 

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -196,14 +196,14 @@ func fillDialInfo(upstream *Upstream, repl caddy.Replacer) (DialInfo, error) {
 	if err != nil {
 		return DialInfo{}, fmt.Errorf("upstream %s: invalid dial address %s: %v", upstream.Dial, dial, err)
 	}
-	if addr.PortSpanSize() != 1 {
+	if numPorts := addr.PortRangeSize(); numPorts != 1 {
 		return DialInfo{}, fmt.Errorf("upstream %s: dial address must represent precisely one socket: %s represents %d",
-			upstream.Dial, dial, addr.PortSpanSize())
+			upstream.Dial, dial, numPorts)
 	}
 	return DialInfo{
 		Upstream: upstream,
 		Network:  addr.Network,
-		Address:  addr.HostPort(0),
+		Address:  addr.JoinHostPort(0),
 		Host:     addr.Host,
 		Port:     strconv.Itoa(int(addr.StartPort)),
 	}, nil

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -17,7 +17,6 @@ package reverseproxy
 import (
 	"fmt"
 	"net"
-	"strings"
 	"sync/atomic"
 
 	"github.com/caddyserver/caddy/v2"
@@ -193,27 +192,20 @@ func (di DialInfo) String() string {
 // the given Replacer. Note that the returned value is not a pointer.
 func fillDialInfo(upstream *Upstream, repl caddy.Replacer) (DialInfo, error) {
 	dial := repl.ReplaceAll(upstream.Dial, "")
-	netw, addrs, err := caddy.ParseNetworkAddress(dial)
+	addr, err := caddy.ParseNetworkAddress(dial)
 	if err != nil {
 		return DialInfo{}, fmt.Errorf("upstream %s: invalid dial address %s: %v", upstream.Dial, dial, err)
 	}
-	if len(addrs) != 1 {
+	if addr.PortSpanSize() != 1 {
 		return DialInfo{}, fmt.Errorf("upstream %s: dial address must represent precisely one socket: %s represents %d",
-			upstream.Dial, dial, len(addrs))
-	}
-	var dialHost, dialPort string
-	if !strings.Contains(netw, "unix") {
-		dialHost, dialPort, err = net.SplitHostPort(addrs[0])
-		if err != nil {
-			dialHost = addrs[0] // assume there was no port
-		}
+			upstream.Dial, dial, addr.PortSpanSize())
 	}
 	return DialInfo{
 		Upstream: upstream,
-		Network:  netw,
-		Address:  addrs[0],
-		Host:     dialHost,
-		Port:     dialPort,
+		Network:  addr.Network,
+		Address:  net.JoinHostPort(addr.Host, fmt.Sprintf("%d", addr.FromPort)),
+		Host:     addr.Host,
+		Port:     fmt.Sprintf("%d", addr.FromPort),
 	}, nil
 }
 

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -252,13 +252,17 @@ func (s *Server) listenersUseAnyPortOtherThan(otherPort int) bool {
 	return false
 }
 
+// hasListenerAddress returns true if s has a listener
+// at the given address fullAddr. Currently, fullAddr
+// must represent exactly one socket address (port
+// ranges are not supported)
 func (s *Server) hasListenerAddress(fullAddr string) bool {
 	laddrs, err := caddy.ParseNetworkAddress(fullAddr)
 	if err != nil {
 		return false
 	}
-	if laddrs.PortSpanSize() != 1 {
-		return false
+	if laddrs.PortRangeSize() != 1 {
+		return false // TODO: support port ranges
 	}
 
 	for _, lnAddr := range s.Listen {
@@ -270,8 +274,7 @@ func (s *Server) hasListenerAddress(fullAddr string) bool {
 			continue
 		}
 
-		// If we have the same host on both sides,
-		// and the port of fullAddr falls within the port range of thisAddrs
+		// host must be the same and port must fall within port range
 		if (thisAddrs.Host == laddrs.Host) &&
 			(laddrs.StartPort <= thisAddrs.EndPort) &&
 			(laddrs.StartPort >= thisAddrs.StartPort) {

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -245,7 +245,7 @@ func (s *Server) listenersUseAnyPortOtherThan(otherPort int) bool {
 		if err != nil {
 			continue
 		}
-		if uint(otherPort) > laddrs.ToPort || uint(otherPort) < laddrs.FromPort {
+		if uint(otherPort) > laddrs.EndPort || uint(otherPort) < laddrs.StartPort {
 			return true
 		}
 	}
@@ -270,8 +270,11 @@ func (s *Server) hasListenerAddress(fullAddr string) bool {
 			continue
 		}
 
-		// If we have the same host on both sides, and the port of fullAddr falls within the port range of thisAddrs
-		if (thisAddrs.Host == laddrs.Host) && (laddrs.FromPort <= thisAddrs.ToPort && laddrs.FromPort >= thisAddrs.FromPort) {
+		// If we have the same host on both sides,
+		// and the port of fullAddr falls within the port range of thisAddrs
+		if (thisAddrs.Host == laddrs.Host) &&
+			(laddrs.StartPort <= thisAddrs.EndPort) &&
+			(laddrs.StartPort >= thisAddrs.StartPort) {
 			return true
 		}
 	}


### PR DESCRIPTION
## 1. What does this change do, exactly?
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

Changes the return of `ParseNetworkAddress` to be an instance of new struct type `Listener` (hardest thing in CS is naming). This should be reducing memory consumption because it'll merely reference the port range instead of allocating into a slice all the possible addresses covered by the range.

## 2. Please link to the relevant issues.
<!-- This adds crucial context to your change. -->


Closes #2851 

## 3. Which documentation changes (if any) need to be made because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->

None. I've already updated code comments.


## 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
