### PR TITLE
v2: http_ntlm: fix panic due to unintialized embedded field

### DIFF
--- a/modules/caddyhttp/reverseproxy/ntlm.go
+++ b/modules/caddyhttp/reverseproxy/ntlm.go
@@ -60,8 +60,12 @@ type NTLMTransport struct {
 // CaddyModule returns the Caddy module information.
 func (NTLMTransport) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		ID:  "http.reverse_proxy.transport.http_ntlm",
-		New: func() caddy.Module { return new(NTLMTransport) },
+		ID: "http.reverse_proxy.transport.http_ntlm",
+		New: func() caddy.Module {
+			m := new(NTLMTransport)
+			m.HTTPTransport = new(HTTPTransport)
+			return m
+		},
 	}
 }
 


### PR DESCRIPTION
Initially reported in the forum: https://caddy.community/t/http-ntlm-option-resulting-in-runtime-error/7155/3

Fixes #3119 