### PR TITLE
Updated custom error page handlers to support more file types

### DIFF
--- a/caddyhttp/errors/errors.go
+++ b/caddyhttp/errors/errors.go
@@ -18,8 +18,10 @@ package errors
 import (
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -83,9 +85,13 @@ func (h ErrorHandler) errorPage(w http.ResponseWriter, r *http.Request, code int
 			return
 		}
 		defer errorPage.Close()
-
+		// Get content type by extension
+		contentType := mime.TypeByExtension(filepath.Ext(pagePath))
+		if contentType == "" {
+			contentType = "text/html; charset=utf-8"
+		}
 		// Copy the page body into the response
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Content-Type", contentType)
 		w.WriteHeader(code)
 		_, err = io.Copy(w, errorPage)
 


### PR DESCRIPTION
At some point I need to support custom error pages for more file types, such as json, text, etc., but the existing code does not meet the requirements.
E.g:

```
localhost:8080 {
    log / stderr "{combined}"
    cors / {
            origin            http://localhost:3000
            methods           POST,PUT,GET,DELETE,OPTION
            allow_credentials false
            max_age           3600
            allowed_headers   Authorization,Content-Type
    }
    errors {
        404 examples/gateway/404.json
        500 examples/gateway/500.json
    }
    ......
}

```
When the error code is 404,500, even if the custom file is json ContentType is still "text / html; charset = utf-8" is not "application / json"

This pr is to solve this problem, the Content-Type is automatically determined according to the file extension, which is well compatible with the old configuration