### PR TITLE
fix(systemd): update caddy.service on Ubuntu 18

### DIFF
--- a/dist/init/linux-systemd/caddy.service
+++ b/dist/init/linux-systemd/caddy.service
@@ -4,13 +4,13 @@ Documentation=https://caddyserver.com/docs
 After=network-online.target
 Wants=network-online.target systemd-networkd-wait-online.service
 
-[Service]
-Restart=on-abnormal
-
 ; Do not allow the process to be restarted in a tight loop. If the
 ; process fails to start, something critical needs to be fixed.
 StartLimitIntervalSec=14400
 StartLimitBurst=10
+
+[Service]
+Restart=on-abnormal
 
 ; User and group the process will run as.
 User=www-data


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. What does this change do, exactly?
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->
Move the config field in this script to the right part.
i.e.
move `StartLimitIntervalSec` and `StartLimitBurst` from [Service] to [Unit]
ref: https://lists.freedesktop.org/archives/systemd-devel/2017-July/039255.html
systemd version: `systemd 237`
(You can check with `man systemd.directives`, mine is `systemd 237`)

I am not sure if it is valid with old ubuntu and others.
Maybe we can mention it in the document, and keep a new version script?

## 2. Please link to the relevant issues.
<!-- This adds crucial context to your change. -->
none



## 3. Which documentation changes (if any) need to be made because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->
Maybe, need a further discuss.



## 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
