### PR TITLE
reverseproxy: Add Alt-Svc to Hop-by-hop headers list

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -725,6 +725,7 @@ type Selector interface {
 // obsoleted RFC 2616 (section 13.5.1) and are used for backward
 // compatibility.
 var hopHeaders = []string{
+	"Alt-Svc",
 	"Connection",
 	"Proxy-Connection", // non-standard but still sent by libcurl and rejected by e.g. google
 	"Keep-Alive",


### PR DESCRIPTION
Adds `Alt-Svc` to the list of headers that get removed when proxying to a backend.

This fixes the issue of having the contents of the Alt-Svc header duplicated when proxying to another Caddy server.

This was already blacklisted in Caddy v1

https://github.com/caddyserver/caddy/blob/891446d06340db2912c9a970bfe862bd54efbb70/caddyhttp/proxy/reverseproxy.go#L584-L600