### PR TITLE
Fixes SNI being applied to http servers

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -418,7 +418,7 @@ func (st *ServerType) serversFromPairings(
 						// make sure the policy covers all hostnames from the block
 						for _, h := range httpsHosts {
 							if h == defaultSNI {
-								httpHosts = append(httpHosts, "")
+								httpHosts = append(httpHosts, "") //nolint
 								cp.DefaultSNI = defaultSNI
 								requiresCatchAllTLSConnPolicy = true
 								break

--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -368,5 +368,9 @@ func consolidateAutomationPolicies(aps []*caddytls.AutomationPolicy) []*caddytls
 		return len(aps[i].Subjects) > len(aps[j].Subjects)
 	})
 
+	for i := 0; i < len(aps); i++ {
+		sort.Strings(aps[i].Subjects)
+	}
+
 	return aps
 }

--- a/caddytest/caddytest.go
+++ b/caddytest/caddytest.go
@@ -384,10 +384,10 @@ type load struct {
 	Apps apps `json:"apps"`
 }
 type apps struct {
-	HTTP hTTP        `json:"http"`
+	HTTP httpServers `json:"http"`
 	TLS  interface{} `json:"tls,omitempty"`
 }
-type hTTP struct {
+type httpServers struct {
 	OrderedServers []interface{}          `json:"_servers,omitempty"`
 	Servers        map[string]interface{} `json:"servers,omitempty"`
 }


### PR DESCRIPTION
Here are some tests were we can agree on what the output should be. Testing against json is a bit of an eye sore, ~I was thinking of adding in a json diff tool to helpout.~ I have added a diffing tool

In the `TestHttpsMultiHostWithAcme` I removed the TLS Connection Policy from the `:80` server.

~I was unsure about the need for the skip https on servers mapped to `:80` as well.~ This was already fixed, I was looking at an earlier beta.