### PR TITLE
v2: debug mode, and 'log' directive for Caddyfile

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -24,8 +24,10 @@ import (
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
+	"go.uber.org/zap/zapcore"
 )
 
 func init() {
@@ -37,6 +39,7 @@ func init() {
 	RegisterHandlerDirective("route", parseRoute)
 	RegisterHandlerDirective("handle", parseSegmentAsSubroute)
 	RegisterDirective("handle_errors", parseHandleErrors)
+	RegisterDirective("log", parseLog)
 }
 
 // parseBind parses the bind directive. Syntax:
@@ -405,4 +408,94 @@ func parseHandleErrors(h Helper) ([]ConfigValue, error) {
 	}, nil
 }
 
-var tagCounter = 0
+// parseLog parses the log directive. Syntax:
+//
+//     log {
+//         output <writer_module> ...
+//         format <encoder_module> ...
+//         level  <level>
+//     }
+//
+func parseLog(h Helper) ([]ConfigValue, error) {
+	var configValues []ConfigValue
+	for h.Next() {
+		cl := new(caddy.CustomLog)
+
+		for h.NextBlock(0) {
+			switch h.Val() {
+			case "output":
+				if !h.NextArg() {
+					return nil, h.ArgErr()
+				}
+				moduleName := h.Val()
+				mod, err := caddy.GetModule("caddy.logging.writers." + moduleName)
+				if err != nil {
+					return nil, h.Errf("getting log writer module named '%s': %v", moduleName, err)
+				}
+				unm, ok := mod.New().(caddyfile.Unmarshaler)
+				if !ok {
+					return nil, h.Errf("log writer module '%s' is not a Caddyfile unmarshaler", mod)
+				}
+				err = unm.UnmarshalCaddyfile(h.NewFromNextSegment())
+				if err != nil {
+					return nil, err
+				}
+				wo, ok := unm.(caddy.WriterOpener)
+				if !ok {
+					return nil, h.Errf("module %s is not a WriterOpener", mod)
+				}
+				cl.WriterRaw = caddyconfig.JSONModuleObject(wo, "output", moduleName, h.warnings)
+
+			case "format":
+				if !h.NextArg() {
+					return nil, h.ArgErr()
+				}
+				moduleName := h.Val()
+				mod, err := caddy.GetModule("caddy.logging.encoders." + moduleName)
+				if err != nil {
+					return nil, h.Errf("getting log encoder module named '%s': %v", moduleName, err)
+				}
+				unm, ok := mod.New().(caddyfile.Unmarshaler)
+				if !ok {
+					return nil, h.Errf("log encoder module '%s' is not a Caddyfile unmarshaler", mod)
+				}
+				err = unm.UnmarshalCaddyfile(h.NewFromNextSegment())
+				if err != nil {
+					return nil, err
+				}
+				enc, ok := unm.(zapcore.Encoder)
+				if !ok {
+					return nil, h.Errf("module %s is not a zapcore.Encoder", mod)
+				}
+				cl.EncoderRaw = caddyconfig.JSONModuleObject(enc, "format", moduleName, h.warnings)
+
+			case "level":
+				if !h.NextArg() {
+					return nil, h.ArgErr()
+				}
+				cl.Level = h.Val()
+				if h.NextArg() {
+					return nil, h.ArgErr()
+				}
+
+			default:
+				return nil, h.Errf("unrecognized subdirective: %s", h.Val())
+			}
+		}
+
+		var val namedCustomLog
+		if !reflect.DeepEqual(cl, new(caddy.CustomLog)) {
+			cl.Include = []string{"http.log.access"}
+			val.name = fmt.Sprintf("log%d", logCounter)
+			val.log = cl
+			logCounter++
+		}
+		configValues = append(configValues, ConfigValue{
+			Class: "custom_log",
+			Value: val,
+		})
+	}
+	return configValues, nil
+}
+
+var tagCounter, logCounter int

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -250,6 +250,35 @@ func (st ServerType) Setup(originalServerBlocks []caddyfile.ServerBlock,
 		}
 	}
 
+	// extract any custom logs, and enforce configured levels
+	var customLogs []namedCustomLog
+	var hasDefaultLog bool
+	for _, sb := range serverBlocks {
+		for _, clVal := range sb.pile["custom_log"] {
+			ncl := clVal.Value.(namedCustomLog)
+			if ncl.name == "" {
+				continue
+			}
+			if ncl.name == "default" {
+				hasDefaultLog = true
+			}
+			if _, ok := options["debug"]; ok && ncl.log.Level == "" {
+				ncl.log.Level = "DEBUG"
+			}
+			customLogs = append(customLogs, ncl)
+		}
+	}
+	if !hasDefaultLog {
+		// if the default log was not customized, ensure we
+		// configure it with any applicable options
+		if _, ok := options["debug"]; ok {
+			customLogs = append(customLogs, namedCustomLog{
+				name: "default",
+				log:  &caddy.CustomLog{Level: "DEBUG"},
+			})
+		}
+	}
+
 	// annnd the top-level config, then we're done!
 	cfg := &caddy.Config{AppsRaw: make(caddy.ModuleMap)}
 	if !reflect.DeepEqual(httpApp, caddyhttp.App{}) {
@@ -266,6 +295,18 @@ func (st ServerType) Setup(originalServerBlocks []caddyfile.ServerBlock,
 	}
 	if adminConfig, ok := options["admin"].(string); ok && adminConfig != "" {
 		cfg.Admin = &caddy.AdminConfig{Listen: adminConfig}
+	}
+	if len(customLogs) > 0 {
+		if cfg.Logging == nil {
+			cfg.Logging = &caddy.Logging{
+				Logs: make(map[string]*caddy.CustomLog),
+			}
+		}
+		for _, ncl := range customLogs {
+			if ncl.name != "" {
+				cfg.Logging.Logs[ncl.name] = ncl.log
+			}
+		}
 	}
 
 	return cfg, warnings, nil
@@ -303,6 +344,8 @@ func (ServerType) evaluateGlobalOptionsBlock(serverBlocks []serverBlock, options
 			val, err = parseOptEmail(disp)
 		case "admin":
 			val, err = parseOptAdmin(disp)
+		case "debug":
+			options["debug"] = true
 		default:
 			return nil, fmt.Errorf("unrecognized parameter name: %s", dir)
 		}
@@ -485,6 +528,25 @@ func (st *ServerType) serversFromPairings(
 				for _, val := range errorSubrouteVals {
 					sr := val.Value.(*caddyhttp.Subroute)
 					srv.Errors.Routes = appendSubrouteToRouteList(srv.Errors.Routes, sr, matcherSetsEnc, p, warnings)
+				}
+			}
+
+			// add log associations
+			for _, cval := range sblock.pile["custom_log"] {
+				ncl := cval.Value.(namedCustomLog)
+				if srv.Logs == nil {
+					srv.Logs = &caddyhttp.ServerLogConfig{
+						LoggerNames: make(map[string]string),
+					}
+				}
+				hosts, err := st.hostsFromServerBlockKeys(sblock.block)
+				if err != nil {
+					return nil, err
+				}
+				for _, h := range hosts {
+					if ncl.name != "" {
+						srv.Logs.LoggerNames[h] = ncl.name
+					}
 				}
 			}
 		}
@@ -906,6 +968,11 @@ func (c counter) nextGroup() string {
 type matcherSetAndTokens struct {
 	matcherSet caddy.ModuleMap
 	tokens     []caddyfile.Token
+}
+
+type namedCustomLog struct {
+	name string
+	log  *caddy.CustomLog
 }
 
 // sbAddrAssocation is a mapping from a list of

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/alecthomas/chroma v0.7.0
 	github.com/andybalholm/brotli v0.0.0-20190821151343-b60f0d972eeb
 	github.com/cenkalti/backoff/v3 v3.1.1 // indirect
-	github.com/dustin/go-humanize v1.0.0
+	github.com/dustin/go-humanize v1.0.1-0.20200219035652-afde56e7acac
 	github.com/go-acme/lego/v3 v3.3.0
 	github.com/golang/groupcache v0.0.0-20191002201903-404acd9df4cc
 	github.com/ilibs/json5 v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/dnaeon/go-vcr v0.0.0-20180814043457-aafff18a5cc2/go.mod h1:aBB1+wY4s9
 github.com/dnsimple/dnsimple-go v0.30.0/go.mod h1:O5TJ0/U6r7AfT8niYNlmohpLbCSG+c71tQlGr9SeGrg=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.1-0.20200219035652-afde56e7acac h1:opbrjaN/L8gg6Xh5D04Tem+8xVcz6ajZlGCs49mQgyg=
+github.com/dustin/go-humanize v1.0.1-0.20200219035652-afde56e7acac/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=

--- a/modules/logging/filewriter.go
+++ b/modules/logging/filewriter.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
@@ -65,6 +66,24 @@ func (FileWriter) CaddyModule() caddy.ModuleInfo {
 		ID:  "caddy.logging.writers.file",
 		New: func() caddy.Module { return new(FileWriter) },
 	}
+}
+
+// UnmarshalCaddyfile sets up the handler from Caddyfile tokens. Syntax:
+//
+//     file <filename>
+//
+// TODO: the rest of the options (log rolling), in a block
+func (fw *FileWriter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		if !d.NextArg() {
+			return d.ArgErr()
+		}
+		fw.Filename = d.Val()
+		if d.NextArg() {
+			return d.ArgErr()
+		}
+	}
+	return nil
 }
 
 // Provision sets up the module
@@ -127,5 +146,7 @@ func (fw FileWriter) OpenWriter() (io.WriteCloser, error) {
 
 // Interface guards
 var (
-	_ caddy.Provisioner = (*FileWriter)(nil)
+	_ caddy.Provisioner     = (*FileWriter)(nil)
+	_ caddy.WriterOpener    = (*FileWriter)(nil)
+	_ caddyfile.Unmarshaler = (*FileWriter)(nil)
 )

--- a/modules/logging/filewriter.go
+++ b/modules/logging/filewriter.go
@@ -19,9 +19,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
+	"time"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/dustin/go-humanize"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
@@ -66,24 +69,6 @@ func (FileWriter) CaddyModule() caddy.ModuleInfo {
 		ID:  "caddy.logging.writers.file",
 		New: func() caddy.Module { return new(FileWriter) },
 	}
-}
-
-// UnmarshalCaddyfile sets up the handler from Caddyfile tokens. Syntax:
-//
-//     file <filename>
-//
-// TODO: the rest of the options (log rolling), in a block
-func (fw *FileWriter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
-	for d.Next() {
-		if !d.NextArg() {
-			return d.ArgErr()
-		}
-		fw.Filename = d.Val()
-		if d.NextArg() {
-			return d.ArgErr()
-		}
-	}
-	return nil
 }
 
 // Provision sets up the module
@@ -142,6 +127,74 @@ func (fw FileWriter) OpenWriter() (io.WriteCloser, error) {
 
 	// otherwise just open a regular file
 	return os.OpenFile(fw.Filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
+}
+
+// UnmarshalCaddyfile sets up the module from Caddyfile tokens. Syntax:
+//
+//     file <filename> {
+//         roll_disabled
+//         roll_size     <size>
+//         roll_keep     <num>
+//         roll_keep_for <days>
+//     }
+//
+// The roll_size value will be rounded down to number of megabytes (MiB).
+// The roll_keep_for duration will be rounded down to number of days.
+func (fw *FileWriter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		if !d.NextArg() {
+			return d.ArgErr()
+		}
+		fw.Filename = d.Val()
+		if d.NextArg() {
+			return d.ArgErr()
+		}
+
+		for d.NextBlock(0) {
+			switch d.Val() {
+			case "roll_disabled":
+				var f bool
+				fw.Roll = &f
+				if d.NextArg() {
+					return d.ArgErr()
+				}
+
+			case "roll_size":
+				var sizeStr string
+				if !d.AllArgs(&sizeStr) {
+					return d.ArgErr()
+				}
+				size, err := humanize.ParseBytes(sizeStr)
+				if err != nil {
+					return d.Errf("parsing size: %v", err)
+				}
+				fw.RollSizeMB = int(size) / 1024 / 1024
+
+			case "roll_keep":
+				var keepStr string
+				if !d.AllArgs(&keepStr) {
+					return d.ArgErr()
+				}
+				keep, err := strconv.Atoi(keepStr)
+				if err != nil {
+					return d.Errf("parsing roll_keep number: %v", err)
+				}
+				fw.RollKeep = keep
+
+			case "roll_keep_for":
+				var keepForStr string
+				if !d.AllArgs(&keepForStr) {
+					return d.ArgErr()
+				}
+				keepFor, err := time.ParseDuration(keepForStr)
+				if err != nil {
+					return d.Errf("parsing roll_keep_for duration: %v", err)
+				}
+				fw.RollKeepDays = int(keepFor.Hours()) / 24
+			}
+		}
+	}
+	return nil
 }
 
 // Interface guards

--- a/modules/logging/netwriter.go
+++ b/modules/logging/netwriter.go
@@ -20,6 +20,7 @@ import (
 	"net"
 
 	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
 func init() {
@@ -75,8 +76,26 @@ func (nw NetWriter) OpenWriter() (io.WriteCloser, error) {
 	return net.Dial(nw.addr.Network, nw.addr.JoinHostPort(0))
 }
 
+// UnmarshalCaddyfile sets up the handler from Caddyfile tokens. Syntax:
+//
+//     net <address>
+//
+func (nw *NetWriter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		if !d.NextArg() {
+			return d.ArgErr()
+		}
+		nw.Address = d.Val()
+		if d.NextArg() {
+			return d.ArgErr()
+		}
+	}
+	return nil
+}
+
 // Interface guards
 var (
-	_ caddy.Provisioner  = (*NetWriter)(nil)
-	_ caddy.WriterOpener = (*NetWriter)(nil)
+	_ caddy.Provisioner     = (*NetWriter)(nil)
+	_ caddy.WriterOpener    = (*NetWriter)(nil)
+	_ caddyfile.Unmarshaler = (*NetWriter)(nil)
 )

--- a/replacer.go
+++ b/replacer.go
@@ -148,11 +148,10 @@ func (r *Replacer) replace(input, empty string,
 			if errOnUnknown {
 				return "", fmt.Errorf("unrecognized placeholder %s%s%s",
 					string(phOpen), key, string(phClose))
-			} else if treatUnknownAsEmpty {
-				if empty != "" {
-					sb.WriteString(empty)
-				}
-			} else {
+			} else if !treatUnknownAsEmpty {
+				// if treatUnknownAsEmpty is true, we'll
+				// handle an empty val later; so only
+				// continue otherwise
 				lastWriteCursor = i
 				continue
 			}

--- a/replacer_test.go
+++ b/replacer_test.go
@@ -67,6 +67,11 @@ func TestReplacer(t *testing.T) {
 			input:  `{{}`,
 			expect: "",
 		},
+		{
+			input:  `{unknown}`,
+			empty:  "-",
+			expect: "-",
+		},
 	} {
 		actual := rep.ReplaceAll(tc.input, tc.empty)
 		if actual != tc.expect {


### PR DESCRIPTION
This change exposes more to the Caddyfile:

- A global option `debug` that enables debug mode, which for right now simply means to set all log levels to DEBUG
- A `log` directive for the HTTP Caddyfile, which enables customizable access logging

Syntax:

```
log {
    output <writer_module> ...
    format <encoder_module> ...
    level  <level>
}
```

I still need to make the various log writer and encoder modules implement `UnmarshalCaddyfile`; for now, though, `FileWriter` at least lets you specify a filename in the Caddyfile:

```
log {
    output file /var/log/access.log
}
```

The most basic way to enable an access log is:

```
log
```

And to enable debug mode, use a global option:

```
{
    debug
}
```

Still lots of open questions, such as what the default format should be -- these and other details can be worked out a little later, but for now I just want to get this PR done. Please test it!