### PR TITLE
FreeBSD init: PID file should not be executable

### DIFF
--- a/dist/init/freebsd/caddy
+++ b/dist/init/freebsd/caddy
@@ -80,7 +80,7 @@ caddy_startprecmd()
 	rc_flags=""
 
 	if [ ! -e "${pidfile}" ]; then
-		install -o "${caddy_user}" -g "${caddy_group}" "/dev/null" "${pidfile}"
+		install -m 644 -o "${caddy_user}" -g "${caddy_group}" "/dev/null" "${pidfile}"
 	fi
 }
 


### PR DESCRIPTION
`install` use 0755 mode by default.