### PR TITLE
Support placeholders in key_type

### DIFF
--- a/modules/caddytls/automation.go
+++ b/modules/caddytls/automation.go
@@ -183,8 +183,14 @@ func (ap *AutomationPolicy) Provision(tlsApp *TLS) error {
 		ap.Issuer = val.(certmagic.Issuer)
 	}
 
+	keyType := ap.KeyType
+	if keyType != "" {
+		repl := caddy.NewReplacer()
+		keyType = repl.ReplaceAll(ap.KeyType, "")
+	}
+
 	keySource := certmagic.StandardKeyGenerator{
-		KeyType: supportedCertKeyTypes[ap.KeyType],
+		KeyType: supportedCertKeyTypes[keyType],
 	}
 
 	storage := ap.storage

--- a/modules/caddytls/automation.go
+++ b/modules/caddytls/automation.go
@@ -185,10 +185,15 @@ func (ap *AutomationPolicy) Provision(tlsApp *TLS) error {
 
 	keyType := ap.KeyType
 	if keyType != "" {
-		repl := caddy.NewReplacer()
-		keyType = repl.ReplaceAll(ap.KeyType, "")
+		var err error
+		keyType, err = caddy.NewReplacer().ReplaceOrErr(ap.KeyType, true, true)
+		if err != nil {
+			return fmt.Errorf("invalid key type %s: %s", ap.KeyType, err)
+		}
+		if _, ok := supportedCertKeyTypes[keyType]; !ok {
+			return fmt.Errorf("unrecognized key type: %s", keyType)
+		}
 	}
-
 	keySource := certmagic.StandardKeyGenerator{
 		KeyType: supportedCertKeyTypes[keyType],
 	}

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -196,6 +196,17 @@ func (t *TLS) Validate() error {
 				}
 				hostSet[h] = i
 			}
+
+			if ap.KeyType != "" {
+				repl := caddy.NewReplacer()
+				keyType, err := repl.ReplaceOrErr(ap.KeyType, true, true)
+				if err != nil {
+					return fmt.Errorf("automation policy %d: invalid key type: %s", i, err)
+				}
+				if _, ok := supportedCertKeyTypes[keyType]; !ok {
+					return fmt.Errorf("automation policy %d: invalid key type: %s", i, keyType)
+				}
+			}
 		}
 	}
 	return nil

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -196,17 +196,6 @@ func (t *TLS) Validate() error {
 				}
 				hostSet[h] = i
 			}
-
-			if ap.KeyType != "" {
-				repl := caddy.NewReplacer()
-				keyType, err := repl.ReplaceOrErr(ap.KeyType, true, true)
-				if err != nil {
-					return fmt.Errorf("automation policy %d: invalid key type: %s", i, err)
-				}
-				if _, ok := supportedCertKeyTypes[keyType]; !ok {
-					return fmt.Errorf("automation policy %d: invalid key type: %s", i, keyType)
-				}
-			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Support the following configuration:

```json
{
  "apps": {
    "tls": {
      "automation": {
        "policies": [
          {
            "key_type": "{env.KEY_TYPE}"
          }
        ]
      }
    }
  }
}

```

Also adds a check to validate key_type is valid (rsa2048, rsa4096, etc.)