### PR TITLE
v2: Module documentation; refactor LoadModule(); new caddy struct tags

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -39,12 +39,33 @@ import (
 
 // TODO: is there a way to make the admin endpoint so that it can be plugged into the HTTP app? see issue #2833
 
-// AdminConfig configures the admin endpoint.
+// AdminConfig configures Caddy's API endpoint, which is used
+// to manage Caddy while it is running.
 type AdminConfig struct {
-	Disabled      bool     `json:"disabled,omitempty"`
-	Listen        string   `json:"listen,omitempty"`
-	EnforceOrigin bool     `json:"enforce_origin,omitempty"`
-	Origins       []string `json:"origins,omitempty"`
+	// If true, the admin endpoint will be completely disabled.
+	// Note that this makes any runtime changes to the config
+	// impossible, since the interface to do so is through the
+	// admin endpoint.
+	Disabled bool `json:"disabled,omitempty"`
+
+	// The address to which the admin endpoint's listener should
+	// bind itself. Can be any single network address that can be
+	// parsed by Caddy.
+	Listen string `json:"listen,omitempty"`
+
+	// If true, CORS headers will be emitted, and requests to the
+	// API will be rejected if their `Host` and `Origin` headers
+	// do not match the expected value(s). Use `origins` to
+	// customize which origins/hosts are allowed.If `origins` is
+	// not set, the listen address is the only value allowed by
+	// default.
+	EnforceOrigin bool `json:"enforce_origin,omitempty"`
+
+	// The list of allowed origins for API requests. Only used if
+	// `enforce_origin` is true. If not set, the listener address
+	// will be the default value. If set but empty, no origins will
+	// be allowed.
+	Origins []string `json:"origins,omitempty"`
 }
 
 // listenAddr extracts a singular listen address from ac.Listen,
@@ -706,7 +727,7 @@ traverseLoop:
 			ptr = v[partInt]
 
 		default:
-			return fmt.Errorf("invalid path: %s", parts[:i+1])
+			return fmt.Errorf("invalid traversal path at: %s", strings.Join(parts[:i+1], "/"))
 		}
 	}
 

--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"reflect"
 
+	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
@@ -71,7 +72,7 @@ func parseRoot(h Helper) ([]ConfigValue, error) {
 		},
 	}
 	if matcherSet != nil {
-		route.MatcherSetsRaw = []map[string]json.RawMessage{matcherSet}
+		route.MatcherSetsRaw = []caddy.ModuleMap{matcherSet}
 	}
 
 	return h.NewVarsRoute(route), nil

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -88,7 +88,7 @@ type Helper struct {
 	*caddyfile.Dispenser
 	options     map[string]interface{}
 	warnings    *[]caddyconfig.Warning
-	matcherDefs map[string]map[string]json.RawMessage
+	matcherDefs map[string]caddy.ModuleMap
 	parentBlock caddyfile.ServerBlock
 }
 
@@ -125,7 +125,7 @@ func (h Helper) JSON(val interface{}, warnings *[]caddyconfig.Warning) json.RawM
 // if so, returns the matcher set along with a true value. If the current
 // token is not a matcher, nil and false is returned. Note that a true
 // value may be returned with a nil matcher set if it is a catch-all.
-func (h Helper) MatcherToken() (map[string]json.RawMessage, bool, error) {
+func (h Helper) MatcherToken() (caddy.ModuleMap, bool, error) {
 	if !h.NextArg() {
 		return nil, false, nil
 	}
@@ -133,13 +133,13 @@ func (h Helper) MatcherToken() (map[string]json.RawMessage, bool, error) {
 }
 
 // NewRoute returns config values relevant to creating a new HTTP route.
-func (h Helper) NewRoute(matcherSet map[string]json.RawMessage,
+func (h Helper) NewRoute(matcherSet caddy.ModuleMap,
 	handler caddyhttp.MiddlewareHandler) []ConfigValue {
 	mod, err := caddy.GetModule(caddy.GetModuleName(handler))
 	if err != nil {
 		// TODO: append to warnings
 	}
-	var matcherSetsRaw []map[string]json.RawMessage
+	var matcherSetsRaw []caddy.ModuleMap
 	if matcherSet != nil {
 		matcherSetsRaw = append(matcherSetsRaw, matcherSet)
 	}
@@ -148,7 +148,7 @@ func (h Helper) NewRoute(matcherSet map[string]json.RawMessage,
 			Class: "route",
 			Value: caddyhttp.Route{
 				MatcherSetsRaw: matcherSetsRaw,
-				HandlersRaw:    []json.RawMessage{caddyconfig.JSONModuleObject(handler, "handler", mod.ID(), h.warnings)},
+				HandlersRaw:    []json.RawMessage{caddyconfig.JSONModuleObject(handler, "handler", mod.ID.Name(), h.warnings)},
 			},
 		},
 	}

--- a/caddyconfig/httpcaddyfile/options.go
+++ b/caddyconfig/httpcaddyfile/options.go
@@ -96,7 +96,7 @@ func parseOptStorage(d *caddyfile.Dispenser) (caddy.StorageConverter, error) {
 	}
 	unm, ok := mod.New().(caddyfile.Unmarshaler)
 	if !ok {
-		return nil, fmt.Errorf("storage module '%s' is not a Caddyfile unmarshaler", mod.Name)
+		return nil, fmt.Errorf("storage module '%s' is not a Caddyfile unmarshaler", mod.ID)
 	}
 	err = unm.UnmarshalCaddyfile(d.NewFromNextTokens())
 	if err != nil {
@@ -104,7 +104,7 @@ func parseOptStorage(d *caddyfile.Dispenser) (caddy.StorageConverter, error) {
 	}
 	storage, ok := unm.(caddy.StorageConverter)
 	if !ok {
-		return nil, fmt.Errorf("module %s is not a StorageConverter", mod.Name)
+		return nil, fmt.Errorf("module %s is not a StorageConverter", mod.ID)
 	}
 	return storage, nil
 }

--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -321,11 +321,11 @@ func cmdListModules(fl Flags) (int, error) {
 		return caddy.ExitCodeSuccess, nil
 	}
 
-	for _, modName := range caddy.Modules() {
-		modInfo, err := caddy.GetModule(modName)
+	for _, modID := range caddy.Modules() {
+		modInfo, err := caddy.GetModule(modID)
 		if err != nil {
 			// that's weird
-			fmt.Println(modName)
+			fmt.Println(modID)
 			continue
 		}
 
@@ -354,13 +354,13 @@ func cmdListModules(fl Flags) (int, error) {
 		}
 
 		// if we could find no matching module, just print out
-		// the module name instead
+		// the module ID instead
 		if matched == nil {
-			fmt.Println(modName)
+			fmt.Println(modID)
 			continue
 		}
 
-		fmt.Printf("%s %s\n", modName, matched.Version)
+		fmt.Printf("%s %s\n", modID, matched.Version)
 	}
 
 	return caddy.ExitCodeSuccess, nil

--- a/context.go
+++ b/context.go
@@ -80,24 +80,211 @@ func (ctx *Context) OnCancel(f func()) {
 	ctx.cleanupFuncs = append(ctx.cleanupFuncs, f)
 }
 
-// LoadModule decodes rawMsg into a new instance of mod and
-// returns the value. If mod.New() does not return a pointer
-// value, it is converted to one so that it is unmarshaled
-// into the underlying concrete type. If mod.New is nil, an
-// error is returned. If the module implements Validator or
-// Provisioner interfaces, those methods are invoked to
-// ensure the module is fully configured and valid before
-// being used.
-func (ctx Context) LoadModule(name string, rawMsg json.RawMessage) (interface{}, error) {
-	modulesMu.Lock()
-	mod, ok := modules[name]
-	modulesMu.Unlock()
+// LoadModule loads the Caddy module(s) from the specified field of the parent struct
+// pointer and returns the loaded module(s). The struct pointer and its field name as
+// a string are necessary so that reflection can be used to read the struct tag on the
+// field to get the module namespace and inline module name key (if specified).
+//
+// The field can be any one of the supported raw module types: json.RawMessage,
+// []json.RawMessage, map[string]json.RawMessage, or []map[string]json.RawMessage.
+// ModuleMap may be used in place of map[string]json.RawMessage. The return value's
+// underlying type mirrors the input field's type:
+//
+//    json.RawMessage              => interface{}
+//    []json.RawMessage            => []interface{}
+//    map[string]json.RawMessage   => map[string]interface{}
+//    []map[string]json.RawMessage => []map[string]interface{}
+//
+// The field must have a "caddy" struct tag in this format:
+//
+//    caddy:"key1=val1 key2=val2"
+//
+// To load modules, a "namespace" key is required. For example, to load modules
+// in the "http.handlers" namespace, you'd put: `namespace=http.handlers` in the
+// Caddy struct tag.
+//
+// The module name must also be available. If the field type is a map or slice of maps,
+// then key is assumed to be the module name if an "inline_key" is NOT specified in the
+// caddy struct tag. In this case, the module name does NOT need to be specified in-line
+// with the module itself.
+//
+// If not a map, or if inline_key is non-empty, then the module name must be embedded
+// into the values, which must be objects; then there must be a key in those objects
+// where its associated value is the module name. This is called the "inline key",
+// meaning the key containing the module's name that is defined inline with the module
+// itself. You must specify the inline key in a struct tag, along with the namespace:
+//
+//    caddy:"namespace=http.handlers inline_key=handler"
+//
+// This will look for a key/value pair like `"handler": "..."` in the json.RawMessage
+// in order to know the module name.
+//
+// To make use of the loaded module(s) (the return value), you will probably want
+// to type-assert each interface{} value(s) to the types that are useful to you
+// and store them on the same struct. Storing them on the same struct makes for
+// easy garbage collection when your host module is no longer needed.
+//
+// Loaded modules have already been provisioned and validated.
+func (ctx Context) LoadModule(structPointer interface{}, fieldName string) (interface{}, error) {
+	val := reflect.ValueOf(structPointer).Elem().FieldByName(fieldName)
+	typ := val.Type()
+
+	field, ok := reflect.TypeOf(structPointer).Elem().FieldByName(fieldName)
 	if !ok {
-		return nil, fmt.Errorf("unknown module: %s", name)
+		panic(fmt.Sprintf("field %s does not exist in %#v", fieldName, structPointer))
+	}
+
+	opts, err := ParseStructTag(field.Tag.Get("caddy"))
+	if err != nil {
+		panic(fmt.Sprintf("malformed tag on field %s: %v", fieldName, err))
+	}
+
+	moduleNamespace, ok := opts["namespace"]
+	if !ok {
+		panic(fmt.Sprintf("missing 'namespace' key in struct tag on field %s", fieldName))
+	}
+	inlineModuleKey := opts["inline_key"]
+
+	var result interface{}
+
+	switch val.Kind() {
+	case reflect.Slice:
+		if isJSONRawMessage(typ) {
+			// val is `json.RawMessage` ([]uint8 under the hood)
+
+			if inlineModuleKey == "" {
+				panic("unable to determine module name without inline_key when type is not a ModuleMap")
+			}
+			val, err := ctx.loadModuleInline(inlineModuleKey, moduleNamespace, val.Interface().(json.RawMessage))
+			if err != nil {
+				return nil, err
+			}
+			result = val
+
+		} else if isJSONRawMessage(typ.Elem()) {
+			// val is `[]json.RawMessage`
+
+			if inlineModuleKey == "" {
+				panic("unable to determine module name without inline_key because type is not a ModuleMap")
+			}
+			var all []interface{}
+			for i := 0; i < val.Len(); i++ {
+				val, err := ctx.loadModuleInline(inlineModuleKey, moduleNamespace, val.Index(i).Interface().(json.RawMessage))
+				if err != nil {
+					return nil, fmt.Errorf("position %d: %v", i, err)
+				}
+				all = append(all, val)
+			}
+			result = all
+
+		} else if isModuleMapType(typ.Elem()) {
+			// val is `[]map[string]json.RawMessage`
+
+			var all []map[string]interface{}
+			for i := 0; i < val.Len(); i++ {
+				thisSet, err := ctx.loadModulesFromSomeMap(moduleNamespace, inlineModuleKey, val.Index(i))
+				if err != nil {
+					return nil, err
+				}
+				all = append(all, thisSet)
+			}
+			result = all
+		}
+
+	case reflect.Map:
+		// val is a ModuleMap or some other kind of map
+		result, err = ctx.loadModulesFromSomeMap(moduleNamespace, inlineModuleKey, val)
+		if err != nil {
+			return nil, err
+		}
+
+	default:
+		return nil, fmt.Errorf("unrecognized type for module: %s", typ)
+	}
+
+	// we're done with the raw bytes; allow GC to deallocate
+	val.Set(reflect.Zero(typ))
+
+	return result, nil
+}
+
+// loadModulesFromSomeMap loads modules from val, which must be a type of map[string]interface{}.
+// Depending on inlineModuleKey, it will be interpeted as either a ModuleMap (key is the module
+// name) or as a regular map (key is not the module name, and module name is defined inline).
+func (ctx Context) loadModulesFromSomeMap(namespace, inlineModuleKey string, val reflect.Value) (map[string]interface{}, error) {
+	// if no inline_key is specified, then val must be a ModuleMap,
+	// where the key is the module name
+	if inlineModuleKey == "" {
+		if !isModuleMapType(val.Type()) {
+			panic(fmt.Sprintf("expected ModuleMap because inline_key is empty; but we do not recognize this type: %s", val.Type()))
+		}
+		return ctx.loadModuleMap(namespace, val)
+	}
+
+	// otherwise, val is a map with modules, but the module name is
+	// inline with each value (the key means something else)
+	return ctx.loadModulesFromRegularMap(namespace, inlineModuleKey, val)
+}
+
+// loadModulesFromRegularMap loads modules from val, where val is a map[string]json.RawMessage.
+// Map keys are NOT interpreted as module names, so module names are still expected to appear
+// inline with the objects.
+func (ctx Context) loadModulesFromRegularMap(namespace, inlineModuleKey string, val reflect.Value) (map[string]interface{}, error) {
+	mods := make(map[string]interface{})
+	iter := val.MapRange()
+	for iter.Next() {
+		k := iter.Key()
+		v := iter.Value()
+		mod, err := ctx.loadModuleInline(inlineModuleKey, namespace, v.Interface().(json.RawMessage))
+		if err != nil {
+			return nil, fmt.Errorf("key %s: %v", k, err)
+		}
+		mods[k.String()] = mod
+	}
+	return mods, nil
+}
+
+// loadModuleMap loads modules from a ModuleMap, i.e. map[string]interface{}, where the key is the
+// module name. With a module map, module names do not need to be defined inline with their values.
+func (ctx Context) loadModuleMap(namespace string, val reflect.Value) (map[string]interface{}, error) {
+	all := make(map[string]interface{})
+	iter := val.MapRange()
+	for iter.Next() {
+		k := iter.Key().Interface().(string)
+		v := iter.Value().Interface().(json.RawMessage)
+		moduleName := namespace + "." + k
+		if namespace == "" {
+			moduleName = k
+		}
+		val, err := ctx.LoadModuleByID(moduleName, v)
+		if err != nil {
+			return nil, fmt.Errorf("module name '%s': %v", k, err)
+		}
+		all[k] = val
+	}
+	return all, nil
+}
+
+// LoadModuleByID decodes rawMsg into a new instance of mod and
+// returns the value. If mod.New is nil, an error is returned.
+// If the module implements Validator or Provisioner interfaces,
+// those methods are invoked to ensure the module is fully
+// configured and valid before being used.
+//
+// This is a lower-level method and will usually not be called
+// directly by most modules. However, this method is useful when
+// dynamically loading/unloading modules in their own context,
+// like from embedded scripts, etc.
+func (ctx Context) LoadModuleByID(id string, rawMsg json.RawMessage) (interface{}, error) {
+	modulesMu.RLock()
+	mod, ok := modules[id]
+	modulesMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown module: %s", id)
 	}
 
 	if mod.New == nil {
-		return nil, fmt.Errorf("module '%s' has no constructor", mod.Name)
+		return nil, fmt.Errorf("module '%s' has no constructor", mod.ID)
 	}
 
 	val := mod.New().(interface{})
@@ -108,7 +295,7 @@ func (ctx Context) LoadModule(name string, rawMsg json.RawMessage) (interface{},
 	if rv := reflect.ValueOf(val); rv.Kind() != reflect.Ptr {
 		log.Printf("[WARNING] ModuleInfo.New() for module '%s' did not return a pointer,"+
 			" so we are using reflection to make a pointer instead; please fix this by"+
-			" using new(Type) or &Type notation in your module's New() function.", name)
+			" using new(Type) or &Type notation in your module's New() function.", id)
 		val = reflect.New(rv.Type()).Elem().Addr().Interface().(Module)
 	}
 
@@ -116,7 +303,7 @@ func (ctx Context) LoadModule(name string, rawMsg json.RawMessage) (interface{},
 	if len(rawMsg) > 0 {
 		err := strictUnmarshalJSON(rawMsg, &val)
 		if err != nil {
-			return nil, fmt.Errorf("decoding module config: %s: %v", mod.Name, err)
+			return nil, fmt.Errorf("decoding module config: %s: %v", mod, err)
 		}
 	}
 
@@ -124,8 +311,8 @@ func (ctx Context) LoadModule(name string, rawMsg json.RawMessage) (interface{},
 		// returned module values are almost always type-asserted
 		// before being used, so a nil value would panic; and there
 		// is no good reason to explicitly declare null modules in
-		// a config; it might be because the user is trying to
-		// achieve a result they aren't expecting, which is a smell
+		// a config; it might be because the user is trying to achieve
+		// a result the developer isn't expecting, which is a smell
 		return nil, fmt.Errorf("module value cannot be null")
 	}
 
@@ -140,7 +327,7 @@ func (ctx Context) LoadModule(name string, rawMsg json.RawMessage) (interface{},
 					err = fmt.Errorf("%v; additionally, cleanup: %v", err, err2)
 				}
 			}
-			return nil, fmt.Errorf("provision %s: %v", mod.Name, err)
+			return nil, fmt.Errorf("provision %s: %v", mod, err)
 		}
 	}
 
@@ -154,33 +341,33 @@ func (ctx Context) LoadModule(name string, rawMsg json.RawMessage) (interface{},
 					err = fmt.Errorf("%v; additionally, cleanup: %v", err, err2)
 				}
 			}
-			return nil, fmt.Errorf("%s: invalid configuration: %v", mod.Name, err)
+			return nil, fmt.Errorf("%s: invalid configuration: %v", mod, err)
 		}
 	}
 
-	ctx.moduleInstances[name] = append(ctx.moduleInstances[name], val)
+	ctx.moduleInstances[id] = append(ctx.moduleInstances[id], val)
 
 	return val, nil
 }
 
-// LoadModuleInline loads a module from a JSON raw message which decodes
-// to a map[string]interface{}, where one of the keys is moduleNameKey
-// and the corresponding value is the module name as a string, which
-// can be found in the given scope.
+// loadModuleInline loads a module from a JSON raw message which decodes to
+// a map[string]interface{}, where one of the object keys is moduleNameKey
+// and the corresponding value is the module name (as a string) which can
+// be found in the given scope. In other words, the module name is declared
+// in-line with the module itself.
 //
-// This allows modules to be decoded into their concrete types and
-// used when their names cannot be the unique key in a map, such as
-// when there are multiple instances in the map or it appears in an
-// array (where there are no custom keys). In other words, the key
-// containing the module name is treated special/separate from all
-// the other keys.
-func (ctx Context) LoadModuleInline(moduleNameKey, moduleScope string, raw json.RawMessage) (interface{}, error) {
+// This allows modules to be decoded into their concrete types and used when
+// their names cannot be the unique key in a map, such as when there are
+// multiple instances in the map or it appears in an array (where there are
+// no custom keys). In other words, the key containing the module name is
+// treated special/separate from all the other keys in the object.
+func (ctx Context) loadModuleInline(moduleNameKey, moduleScope string, raw json.RawMessage) (interface{}, error) {
 	moduleName, raw, err := getModuleNameInline(moduleNameKey, raw)
 	if err != nil {
 		return nil, err
 	}
 
-	val, err := ctx.LoadModule(moduleScope+"."+moduleName, raw)
+	val, err := ctx.LoadModuleByID(moduleScope+"."+moduleName, raw)
 	if err != nil {
 		return nil, fmt.Errorf("loading module '%s': %v", moduleName, err)
 	}
@@ -195,7 +382,7 @@ func (ctx Context) App(name string) (interface{}, error) {
 	if app, ok := ctx.cfg.apps[name]; ok {
 		return app, nil
 	}
-	modVal, err := ctx.LoadModule(name, nil)
+	modVal, err := ctx.LoadModuleByID(name, nil)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating new module %s: %v", name, err)
 	}

--- a/modules/caddyhttp/caddyauth/caddyfile.go
+++ b/modules/caddyhttp/caddyauth/caddyfile.go
@@ -16,8 +16,8 @@ package caddyauth
 
 import (
 	"encoding/base64"
-	"encoding/json"
 
+	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
@@ -97,7 +97,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 	}
 
 	return Authentication{
-		ProvidersRaw: map[string]json.RawMessage{
+		ProvidersRaw: caddy.ModuleMap{
 			"http_basic": caddyconfig.JSON(ba, nil),
 		},
 	}, nil

--- a/modules/caddyhttp/caddyauth/hashes.go
+++ b/modules/caddyhttp/caddyauth/hashes.go
@@ -33,8 +33,8 @@ type BcryptHash struct{}
 // CaddyModule returns the Caddy module information.
 func (BcryptHash) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.authentication.hashes.bcrypt",
-		New:  func() caddy.Module { return new(BcryptHash) },
+		ID:  "http.authentication.hashes.bcrypt",
+		New: func() caddy.Module { return new(BcryptHash) },
 	}
 }
 
@@ -61,8 +61,8 @@ type ScryptHash struct {
 // CaddyModule returns the Caddy module information.
 func (ScryptHash) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.authentication.hashes.scrypt",
-		New:  func() caddy.Module { return new(ScryptHash) },
+		ID:  "http.authentication.hashes.scrypt",
+		New: func() caddy.Module { return new(ScryptHash) },
 	}
 }
 

--- a/modules/caddyhttp/encode/brotli/brotli.go
+++ b/modules/caddyhttp/encode/brotli/brotli.go
@@ -37,8 +37,8 @@ type Brotli struct {
 // CaddyModule returns the Caddy module information.
 func (Brotli) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.encoders.brotli",
-		New:  func() caddy.Module { return new(Brotli) },
+		ID:  "http.encoders.brotli",
+		New: func() caddy.Module { return new(Brotli) },
 	}
 }
 

--- a/modules/caddyhttp/encode/caddyfile.go
+++ b/modules/caddyhttp/encode/caddyfile.go
@@ -15,7 +15,6 @@
 package encode
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/caddyserver/caddy/v2"
@@ -52,14 +51,14 @@ func (enc *Encode) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		for _, arg := range d.RemainingArgs() {
 			mod, err := caddy.GetModule("http.encoders." + arg)
 			if err != nil {
-				return fmt.Errorf("finding encoder module '%s': %v", mod.Name, err)
+				return fmt.Errorf("finding encoder module '%s': %v", mod, err)
 			}
 			encoding, ok := mod.New().(Encoding)
 			if !ok {
-				return fmt.Errorf("module %s is not an HTTP encoding", mod.Name)
+				return fmt.Errorf("module %s is not an HTTP encoding", mod)
 			}
 			if enc.EncodingsRaw == nil {
-				enc.EncodingsRaw = make(map[string]json.RawMessage)
+				enc.EncodingsRaw = make(caddy.ModuleMap)
 			}
 			enc.EncodingsRaw[arg] = caddyconfig.JSON(encoding, nil)
 		}
@@ -72,7 +71,7 @@ func (enc *Encode) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			}
 			unm, ok := mod.New().(caddyfile.Unmarshaler)
 			if !ok {
-				return fmt.Errorf("encoder module '%s' is not a Caddyfile unmarshaler", mod.Name)
+				return fmt.Errorf("encoder module '%s' is not a Caddyfile unmarshaler", mod)
 			}
 			err = unm.UnmarshalCaddyfile(d.NewFromNextTokens())
 			if err != nil {
@@ -80,10 +79,10 @@ func (enc *Encode) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			}
 			encoding, ok := unm.(Encoding)
 			if !ok {
-				return fmt.Errorf("module %s is not an HTTP encoding", mod.Name)
+				return fmt.Errorf("module %s is not an HTTP encoding", mod)
 			}
 			if enc.EncodingsRaw == nil {
-				enc.EncodingsRaw = make(map[string]json.RawMessage)
+				enc.EncodingsRaw = make(caddy.ModuleMap)
 			}
 			enc.EncodingsRaw[name] = caddyconfig.JSON(encoding, nil)
 		}

--- a/modules/caddyhttp/encode/gzip/gzip.go
+++ b/modules/caddyhttp/encode/gzip/gzip.go
@@ -37,8 +37,8 @@ type Gzip struct {
 // CaddyModule returns the Caddy module information.
 func (Gzip) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.encoders.gzip",
-		New:  func() caddy.Module { return new(Gzip) },
+		ID:  "http.encoders.gzip",
+		New: func() caddy.Module { return new(Gzip) },
 	}
 }
 

--- a/modules/caddyhttp/encode/zstd/zstd.go
+++ b/modules/caddyhttp/encode/zstd/zstd.go
@@ -31,8 +31,8 @@ type Zstd struct{}
 // CaddyModule returns the Caddy module information.
 func (Zstd) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.encoders.zstd",
-		New:  func() caddy.Module { return new(Zstd) },
+		ID:  "http.encoders.zstd",
+		New: func() caddy.Module { return new(Zstd) },
 	}
 }
 

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -15,8 +15,7 @@
 package fileserver
 
 import (
-	"encoding/json"
-
+	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/rewrite"
@@ -122,7 +121,7 @@ func parseTryFiles(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error) 
 		URI: "{http.matchers.file.relative}{http.request.uri.query_string}",
 	}
 
-	matcherSet := map[string]json.RawMessage{
+	matcherSet := caddy.ModuleMap{
 		"file": h.JSON(MatchFile{
 			TryFiles: try,
 		}, nil),

--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -75,8 +75,8 @@ func cmdFileServer(fs caddycmd.Flags) (int, error) {
 		},
 	}
 	if domain != "" {
-		route.MatcherSetsRaw = []map[string]json.RawMessage{
-			map[string]json.RawMessage{
+		route.MatcherSetsRaw = []caddy.ModuleMap{
+			caddy.ModuleMap{
 				"host": caddyconfig.JSON(caddyhttp.MatchHost{domain}, nil),
 			},
 		}
@@ -100,7 +100,7 @@ func cmdFileServer(fs caddycmd.Flags) (int, error) {
 
 	cfg := &caddy.Config{
 		Admin: &caddy.AdminConfig{Disabled: true},
-		AppsRaw: map[string]json.RawMessage{
+		AppsRaw: caddy.ModuleMap{
 			"http": caddyconfig.JSON(httpApp, nil),
 		},
 	}

--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -54,8 +54,8 @@ type MatchFile struct {
 // CaddyModule returns the Caddy module information.
 func (MatchFile) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.matchers.file",
-		New:  func() caddy.Module { return new(MatchFile) },
+		ID:  "http.matchers.file",
+		New: func() caddy.Module { return new(MatchFile) },
 	}
 }
 

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -53,8 +53,8 @@ type FileServer struct {
 // CaddyModule returns the Caddy module information.
 func (FileServer) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.file_server",
-		New:  func() caddy.Module { return new(FileServer) },
+		ID:  "http.handlers.file_server",
+		New: func() caddy.Module { return new(FileServer) },
 	}
 }
 

--- a/modules/caddyhttp/headers/headers.go
+++ b/modules/caddyhttp/headers/headers.go
@@ -37,8 +37,8 @@ type Handler struct {
 // CaddyModule returns the Caddy module information.
 func (Handler) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.headers",
-		New:  func() caddy.Module { return new(Handler) },
+		ID:  "http.handlers.headers",
+		New: func() caddy.Module { return new(Handler) },
 	}
 }
 

--- a/modules/caddyhttp/httpcache/httpcache.go
+++ b/modules/caddyhttp/httpcache/httpcache.go
@@ -43,8 +43,8 @@ type Cache struct {
 // CaddyModule returns the Caddy module information.
 func (Cache) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.cache",
-		New:  func() caddy.Module { return new(Cache) },
+		ID:  "http.handlers.cache",
+		New: func() caddy.Module { return new(Cache) },
 	}
 }
 

--- a/modules/caddyhttp/markdown/markdown.go
+++ b/modules/caddyhttp/markdown/markdown.go
@@ -38,8 +38,8 @@ type Markdown struct {
 // CaddyModule returns the Caddy module information.
 func (Markdown) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.markdown",
-		New:  func() caddy.Module { return new(Markdown) },
+		ID:  "http.handlers.markdown",
+		New: func() caddy.Module { return new(Markdown) },
 	}
 }
 

--- a/modules/caddyhttp/requestbody/requestbody.go
+++ b/modules/caddyhttp/requestbody/requestbody.go
@@ -33,8 +33,8 @@ type RequestBody struct {
 // CaddyModule returns the Caddy module information.
 func (RequestBody) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.request_body", // TODO: better name for this?
-		New:  func() caddy.Module { return new(RequestBody) },
+		ID:  "http.handlers.request_body", // TODO: better name for this?
+		New: func() caddy.Module { return new(RequestBody) },
 	}
 }
 

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -108,11 +108,11 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				name := d.Val()
 				mod, err := caddy.GetModule("http.handlers.reverse_proxy.selection_policies." + name)
 				if err != nil {
-					return d.Errf("getting load balancing policy module '%s': %v", mod.Name, err)
+					return d.Errf("getting load balancing policy module '%s': %v", mod, err)
 				}
 				unm, ok := mod.New().(caddyfile.Unmarshaler)
 				if !ok {
-					return d.Errf("load balancing policy module '%s' is not a Caddyfile unmarshaler", mod.Name)
+					return d.Errf("load balancing policy module '%s' is not a Caddyfile unmarshaler", mod)
 				}
 				err = unm.UnmarshalCaddyfile(d.NewFromNextTokens())
 				if err != nil {
@@ -120,7 +120,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				}
 				sel, ok := unm.(Selector)
 				if !ok {
-					return d.Errf("module %s is not a Selector", mod.Name)
+					return d.Errf("module %s is not a Selector", mod)
 				}
 				if h.LoadBalancing == nil {
 					h.LoadBalancing = new(LoadBalancing)
@@ -391,11 +391,11 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				name := d.Val()
 				mod, err := caddy.GetModule("http.handlers.reverse_proxy.transport." + name)
 				if err != nil {
-					return d.Errf("getting transport module '%s': %v", mod.Name, err)
+					return d.Errf("getting transport module '%s': %v", mod, err)
 				}
 				unm, ok := mod.New().(caddyfile.Unmarshaler)
 				if !ok {
-					return d.Errf("transport module '%s' is not a Caddyfile unmarshaler", mod.Name)
+					return d.Errf("transport module '%s' is not a Caddyfile unmarshaler", mod)
 				}
 				err = unm.UnmarshalCaddyfile(d.NewFromNextTokens())
 				if err != nil {
@@ -403,7 +403,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				}
 				rt, ok := unm.(http.RoundTripper)
 				if !ok {
-					return d.Errf("module %s is not a RoundTripper", mod.Name)
+					return d.Errf("module %s is not a RoundTripper", mod)
 				}
 				h.TransportRaw = caddyconfig.JSONModuleObject(rt, "protocol", name, nil)
 

--- a/modules/caddyhttp/reverseproxy/circuitbreaker.go
+++ b/modules/caddyhttp/reverseproxy/circuitbreaker.go
@@ -41,8 +41,8 @@ type localCircuitBreaker struct {
 // CaddyModule returns the Caddy module information.
 func (localCircuitBreaker) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.reverse_proxy.circuit_breakers.local",
-		New:  func() caddy.Module { return new(localCircuitBreaker) },
+		ID:  "http.reverse_proxy.circuit_breakers.local",
+		New: func() caddy.Module { return new(localCircuitBreaker) },
 	}
 }
 

--- a/modules/caddyhttp/reverseproxy/command.go
+++ b/modules/caddyhttp/reverseproxy/command.go
@@ -113,8 +113,8 @@ func cmdReverseProxy(fs caddycmd.Flags) (int, error) {
 	}
 	urlHost := fromURL.Hostname()
 	if urlHost != "" {
-		route.MatcherSetsRaw = []map[string]json.RawMessage{
-			map[string]json.RawMessage{
+		route.MatcherSetsRaw = []caddy.ModuleMap{
+			caddy.ModuleMap{
 				"host": caddyconfig.JSON(caddyhttp.MatchHost{urlHost}, nil),
 			},
 		}
@@ -138,7 +138,7 @@ func cmdReverseProxy(fs caddycmd.Flags) (int, error) {
 
 	cfg := &caddy.Config{
 		Admin: &caddy.AdminConfig{Disabled: true},
-		AppsRaw: map[string]json.RawMessage{
+		AppsRaw: caddy.ModuleMap{
 			"http": caddyconfig.JSON(httpApp, nil),
 		},
 	}

--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -73,8 +73,8 @@ type Transport struct {
 // CaddyModule returns the Caddy module information.
 func (Transport) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.reverse_proxy.transport.fastcgi",
-		New:  func() caddy.Module { return new(Transport) },
+		ID:  "http.reverse_proxy.transport.fastcgi",
+		New: func() caddy.Module { return new(Transport) },
 	}
 }
 

--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -40,6 +40,7 @@ type HTTPTransport struct {
 	// TODO: It's possible that other transports (like fastcgi) might be
 	// able to borrow/use at least some of these config fields; if so,
 	// maybe move them into a type called CommonTransport and embed it?
+
 	TLS                   *TLSConfig     `json:"tls,omitempty"`
 	KeepAlive             *KeepAlive     `json:"keep_alive,omitempty"`
 	Compression           *bool          `json:"compression,omitempty"`
@@ -59,8 +60,8 @@ type HTTPTransport struct {
 // CaddyModule returns the Caddy module information.
 func (HTTPTransport) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.reverse_proxy.transport.http",
-		New:  func() caddy.Module { return new(HTTPTransport) },
+		ID:  "http.reverse_proxy.transport.http",
+		New: func() caddy.Module { return new(HTTPTransport) },
 	}
 }
 

--- a/modules/caddyhttp/reverseproxy/ntlm.go
+++ b/modules/caddyhttp/reverseproxy/ntlm.go
@@ -30,12 +30,12 @@ func init() {
 	caddy.RegisterModule(NTLMTransport{})
 }
 
-// NTLMTransport proxies HTTP+NTLM authentication is being used.
+// NTLMTransport proxies HTTP with NTLM authentication.
 // It basically wraps HTTPTransport so that it is compatible with
 // NTLM's HTTP-hostile requirements. Specifically, it will use
 // HTTPTransport's single, default *http.Transport for all requests
 // (unless the client's connection is already mapped to a different
-// transport) until a request comes in with Authorization header
+// transport) until a request comes in with an Authorization header
 // that has "NTLM" or "Negotiate"; when that happens, NTLMTransport
 // maps the client's connection (by its address, req.RemoteAddr)
 // to a new transport that is used only by that downstream conn.
@@ -56,8 +56,8 @@ type NTLMTransport struct {
 // CaddyModule returns the Caddy module information.
 func (NTLMTransport) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.reverse_proxy.transport.http_ntlm",
-		New:  func() caddy.Module { return new(NTLMTransport) },
+		ID:  "http.reverse_proxy.transport.http_ntlm",
+		New: func() caddy.Module { return new(NTLMTransport) },
 	}
 }
 

--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -48,8 +48,8 @@ type RandomSelection struct{}
 // CaddyModule returns the Caddy module information.
 func (RandomSelection) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.reverse_proxy.selection_policies.random",
-		New:  func() caddy.Module { return new(RandomSelection) },
+		ID:  "http.reverse_proxy.selection_policies.random",
+		New: func() caddy.Module { return new(RandomSelection) },
 	}
 }
 
@@ -84,8 +84,8 @@ type RandomChoiceSelection struct {
 // CaddyModule returns the Caddy module information.
 func (RandomChoiceSelection) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.reverse_proxy.selection_policies.random_choose",
-		New:  func() caddy.Module { return new(RandomChoiceSelection) },
+		ID:  "http.reverse_proxy.selection_policies.random_choose",
+		New: func() caddy.Module { return new(RandomChoiceSelection) },
 	}
 }
 
@@ -154,8 +154,8 @@ type LeastConnSelection struct{}
 // CaddyModule returns the Caddy module information.
 func (LeastConnSelection) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.reverse_proxy.selection_policies.least_conn",
-		New:  func() caddy.Module { return new(LeastConnSelection) },
+		ID:  "http.reverse_proxy.selection_policies.least_conn",
+		New: func() caddy.Module { return new(LeastConnSelection) },
 	}
 }
 
@@ -199,8 +199,8 @@ type RoundRobinSelection struct {
 // CaddyModule returns the Caddy module information.
 func (RoundRobinSelection) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.reverse_proxy.selection_policies.round_robin",
-		New:  func() caddy.Module { return new(RoundRobinSelection) },
+		ID:  "http.reverse_proxy.selection_policies.round_robin",
+		New: func() caddy.Module { return new(RoundRobinSelection) },
 	}
 }
 
@@ -227,8 +227,8 @@ type FirstSelection struct{}
 // CaddyModule returns the Caddy module information.
 func (FirstSelection) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.reverse_proxy.selection_policies.first",
-		New:  func() caddy.Module { return new(FirstSelection) },
+		ID:  "http.reverse_proxy.selection_policies.first",
+		New: func() caddy.Module { return new(FirstSelection) },
 	}
 }
 
@@ -249,8 +249,8 @@ type IPHashSelection struct{}
 // CaddyModule returns the Caddy module information.
 func (IPHashSelection) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.reverse_proxy.selection_policies.ip_hash",
-		New:  func() caddy.Module { return new(IPHashSelection) },
+		ID:  "http.reverse_proxy.selection_policies.ip_hash",
+		New: func() caddy.Module { return new(IPHashSelection) },
 	}
 }
 
@@ -270,8 +270,8 @@ type URIHashSelection struct{}
 // CaddyModule returns the Caddy module information.
 func (URIHashSelection) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.reverse_proxy.selection_policies.uri_hash",
-		New:  func() caddy.Module { return new(URIHashSelection) },
+		ID:  "http.reverse_proxy.selection_policies.uri_hash",
+		New: func() caddy.Module { return new(URIHashSelection) },
 	}
 }
 
@@ -289,8 +289,8 @@ type HeaderHashSelection struct {
 // CaddyModule returns the Caddy module information.
 func (HeaderHashSelection) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.reverse_proxy.selection_policies.header",
-		New:  func() caddy.Module { return new(HeaderHashSelection) },
+		ID:  "http.reverse_proxy.selection_policies.header",
+		New: func() caddy.Module { return new(HeaderHashSelection) },
 	}
 }
 

--- a/modules/caddyhttp/rewrite/rewrite.go
+++ b/modules/caddyhttp/rewrite/rewrite.go
@@ -47,8 +47,8 @@ type Rewrite struct {
 // CaddyModule returns the Caddy module information.
 func (Rewrite) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.rewrite",
-		New:  func() caddy.Module { return new(Rewrite) },
+		ID:  "http.handlers.rewrite",
+		New: func() caddy.Module { return new(Rewrite) },
 	}
 }
 

--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -22,14 +22,73 @@ import (
 	"github.com/caddyserver/caddy/v2"
 )
 
-// Route represents a set of matching rules,
-// middlewares, and a responder for handling HTTP
-// requests.
+// Route consists of a set of rules for matching HTTP requests,
+// a list of handlers to execute, and optional flow control
+// parameters which customize the handling of HTTP requests
+// in a highly flexible and performant manner.
 type Route struct {
-	Group          string            `json:"group,omitempty"`
-	MatcherSetsRaw RawMatcherSets    `json:"match,omitempty"`
-	HandlersRaw    []json.RawMessage `json:"handle,omitempty"`
-	Terminal       bool              `json:"terminal,omitempty"`
+	// Group is an optional name for a group to which this
+	// route belongs. If a route belongs to a group, only
+	// the first matching route in the group will be used.
+	Group string `json:"group,omitempty"`
+
+	// The matcher sets which will be used to qualify this
+	// route for a request. Essentially the "if" statement
+	// of this route. Each matcher set is OR'ed, but matchers
+	// within a set are AND'ed together.
+	MatcherSetsRaw RawMatcherSets `json:"match,omitempty" caddy:"namespace=http.matchers"`
+
+	// The list of handlers for this route. Upon matching a request, they are chained
+	// together in a middleware fashion: requests flow from the first handler to the last
+	// (top of the list to the bottom), with the possibility that any handler could stop
+	// the chain and/or return an error. Responses flow back through the chain (bottom of
+	// the list to the top) as they are written out to the client.
+	//
+	// Not all handlers call the next handler in the chain. For example, the reverse_proxy
+	// handler always sends a request upstream or returns an error. Thus, configuring
+	// handlers after reverse_proxy in the same route is illogical, since they would never
+	// be executed. You will want to put handlers which originate the response at the very
+	// end of your route(s). The documentation for a module should state whether it invokes
+	// the next handler, but sometimes it is common sense.
+	//
+	// Some handlers manipulate the response. Remember that requests flow down the list, and
+	// responses flow up the list.
+	//
+	// For example, if you wanted to use both `templates` and `encode` handlers, you would
+	// need to put `templates` after `encode` in your route, because responses flow up.
+	// Thus, `templates` will be able to parse and execute the plain-text response as a
+	// template, and then return it up to the `encode` handler which will then compress it
+	// into a binary format.
+	//
+	// If `templates` came before `encode`, then `encode` would write a compressed,
+	// binary-encoded response to `templates` which would not be able to parse the response
+	// properly.
+	//
+	// The correct order, then, is this:
+	//
+	//     [
+	//         {"handler": "encode"},
+	//         {"handler": "templates"},
+	//         {"handler": "file_server"}
+	//     ]
+	//
+	// The request flows ⬇️ DOWN (`encode` -> `templates` -> `file_server`).
+	//
+	// 1. First, `encode` will choose how to `encode` the response and wrap the response.
+	// 2. Then, `templates` will wrap the response with a buffer.
+	// 3. Finally, `file_server` will originate the content from a file.
+	//
+	// The response flows ⬆️ UP (`file_server` -> `templates` -> `encode`):
+	//
+	// 1. First, `file_server` will write the file to the response.
+	// 2. That write will be buffered and then executed by `templates`.
+	// 3. Lastly, the write from `templates` will flow into `encode` which will compress the stream.
+	//
+	// If you think of routes in this way, it will be easy and even fun to solve the puzzle of writing correct routes.
+	HandlersRaw []json.RawMessage `json:"handle,omitempty" caddy:"namespace=http.handlers inline_key=handler"`
+
+	// If true, no more routes will be executed after this one, even if they matched.
+	Terminal bool `json:"terminal,omitempty"`
 
 	// decoded values
 	MatcherSets MatcherSets         `json:"-"`
@@ -54,22 +113,23 @@ type RouteList []Route
 func (routes RouteList) Provision(ctx caddy.Context) error {
 	for i, route := range routes {
 		// matchers
-		matcherSets, err := route.MatcherSetsRaw.Setup(ctx)
+		matchersIface, err := ctx.LoadModule(&route, "MatcherSetsRaw")
 		if err != nil {
-			return err
+			return fmt.Errorf("loadng matchers in route %d: %v", i, err)
 		}
-		routes[i].MatcherSets = matcherSets
-		routes[i].MatcherSetsRaw = nil // allow GC to deallocate
+		err = routes[i].MatcherSets.FromInterface(matchersIface)
+		if err != nil {
+			return fmt.Errorf("route %d: %v", i, err)
+		}
 
 		// handlers
-		for j, rawMsg := range route.HandlersRaw {
-			mh, err := ctx.LoadModuleInline("handler", "http.handlers", rawMsg)
-			if err != nil {
-				return fmt.Errorf("loading handler module in position %d: %v", j, err)
-			}
-			routes[i].Handlers = append(routes[i].Handlers, mh.(MiddlewareHandler))
+		handlersIface, err := ctx.LoadModule(&route, "HandlersRaw")
+		if err != nil {
+			return fmt.Errorf("loading handler modules in route %d: %v", i, err)
 		}
-		routes[i].HandlersRaw = nil // allow GC to deallocate
+		for _, handler := range handlersIface.([]interface{}) {
+			routes[i].Handlers = append(routes[i].Handlers, handler.(MiddlewareHandler))
+		}
 	}
 	return nil
 }
@@ -171,28 +231,7 @@ func (mset MatcherSet) Match(r *http.Request) bool {
 
 // RawMatcherSets is a group of matcher sets
 // in their raw, JSON form.
-type RawMatcherSets []map[string]json.RawMessage
-
-// Setup sets up all matcher sets by loading each matcher module
-// and returning the group of provisioned matcher sets.
-func (rm RawMatcherSets) Setup(ctx caddy.Context) (MatcherSets, error) {
-	if rm == nil {
-		return nil, nil
-	}
-	var ms MatcherSets
-	for _, matcherSet := range rm {
-		var matchers MatcherSet
-		for modName, rawMsg := range matcherSet {
-			val, err := ctx.LoadModule("http.matchers."+modName, rawMsg)
-			if err != nil {
-				return nil, fmt.Errorf("loading matcher module '%s': %v", modName, err)
-			}
-			matchers = append(matchers, val.(RequestMatcher))
-		}
-		ms = append(ms, matchers)
-	}
-	return ms, nil
-}
+type RawMatcherSets []caddy.ModuleMap
 
 // MatcherSets is a group of matcher sets capable
 // of checking whether a request matches any of
@@ -202,11 +241,27 @@ type MatcherSets []MatcherSet
 // AnyMatch returns true if req matches any of the
 // matcher sets in mss or if there are no matchers,
 // in which case the request always matches.
-func (mss MatcherSets) AnyMatch(req *http.Request) bool {
-	for _, ms := range mss {
-		if ms.Match(req) {
+func (ms MatcherSets) AnyMatch(req *http.Request) bool {
+	for _, m := range ms {
+		if m.Match(req) {
 			return true
 		}
 	}
-	return len(mss) == 0
+	return len(ms) == 0
+}
+
+// FromInterface fills ms from an interface{} value obtained from LoadModule.
+func (ms *MatcherSets) FromInterface(matcherSets interface{}) error {
+	for _, matcherSetIfaces := range matcherSets.([]map[string]interface{}) {
+		var matcherSet MatcherSet
+		for _, matcher := range matcherSetIfaces {
+			reqMatcher, ok := matcher.(RequestMatcher)
+			if !ok {
+				return fmt.Errorf("decoded module is not a RequestMatcher: %#v", matcher)
+			}
+			matcherSet = append(matcherSet, reqMatcher)
+		}
+		*ms = append(*ms, matcherSet)
+	}
+	return nil
 }

--- a/modules/caddyhttp/starlarkmw/internal/lib/module.go
+++ b/modules/caddyhttp/starlarkmw/internal/lib/module.go
@@ -64,7 +64,7 @@ func (r *LoadMiddleware) Run(thread *starlark.Thread, fn *starlark.Builtin, args
 		name = fmt.Sprintf("http.handlers.%s", name)
 	}
 
-	inst, err := r.Ctx.LoadModule(name, js)
+	inst, err := r.Ctx.LoadModuleByID(name, js)
 	if err != nil {
 		return starlark.None, err
 	}
@@ -112,7 +112,7 @@ func (r *LoadResponder) Run(thread *starlark.Thread, fn *starlark.Builtin, args 
 		name = fmt.Sprintf("http.handlers.%s", name)
 	}
 
-	inst, err := r.Ctx.LoadModule(name, js)
+	inst, err := r.Ctx.LoadModuleByID(name, js)
 	if err != nil {
 		return starlark.None, err
 	}

--- a/modules/caddyhttp/starlarkmw/starlarkmw.go
+++ b/modules/caddyhttp/starlarkmw/starlarkmw.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	caddyscript "github.com/caddyserver/caddy/v2/pkg/caddyscript/lib"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/starlarkmw/internal/lib"
+	caddyscript "github.com/caddyserver/caddy/v2/pkg/caddyscript/lib"
 	"github.com/starlight-go/starlight/convert"
 	"go.starlark.net/starlark"
 )
@@ -34,8 +34,8 @@ type StarlarkMW struct {
 // CaddyModule returns the Caddy module information.
 func (StarlarkMW) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.starlark",
-		New:  func() caddy.Module { return new(StarlarkMW) },
+		ID:  "http.handlers.starlark",
+		New: func() caddy.Module { return new(StarlarkMW) },
 	}
 }
 

--- a/modules/caddyhttp/staticerror.go
+++ b/modules/caddyhttp/staticerror.go
@@ -35,8 +35,8 @@ type StaticError struct {
 // CaddyModule returns the Caddy module information.
 func (StaticError) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.error",
-		New:  func() caddy.Module { return new(StaticError) },
+		ID:  "http.handlers.error",
+		New: func() caddy.Module { return new(StaticError) },
 	}
 }
 

--- a/modules/caddyhttp/staticresp.go
+++ b/modules/caddyhttp/staticresp.go
@@ -38,8 +38,8 @@ type StaticResponse struct {
 // CaddyModule returns the Caddy module information.
 func (StaticResponse) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.static_response",
-		New:  func() caddy.Module { return new(StaticResponse) },
+		ID:  "http.handlers.static_response",
+		New: func() caddy.Module { return new(StaticResponse) },
 	}
 }
 

--- a/modules/caddyhttp/subroute.go
+++ b/modules/caddyhttp/subroute.go
@@ -44,8 +44,8 @@ type Subroute struct {
 // CaddyModule returns the Caddy module information.
 func (Subroute) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.subroute",
-		New:  func() caddy.Module { return new(Subroute) },
+		ID:  "http.handlers.subroute",
+		New: func() caddy.Module { return new(Subroute) },
 	}
 }
 

--- a/modules/caddyhttp/templates/templates.go
+++ b/modules/caddyhttp/templates/templates.go
@@ -39,8 +39,8 @@ type Templates struct {
 // CaddyModule returns the Caddy module information.
 func (Templates) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.templates",
-		New:  func() caddy.Module { return new(Templates) },
+		ID:  "http.handlers.templates",
+		New: func() caddy.Module { return new(Templates) },
 	}
 }
 

--- a/modules/caddyhttp/vars.go
+++ b/modules/caddyhttp/vars.go
@@ -32,8 +32,8 @@ type VarsMiddleware map[string]string
 // CaddyModule returns the Caddy module information.
 func (VarsMiddleware) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.handlers.vars",
-		New:  func() caddy.Module { return new(VarsMiddleware) },
+		ID:  "http.handlers.vars",
+		New: func() caddy.Module { return new(VarsMiddleware) },
 	}
 }
 
@@ -55,8 +55,8 @@ type VarsMatcher map[string]string
 // CaddyModule returns the Caddy module information.
 func (VarsMatcher) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "http.matchers.vars",
-		New:  func() caddy.Module { return new(VarsMatcher) },
+		ID:  "http.matchers.vars",
+		New: func() caddy.Module { return new(VarsMatcher) },
 	}
 }
 

--- a/modules/caddytls/certselection.go
+++ b/modules/caddytls/certselection.go
@@ -28,8 +28,8 @@ type Policy struct {
 // CaddyModule returns the Caddy module information.
 func (Policy) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "tls.certificate_selection.custom",
-		New:  func() caddy.Module { return new(Policy) },
+		ID:  "tls.certificate_selection.custom",
+		New: func() caddy.Module { return new(Policy) },
 	}
 }
 

--- a/modules/caddytls/fileloader.go
+++ b/modules/caddytls/fileloader.go
@@ -32,18 +32,27 @@ type FileLoader []CertKeyFilePair
 // CaddyModule returns the Caddy module information.
 func (FileLoader) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "tls.certificates.load_files",
-		New:  func() caddy.Module { return new(FileLoader) },
+		ID:  "tls.certificates.load_files",
+		New: func() caddy.Module { return new(FileLoader) },
 	}
 }
 
 // CertKeyFilePair pairs certificate and key file names along with their
 // encoding format so that they can be loaded from disk.
 type CertKeyFilePair struct {
-	Certificate string   `json:"certificate"`
-	Key         string   `json:"key"`
-	Format      string   `json:"format,omitempty"` // "pem" is default
-	Tags        []string `json:"tags,omitempty"`
+	// Path to the certificate (public key) file.
+	Certificate string `json:"certificate"`
+
+	// Path to the private key file.
+	Key string `json:"key"`
+
+	// The format of the cert and key. Can be "pem". Default: "pem"
+	Format string `json:"format,omitempty"`
+
+	// Arbitrary values to associate with this certificate.
+	// Can be useful when you want to select a particular
+	// certificate when there may be multiple valid candidates.
+	Tags []string `json:"tags,omitempty"`
 }
 
 // LoadCertificates returns the certificates to be loaded by fl.

--- a/modules/caddytls/folderloader.go
+++ b/modules/caddytls/folderloader.go
@@ -39,8 +39,8 @@ type FolderLoader []string
 // CaddyModule returns the Caddy module information.
 func (FolderLoader) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "tls.certificates.load_folders",
-		New:  func() caddy.Module { return new(FolderLoader) },
+		ID:  "tls.certificates.load_folders",
+		New: func() caddy.Module { return new(FolderLoader) },
 	}
 }
 

--- a/modules/caddytls/matchers.go
+++ b/modules/caddytls/matchers.go
@@ -30,8 +30,8 @@ type MatchServerName []string
 // CaddyModule returns the Caddy module information.
 func (MatchServerName) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "tls.handshake_match.sni",
-		New:  func() caddy.Module { return new(MatchServerName) },
+		ID:  "tls.handshake_match.sni",
+		New: func() caddy.Module { return new(MatchServerName) },
 	}
 }
 

--- a/modules/caddytls/pemloader.go
+++ b/modules/caddytls/pemloader.go
@@ -33,16 +33,23 @@ type PEMLoader []CertKeyPEMPair
 // CaddyModule returns the Caddy module information.
 func (PEMLoader) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "tls.certificates.load_pem",
-		New:  func() caddy.Module { return PEMLoader{} },
+		ID:  "tls.certificates.load_pem",
+		New: func() caddy.Module { return PEMLoader{} },
 	}
 }
 
 // CertKeyPEMPair pairs certificate and key PEM blocks.
 type CertKeyPEMPair struct {
-	CertificatePEM string   `json:"certificate"`
-	KeyPEM         string   `json:"key"`
-	Tags           []string `json:"tags,omitempty"`
+	// The certificate (public key) in PEM format.
+	CertificatePEM string `json:"certificate"`
+
+	// The private key in PEM format.
+	KeyPEM string `json:"key"`
+
+	// Arbitrary values to associate with this certificate.
+	// Can be useful when you want to select a particular
+	// certificate when there may be multiple valid candidates.
+	Tags []string `json:"tags,omitempty"`
 }
 
 // LoadCertificates returns the certificates contained in pl.

--- a/modules/caddytls/standardstek/stek.go
+++ b/modules/caddytls/standardstek/stek.go
@@ -35,8 +35,8 @@ type standardSTEKProvider struct {
 // CaddyModule returns the Caddy module information.
 func (standardSTEKProvider) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "tls.stek.standard",
-		New:  func() caddy.Module { return new(standardSTEKProvider) },
+		ID:  "tls.stek.standard",
+		New: func() caddy.Module { return new(standardSTEKProvider) },
 	}
 }
 

--- a/modules/filestorage/filestorage.go
+++ b/modules/filestorage/filestorage.go
@@ -32,8 +32,8 @@ type FileStorage struct {
 // CaddyModule returns the Caddy module information.
 func (FileStorage) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "caddy.storage.file_system",
-		New:  func() caddy.Module { return new(FileStorage) },
+		ID:  "caddy.storage.file_system",
+		New: func() caddy.Module { return new(FileStorage) },
 	}
 }
 

--- a/modules/logging/encoders.go
+++ b/modules/logging/encoders.go
@@ -43,8 +43,8 @@ type ConsoleEncoder struct {
 // CaddyModule returns the Caddy module information.
 func (ConsoleEncoder) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "caddy.logging.encoders.console",
-		New:  func() caddy.Module { return new(ConsoleEncoder) },
+		ID:  "caddy.logging.encoders.console",
+		New: func() caddy.Module { return new(ConsoleEncoder) },
 	}
 }
 
@@ -63,8 +63,8 @@ type JSONEncoder struct {
 // CaddyModule returns the Caddy module information.
 func (JSONEncoder) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "caddy.logging.encoders.json",
-		New:  func() caddy.Module { return new(JSONEncoder) },
+		ID:  "caddy.logging.encoders.json",
+		New: func() caddy.Module { return new(JSONEncoder) },
 	}
 }
 
@@ -84,8 +84,8 @@ type LogfmtEncoder struct {
 // CaddyModule returns the Caddy module information.
 func (LogfmtEncoder) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "caddy.logging.encoders.logfmt",
-		New:  func() caddy.Module { return new(LogfmtEncoder) },
+		ID:  "caddy.logging.encoders.logfmt",
+		New: func() caddy.Module { return new(LogfmtEncoder) },
 	}
 }
 
@@ -102,25 +102,24 @@ func (lfe *LogfmtEncoder) Provision(_ caddy.Context) error {
 type StringEncoder struct {
 	zapcore.Encoder
 	FieldName   string          `json:"field,omitempty"`
-	FallbackRaw json.RawMessage `json:"fallback,omitempty"`
+	FallbackRaw json.RawMessage `json:"fallback,omitempty" caddy:"namespace=caddy.logging.encoders inline_key=format"`
 }
 
 // CaddyModule returns the Caddy module information.
 func (StringEncoder) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "caddy.logging.encoders.string",
-		New:  func() caddy.Module { return new(StringEncoder) },
+		ID:  "caddy.logging.encoders.string",
+		New: func() caddy.Module { return new(StringEncoder) },
 	}
 }
 
 // Provision sets up the encoder.
 func (se *StringEncoder) Provision(ctx caddy.Context) error {
 	if se.FallbackRaw != nil {
-		val, err := ctx.LoadModuleInline("format", "caddy.logging.encoders", se.FallbackRaw)
+		val, err := ctx.LoadModule(se, "FallbackRaw")
 		if err != nil {
 			return fmt.Errorf("loading fallback encoder module: %v", err)
 		}
-		se.FallbackRaw = nil // allow GC to deallocate
 		se.Encoder = val.(zapcore.Encoder)
 	}
 	if se.Encoder == nil {

--- a/modules/logging/filewriter.go
+++ b/modules/logging/filewriter.go
@@ -28,22 +28,42 @@ func init() {
 	caddy.RegisterModule(FileWriter{})
 }
 
-// FileWriter can write logs to files.
+// FileWriter can write logs to files. By default, log files
+// are rotated ("rolled") when they get large, and old log
+// files get deleted, to ensure that the process does not
+// exhaust disk space.
 type FileWriter struct {
-	Filename      string `json:"filename,omitempty"`
-	Roll          *bool  `json:"roll,omitempty"`
-	RollSizeMB    int    `json:"roll_size_mb,omitempty"`
-	RollCompress  *bool  `json:"roll_gzip,omitempty"`
-	RollLocalTime bool   `json:"roll_local_time,omitempty"`
-	RollKeep      int    `json:"roll_keep,omitempty"`
-	RollKeepDays  int    `json:"roll_keep_days,omitempty"`
+	// Filename is the name of the file to write.
+	Filename string `json:"filename,omitempty"`
+
+	// Roll toggles log rolling or rotation, which is
+	// enabled by default.
+	Roll *bool `json:"roll,omitempty"`
+
+	// When a log file reaches approximately this size,
+	// it will be rotated.
+	RollSizeMB int `json:"roll_size_mb,omitempty"`
+
+	// Whether to compress rolled files. Default: true
+	RollCompress *bool `json:"roll_gzip,omitempty"`
+
+	// Whether to use local timestamps in rolled filenames.
+	// Default: false
+	RollLocalTime bool `json:"roll_local_time,omitempty"`
+
+	// The maximum number of rolled log files to keep.
+	// Default: 10
+	RollKeep int `json:"roll_keep,omitempty"`
+
+	// How many days to keep rolled log files. Default: 90
+	RollKeepDays int `json:"roll_keep_days,omitempty"`
 }
 
 // CaddyModule returns the Caddy module information.
 func (FileWriter) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "caddy.logging.writers.file",
-		New:  func() caddy.Module { return new(FileWriter) },
+		ID:  "caddy.logging.writers.file",
+		New: func() caddy.Module { return new(FileWriter) },
 	}
 }
 

--- a/modules/logging/filterencoder.go
+++ b/modules/logging/filterencoder.go
@@ -29,13 +29,17 @@ func init() {
 	caddy.RegisterModule(FilterEncoder{})
 }
 
-// FilterEncoder wraps an underlying encoder. It does
-// not do any encoding itself, but it can manipulate
-// (filter) fields before they are actually encoded.
-// A wrapped encoder is required.
+// FilterEncoder can filter (manipulate) fields on
+// log entries before they are actually encoded by
+// an underlying encoder.
 type FilterEncoder struct {
-	WrappedRaw json.RawMessage            `json:"wrap,omitempty"`
-	FieldsRaw  map[string]json.RawMessage `json:"fields,omitempty"`
+	// The underlying encoder that actually
+	// encodes the log entries. Required.
+	WrappedRaw json.RawMessage `json:"wrap,omitempty" caddy:"namespace=caddy.logging.encoders inline_key=format"`
+
+	// A map of field names to their filters. Note that this
+	// is not a module map; the keys are field names.
+	FieldsRaw map[string]json.RawMessage `json:"fields,omitempty" caddy:"namespace=caddy.logging.encoders.filter inline_key=filter"`
 
 	wrapped zapcore.Encoder
 	Fields  map[string]LogFieldFilter `json:"-"`
@@ -47,8 +51,8 @@ type FilterEncoder struct {
 // CaddyModule returns the Caddy module information.
 func (FilterEncoder) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "caddy.logging.encoders.filter",
-		New:  func() caddy.Module { return new(FilterEncoder) },
+		ID:  "caddy.logging.encoders.filter",
+		New: func() caddy.Module { return new(FilterEncoder) },
 	}
 }
 
@@ -59,28 +63,23 @@ func (fe *FilterEncoder) Provision(ctx caddy.Context) error {
 	}
 
 	// set up wrapped encoder (required)
-	val, err := ctx.LoadModuleInline("format", "caddy.logging.encoders", fe.WrappedRaw)
+	val, err := ctx.LoadModule(fe, "WrappedRaw")
 	if err != nil {
 		return fmt.Errorf("loading fallback encoder module: %v", err)
 	}
-	fe.WrappedRaw = nil // allow GC to deallocate
 	fe.wrapped = val.(zapcore.Encoder)
 
 	// set up each field filter
 	if fe.Fields == nil {
 		fe.Fields = make(map[string]LogFieldFilter)
 	}
-	for field, filterRaw := range fe.FieldsRaw {
-		if filterRaw == nil {
-			continue
-		}
-		val, err := ctx.LoadModuleInline("filter", "caddy.logging.encoders.filter", filterRaw)
-		if err != nil {
-			return fmt.Errorf("loading log filter module: %v", err)
-		}
-		fe.Fields[field] = val.(LogFieldFilter)
+	vals, err := ctx.LoadModule(fe, "FieldsRaw")
+	if err != nil {
+		return fmt.Errorf("loading log filter modules: %v", err)
 	}
-	fe.FieldsRaw = nil // allow GC to deallocate
+	for fieldName, modIface := range vals.(map[string]interface{}) {
+		fe.Fields[fieldName] = modIface.(LogFieldFilter)
+	}
 
 	return nil
 }

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -41,8 +41,8 @@ type DeleteFilter struct{}
 // CaddyModule returns the Caddy module information.
 func (DeleteFilter) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "caddy.logging.encoders.filter.delete",
-		New:  func() caddy.Module { return new(DeleteFilter) },
+		ID:  "caddy.logging.encoders.filter.delete",
+		New: func() caddy.Module { return new(DeleteFilter) },
 	}
 }
 
@@ -55,15 +55,18 @@ func (DeleteFilter) Filter(in zapcore.Field) zapcore.Field {
 // IPMaskFilter is a Caddy log field filter that
 // masks IP addresses.
 type IPMaskFilter struct {
+	// The IPv4 range in CIDR notation.
 	IPv4CIDR int `json:"ipv4_cidr,omitempty"`
+
+	// The IPv6 range in CIDR notation.
 	IPv6CIDR int `json:"ipv6_cidr,omitempty"`
 }
 
 // CaddyModule returns the Caddy module information.
 func (IPMaskFilter) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		Name: "caddy.logging.encoders.filter.ip_mask",
-		New:  func() caddy.Module { return new(IPMaskFilter) },
+		ID:  "caddy.logging.encoders.filter.ip_mask",
+		New: func() caddy.Module { return new(IPMaskFilter) },
 	}
 }
 

--- a/modules_test.go
+++ b/modules_test.go
@@ -22,17 +22,17 @@ import (
 func TestGetModules(t *testing.T) {
 	modulesMu.Lock()
 	modules = map[string]ModuleInfo{
-		"a":      {Name: "a"},
-		"a.b":    {Name: "a.b"},
-		"a.b.c":  {Name: "a.b.c"},
-		"a.b.cd": {Name: "a.b.cd"},
-		"a.c":    {Name: "a.c"},
-		"a.d":    {Name: "a.d"},
-		"b":      {Name: "b"},
-		"b.a":    {Name: "b.a"},
-		"b.b":    {Name: "b.b"},
-		"b.a.c":  {Name: "b.a.c"},
-		"c":      {Name: "c"},
+		"a":      {ID: "a"},
+		"a.b":    {ID: "a.b"},
+		"a.b.c":  {ID: "a.b.c"},
+		"a.b.cd": {ID: "a.b.cd"},
+		"a.c":    {ID: "a.c"},
+		"a.d":    {ID: "a.d"},
+		"b":      {ID: "b"},
+		"b.a":    {ID: "b.a"},
+		"b.b":    {ID: "b.b"},
+		"b.a.c":  {ID: "b.a.c"},
+		"c":      {ID: "c"},
 	}
 	modulesMu.Unlock()
 
@@ -43,24 +43,24 @@ func TestGetModules(t *testing.T) {
 		{
 			input: "",
 			expect: []ModuleInfo{
-				{Name: "a"},
-				{Name: "b"},
-				{Name: "c"},
+				{ID: "a"},
+				{ID: "b"},
+				{ID: "c"},
 			},
 		},
 		{
 			input: "a",
 			expect: []ModuleInfo{
-				{Name: "a.b"},
-				{Name: "a.c"},
-				{Name: "a.d"},
+				{ID: "a.b"},
+				{ID: "a.c"},
+				{ID: "a.d"},
 			},
 		},
 		{
 			input: "a.b",
 			expect: []ModuleInfo{
-				{Name: "a.b.c"},
-				{Name: "a.b.cd"},
+				{ID: "a.b.c"},
+				{ID: "a.b.cd"},
 			},
 		},
 		{
@@ -69,8 +69,8 @@ func TestGetModules(t *testing.T) {
 		{
 			input: "b",
 			expect: []ModuleInfo{
-				{Name: "b.a"},
-				{Name: "b.b"},
+				{ID: "b.a"},
+				{ID: "b.b"},
 			},
 		},
 		{


### PR DESCRIPTION
This commit goes a long way toward making automated documentation of
Caddy config and Caddy modules possible. It's a broad, sweeping change,
but mostly internal. It allows us to automatically generate docs for all
Caddy modules (including future third-party ones) and make them viewable
on a web page; it also doubles as godoc comments.

As such, this commit makes significant progress in migrating the docs
from our temporary wiki page toward our new website which is still under
construction.

With this change, all host modules will use ctx.LoadModule() and pass in
both the struct pointer and the field name as a string. This allows the
reflect package to read the struct tag from that field so that it can
get the necessary information like the module namespace and the inline
key.

This has the nice side-effect of unifying the code and documentation. It
also simplifies module loading, and handles several variations on field
types for raw module fields (i.e. variations on json.RawMessage, such as
arrays and maps).

I also renamed ModuleInfo.Name -> ModuleInfo.ID, to make it clear that
the ID is the "full name" which includes both the module namespace and
the name. This clarity is helpful when describing module hierarchy.

As of this change, Caddy modules are no longer an experimental design.
I think the architecture is good enough to go forward.