### PR TITLE
ci: improve CI flow

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,7 @@ variables:
   GOPATH: $(system.defaultWorkingDirectory)/gopath
   GOBIN:  $(GOPATH)/bin
   modulePath: '$(GOPATH)/src/github.com/$(build.repository.name)'
+  GO111MODULE: on
 
 jobs:
 - job: crossPlatformTest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,8 +17,6 @@ variables:
   GOPATH: $(system.defaultWorkingDirectory)/gopath
   GOBIN:  $(GOPATH)/bin
   modulePath: '$(GOPATH)/src/github.com/$(build.repository.name)'
-  # TODO: Remove once it's enabled by default
-  GO111MODULE: on
 
 jobs:
 - job: crossPlatformTest
@@ -78,7 +76,7 @@ jobs:
     condition: eq( variables['Agent.OS'], 'Windows_NT' )
     displayName: Install Go on Windows
 
-  - bash: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.22.2
+  - bash: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.6
     displayName: Install golangci-lint
 
   - script: |
@@ -99,8 +97,12 @@ jobs:
   - script: |
       go get -v -t -d ./...
       mkdir test-results
-    workingDirectory: '$(modulePath)'
+    workingDirectory: '$(modulePath)/cmd/caddy'
     displayName: Get dependencies
+
+  - bash: go build -v
+    workingDirectory: '$(modulePath)'
+    displayName: Build Caddy packages
 
   # its behavior is governed by .golangci.yml
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,6 @@ variables:
   GOPATH: $(system.defaultWorkingDirectory)/gopath
   GOBIN:  $(GOPATH)/bin
   modulePath: '$(GOPATH)/src/github.com/$(build.repository.name)'
-  GO111MODULE: on
 
 jobs:
 - job: crossPlatformTest
@@ -28,7 +27,7 @@ jobs:
         imageName: ubuntu-16.04
         gorootDir: /usr/local
       mac:
-        imageName: macos-10.13
+        imageName: macos-10.14
         gorootDir: /usr/local
       windows:
         imageName: windows-2019
@@ -98,12 +97,12 @@ jobs:
   - script: |
       go get -v -t -d ./...
       mkdir test-results
-    workingDirectory: '$(modulePath)/cmd/caddy'
+    workingDirectory: '$(modulePath)'
     displayName: Get dependencies
 
   - bash: go build -v
-    workingDirectory: '$(modulePath)'
-    displayName: Build Caddy packages
+    workingDirectory: '$(modulePath)/cmd/caddy'
+    displayName: Build Caddy
 
   # its behavior is governed by .golangci.yml
   - script: |


### PR DESCRIPTION
The recent experience in #3047 shows a pain point in the CI flow where logs of build errors aren't easily accessible. This PR attempts to address it. It updates a few other things on the way.