### PR TITLE
Fix #3130: Crash at fuzzing target replacer

### DIFF
--- a/replacer.go
+++ b/replacer.go
@@ -124,6 +124,8 @@ func (r *Replacer) replace(input, empty string,
 
 	// iterate the input to find each placeholder
 	var lastWriteCursor int
+	
+scan:
 	for i := 0; i < len(input); i++ {
 
 		// check for escaped braces
@@ -145,7 +147,11 @@ func (r *Replacer) replace(input, empty string,
 
 		// if necessary look for the first closing brace that is not escaped
 		for end > 0 && end < len(input)-1 && input[end-1] == phEscape {
-			end = strings.Index(input[end+1:], string(phClose)) + end + 1
+			nextEnd := strings.Index(input[end+1:], string(phClose))
+			if nextEnd < 0 {
+				continue scan
+			}
+			end += nextEnd + 1
 		}
 
 		// write the substring from the last cursor to this point

--- a/replacer_test.go
+++ b/replacer_test.go
@@ -156,6 +156,10 @@ func TestReplacer(t *testing.T) {
 			input:  `\{'group':'default','max_age':3600,'endpoints':[\{'url':'https://some.domain.local/a/d/g'\}],'include_subdomains':true\}`,
 			expect: `{'group':'default','max_age':3600,'endpoints':[{'url':'https://some.domain.local/a/d/g'}],'include_subdomains':true}`,
 		},
+		{
+			input:  `{}{}{}{\\\\}\\\\`,
+			expect: `{\\\}\\\\`,
+		},
 	} {
 		actual := rep.ReplaceAll(tc.input, tc.empty)
 		if actual != tc.expect {

--- a/replacer_test.go
+++ b/replacer_test.go
@@ -160,6 +160,10 @@ func TestReplacer(t *testing.T) {
 			input:  `{}{}{}{\\\\}\\\\`,
 			expect: `{\\\}\\\\`,
 		},
+		{
+			input:  string([]byte{0x26, 0x00, 0x83, 0x7B, 0x84, 0x07, 0x5C, 0x7D, 0x84}),
+			expect: string([]byte{0x26, 0x00, 0x83, 0x7B, 0x84, 0x07, 0x7D, 0x84}),
+		},
 	} {
 		actual := rep.ReplaceAll(tc.input, tc.empty)
 		if actual != tc.expect {


### PR DESCRIPTION
This fixes the specific issue flagged by the fuzzer.

It does beg the question what the expected output should be for this input, but I went with this:

```plain
{
	input:  `{}{}{}{\\\\}\\\\`,
	expect: `{\\\}\\\\`,
},
```

My reasoning is that the first three braces are valid, but match no keys so get removed. The second brace is opened by never closed and so it is not replaced. The closing brace is escaped and so we loose the escape character but retain the brace.

I've made an assumption that handling of escaped escape characters is an edge case and one that will need to be handled if requested.

I'll post benchmarks in a comment.