### PR TITLE
[v2] Add build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ This is the development branch for Caddy 2, the web server of the Go community.
 ### Menu
 
 - [Build from source](#build-from-source)
-	- [For development](#for-development)
-	- [With version information and/or plugins](#with-version-information-andor-plugins)
+	- [With the build script](#with-the-build-script)
+	- [Custom with plugins](#custom-with-plugins)
 - [Getting started](#getting-started)
 - [Overview](#overview)
 - [Full documentation](#full-documentation)
@@ -53,17 +53,34 @@ Requirements:
 - [Go 1.14 or newer](https://golang.org/dl/)
 - Do NOT disable [Go modules](https://github.com/golang/go/wiki/Modules) (`export GO111MODULE=on`)
 
-### For development
+### With the build script
 
-_**Note:** These steps [will not embed proper version information](https://github.com/golang/go/issues/29228). For that, please follow the instructions below._
- 
+The Caddy source comes with a build script that will embed the proper version information into the Caddy binary.
+
+**Download the `v2` source code:**
+
 ```bash
 $ git clone -b v2 "https://github.com/caddyserver/caddy.git"
-$ cd caddy/cmd/caddy/
-$ go build
 ```
 
-### With version information and/or plugins
+**Build:**
+
+```bash
+$ caddy/build.sh [<destination>] [<version>]
+```
+
+- `<destination>` is the optional destination path for the `caddy` binary (including the filename).
+	If not given, it will default to a file named `caddy` in the current directory.
+- `<version>` is the Caddy version (Git tag or commit SHA) you want to build.
+	If not given, the build script will try to autodetect the version from the Git repository. Otherwise it will build a `(devel)` build without embedded version information.
+
+**Example:**
+
+```bash
+$ caddy/build.sh /usr/local/bin/caddy
+```
+
+### Custom with plugins
 
 1. Create a new folder: `mkdir caddy`
 2. Change into it: `cd caddy`

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# ------------------------------------------
+# Caddy 2 build script
+#
+# Builds Caddy 2 from source with the
+# proper embedded version information
+#
+# Optional arguments:
+#  $destination Path to the resulting binary
+#               (default: "./caddy")
+#  $version     Version to build
+#               (default: autodetected)
+# ------------------------------------------
+
+destination="${1:-./caddy}"
+version="$2"
+
+# resolve the destination to its actual absolute path
+destination="$(cd "${destination%/*}" && echo "$PWD/${destination##*/}")"
+
+if [[ -d "$destination" ]]; then
+	echo -e "\033[1m🚫  Destination $destination is a directory,"
+	echo -e "   please pass the full path to the destination file.\033[0m"
+	exit 1
+fi
+
+# our working directory is always the
+# cmd/caddy directory inside the repo
+buildPath="$(dirname "$0")/cmd/caddy"
+echo -e "\033[1m🛠  cd $buildPath\033[0m"
+cd "$buildPath"
+
+# try to determine the version from the Git repo if not given
+if [[ -z "$version" ]]; then
+	if tagVersion="$(git describe --exact-match HEAD 2>/dev/null)"; then
+		version="$tagVersion"
+
+		echo -e "\033[1m📍  Detected Caddy version as $tagVersion (tag)\033[0m"
+	elif commitVersion="$(git rev-parse --short HEAD 2>/dev/null)"; then
+		version="$commitVersion"
+
+		echo -e "\033[1m📍  Detected Caddy version as $commitVersion (commit)\033[0m"
+	else
+		echo -e "\033[1m⚠️  Could not autodetect Caddy version, the binary won't have embedded version information."
+	fi
+fi
+
+# exit on error of any of the following commands
+set -e
+
+# if we (now) have a version, initialize a Go module and fetch the correct version
+if [[ -n "$version" ]]; then
+	if [[ ! -e "go.mod" ]]; then
+		echo -e "\033[1m🛠  go mod init caddy\033[0m"
+		go mod init caddy
+	fi
+
+	echo -e "\033[1m🛠  go get \"github.com/caddyserver/caddy/v2@$version\"\033[0m"
+	go get "github.com/caddyserver/caddy/v2@$version"
+fi
+
+# actual build
+echo -e "\033[1m🛠  go build -o \"$destination\"\033[0m"
+go build -o "$destination"
+
+# cleanup
+if [[ -n "$version" ]]; then
+	echo -e "\033[1m🛠  rm go.mod go.sum\033[0m"
+	rm go.mod go.sum
+fi
+
+echo -e "\033[1m🏁  $destination version\033[0m"
+"$destination" version


### PR DESCRIPTION
As discussed in the [forum](https://caddy.community/t/v2-build-from-source-with-version-info-without-go-get/7132/16?u=lukas), here's the implementation of a simple but versatile build script that will also be useful for users who want to build Caddy 2 from source themselves.

I've decided to add it to the core repo as that reduces the complexity of the build instructions in the README. If that's not acceptable for you, please let me know.

I'm confident we will be able to ship a Homebrew formula using the script and it may also be useful for other packagers.