### PR TITLE
Make comment more readable about caddy ModuleID's Name() method.

### DIFF
--- a/modules.go
+++ b/modules.go
@@ -101,7 +101,7 @@ func (id ModuleID) Namespace() string {
 	return string(id)[:lastDot]
 }
 
-// Name returns the Name (last element) of a module name.
+// Name returns the Name (last element) of a module ID.
 func (id ModuleID) Name() string {
 	if id == "" {
 		return ""


### PR DESCRIPTION
fix #3079 