### PR TITLE
v2: Enabling order in RegisterHandlerDirective for better external plugin development

### DIFF
--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -107,6 +107,28 @@ func RegisterHandlerDirective(dir string, setupFunc UnmarshalHandlerFunc) {
 	})
 }
 
+// RegisterHandlerDirectiveWithOrder is like RegisterHandlerDirective, but
+// adding dir param to directive order list after the specified insertAfterDirective
+func RegisterHandlerDirectiveWithOrder(dir string, setupFunc UnmarshalHandlerFunc, insertAfterDirective string) {
+	RegisterHandlerDirective(dir, setupFunc)
+	if insertAfterDirective == "" {
+		directiveOrder = append(directiveOrder, dir)
+	} else {
+		var indexOfAfter = -1
+		for i, directive := range directiveOrder {
+			if directive == insertAfterDirective {
+				indexOfAfter = i
+				break
+			}
+		}
+		if indexOfAfter == -1 {
+			directiveOrder = append(directiveOrder, dir)
+		} else {
+			directiveOrder = append(directiveOrder[:indexOfAfter+1], append([]string{dir}, directiveOrder[indexOfAfter+1:]...)...)
+		}
+	}
+}
+
 // Helper is a type which helps setup a value from
 // Caddyfile tokens.
 type Helper struct {


### PR DESCRIPTION
Currently a http module directive can be registered through RegisterHandlerDirective, but to make the module works there is a need to change directiveOrder slice in directive.go file at caddyconfig package. This approach doesn't work if we use caddy as library and adding extra http module. So with this PR, we can register a module with order!