### PR TITLE
Update README.md

### DIFF
--- a/dist/init/mac-launchd/README.md
+++ b/dist/init/mac-launchd/README.md
@@ -12,8 +12,8 @@ To create the proper directories as used in the example file:
 ```bash
 sudo mkdir -p /etc/caddy /etc/ssl/caddy /var/log/caddy /usr/local/bin /var/tmp /srv/www/localhost
 sudo touch /etc/caddy/Caddyfile
-sudo chown root:wheel -R /usr/local/bin/caddy /Library/LaunchDaemons/
-sudo chown _www:_www -R /etc/caddy /etc/ssl/caddy /var/log/caddy
+sudo chown root:wheel /usr/local/bin/caddy /Library/LaunchDaemons/
+sudo chown _www:_www /etc/caddy /etc/ssl/caddy /var/log/caddy
 sudo chmod 0750 /etc/ssl/caddy
 ```
 
@@ -36,7 +36,13 @@ launchctl unload /Library/LaunchDaemons/com.caddyserver.web.plist
 To start on every boot use the `-w` flag (to write):
 
 ```bash
-launchctl load -w /Library/LaunchAgents/com.caddyserver.web.plist
+launchctl load -w /Library/LaunchDaemons/com.caddyserver.web.plist
+```
+
+To start the service now:
+
+```bash
+launchctl start -w /Library/LaunchDaemons/com.caddyserver.web.plist
 ```
 
 More information can be found in this blogpost: [Running Caddy as a service on macOS X server](https://denbeke.be/blog/software/running-caddy-as-a-service-on-macos-os-x-server/)


### PR DESCRIPTION
removing `-R` because of this error in MacOS `chown: -R: No such file or directory`