### PR TITLE
fmt: Add support for block nesting.

### DIFF
--- a/caddyconfig/caddyfile/formatter.go
+++ b/caddyconfig/caddyfile/formatter.go
@@ -29,11 +29,12 @@ func Format(body []byte) []byte {
 		commented,
 		quoted,
 		escaped,
-		block,
 		environ,
 		lineBegin bool
 
 		firstIteration = true
+
+		indentation = 0
 
 		prev,
 		curr,
@@ -93,13 +94,13 @@ func Format(body []byte) []byte {
 			if curr == '}' {
 				if environ {
 					environ = false
-				} else if block {
-					block = false
+				} else if indentation > 0 {
+					indentation--
 				}
 			}
 			if curr == '{' {
 				if unicode.IsSpace(next) {
-					block = true
+					indentation++
 
 					if !unicode.IsSpace(prev) {
 						result.WriteRune(' ')
@@ -113,8 +114,10 @@ func Format(body []byte) []byte {
 					continue
 				} else {
 					lineBegin = false
-					if block {
-						result.WriteRune('\t')
+					if indentation > 0 {
+						for tabs := indentation; tabs > 0; tabs-- {
+							result.WriteRune('\t')
+						}
 					}
 				}
 			} else {

--- a/caddyconfig/caddyfile/formatter_test.go
+++ b/caddyconfig/caddyfile/formatter_test.go
@@ -29,6 +29,22 @@ b
 
 e { f
 }
+
+g {
+h {
+i
+}
+}
+
+j { k {
+l
+}
+}
+
+m {
+	n { o
+	}
+}
 `)
 	expected := []byte(`
 a
@@ -40,6 +56,24 @@ c {
 
 e {
 	f
+}
+
+g {
+	h {
+		i
+	}
+}
+
+j {
+	k {
+		l
+	}
+}
+
+m {
+	n {
+		o
+	}
 }
 `)
 	testFormat(t, input, expected)


### PR DESCRIPTION
Previously the formatter did not include support for
blocks inside other blocks. Hence the formatter could
not indent some files properly. This fixes it.

Fixes #3104 