### PR TITLE
php_fastcgi: No longer try index.php by default

### DIFF
--- a/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
@@ -93,7 +93,7 @@ func (t *Transport) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 //     }
 //     redir @canonicalPath {path}/ 308
 //
-//     try_files {path} {path}/index.php index.php
+//     try_files {path} {path}/index.php
 //
 //     @phpFiles {
 //         path *.php
@@ -145,7 +145,7 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 	// route to rewrite to PHP index file
 	rewriteMatcherSet := caddy.ModuleMap{
 		"file": h.JSON(fileserver.MatchFile{
-			TryFiles: []string{"{http.request.uri.path}", "{http.request.uri.path}/index.php", "index.php"},
+			TryFiles: []string{"{http.request.uri.path}", "{http.request.uri.path}/index.php"},
 		}),
 	}
 	rewriteHandler := rewrite.Rewrite{


### PR DESCRIPTION
The user can still explicitly configure this manually with a try_files if they want to fall back to a PHP file if there's no match.

fix #2989