### PR TITLE
require client certificate

### DIFF
--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -244,6 +244,9 @@ type ClientAuthentication struct {
 	// which are not in this list will be rejected.
 	TrustedLeafCerts []string `json:"trusted_leaf_certs,omitempty"`
 
+	// requires a client certificate, but will not verify it
+	ClientRequire bool `json:"require,omitempty"`
+
 	// state established with the last call to ConfigureTLSConfig
 	trustedLeafCerts       []*x509.Certificate
 	existingVerifyPeerCert func([][]byte, [][]*x509.Certificate) error
@@ -251,7 +254,7 @@ type ClientAuthentication struct {
 
 // Active returns true if clientauth has an actionable configuration.
 func (clientauth ClientAuthentication) Active() bool {
-	return len(clientauth.TrustedCACerts) > 0 || len(clientauth.TrustedLeafCerts) > 0
+	return len(clientauth.TrustedCACerts) > 0 || len(clientauth.TrustedLeafCerts) > 0 || clientauth.ClientRequire
 }
 
 // ConfigureTLSConfig sets up cfg to enforce clientauth's configuration.


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to the code
title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. What does this change do, exactly?
Makes it possible to require that a client cert is present in SSL connections


## 2. Please link to the relevant issues.
https://caddy.community/t/v2-client-auth/6581


## 3. Which documentation changes (if any) need to be made because of this PR?
Documentation of the tls app.
here: https://github.com/caddyserver/caddy/wiki/v2:-Documentation#httpserverstls_connection_policies
add "require" and documentation: requires a client certificate, but will not verify it

## 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ x] I have squashed any insignificant commits
- [ x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [ x] I am willing to help maintain this change if there are issues with it later
