### PR TITLE
Fix for 2917 - Replace trailing . and [ ] with x to prevent match.

### DIFF
--- a/caddyhttp/staticfiles/fileserver.go
+++ b/caddyhttp/staticfiles/fileserver.go
@@ -79,13 +79,15 @@ func (fs FileServer) serveFile(w http.ResponseWriter, r *http.Request) (int, err
 
 	// Prevent absolute path access on Windows.
 	// TODO remove when stdlib http.Dir fixes this.
-	if runtime.GOOS == "windows" && len(reqPath) > 0 && filepath.IsAbs(reqPath[1:]) {
-		return http.StatusNotFound, nil
-	}
+	if runtime.GOOS == "windows" {
+		if len(reqPath) > 0 && filepath.IsAbs(reqPath[1:]) {
+			return http.StatusNotFound, nil
+		}
 
-	// Github 2917 Replace Trailing . and [ ] since windows wont match propertly.
-	// Otherwise index.php. matches index.php and returns.  Should be 404
-	reqPath = fs.replaceTrailingDotSpace(reqPath)
+		// Github 2917 Replace Trailing . and [ ] since windows wont match propertly.
+		// Otherwise index.php. matches index.php and returns.  Should be 404
+		reqPath = fs.replaceTrailingDotSpace(reqPath)
+	}
 
 	// open the requested file
 	f, err := fs.Root.Open(reqPath)

--- a/caddyhttp/staticfiles/fileserver_test.go
+++ b/caddyhttp/staticfiles/fileserver_test.go
@@ -246,9 +246,7 @@ func TestServeHTTP(t *testing.T) {
 		{
 			// Test 28 - Prevent path-based open redirects (directory)
 			url:                 "https://foo//example.com%2f..",
-			expectedStatus:      http.StatusMovedPermanently,
-			expectedLocation:    "https://foo/example.com/../",
-			expectedBodyContent: movedPermanently,
+			expectedStatus:      http.StatusNotFound,
 		},
 		{
 			// Test 29 - Prevent path-based open redirects (file)
@@ -258,13 +256,11 @@ func TestServeHTTP(t *testing.T) {
 			expectedBodyContent: movedPermanently,
 		},
 		{
-			// Test 29 - Prevent path-based open redirects (extra leading slashes)
+			// Test 30 - Prevent path-based open redirects (extra leading slashes)
 			url:                 "https://foo///example.com%2f..",
-			expectedStatus:      http.StatusMovedPermanently,
-			expectedLocation:    "https://foo/example.com/../",
-			expectedBodyContent: movedPermanently,
+			expectedStatus:      http.StatusNotFound,
 		},
-		// Test 30 - try to get pre- file.
+		// Test 31 - try to get pre- file.
 		{
 			url:                   "https://foo/sub/gzipped.html",
 			acceptEncoding:        "zstd",


### PR DESCRIPTION
This is a fix for #2917 

Additional trailing . and [  ] (space) can cause a php page to be returned without execution on *Windows*.

There was a suggestion in #2917 to trim these in fastcgi, but I feel a better place to do this is in fileserver.go as really these should never match.

The solution is a little bit of a kludge and I am happy if someone can find another solution ( I have one idea which I have outlined below)



Reasons for this issue
--

- A request for a file on windows will ignore any trailing . or ' ' 
- This mean a index.php. request will be rejected by fastcgi for not matching .php but was then being matched by fileserver via the FileSystem.Open  call.
- There are two ways to prevent this, 
- I have chosen the first which is to replace the trailing characters with a character that will not be ignored such as x 
- The second way is to get a listing of all files in the directory and compare against the filename being requested before opening.

Security issues
--

The only possible issue I can think of is that if someone can manage to create a file on the server index.phpxxx and request index.php... it will be shown, but I'm not sure how much use that would be as it will not be executed.

If we are concerned about this perhaps we could randomly pick a letter that replaces the . and [ ]

Testing
--
- updated 2 Tests that checked for .. at the end of url and now return 404
- I am now running this in production.