### PR TITLE
caddyhttp: Fix terms error by provisioning new ACMEIssuer

### DIFF
--- a/modules/caddyhttp/autohttps.go
+++ b/modules/caddyhttp/autohttps.go
@@ -394,6 +394,7 @@ func (app *App) createAutomationPolicy(ctx caddy.Context) error {
 	if acmeIssuer.Challenges.HTTP.AlternatePort == 0 {
 		// don't overwrite existing explicit config
 		acmeIssuer.Challenges.HTTP.AlternatePort = app.HTTPPort
+		acmeIssuer.Provision(ctx)
 	}
 	if acmeIssuer.Challenges.TLSALPN == nil {
 		acmeIssuer.Challenges.TLSALPN = new(caddytls.TLSALPNChallengeConfig)


### PR DESCRIPTION
This is an attempt to fix the `must agree to terms of service` error that originated in discussion [here](https://github.com/caddyserver/caddy/pull/3128#issuecomment-596708316). Somehow we were attempting ACME requests without first agreeing to the terms (at least as far as the ACME server knew).

This commit spawned from instructions in this comment https://github.com/caddyserver/caddy/pull/3128#issuecomment-596807622 however are likely not a proper fix.

While it appeared that the change had solved everything, it seemed more likely that while jumping about older commits, `go build`ing and restarting caddy, the certificates were provisioned successfully thus making it so I no longer had the `must agree to terms of service` error, fix or not.

I suspect that perhaps deleting my certificates would allow me to test again, but I'll refer to @mholt's judgement before attempting that.

Also be aware that it's quite late here, so I'm going to pop off now, but will be back in the morning :)