### PR TITLE
v2: only compare custom TLS protocol relative to each other if both are set

### DIFF
--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -222,14 +222,14 @@ func (p *ConnectionPolicy) buildStandardTLSConfig(ctx caddy.Context) error {
 	}
 
 	// min and max protocol versions
+	if (p.ProtocolMin != "" && p.ProtocolMax != "") && p.ProtocolMin > p.ProtocolMax {
+		return fmt.Errorf("protocol min (%x) cannot be greater than protocol max (%x)", p.ProtocolMin, p.ProtocolMax)
+	}
 	if p.ProtocolMin != "" {
 		cfg.MinVersion = SupportedProtocols[p.ProtocolMin]
 	}
 	if p.ProtocolMax != "" {
 		cfg.MaxVersion = SupportedProtocols[p.ProtocolMax]
-	}
-	if p.ProtocolMin > p.ProtocolMax {
-		return fmt.Errorf("protocol min (%x) cannot be greater than protocol max (%x)", p.ProtocolMin, p.ProtocolMax)
 	}
 
 	// client authentication


### PR DESCRIPTION
The `max` argument for the `protocols` setting of the `tls` directive is optional. If not specified, the created `*tls.Config` has its MaxVersion set to TLS 1.3. That is, given such Caddyfile:

```
example.com {
    root * /path/to/root
    tls cert.pem cert.key {
        protocols tls1.2
    }
}
```
Caddy should have TLS config with minimum of tls1.2 and max tls1.3 (which is the default max). Because max is not specified, the `ConnectionPolicy` struct has an empty string as value of `ProtocolMax`. So the comparison `p.ProtocolMin > p.ProtocolMax` results in `true` because string with content is greater than an empty string.

We should check if both knobs have custom values in them before comparing them, and we should check first before actually changing values in `*tls.Config`.

Found via: https://caddy.community/t/caddy-and-staticfiles-django/6889/3