### PR TITLE
Add insecure_disable_sni_matching directive to tls

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -292,13 +292,6 @@ func (h *httpContext) MakeServers() ([]caddy.Server, error) {
 			if QUIC {
 				return nil, fmt.Errorf("cannot enable TLS client authentication with QUIC, because QUIC does not yet support it")
 			}
-			// this must be false so that a client cannot connect
-			// using SNI for another site on this listener that
-			// does NOT require ClientAuth, and then send HTTP
-			// requests with the Host header of this site which DOES
-			// require client auth, thus bypassing it.
-			// if set to true via `insecure_disable_sni_matching` directive, the behaviour above is allowed
-			cfg.TLS.InsecureDisableSNIMatching = false
 		}
 	}
 

--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -251,9 +251,9 @@ func (h *httpContext) MakeServers() ([]caddy.Server, error) {
 	// 2) if QUIC is enabled, TLS ClientAuth is not, because
 	//    currently, QUIC does not support ClientAuth (TODO:
 	//    revisit this when our QUIC implementation supports it)
-	// 3) if TLS ClientAuth is used and there is more than 1 server instance, StrictHostMatching is on
+	// 3) if TLS ClientAuth is used and InsecureDisableSNIMatching is not set, Strict SNI and HTTP request Host header matching is enforced
 	var atLeastOneSiteLooksLikeProduction bool
-	for cfgIndex, cfg := range h.siteConfigs {
+	for _, cfg := range h.siteConfigs {
 		// see if all the addresses (both sites and
 		// listeners) are loopback to help us determine
 		// if this is a "production" instance or not
@@ -292,15 +292,13 @@ func (h *httpContext) MakeServers() ([]caddy.Server, error) {
 			if QUIC {
 				return nil, fmt.Errorf("cannot enable TLS client authentication with QUIC, because QUIC does not yet support it")
 			}
-			// this must be enabled for configs with more than 1 server instance
-			// so that a client cannot connect 
+			// this must be false so that a client cannot connect
 			// using SNI for another site on this listener that
 			// does NOT require ClientAuth, and then send HTTP
 			// requests with the Host header of this site which DOES
-			// require client auth, thus bypassing it...
-			if cfgIndex > 0 {				
-				cfg.StrictHostMatching = true
-			}
+			// require client auth, thus bypassing it.
+			// if set to true via `insecure_disable_sni_matching` directive, the behaviour above is allowed
+			cfg.TLS.InsecureDisableSNIMatching = false
 		}
 	}
 

--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -251,7 +251,6 @@ func (h *httpContext) MakeServers() ([]caddy.Server, error) {
 	// 2) if QUIC is enabled, TLS ClientAuth is not, because
 	//    currently, QUIC does not support ClientAuth (TODO:
 	//    revisit this when our QUIC implementation supports it)
-	// 3) if TLS ClientAuth is used and InsecureDisableSNIMatching is not set, Strict SNI and HTTP request Host header matching is enforced
 	var atLeastOneSiteLooksLikeProduction bool
 	for _, cfg := range h.siteConfigs {
 		// see if all the addresses (both sites and

--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -442,6 +442,7 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 		r.URL = trimPathPrefix(r.URL, pathPrefix)
 	}
 
+	// if not disabled via `insecure_disable_sni_matching`
 	// enforce strict host matching, which ensures that the SNI
 	// value (if any), matches the Host header; essential for
 	// sites that rely on TLS ClientAuth sharing a port with

--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -446,7 +446,7 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 	// value (if any), matches the Host header; essential for
 	// sites that rely on TLS ClientAuth sharing a port with
 	// sites that do not - if mismatched, close the connection
-	if vhost.StrictHostMatching && r.TLS != nil &&
+	if !vhost.TLS.InsecureDisableSNIMatching && r.TLS != nil &&
 		strings.ToLower(r.TLS.ServerName) != strings.ToLower(hostname) {
 		r.Close = true
 		log.Printf("[ERROR] %s - strict host matching: SNI (%s) and HTTP Host (%s) values differ",

--- a/caddyhttp/httpserver/siteconfig.go
+++ b/caddyhttp/httpserver/siteconfig.go
@@ -36,16 +36,6 @@ type SiteConfig struct {
 	// TLS configuration
 	TLS *caddytls.Config
 
-	// If true, the Host header in the HTTP request must
-	// match the SNI value in the TLS handshake (if any).
-	// This should be enabled whenever a site relies on
-	// TLS client authentication, for example; or any time
-	// you want to enforce that THIS site's TLS config
-	// is used and not the TLS config of any other site
-	// on the same listener. TODO: Check how relevant this
-	// is with TLS 1.3.
-	StrictHostMatching bool
-
 	// Uncompiled middleware stack
 	middleware []Middleware
 

--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -62,6 +62,18 @@ type Config struct {
 	// client authentication is enabled
 	ClientCerts []string
 
+	// Allow mismatched TLS SNI and Host header when using TLS client authentication
+	// If false (the default), the Host header in the HTTP request must
+	// match the SNI value in the TLS handshake (if any).
+	// This should be enabled whenever the TLS SNI and Host header
+	// in the HTTP request can be different, for example when doing mTLS with multiple servers
+	// and the upstream addresses do not match the HTTP request Host header.
+	// If a site relies on TLS client authentication or any time you want to enforce that THIS site's TLS config
+	// is used and not the TLS config of any other site
+	// on the same listener, set this to false.
+	// TODO: Check how relevant this is with TLS 1.3.
+	InsecureDisableSNIMatching bool
+
 	// Manual means user provides own certs and keys
 	Manual bool
 

--- a/caddytls/setup.go
+++ b/caddytls/setup.go
@@ -222,6 +222,8 @@ func setupTLS(c *caddy.Controller) error {
 				}
 
 				config.ClientCerts = clientCertList[listStart:]
+			case "insecure_disable_sni_matching":
+				config.InsecureDisableSNIMatching = true
 			case "load":
 				c.Args(&loadDir)
 				config.Manual = true


### PR DESCRIPTION
~~This basically disables `StrictHostMatching` for Caddy with single server configurations and TLS Client auth enabled.~~

~~Since its a single server configuration, the concerns about someone being able to bypass the TLS Client Auth by connecting to another server running without TLS Client auth and using the `Host` header is not applicable anymore.~~

This PR adds a new `insecure_disable_sni_matching` subdirective to the `tls` directive and it will disable the default behaviour of caddy denying a TLS client authenticated connection using a mismatched TLS SNI and `Host` request header