### PR TITLE
ability to use client certs in reverse proxy

### DIFF
--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -337,6 +337,26 @@ func (rp *ReverseProxy) UseOwnCACertificates(CaCertPool *x509.CertPool) {
 	}
 }
 
+// UseClientCertificates is used to facilitate HTTPS proxying
+// with locally provided certificate.
+func (rp *ReverseProxy) UseClientCertificates(keyPair *tls.Certificate) {
+        if transport, ok := rp.Transport.(*http.Transport); ok {
+                if transport.TLSClientConfig == nil {
+                        transport.TLSClientConfig = &tls.Config{}
+                }
+                transport.TLSClientConfig.Certificates = []tls.Certificate{ *keyPair }
+                // No http2.ConfigureTransport() here.
+                // For now this is only added in places where
+                // an http.Transport is actually created.
+        } else if transport, ok := rp.Transport.(*h2quic.RoundTripper); ok {
+                if transport.TLSClientConfig == nil {
+                        transport.TLSClientConfig = &tls.Config{}
+                }
+                transport.TLSClientConfig.Certificates = []tls.Certificate{ *keyPair }
+        }
+}
+
+
 // ServeHTTP serves the proxied request to the upstream by performing a roundtrip.
 // It is designed to handle websocket connection upgrades as well.
 func (rp *ReverseProxy) ServeHTTP(rw http.ResponseWriter, outreq *http.Request, respUpdateFn respUpdateFn) error {

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -348,7 +348,7 @@ func (rp *ReverseProxy) UseClientCertificates(keyPair *tls.Certificate) {
                 // No http2.ConfigureTransport() here.
                 // For now this is only added in places where
                 // an http.Transport is actually created.
-        } else if transport, ok := rp.Transport.(*h2quic.RoundTripper); ok {
+        } else if transport, ok := rp.Transport.(*http3.RoundTripper); ok {
                 if transport.TLSClientConfig == nil {
                         transport.TLSClientConfig = &tls.Config{}
                 }


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to the code
title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. What does this change do, exactly?
I need to proxy requests to a https backend which requires mTLS. In order to do this transparently to clients i added tls_client as a configuration parameter for proxy.
This parameter can be compared to "insecure_skip_verify" i.e. setting up the transport



## 2. Please link to the relevant issues.




## 3. Which documentation changes (if any) need to be made because of this PR?
Add "tls_client" to proxy documentation
tls_client /certificatefile /keyfile
is the correct documentation




## 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x ] I have squashed any insignificant commits
- [ x] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [ x] I am willing to help maintain this change if there are issues with it later
