### PR TITLE
Don't lie: default basicauth hash to bcrypt

### DIFF
--- a/modules/caddyhttp/caddyauth/basicauth.go
+++ b/modules/caddyhttp/caddyauth/basicauth.go
@@ -53,7 +53,7 @@ func (HTTPBasicAuth) CaddyModule() caddy.ModuleInfo {
 // Provision provisions the HTTP basic auth provider.
 func (hba *HTTPBasicAuth) Provision(ctx caddy.Context) error {
 	if hba.HashRaw == nil {
-		return fmt.Errorf("passwords must be hashed, so a hash must be defined")
+		hba.HashRaw = json.RawMessage(`{"algorithm": "bcrypt"}`)
 	}
 
 	// load password hasher


### PR DESCRIPTION
Came across this small inconsistency between docs and implementation. basicauth docs says algorithm defaults to bcrypt, but implementation will raise an error if no hash is specified.