### PR TITLE
v2: Proposal: Support tls_trusted_ca_certs in reverse_proxy.transport

### DIFF
--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -425,6 +425,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 //         tls_client_auth <cert_file> <key_file>
 //         tls_insecure_skip_verify
 //         tls_timeout <duration>
+//         tls_trusted_ca_certs <cert_files...>
 //         keepalive [off|<duration>]
 //         keepalive_idle_conns <max_count>
 //     }
@@ -500,6 +501,17 @@ func (h *HTTPTransport) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					h.TLS = new(TLSConfig)
 				}
 				h.TLS.HandshakeTimeout = caddy.Duration(dur)
+
+			case "tls_trusted_ca_certs":
+				args := d.RemainingArgs()
+				if len(args) == 0 {
+					return d.ArgErr()
+				}
+				if h.TLS == nil {
+					h.TLS = new(TLSConfig)
+				}
+
+				h.TLS.RootCAPemFiles = args
 
 			case "keepalive":
 				if !d.NextArg() {


### PR DESCRIPTION
Allows specifying ca certs with by filename in
`reverse_proxy.transport`.

Example
```
:443

root * app

# Make HTML file extension optional
try_files {path}.html {path}

# Send requests to /api to backend
reverse_proxy /api api:443 {
    transport http {
        tls
        tls_trusted_ca_certs certs/rootCA.pem
    }
}

# Serve everything else from the file system
file_server

tls certs/cert.pem certs/key.pem
```

These changes should be backwards compatible by simply opting to add a new way of specifying certs in `modules/reverseproxy/httptransport.go`