### PR TITLE
fmt: Fix brace opening block indentation.

### DIFF
--- a/caddyconfig/caddyfile/formatter.go
+++ b/caddyconfig/caddyfile/formatter.go
@@ -43,6 +43,12 @@ func Format(body []byte) []byte {
 		err error
 	)
 
+	insertTabs := func(num int) {
+		for tabs := num; tabs > 0; tabs-- {
+			result.WriteRune('\t')
+		}
+	}
+
 	for {
 		prev = curr
 		curr = next
@@ -102,7 +108,7 @@ func Format(body []byte) []byte {
 				if unicode.IsSpace(next) {
 					indentation++
 
-					if !unicode.IsSpace(prev) {
+					if !unicode.IsSpace(prev) && !lineBegin {
 						result.WriteRune(' ')
 					}
 				} else {
@@ -114,10 +120,12 @@ func Format(body []byte) []byte {
 					continue
 				} else {
 					lineBegin = false
-					if indentation > 0 {
-						for tabs := indentation; tabs > 0; tabs-- {
-							result.WriteRune('\t')
-						}
+					if curr == '{' && unicode.IsSpace(next) {
+						// If the block is global, i.e., starts with '{'
+						// One less indentation for these blocks.
+						insertTabs(indentation - 1)
+					} else {
+						insertTabs(indentation)
 					}
 				}
 			} else {

--- a/caddyconfig/caddyfile/formatter_test.go
+++ b/caddyconfig/caddyfile/formatter_test.go
@@ -45,6 +45,18 @@ m {
 	n { o
 	}
 }
+
+{
+	p
+}
+
+  { q
+}
+
+	{
+{ r
+}
+}
 `)
 	expected := []byte(`
 a
@@ -73,6 +85,20 @@ j {
 m {
 	n {
 		o
+	}
+}
+
+{
+	p
+}
+
+{
+	q
+}
+
+{
+	{
+		r
 	}
 }
 `)
@@ -110,6 +136,9 @@ b {
 
 d { {$E}
 }
+
+{ {$F}
+}
 `)
 	expected := []byte(`
 {$A}
@@ -120,6 +149,10 @@ b {
 
 d {
 	{$E}
+}
+
+{
+	{$F}
 }
 `)
 	testFormat(t, input, expected)
@@ -190,6 +223,6 @@ g {
 func testFormat(t *testing.T, input, expected []byte) {
 	output := Format(input)
 	if string(output) != string(expected) {
-		t.Errorf("Expected:\n%s\ngot:\n%s", string(output), string(expected))
+		t.Errorf("Expected:\n%s\ngot:\n%s", string(expected), string(output))
 	}
 }


### PR DESCRIPTION
This fixes indentation for blocks starting with
a brace as:
```Caddyfile
{
    ...
}
```

Fixes #3144