### PR TITLE
v2: fixes query matcher parsing

### DIFF
--- a/caddyconfig/httpcaddyfile/parser_test.go
+++ b/caddyconfig/httpcaddyfile/parser_test.go
@@ -1,0 +1,66 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpcaddyfile
+
+import (
+	"testing"
+
+	caddyfile "github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+)
+
+func TestParse(t *testing.T) {
+
+	for i, tc := range []struct {
+		input       string
+		expectWarn  bool
+		expectError bool
+	}{
+		{
+			input: `http://localhost
+			matcher debug {
+			  query showdebug=1
+			}
+			`,
+			expectWarn:  false,
+			expectError: false,
+		},
+		{
+			input: `http://localhost
+			matcher debug {
+			  query bad format
+			}
+			`,
+			expectWarn:  false,
+			expectError: true,
+		},
+	} {
+
+		adapter := caddyfile.Adapter{
+			ServerType: ServerType{},
+		}
+
+		_, warnings, err := adapter.Adapt([]byte(tc.input), nil)
+
+		if len(warnings) > 0 != tc.expectWarn {
+			t.Errorf("Test %d warning expectation failed Expected: %v, got %v", i, tc.expectWarn, warnings)
+			continue
+		}
+
+		if err != nil != tc.expectError {
+			t.Errorf("Test %d error expectation failed Expected: %v, got %s", i, tc.expectError, err)
+			continue
+		}
+	}
+}

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -248,7 +248,7 @@ func (m *MatchQuery) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		var query string
 		if !d.Args(&query) {
-			return d.Errf("malformed query matcher token: %s; must be in param=val format", d.Val())
+			return d.ArgErr()
 		}
 		parts := strings.SplitN(query, "=", 2)
 		if len(parts) != 2 {

--- a/modules/caddyhttp/matchers_test.go
+++ b/modules/caddyhttp/matchers_test.go
@@ -376,6 +376,62 @@ func TestHeaderMatcher(t *testing.T) {
 	}
 }
 
+func TestQueryMatcher(t *testing.T) {
+	for i, tc := range []struct {
+		scenario string
+		match    MatchQuery
+		input    string
+		expect   bool
+	}{
+		{
+			scenario: "non match against a specific value",
+			match:    MatchQuery{"debug": []string{"1"}},
+			input:    "/",
+			expect:   false,
+		},
+		{
+			scenario: "match against a specific value",
+			match:    MatchQuery{"debug": []string{"1"}},
+			input:    "/?debug=1",
+			expect:   true,
+		},
+		{
+			scenario: "match against a wildcard",
+			match:    MatchQuery{"debug": []string{"*"}},
+			input:    "/?debug=something",
+			expect:   true,
+		},
+		{
+			scenario: "non match against a wildcarded",
+			match:    MatchQuery{"debug": []string{"*"}},
+			input:    "/?other=something",
+			expect:   false,
+		},
+		{
+			scenario: "match against an empty value",
+			match:    MatchQuery{"debug": []string{""}},
+			input:    "/?debug",
+			expect:   true,
+		},
+		{
+			scenario: "non match against an empty value",
+			match:    MatchQuery{"debug": []string{""}},
+			input:    "/?someparam",
+			expect:   false,
+		},
+	} {
+
+		u, _ := url.Parse(tc.input)
+
+		req := &http.Request{URL: u}
+		actual := tc.match.Match(req)
+		if actual != tc.expect {
+			t.Errorf("Test %d %v: Expected %t, got %t for '%s'", i, tc.match, tc.expect, actual, tc.input)
+			continue
+		}
+	}
+}
+
 func TestHeaderREMatcher(t *testing.T) {
 	for i, tc := range []struct {
 		match      MatchHeaderRE


### PR DESCRIPTION
---
name: Pull request
about: This addresses a bug in the caddy file parser when parsing query matchers
title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

As discussed in #2899 


## 1. What does this change do, exactly?
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

I have had a go at what a set of parser tests could look like. Open to suggestions about getting the state of a particular parsed entity and verifying it contains the parsed data.


## 2. Please link to the relevant issues.
<!-- This adds crucial context to your change. -->

#2899


## 3. Which documentation changes (if any) need to be made because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->

https://github.com/caddyserver/caddy/wiki/v2:-Documentation#matcher

> query <key=val...>

becomes

> query <key=[val...]>  | val can be the value to match or the wildcard '*' to match any value.

 

## 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
