### PR TITLE
caddyauth: Add Metadata field to caddyauth.User

### DIFF
--- a/modules/caddyhttp/caddyauth/caddyauth.go
+++ b/modules/caddyhttp/caddyauth/caddyauth.go
@@ -78,6 +78,9 @@ func (a Authentication) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 	repl.Set("http.authentication.user.id", user.ID)
+	for k, v := range user.Metadata {
+		repl.Set("http.authentication.user.metadata." + k, v)
+	}
 
 	return next.ServeHTTP(w, r)
 }
@@ -93,6 +96,7 @@ type Authenticator interface {
 // User represents an authenticated user.
 type User struct {
 	ID string
+	Metadata map[string]string
 }
 
 // Interface guards

--- a/modules/caddyhttp/caddyauth/caddyauth.go
+++ b/modules/caddyhttp/caddyauth/caddyauth.go
@@ -77,9 +77,9 @@ func (a Authentication) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 	}
 
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
-	repl.Set("http.authentication.user.id", user.ID)
+	repl.Set("http.auth.user.id", user.ID)
 	for k, v := range user.Metadata {
-		repl.Set("http.authentication.user.metadata."+k, v)
+		repl.Set("http.auth.user."+k, v)
 	}
 
 	return next.ServeHTTP(w, r)
@@ -95,7 +95,14 @@ type Authenticator interface {
 
 // User represents an authenticated user.
 type User struct {
-	ID       string
+	// The ID of the authenticated user.
+	ID string
+
+	// Any other relevant data about this
+	// user. Keys should be adhere to Caddy
+	// conventions (snake_casing), as all
+	// keys will be made available as
+	// placeholders.
 	Metadata map[string]string
 }
 

--- a/modules/caddyhttp/caddyauth/caddyauth.go
+++ b/modules/caddyhttp/caddyauth/caddyauth.go
@@ -79,7 +79,7 @@ func (a Authentication) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 	repl.Set("http.authentication.user.id", user.ID)
 	for k, v := range user.Metadata {
-		repl.Set("http.authentication.user.metadata." + k, v)
+		repl.Set("http.authentication.user.metadata."+k, v)
 	}
 
 	return next.ServeHTTP(w, r)
@@ -95,7 +95,7 @@ type Authenticator interface {
 
 // User represents an authenticated user.
 type User struct {
-	ID string
+	ID       string
 	Metadata map[string]string
 }
 


### PR DESCRIPTION
Long overdue PR to allow Authentication modules to add arbitrary data to a User.