### PR TITLE
v2: expand environment variables within caddy files

### DIFF
--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -64,7 +64,7 @@ func replaceEnvVars(input []byte) ([]byte, error) {
 		}
 
 		// get the value of the environment variable
-		envVarValue := []byte(os.Getenv(string(envVarName)))
+		envVarValue := []byte(os.ExpandEnv(os.Getenv(string(envVarName))))
 
 		// splice in the value
 		input = append(input[:begin],


### PR DESCRIPTION
Small expansion to the work done in https://github.com/caddyserver/caddy/pull/2963 which simply calls `os.ExpandEnv` so env vars like `{$URL}` where `$URL=$SCHEME://$HOST:$PORT` (contrived) get the expanded $SCHEME, $HOST, and $PORT variables included