### PR TITLE
v2: Added missing context for embedding

### DIFF
--- a/caddy.iml
+++ b/caddy.iml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="GO_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="GOPATH &lt;caddy&gt;" level="project" />
+  </component>
+</module>

--- a/caddyhttp/httpserver/https.go
+++ b/caddyhttp/httpserver/https.go
@@ -20,12 +20,14 @@ import (
 	"net/http"
 	"strconv"
 
+	"context"
 	"github.com/caddyserver/caddy"
 	"github.com/caddyserver/caddy/caddytls"
 	"github.com/mholt/certmagic"
 )
 
 func activateHTTPS(cctx caddy.Context) error {
+	var newctx context.Context
 	operatorPresent := !caddy.Started()
 
 	if !caddy.Quiet && operatorPresent {
@@ -45,7 +47,7 @@ func activateHTTPS(cctx caddy.Context) error {
 		if c.TLS.Manager.OnDemand != nil {
 			continue // obtain these certificates on-demand instead
 		}
-		err := c.TLS.Manager.ObtainCert(c.TLS.Hostname, operatorPresent)
+		err := c.TLS.Manager.ObtainCert(newctx, c.TLS.Hostname, operatorPresent)
 		if err != nil {
 			return err
 		}
@@ -71,7 +73,7 @@ func activateHTTPS(cctx caddy.Context) error {
 		certCache, ok := ctx.instance.Storage[caddytls.CertCacheInstStorageKey].(*certmagic.Cache)
 		ctx.instance.StorageMu.RUnlock()
 		if ok && certCache != nil {
-			err = certCache.RenewManagedCertificates()
+			err = certCache.RenewManagedCertificates(newctx)
 			if err != nil {
 				return err
 			}

--- a/caddytls/tls.go
+++ b/caddytls/tls.go
@@ -29,6 +29,7 @@
 package caddytls
 
 import (
+	"context"
 	"github.com/caddyserver/caddy"
 	"github.com/go-acme/lego/v3/challenge"
 	"github.com/mholt/certmagic"
@@ -77,7 +78,8 @@ func QualifiesForManagedTLS(c ConfigHolder) bool {
 // Revoke revokes the certificate fro host via the ACME protocol.
 // It assumes the certificate was obtained from certmagic.CA.
 func Revoke(domainName string) error {
-	return certmagic.NewDefault().RevokeCert(domainName, true)
+	var ctx context.Context
+	return certmagic.NewDefault().RevokeCert(ctx, domainName, true)
 }
 
 // KnownACMECAs is a list of ACME directory endpoints of


### PR DESCRIPTION
	modified:   caddyhttp/httpserver/https.go
	modified:   caddytls/tls.go