### PR TITLE
remove the certificate tag tracking from global state

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -524,10 +524,12 @@ func parseLog(h Helper) ([]ConfigValue, error) {
 
 		var val namedCustomLog
 		if !reflect.DeepEqual(cl, new(caddy.CustomLog)) {
+			logCounter := h.state["logCounter"].(int)
 			cl.Include = []string{"http.log.access"}
 			val.name = fmt.Sprintf("log%d", logCounter)
 			val.log = cl
 			logCounter++
+			h.state["logCounter"] = logCounter
 		}
 		configValues = append(configValues, ConfigValue{
 			Class: "custom_log",
@@ -536,5 +538,3 @@ func parseLog(h Helper) ([]ConfigValue, error) {
 	}
 	return configValues, nil
 }
-
-var logCounter int

--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -152,6 +152,9 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 			// policy that is looking for any tag but the last one to be
 			// loaded won't find it, and TLS handshakes will fail (see end)
 			// of issue #3004)
+
+			tlsCertTags := h.state["tlsCertTags"].(map[string]string)
+
 			tag, ok := tlsCertTags[certFilename]
 			if !ok {
 				// haven't seen this cert file yet, let's give it a tag
@@ -533,12 +536,5 @@ func parseLog(h Helper) ([]ConfigValue, error) {
 	}
 	return configValues, nil
 }
-
-// tlsCertTags maps certificate filenames to their tag.
-// This is used to remember which tag is used for each
-// certificate files, since we need to avoid loading
-// the same certificate files more than once, overwriting
-// previous tags
-var tlsCertTags = make(map[string]string)
 
 var logCounter int

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -119,6 +119,7 @@ type Helper struct {
 	matcherDefs  map[string]caddy.ModuleMap
 	parentBlock  caddyfile.ServerBlock
 	groupCounter counter
+	state        map[string]interface{}
 }
 
 // Option gets the option keyed by name.

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -114,12 +114,13 @@ func RegisterHandlerDirective(dir string, setupFunc UnmarshalHandlerFunc) {
 // Caddyfile tokens.
 type Helper struct {
 	*caddyfile.Dispenser
+	// State stores intermediate variables during caddyfile adaptation.
+	State        map[string]interface{}
 	options      map[string]interface{}
 	warnings     *[]caddyconfig.Warning
 	matcherDefs  map[string]caddy.ModuleMap
 	parentBlock  caddyfile.ServerBlock
 	groupCounter counter
-	State        map[string]interface{}
 }
 
 // Option gets the option keyed by name.

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -119,7 +119,7 @@ type Helper struct {
 	matcherDefs  map[string]caddy.ModuleMap
 	parentBlock  caddyfile.ServerBlock
 	groupCounter counter
-	state        map[string]interface{}
+	State        map[string]interface{}
 }
 
 // Option gets the option keyed by name.

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -43,6 +43,13 @@ func (st ServerType) Setup(originalServerBlocks []caddyfile.ServerBlock,
 	var warnings []caddyconfig.Warning
 	gc := counter{new(int)}
 
+	// tlsCertTags maps certificate filenames to their tag.
+	// This is used to remember which tag is used for each
+	// certificate files, since we need to avoid loading
+	// the same certificate files more than once, overwriting
+	// previous tags
+	var tlsCertTags = make(map[string]string)
+
 	// load all the server blocks and associate them with a "pile"
 	// of config values; also prohibit duplicate keys because they
 	// can make a config confusing if more than one server block is
@@ -133,14 +140,19 @@ func (st ServerType) Setup(originalServerBlocks []caddyfile.ServerBlock,
 				return nil, warnings, fmt.Errorf("%s:%d: unrecognized directive: %s", tkn.File, tkn.Line, dir)
 			}
 
-			results, err := dirFunc(Helper{
+			h := Helper{
 				Dispenser:    caddyfile.NewDispenser(segment),
 				options:      options,
 				warnings:     &warnings,
 				matcherDefs:  matcherDefs,
 				parentBlock:  sb.block,
 				groupCounter: gc,
-			})
+				state:        make(map[string]interface{}),
+			}
+			h.state["tlsCertTags"] = tlsCertTags
+
+			results, err := dirFunc(h)
+
 			if err != nil {
 				return nil, warnings, fmt.Errorf("parsing caddyfile tokens for '%s': %v", dir, err)
 			}

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -43,12 +43,15 @@ func (st ServerType) Setup(originalServerBlocks []caddyfile.ServerBlock,
 	var warnings []caddyconfig.Warning
 	gc := counter{new(int)}
 
+	state := make(map[string]interface{})
 	// tlsCertTags maps certificate filenames to their tag.
 	// This is used to remember which tag is used for each
 	// certificate files, since we need to avoid loading
 	// the same certificate files more than once, overwriting
 	// previous tags
-	var tlsCertTags = make(map[string]string)
+	state["tlsCertTags"] = make(map[string]string)
+	// this tracks the logCounter across all servers
+	state["logCounter"] = 0
 
 	// load all the server blocks and associate them with a "pile"
 	// of config values; also prohibit duplicate keys because they
@@ -147,12 +150,10 @@ func (st ServerType) Setup(originalServerBlocks []caddyfile.ServerBlock,
 				matcherDefs:  matcherDefs,
 				parentBlock:  sb.block,
 				groupCounter: gc,
-				state:        make(map[string]interface{}),
+				state:        state,
 			}
-			h.state["tlsCertTags"] = tlsCertTags
 
 			results, err := dirFunc(h)
-
 			if err != nil {
 				return nil, warnings, fmt.Errorf("parsing caddyfile tokens for '%s': %v", dir, err)
 			}

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -42,16 +42,7 @@ func (st ServerType) Setup(originalServerBlocks []caddyfile.ServerBlock,
 	options map[string]interface{}) (*caddy.Config, []caddyconfig.Warning, error) {
 	var warnings []caddyconfig.Warning
 	gc := counter{new(int)}
-
 	state := make(map[string]interface{})
-	// tlsCertTags maps certificate filenames to their tag.
-	// This is used to remember which tag is used for each
-	// certificate files, since we need to avoid loading
-	// the same certificate files more than once, overwriting
-	// previous tags
-	state["tlsCertTags"] = make(map[string]string)
-	// this tracks the logCounter across all servers
-	state["logCounter"] = 0
 
 	// load all the server blocks and associate them with a "pile"
 	// of config values; also prohibit duplicate keys because they
@@ -150,7 +141,7 @@ func (st ServerType) Setup(originalServerBlocks []caddyfile.ServerBlock,
 				matcherDefs:  matcherDefs,
 				parentBlock:  sb.block,
 				groupCounter: gc,
-				state:        state,
+				State:        state,
 			}
 
 			results, err := dirFunc(h)


### PR DESCRIPTION
Remove the tag tracking from global state. This better supports reloading configuration via the admin reload function.

@mholt thoughts about the `logCounter` it will mutate the log files unnecessarily I think https://github.com/caddyserver/caddy/pull/3111/files#diff-3235e86b75f6440c822f6d7d8f4beb61R540