### PR TITLE
exclude integration tests in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       # continue-on-error: true
       run: |
         # (go test -v -coverprofile=cover-profile.out -race ./... 2>&1) > test-results/test-result.out
-        go test -v -coverprofile="cover-profile.out" -race ./...
+        go test -v -coverprofile="cover-profile.out" -short -race ./...
         # echo "::set-output name=status::$?"
 
     # Relevant step if we reinvestigate publishing test/coverage reports

--- a/caddytest/caddytest.go
+++ b/caddytest/caddytest.go
@@ -68,6 +68,11 @@ func InitServer(t *testing.T, rawConfig string, configType string) {
 // type. The configType must be either "json" or the adapter type.
 func initServer(t *testing.T, rawConfig string, configType string) error {
 
+	if testing.Short() {
+		t.SkipNow()
+		return nil
+	}
+
 	err := validateTestPrerequisites()
 	if err != nil {
 		t.Skipf("skipping tests as failed integration prerequisites. %s", err)


### PR DESCRIPTION
So here is an approach to not having the tests run in CI while we get to the bottom of Windows networking stack.