### PR TITLE
v2: add remaining subdirectives to rewrite directive

### DIFF
--- a/modules/caddyhttp/rewrite/caddyfile.go
+++ b/modules/caddyhttp/rewrite/caddyfile.go
@@ -36,10 +36,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 	)
 
 	for h.Next() {
-		args := h.RemainingArgs()
-		if len(args) == 1 {
-			rewr.URI = h.Val()
-		} else {
+		if !h.Args(&rewr.URI) {
 			return nil, h.ArgErr()
 		}
 

--- a/modules/caddyhttp/rewrite/caddyfile.go
+++ b/modules/caddyhttp/rewrite/caddyfile.go
@@ -15,6 +15,8 @@
 package rewrite
 
 import (
+	"strconv"
+
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 )
@@ -25,20 +27,116 @@ func init() {
 
 // parseCaddyfile sets up the handler from Caddyfile tokens. Syntax:
 //
-//     rewrite [<matcher>] <to>
+//     rewrite [<matcher>] [<to>] {
+//         to                <string>
+//         method            <string>
+//         strip_path_prefix <string>
+//         strip_path_suffix <string>
+//         rehandle          <bool>
+//         http_redirect     <status_code>
+//     }
 //
-// The <to> parameter becomes the new URI.
 func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
-	var rewr Rewrite
+	var (
+		rewr Rewrite
+
+		toIsSet        bool
+		nextBlockIsSet bool
+		rehandleIsSet  bool
+		redirectIsSet  bool
+	)
+
 	for h.Next() {
-		if !h.NextArg() {
+		args := h.RemainingArgs()
+		switch len(args) {
+		case 0:
+		case 1:
+			toIsSet = true
+			rewr.URI = h.Val()
+		default:
 			return nil, h.ArgErr()
 		}
-		rewr.URI = h.Val()
-		if h.NextArg() {
-			return nil, h.ArgErr()
+
+		for h.NextBlock(0) {
+			nextBlockIsSet = true
+			switch h.Val() {
+			case "to":
+				if toIsSet {
+					return nil, h.Err("to is already set")
+				}
+				if !h.Args(&rewr.URI) {
+					return nil, h.ArgErr()
+				}
+			case "method":
+				if !h.Args(&rewr.Method) {
+					return nil, h.ArgErr()
+				}
+				switch rewr.Method {
+				case "GET", "HEAD", "POST", "PUT", "DELETE",
+					"CONNECT", "OPTIONS", "TRACE", "PATCH":
+				default:
+					return nil, h.Errf("unknown method '%s'", rewr.Method)
+				}
+			case "strip_path_prefix":
+				if !h.Args(&rewr.StripPathPrefix) {
+					return nil, h.ArgErr()
+				}
+			case "strip_path_suffix":
+				if !h.Args(&rewr.StripPathSuffix) {
+					return nil, h.ArgErr()
+				}
+			case "rehandle":
+				rehandleIsSet = true
+				if redirectIsSet {
+					return nil, h.Err("http_redirect is already set")
+				}
+
+				var rehandle string
+				if !h.Args(&rehandle) {
+					return nil, h.ArgErr()
+				}
+
+				switch rehandle {
+				case "true":
+					rewr.Rehandle = true
+				case "false":
+				default:
+					return nil, h.Errf("invalid rehandle argument '%s', expected bool", rehandle)
+				}
+			case "http_redirect":
+				redirectIsSet = true
+				if rehandleIsSet {
+					return nil, h.Err("rehandle is already set")
+				}
+
+				var status string
+				if !h.Args(&status) {
+					return nil, h.ArgErr()
+				}
+
+				if len(status) != 3 {
+					return nil, h.Errf("bad status value '%s'", status)
+				}
+
+				statusNum, err := strconv.Atoi(status)
+				if err != nil {
+					return nil, h.Errf("bad status value '%s': %v", status, err)
+				}
+
+				if statusNum < 300 || statusNum > 399 {
+					return nil, h.Errf("bad status value '%s', must be in 3xx range", status)
+				}
+			default:
+				return nil, h.Errf("unknown subdirective '%s'", h.Val())
+			}
+		}
+
+		if !toIsSet && !nextBlockIsSet {
+			return nil, h.Err("must provide 'to' or subdirectives")
 		}
 	}
-	rewr.Rehandle = true
+	if !rehandleIsSet && !redirectIsSet {
+		rewr.Rehandle = true
+	}
 	return rewr, nil
 }


### PR DESCRIPTION
## 1. What does this change do, exactly?
This PR adds the remaining subdirectives for rewrite to match the full JSON config. The 'to' argument has been made optional if subdirectives are also provided.

## 2. Please link to the relevant issues.
N/A

## 3. Which documentation changes (if any) need to be made because of this PR?
The Caddyfile documentation for rewrite will need to be updated to include the new subdirectives and a statement that the 'to' argument is optional if subdirectives are also provided.

https://github.com/caddyserver/caddy/wiki/v2:-Documentation#rewrite

## 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later

I am not sure where tests for this directive or the changes belong. Let me know and I will work on them.