### PR TITLE
ability to specify that client cert must be present in SSL

### DIFF
--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -258,7 +258,7 @@ type ClientAuthentication struct {
 
 // Active returns true if clientauth has an actionable configuration.
 func (clientauth ClientAuthentication) Active() bool {
-	return len(clientauth.TrustedCACerts) > 0 || len(clientauth.TrustedLeafCerts) > 0 || len(clientauth.ClientAuthType) > 0
+	return len(clientauth.TrustedCACerts) > 0 || len(clientauth.TrustedLeafCerts) > 0 || len(clientauth.Mode) > 0
 }
 
 // ConfigureTLSConfig sets up cfg to enforce clientauth's configuration.

--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -244,9 +244,12 @@ type ClientAuthentication struct {
 	// which are not in this list will be rejected.
 	TrustedLeafCerts []string `json:"trusted_leaf_certs,omitempty"`
 
-	// requires a client certificate, but will not verify it
-	ClientAuthType string `json:"client_auth_type,omitempty"`
-
+	// The mode of the client authentication - the allowed values are
+	// 'request'		- A client certificate is retrieved if available (but is not otherwise verified), if no client cert is presented this is also ok
+	// 'require'		- A client certificate must be presented (but is not otherwise verified)
+	// 'verify_if_given'	- Verify the presented client certificate if a client cert is presented, if no client cert is presented this is also ok
+	// 'require_and_verify'	- Verify the presented client certificate. A client certificate must be presented
+	Mode string `json:"mode,omitempty"`
 
 	// state established with the last call to ConfigureTLSConfig
 	trustedLeafCerts       []*x509.Certificate
@@ -267,8 +270,8 @@ func (clientauth *ClientAuthentication) ConfigureTLSConfig(cfg *tls.Config) erro
 	}
 
 	// Setup the Client auth according to the possibilites for TLS client auth 
-	if (len(clientauth.ClientAuthType) > 0) {
-		switch clientauth.ClientAuthType {
+	if (len(clientauth.Mode) > 0) {
+		switch clientauth.Mode {
 			case "request": {
 				cfg.ClientAuth = tls.RequestClientCert
 			}
@@ -282,7 +285,7 @@ func (clientauth *ClientAuthentication) ConfigureTLSConfig(cfg *tls.Config) erro
 				cfg.ClientAuth = tls.RequireAndVerifyClientCert
 			}
 			default: {
-				return fmt.Errorf("client_auth_type %s not allowed", clientauth.ClientAuthType)
+				return fmt.Errorf("client auth mode %s not allowed", clientauth.Mode)
 			}
 		}
 	} else {

--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -244,6 +244,10 @@ type ClientAuthentication struct {
 	// which are not in this list will be rejected.
 	TrustedLeafCerts []string `json:"trusted_leaf_certs,omitempty"`
 
+	// requires a client certificate, but will not verify it
+	ClientRequire bool `json:"require,omitempty"`
+
+
 	// state established with the last call to ConfigureTLSConfig
 	trustedLeafCerts       []*x509.Certificate
 	existingVerifyPeerCert func([][]byte, [][]*x509.Certificate) error
@@ -251,7 +255,7 @@ type ClientAuthentication struct {
 
 // Active returns true if clientauth has an actionable configuration.
 func (clientauth ClientAuthentication) Active() bool {
-	return len(clientauth.TrustedCACerts) > 0 || len(clientauth.TrustedLeafCerts) > 0
+	return len(clientauth.TrustedCACerts) > 0 || len(clientauth.TrustedLeafCerts) > 0 || clientauth.ClientRequire
 }
 
 // ConfigureTLSConfig sets up cfg to enforce clientauth's configuration.


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to the code
title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. What does this change do, exactly?
Ability to specify in tls connection policy that a client SSL cert be present.

## 2. Please link to the relevant issues.
https://caddy.community/t/v2-client-auth/6581/2



## 3. Which documentation changes (if any) need to be made because of this PR?
https://github.com/caddyserver/caddy/wiki/v2:-Documentation#httpserverstls_connection_policies need to be updated to include
"require" boolean "requires a client certificate, but will not verify it"



## 4. Checklist

- [x ] I have written tests and verified that they fail without my change
- [ x] I have squashed any insignificant commits
- [ x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [ x] I am willing to help maintain this change if there are issues with it later
