### PR TITLE
ci: better published executables

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,7 +100,7 @@ jobs:
     workingDirectory: '$(modulePath)'
     displayName: Get dependencies
 
-  - bash: go build -v
+  - bash: CGO_ENABLED=0 go build -trimpath -a -ldflags="-w -s" -v
     workingDirectory: '$(modulePath)/cmd/caddy'
     displayName: Build Caddy
 


### PR DESCRIPTION
Build the published executables with CGO disabled, stripped, and with `-trimpath` for more reproducible build.

Any thoughts on publishing checksum alongside the executables?