### PR TITLE
fix replacing variables on imported files

### DIFF
--- a/caddyconfig/caddyfile/dispenser_test.go
+++ b/caddyconfig/caddyfile/dispenser_test.go
@@ -308,7 +308,7 @@ func TestDispenser_ArgErr_Err(t *testing.T) {
 }
 
 func newTestDispenser(input string) *Dispenser {
-	tokens, err := allTokens("Testfile", strings.NewReader(input))
+	tokens, err := allTokens("Testfile", []byte(input))
 	if err != nil && err != io.EOF {
 		log.Fatalf("getting all tokens from input: %v", err)
 	}

--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -16,7 +16,6 @@ package caddyfile
 
 import (
 	"bytes"
-	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -34,7 +33,7 @@ import (
 // Environment variables in {$ENVIRONMENT_VARIABLE} notation
 // will be replaced before parsing begins.
 func Parse(filename string, input []byte) ([]ServerBlock, error) {
-	tokens, err := allTokens(filename, bytes.NewReader(input))
+	tokens, err := allTokens(filename, input)
 	if err != nil {
 		return nil, err
 	}
@@ -43,13 +42,7 @@ func Parse(filename string, input []byte) ([]ServerBlock, error) {
 }
 
 // replaceEnvVars replaces all occurrences of environment variables.
-func replaceEnvVars(i io.Reader) (io.Reader, error) {
-
-	input, err := ioutil.ReadAll(i)
-	if err != nil {
-		return nil, err
-	}
-
+func replaceEnvVars(input []byte) ([]byte, error) {
 	var offset int
 	for {
 		begin := bytes.Index(input[offset:], spanOpen)
@@ -80,21 +73,19 @@ func replaceEnvVars(i io.Reader) (io.Reader, error) {
 		// continue at the end of the replacement
 		offset = begin + len(envVarValue)
 	}
-	return bytes.NewReader(input), nil
+	return input, nil
 }
 
 // allTokens lexes the entire input, but does not parse it.
 // It returns all the tokens from the input, unstructured
 // and in order.
-func allTokens(filename string, input io.Reader) ([]Token, error) {
-
+func allTokens(filename string, input []byte) ([]Token, error) {
 	input, err := replaceEnvVars(input)
-	if err != nil{
+	if err != nil {
 		return nil, err
 	}
-
 	l := new(lexer)
-	err = l.load(input)
+	err = l.load(bytes.NewReader(input))
 	if err != nil {
 		return nil, err
 	}
@@ -385,7 +376,7 @@ func (p *parser) doSingleImport(importFile string) ([]Token, error) {
 		return nil, p.Errf("Could not read imported file %s: %v", importFile, err)
 	}
 
-	importedTokens, err := allTokens(importFile, bytes.NewReader(input))
+	importedTokens, err := allTokens(importFile, input)
 	if err != nil {
 		return nil, p.Errf("Could not read tokens while importing %s: %v", importFile, err)
 	}

--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -17,6 +17,7 @@ package caddyfile
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -368,7 +369,14 @@ func (p *parser) doSingleImport(importFile string) ([]Token, error) {
 		return nil, p.Errf("Could not import %s: is a directory", importFile)
 	}
 
-	importedTokens, err := allTokens(importFile, file)
+	input, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, p.Errf("Could not read imported file %s: %v", importFile, err)
+	}
+
+	input = replaceEnvVars(input)
+
+	importedTokens, err := allTokens(importFile, bytes.NewReader(input))
 	if err != nil {
 		return nil, p.Errf("Could not read tokens while importing %s: %v", importFile, err)
 	}

--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -34,7 +34,6 @@ import (
 // Environment variables in {$ENVIRONMENT_VARIABLE} notation
 // will be replaced before parsing begins.
 func Parse(filename string, input []byte) ([]ServerBlock, error) {
-	input = replaceEnvVars(input)
 	tokens, err := allTokens(filename, bytes.NewReader(input))
 	if err != nil {
 		return nil, err
@@ -44,7 +43,13 @@ func Parse(filename string, input []byte) ([]ServerBlock, error) {
 }
 
 // replaceEnvVars replaces all occurrences of environment variables.
-func replaceEnvVars(input []byte) []byte {
+func replaceEnvVars(i io.Reader) (io.Reader, error) {
+
+	input, err := ioutil.ReadAll(i)
+	if err != nil {
+		return nil, err
+	}
+
 	var offset int
 	for {
 		begin := bytes.Index(input[offset:], spanOpen)
@@ -75,15 +80,21 @@ func replaceEnvVars(input []byte) []byte {
 		// continue at the end of the replacement
 		offset = begin + len(envVarValue)
 	}
-	return input
+	return bytes.NewReader(input), nil
 }
 
 // allTokens lexes the entire input, but does not parse it.
 // It returns all the tokens from the input, unstructured
 // and in order.
 func allTokens(filename string, input io.Reader) ([]Token, error) {
+
+	input, err := replaceEnvVars(input)
+	if err != nil{
+		return nil, err
+	}
+
 	l := new(lexer)
-	err := l.load(input)
+	err = l.load(input)
 	if err != nil {
 		return nil, err
 	}
@@ -373,8 +384,6 @@ func (p *parser) doSingleImport(importFile string) ([]Token, error) {
 	if err != nil {
 		return nil, p.Errf("Could not read imported file %s: %v", importFile, err)
 	}
-
-	input = replaceEnvVars(input)
 
 	importedTokens, err := allTokens(importFile, bytes.NewReader(input))
 	if err != nil {

--- a/caddyconfig/caddyfile/parse_test.go
+++ b/caddyconfig/caddyfile/parse_test.go
@@ -19,12 +19,11 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
 func TestAllTokens(t *testing.T) {
-	input := strings.NewReader("a b c\nd e")
+	input := []byte("a b c\nd e")
 	expected := []string{"a", "b", "c", "d", "e"}
 	tokens, err := allTokens("TestAllTokens", input)
 
@@ -545,11 +544,7 @@ func TestEnvironmentReplacement(t *testing.T) {
 			expect: "}{$",
 		},
 	} {
-		result, err := replaceEnvVars(bytes.NewReader([]byte(test.input)))
-		if err != nil {
-			t.Fatal(err)
-		}
-		actual, err := ioutil.ReadAll(result)
+		actual, err := replaceEnvVars([]byte(test.input))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/caddyconfig/caddyfile/parse_test.go
+++ b/caddyconfig/caddyfile/parse_test.go
@@ -545,7 +545,14 @@ func TestEnvironmentReplacement(t *testing.T) {
 			expect: "}{$",
 		},
 	} {
-		actual := replaceEnvVars([]byte(test.input))
+		result, err := replaceEnvVars(bytes.NewReader([]byte(test.input)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		actual, err := ioutil.ReadAll(result)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if !bytes.Equal(actual, []byte(test.expect)) {
 			t.Errorf("Test %d: Expected: '%s' but got '%s'", i, test.expect, actual)
 		}


### PR DESCRIPTION
Fixes small issue when importing files.

The parse time replacements are not happening.

