### PR TITLE
Avoid duplicated Vary header

### DIFF
--- a/caddyhttp/gzip/gzip.go
+++ b/caddyhttp/gzip/gzip.go
@@ -130,7 +130,19 @@ type gzipResponseWriter struct {
 func (w *gzipResponseWriter) WriteHeader(code int) {
 	w.Header().Del("Content-Length")
 	w.Header().Set("Content-Encoding", "gzip")
-	w.Header().Add("Vary", "Accept-Encoding")
+	varyList, exist := w.Header()["Vary"]
+	shouldAddVary := true
+	if exist {
+		for _, vary := range varyList {
+			if vary == "Accept-Encoding" {
+				shouldAddVary = false
+				break
+			}
+		}
+	}
+	if shouldAddVary {
+		w.Header().Add("Vary", "Accept-Encoding")
+	}
 	originalEtag := w.Header().Get("ETag")
 	if originalEtag != "" && !strings.HasPrefix(originalEtag, "W/") {
 		w.Header().Set("ETag", "W/"+originalEtag)


### PR DESCRIPTION
If using caddy as a reverse proxy, when the upstream returns HTTP header `Vary: Accept-Encoding`, caddy will add this header again.

```bash
curl localhost:8080/test -v
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /test HTTP/1.1
> User-Agent: curl/7.64.1
> Accept: */*
> Accept-Encoding: deflate, gzip
>
< HTTP/1.1 200 OK
< Cache-Control: private, no-cache
< Content-Encoding: gzip
< Content-Type: application/json; charset=utf-8
< Date: Wed, 18 Dec 2019 10:52:58 GMT
< Expires: Wed, 17 Sep 1975 21:32:10 GMT
< Vary: Accept-Encoding
< Vary: Accept-Encoding
```