### PR TITLE
Repair broken README link: "become a sponsor" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Thanks for making Caddy -- and the Web -- better!
 - [DNSimple](https://dnsimple.link/resolving-caddy) provides DNS services for Caddy's sites.
 - [DNS Spy](https://dnsspy.io) keeps an eye on Caddy's DNS properties.
 
-We thank them for their services. **If you want to help keep Caddy free, please [become a sponsor](https://caddyserver.com/pricing)!**
+We thank them for their services. **If you want to help keep Caddy free, please [become a sponsor](https://github.com/sponsors/mholt)!**
 
 
 ## About the Project


### PR DESCRIPTION
`caddyserver.com/pricing` is a broken link (looks like pricing for individual products is no longer *A Thing*), so it could be appropriate to replace it with a link to mholt's GitHub Sponsor page.

--
