### PR TITLE
v2: fuzz: accommodate the change of function signature

### DIFF
--- a/caddyconfig/caddyfile/parse_fuzz.go
+++ b/caddyconfig/caddyfile/parse_fuzz.go
@@ -17,12 +17,8 @@
 
 package caddyfile
 
-import (
-	"bytes"
-)
-
 func FuzzParseCaddyfile(data []byte) (score int) {
-	sb, err := Parse("Caddyfile", bytes.NewReader(data))
+	sb, err := Parse("Caddyfile", data)
 	if err != nil {
 		// if both an error is received and some ServerBlocks,
 		// then the parse was able to parse partially. Mark this


### PR DESCRIPTION
The input type the `caddyfile.Parse` func accepts has changed from `io.Reader` to `[]byte`. The amendment of the fuzzer func was missed.

The failure was detected in #3152 