### PR TITLE
reverse_proxy: Add support for SRV backends

### DIFF
--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -41,7 +41,7 @@ type (
 	// especially A/AAAA pointed at your server.
 	//
 	// Automatic HTTPS can be
-	// [customized or disabled](/docs/json/apps/http/servers/automatic_https/).
+	// [customized or disabled](/docs/modules/http#servers/automatic_https).
 	MatchHost []string
 
 	// MatchPath matches requests by the URI's path (case-insensitive). Path

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -17,6 +17,8 @@ package reverseproxy
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/http"
 	"strconv"
 	"sync/atomic"
 
@@ -75,13 +77,15 @@ type Upstream struct {
 	// backends is down. Also be aware of open proxy vulnerabilities.
 	Dial string `json:"dial,omitempty"`
 
+	// If DNS SRV records are used for service discovery with this
+	// upstream, specify the DNS name for which to look up SRV
+	// records here, instead of specifying a dial address.
+	LookupSRV string `json:"lookup_srv,omitempty"`
+
 	// The maximum number of simultaneous requests to allow to
 	// this upstream. If set, overrides the global passive health
 	// check UnhealthyRequestCount value.
 	MaxRequests int `json:"max_requests,omitempty"`
-
-	// TODO:...
-	SRV bool
 
 	// TODO: This could be really useful, to bind requests
 	// with certain properties to specific backends
@@ -119,6 +123,47 @@ func (u *Upstream) Healthy() bool {
 // cannot receive more requests at this time.
 func (u *Upstream) Full() bool {
 	return u.MaxRequests > 0 && u.Host.NumRequests() >= u.MaxRequests
+}
+
+// fillDialInfo returns a filled DialInfo for upstream u, using the request
+// context. If the upstream has a SRV lookup configured, that is done and a
+// returned address is chosen; otherwise, the upstream's regular dial address
+// field is used. Note that the returned value is not a pointer.
+func (u *Upstream) fillDialInfo(r *http.Request) (DialInfo, error) {
+	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+	var addr caddy.ParsedAddress
+
+	if u.LookupSRV != "" {
+		// perform DNS lookup for SRV records and choose one
+		srvName := repl.ReplaceAll(u.LookupSRV, "")
+		_, records, err := net.DefaultResolver.LookupSRV(r.Context(), "", "", srvName)
+		if err != nil {
+			return DialInfo{}, err
+		}
+		addr.Network = "tcp"
+		addr.Host = records[0].Target
+		addr.StartPort, addr.EndPort = uint(records[0].Port), uint(records[0].Port)
+	} else {
+		// use provided dial address
+		var err error
+		dial := repl.ReplaceAll(u.Dial, "")
+		addr, err = caddy.ParseNetworkAddress(dial)
+		if err != nil {
+			return DialInfo{}, fmt.Errorf("upstream %s: invalid dial address %s: %v", u.Dial, dial, err)
+		}
+		if numPorts := addr.PortRangeSize(); numPorts != 1 {
+			return DialInfo{}, fmt.Errorf("upstream %s: dial address must represent precisely one socket: %s represents %d",
+				u.Dial, dial, numPorts)
+		}
+	}
+
+	return DialInfo{
+		Upstream: u,
+		Network:  addr.Network,
+		Address:  addr.JoinHostPort(0),
+		Host:     addr.Host,
+		Port:     strconv.Itoa(int(addr.StartPort)),
+	}, nil
 }
 
 // upstreamHost is the basic, in-memory representation
@@ -205,27 +250,6 @@ type DialInfo struct {
 // forward slash.
 func (di DialInfo) String() string {
 	return caddy.JoinNetworkAddress(di.Network, di.Host, di.Port)
-}
-
-// fillDialInfo returns a filled DialInfo for the given upstream, using
-// the given Replacer. Note that the returned value is not a pointer.
-func fillDialInfo(upstream *Upstream, repl *caddy.Replacer) (DialInfo, error) {
-	dial := repl.ReplaceAll(upstream.Dial, "")
-	addr, err := caddy.ParseNetworkAddress(dial)
-	if err != nil {
-		return DialInfo{}, fmt.Errorf("upstream %s: invalid dial address %s: %v", upstream.Dial, dial, err)
-	}
-	if numPorts := addr.PortRangeSize(); numPorts != 1 {
-		return DialInfo{}, fmt.Errorf("upstream %s: dial address must represent precisely one socket: %s represents %d",
-			upstream.Dial, dial, numPorts)
-	}
-	return DialInfo{
-		Upstream: upstream,
-		Network:  addr.Network,
-		Address:  addr.JoinHostPort(0),
-		Host:     addr.Host,
-		Port:     strconv.Itoa(int(addr.StartPort)),
-	}, nil
 }
 
 // GetDialInfo gets the upstream dialing info out of the context,

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -63,10 +63,10 @@ type UpstreamPool []*Upstream
 type Upstream struct {
 	Host `json:"-"`
 
-	// The [network address](/docs/json/apps/http/#servers/listen)
+	// The [network address](/docs/conventions#network-addresses)
 	// to dial to connect to the upstream. Must represent precisely
 	// one socket (i.e. no port ranges). A valid network address
-	// either has a host and port, or is a unix socket address.
+	// either has a host and port or is a unix socket address.
 	//
 	// Placeholders may be used to make the upstream dynamic, but be
 	// aware of the health check implications of this: a single
@@ -79,6 +79,9 @@ type Upstream struct {
 	// this upstream. If set, overrides the global passive health
 	// check UnhealthyRequestCount value.
 	MaxRequests int `json:"max_requests,omitempty"`
+
+	// TODO:...
+	SRV bool
 
 	// TODO: This could be really useful, to bind requests
 	// with certain properties to specific backends

--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -24,7 +24,6 @@ import (
 	"net"
 	"net/http"
 	"reflect"
-	"strconv"
 	"time"
 
 	"github.com/caddyserver/caddy/v2"
@@ -96,14 +95,6 @@ func (h *HTTPTransport) newTransport() (*http.Transport, error) {
 			if dialInfo, ok := GetDialInfo(ctx); ok {
 				network = dialInfo.Network
 				address = dialInfo.Address
-				// TODO: experimental SRV lookups
-				if dialInfo.Upstream.SRV {
-					_, addrs, err := net.DefaultResolver.LookupSRV(ctx, "", "", dialInfo.Host)
-					if err != nil {
-						return nil, err
-					}
-					address = net.JoinHostPort(addrs[0].Target, strconv.Itoa(int(addrs[0].Port)))
-				}
 			}
 			conn, err := dialer.DialContext(ctx, network, address)
 			if err != nil {

--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/http"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/caddyserver/caddy/v2"
@@ -95,6 +96,14 @@ func (h *HTTPTransport) newTransport() (*http.Transport, error) {
 			if dialInfo, ok := GetDialInfo(ctx); ok {
 				network = dialInfo.Network
 				address = dialInfo.Address
+				// TODO: experimental SRV lookups
+				if dialInfo.Upstream.SRV {
+					_, addrs, err := net.DefaultResolver.LookupSRV(ctx, "", "", dialInfo.Host)
+					if err != nil {
+						return nil, err
+					}
+					address = net.JoinHostPort(addrs[0].Target, strconv.Itoa(int(addrs[0].Port)))
+				}
 			}
 			conn, err := dialer.DialContext(ctx, network, address)
 			if err != nil {

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -313,7 +313,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 		// the dial address may vary per-request if placeholders are
 		// used, so perform those replacements here; the resulting
 		// DialInfo struct should have valid network address syntax
-		dialInfo, err := fillDialInfo(upstream, repl)
+		dialInfo, err := upstream.fillDialInfo(r)
 		if err != nil {
 			return fmt.Errorf("making dial info: %v", err)
 		}


### PR DESCRIPTION
This change allows you to specify the `"lookup_srv"` field on a proxy upstream to lookup a name's SRV records to get the upstream dial address. Resolves #3179.

In the Caddyfile, prefix proxy upstream addresses with `srv+`, for example:

```
reverse_proxy srv+example.com
```

or

```
reverse_proxy srv+https://example.com
```

(It's a little weird but that's how it goes I guess.)

@danlsgiga Can you please try this? Once the CI is finished, it should have a binary you can download and use, or you can just pull it yourself and build. Let me know!