### PR TITLE
v2: housekeeping: address minor lint complaints

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ jobs:
     condition: eq( variables['Agent.OS'], 'Windows_NT' )
     displayName: Install Go on Windows
 
-  - bash: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.19.1
+  - bash: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.22.2
     displayName: Install golangci-lint
 
   - script: |
@@ -198,7 +198,7 @@ jobs:
       sudo apt update && sudo apt install -y clang-7 lldb-7 lld-7
 
       go get -v github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
-      wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.74/fuzzit_Linux_x86_64
+      wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.77/fuzzit_Linux_x86_64
       chmod a+x fuzzit
       mv fuzzit $(GOBIN)
     displayName: Download go-fuzz tools and the Fuzzit CLI, and move Fuzzit CLI to GOBIN

--- a/context.go
+++ b/context.go
@@ -30,7 +30,7 @@ import (
 // that spawned the modules which are loaded. It should be used
 // with care and wrapped with derivation functions from the
 // standard context package only if you don't need the Caddy
-// specific features. These contexts are cancelled when the
+// specific features. These contexts are canceled when the
 // lifetime of the modules loaded from it is over.
 //
 // Use NewContext() to get a valid value (but most modules will
@@ -75,7 +75,7 @@ func NewContext(ctx Context) (Context, context.CancelFunc) {
 	return newCtx, wrappedCancel
 }
 
-// OnCancel executes f when ctx is cancelled.
+// OnCancel executes f when ctx is canceled.
 func (ctx *Context) OnCancel(f func()) {
 	ctx.cleanupFuncs = append(ctx.cleanupFuncs, f)
 }

--- a/listeners.go
+++ b/listeners.go
@@ -138,7 +138,7 @@ func (fcl *fakeCloseListener) Accept() (net.Conn, error) {
 	fcl.deadlineMu.Unlock()
 
 	if atomic.LoadInt32(&fcl.closed) == 1 {
-		// if we cancelled the Accept() by setting a deadline
+		// if we canceled the Accept() by setting a deadline
 		// on the listener, we need to make sure any callers of
 		// Accept() think the listener was actually closed;
 		// if we return the timeout error instead, callers might

--- a/logging.go
+++ b/logging.go
@@ -76,7 +76,7 @@ type Logging struct {
 }
 
 // openLogs sets up the config and opens all the configured writers.
-// It closes its logs when ctx is cancelled, so it should clean up
+// It closes its logs when ctx is canceled, so it should clean up
 // after itself.
 func (logging *Logging) openLogs(ctx Context) error {
 	// make sure to deallocate resources when context is done
@@ -184,7 +184,7 @@ func (logging *Logging) setupNewDefault(ctx Context) error {
 
 // closeLogs cleans up resources allocated during openLogs.
 // A successful call to openLogs calls this automatically
-// when the context is cancelled.
+// when the context is canceled.
 func (logging *Logging) closeLogs() error {
 	for _, key := range logging.writerKeys {
 		_, err := writers.Delete(key)

--- a/modules/caddyhttp/reverseproxy/streaming.go
+++ b/modules/caddyhttp/reverseproxy/streaming.go
@@ -68,7 +68,6 @@ func (h Handler) handleUpgradeResponse(rw http.ResponseWriter, req *http.Request
 	go spc.copyToBackend(errc)
 	go spc.copyFromBackend(errc)
 	<-errc
-	return
 }
 
 // flushInterval returns the p.FlushInterval value, conditionally

--- a/modules/caddyhttp/starlarkmw/internal/lib/module.go
+++ b/modules/caddyhttp/starlarkmw/internal/lib/module.go
@@ -60,7 +60,7 @@ func (r *LoadMiddleware) Run(thread *starlark.Thread, fn *starlark.Builtin, args
 
 	js := json.RawMessage(cfg.String())
 
-	if strings.Index(name, "http.handlers.") == -1 {
+	if !strings.Contains(name, "http.handlers.") {
 		name = fmt.Sprintf("http.handlers.%s", name)
 	}
 
@@ -108,7 +108,7 @@ func (r *LoadResponder) Run(thread *starlark.Thread, fn *starlark.Builtin, args 
 
 	js := json.RawMessage(cfg.String())
 
-	if strings.Index(name, "http.handlers.") == -1 {
+	if !strings.Contains(name, "http.handlers.") {
 		name = fmt.Sprintf("http.handlers.%s", name)
 	}
 

--- a/modules/caddyhttp/templates/templates.go
+++ b/modules/caddyhttp/templates/templates.go
@@ -259,9 +259,7 @@ func (t *Templates) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 	// refresh, so disable them until we find a better way to do this
 	rec.Header().Del("Etag")
 
-	rec.WriteResponse()
-
-	return nil
+	return rec.WriteResponse()
 }
 
 // executeTemplate executes the template contained in wb.buf and replaces it with the results.

--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -179,7 +179,7 @@ func (p *ConnectionPolicy) buildStandardTLSConfig(ctx caddy.Context) error {
 		// session ticket key rotation
 		tlsApp.SessionTickets.register(cfg)
 		ctx.OnCancel(func() {
-			// do cleanup when the context is cancelled because,
+			// do cleanup when the context is canceled because,
 			// though unlikely, it is possible that a context
 			// needing a TLS server config could exist for less
 			// than the lifetime of the whole app

--- a/modules/logging/filewriter.go
+++ b/modules/logging/filewriter.go
@@ -96,7 +96,7 @@ func (fw FileWriter) WriterKey() string {
 // OpenWriter opens a new file writer.
 func (fw FileWriter) OpenWriter() (io.WriteCloser, error) {
 	// roll log files by default
-	if fw.Roll == nil || *fw.Roll == true {
+	if fw.Roll == nil || *fw.Roll {
 		if fw.RollSizeMB == 0 {
 			fw.RollSizeMB = 100
 		}


### PR DESCRIPTION
This PR addresses:

- Updating `golangci-lint` addresses a false-negative in the `bodyclose` linter.
- Use US spelling of `canceled`
- Simplify some of the code (one of them addresses linter complaint of lack of error check)


Addressing errcheck lints requires more elaborate study of the code to know where it can be ignored. Catching and checking these `(*http.Server).Serve()` and `(*http3.Server).Serve()` requires some restructuring of the code. I imagine using the `Group` type from either `go4.org/syncutil` or `golang.org/x/sync/errgroup` is needed to capture those errors and react properly, but haven't looked deep enough into how the structure should look like and how they'll be employed:

- admin.go
https://github.com/caddyserver/caddy/blob/8c7c2e4af2e4e7ad842b959e2100855f6edadd68/admin.go#L221

- modules/caddyhttp/caddyhttp.go
https://github.com/caddyserver/caddy/blob/8c7c2e4af2e4e7ad842b959e2100855f6edadd68/modules/caddyhttp/caddyhttp.go#L284

- modules/caddyhttp/caddyhttp.go
https://github.com/caddyserver/caddy/blob/8c7c2e4af2e4e7ad842b959e2100855f6edadd68/modules/caddyhttp/caddyhttp.go#L292