### PR TITLE
Only enforces SNI matching if ClientAuth is enabled

### DIFF
--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -448,6 +448,7 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 	// sites that rely on TLS ClientAuth sharing a port with
 	// sites that do not - if mismatched, close the connection
 	if !vhost.TLS.InsecureDisableSNIMatching && r.TLS != nil &&
+		vhost.TLS.ClientAuth != tls.NoClientCert &&
 		strings.ToLower(r.TLS.ServerName) != strings.ToLower(hostname) {
 		r.Close = true
 		log.Printf("[ERROR] %s - strict host matching: SNI (%s) and HTTP Host (%s) values differ",


### PR DESCRIPTION
This PR fixes an issue introduced by #3075 (sorry about that) where SNI matching was being applied globally even if ClientAuth was not being used and causing all websites listening in a TLS port to fail randomly with status `403 Forbidden`

We now enforce SNI Host matching will happen only if ClientAuth is enabled and only if `insecure_disable_sni_matching` is *NOT* set.