### PR TITLE
Add handler for unhandled errors in errorChain

### DIFF
--- a/modules/caddyhttp/caddyhttp.go
+++ b/modules/caddyhttp/caddyhttp.go
@@ -419,11 +419,11 @@ var emptyHandler Handler = HandlerFunc(func(http.ResponseWriter, *http.Request) 
 // Error chain does not actually handle the error (for instance, it matches only
 // on some errors). See #3053
 var errorEmptyHandler Handler = HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-	http_error := r.Context().Value(ErrorCtxKey)
-	if handler_err, ok := http_error.(HandlerError); ok {
-		w.WriteHeader(handler_err.StatusCode)
+	httpError := r.Context().Value(ErrorCtxKey)
+	if handlerError, ok := httpError.(HandlerError); ok {
+		w.WriteHeader(handlerError.StatusCode)
 	} else {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 	}
 	return nil
 })

--- a/modules/caddyhttp/caddyhttp.go
+++ b/modules/caddyhttp/caddyhttp.go
@@ -186,20 +186,7 @@ func (app *App) Provision(ctx caddy.Context) error {
 				return fmt.Errorf("server %s: setting up server error handling routes: %v", srvName, err)
 			}
 
-			// Add an implicit suffix middleware that, if reached, sets the
-			// StatusCode to the error stored in the ErrorCtxKey. This is to
-			// prevent situations where the Error chain does not actually handle
-			// the error (for instance, it matches only on some errors). See
-			// #3053
-			srv.errorHandlerChain = srv.Errors.Routes.Compile(HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-				http_error := r.Context().Value(ErrorCtxKey)
-				if handler_err, ok := http_error.(HandlerError); ok {
-					w.WriteHeader(handler_err.StatusCode)
-				} else {
-					w.WriteHeader(500)
-				}
-				return nil
-			}))
+			srv.errorHandlerChain = srv.Errors.Routes.Compile(errorEmptyHandler)
 		}
 	}
 
@@ -426,6 +413,20 @@ type MiddlewareHandler interface {
 
 // emptyHandler is used as a no-op handler.
 var emptyHandler Handler = HandlerFunc(func(http.ResponseWriter, *http.Request) error { return nil })
+
+// An implicit suffix middleware that, if reached, sets the StatusCode to the
+// error stored in the ErrorCtxKey. This is to prevent situations where the
+// Error chain does not actually handle the error (for instance, it matches only
+// on some errors). See #3053
+var errorEmptyHandler Handler = HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+	http_error := r.Context().Value(ErrorCtxKey)
+	if handler_err, ok := http_error.(HandlerError); ok {
+		w.WriteHeader(handler_err.StatusCode)
+	} else {
+		w.WriteHeader(500)
+	}
+	return nil
+})
 
 // WeakString is a type that unmarshals any JSON value
 // as a string literal, with the following exceptions:


### PR DESCRIPTION
Currently, when an error chain is defined, the default error handler is bypassed entirely - even if the error chain doesn't handle every error. This may result in pages returning a blank 200 OK page instead of the error status defined by the error.

For instance, it's possible for an error chain to match on the error status code and only handle a certain subtype of errors (like 403s). In this case, we'd want any other errors to still go through the default handler and return an empty page with the status code.

This PR changes the "suffix handler" passed to errorChain.Compile toset the status code of the response to the error status code.

Fixes #3053