### PR TITLE
caddyhttp: Add `map` handler

### DIFF
--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -39,7 +39,9 @@ import (
 var directiveOrder = []string{
 	"map",
 	"root",
+
 	"header",
+
 	"redir",
 	"rewrite",
 

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -37,10 +37,9 @@ import (
 // The header directive goes second so that headers
 // can be manipulated before doing redirects.
 var directiveOrder = []string{
+	"map",
 	"root",
-
 	"header",
-
 	"redir",
 	"rewrite",
 

--- a/caddytest/integration/map_test.go
+++ b/caddytest/integration/map_test.go
@@ -15,12 +15,12 @@ func TestMap(t *testing.T) {
 		http_port     9080
 		https_port    9443
 	}
-	
+
 	localhost:9080 {
 
 		map http.request.method dest-name {
 			default unknown
-			GET get-called
+			G.T get-called
 			POST post-called
 		}
 

--- a/caddytest/integration/map_test.go
+++ b/caddytest/integration/map_test.go
@@ -91,11 +91,11 @@ func TestMapAsJson(t *testing.T) {
 								"default": "unknown",
 								"items": [
 									{
-									"key": "GET",
+									"expression": "GET",
 									"value": "get-called"
 									},
 									{
-									"key": "POST",
+									"expression": "POST",
 									"value": "post-called"
 									}
 								]

--- a/caddytest/integration/map_test.go
+++ b/caddytest/integration/map_test.go
@@ -1,0 +1,143 @@
+package integration
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/caddytest"
+)
+
+func TestMap(t *testing.T) {
+
+	// arrange
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`{
+		http_port     9080
+		https_port    9443
+	}
+	
+	localhost:9080 {
+
+		map http.request.method dest-name {
+			default unknown
+			GET get-called
+			POST post-called
+		}
+
+		respond /version 200 {
+			body "hello from localhost {dest-name}"
+		}	
+	}
+	`, "caddyfile")
+
+	// act and assert
+	tester.AssertGetResponse("http://localhost:9080/version", 200, "hello from localhost get-called")
+	tester.AssertPostResponseBody("http://localhost:9080/version", []string{}, bytes.NewBuffer([]byte{}), 200, "hello from localhost post-called")
+}
+
+func TestMapRespondWithDefault(t *testing.T) {
+
+	// arrange
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`{
+		http_port     9080
+		https_port    9443
+		}
+		
+		localhost:9080 {
+	
+			map http.request.method dest-name {
+				default unknown
+				GET get-called
+			}
+		
+			respond /version 200 {
+				body "hello from localhost {dest-name}"
+			}	
+		}
+	`, "caddyfile")
+
+	// act and assert
+	tester.AssertGetResponse("http://localhost:9080/version", 200, "hello from localhost get-called")
+	tester.AssertPostResponseBody("http://localhost:9080/version", []string{}, bytes.NewBuffer([]byte{}), 200, "hello from localhost unknown")
+}
+
+func TestMapAsJson(t *testing.T) {
+
+	// arrange
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`{
+		"apps": {
+			"http": {
+			"http_port": 9080,
+			"https_port": 9443,
+			"servers": {
+				"srv0": {
+				"listen": [
+					":9080"
+				],
+				"routes": [
+					{
+					"handle": [
+						{
+						"handler": "subroute",
+						"routes": [
+							{
+							"handle": [
+								{
+								"handler": "map",
+								"source": "http.request.method",
+								"destination": "dest-name",
+								"default": "unknown",
+								"items": [
+									{
+									"key": "GET",
+									"value": "get-called"
+									},
+									{
+									"key": "POST",
+									"value": "post-called"
+									}
+								]
+								}
+							]
+							},
+							{
+							"handle": [
+								{
+								"body": "hello from localhost {dest-name}",
+								"handler": "static_response",
+								"status_code": 200
+								}
+							],
+							"match": [
+								{
+								"path": [
+									"/version"
+								]
+								}
+							]
+							}
+						]
+						}
+					],
+					"match": [
+						{
+						"host": [
+							"localhost"
+						]
+						}
+					],
+					"terminal": true
+					}
+				]
+				}
+			}
+			}
+		}
+		}
+		`, "json")
+
+	tester.AssertGetResponse("http://localhost:9080/version", 200, "hello from localhost get-called")
+	tester.AssertPostResponseBody("http://localhost:9080/version", []string{}, bytes.NewBuffer([]byte{}), 200, "hello from localhost post-called")
+}

--- a/modules/caddyhttp/map/caddyfile.go
+++ b/modules/caddyhttp/map/caddyfile.go
@@ -25,10 +25,15 @@ func init() {
 
 // parseCaddyfile sets up the handler for a map from
 // Caddyfile tokens. Syntax:
+//     The map takes a <source> variable and maps it into the <dest> variable. The mapping process
+//     will check the <source> variable for the first succesful match against a list of regular expressions.
+//     If a succesful match is found the <dest> variable will contain the <replacement> value.
+//     If no successful match is found and the <default> is specified then the <dest> will contain the <default> value.
 //
-//     map source dest {
-//         [[default] value]
-//         [+][<value|regexp> [<replacement>]]
+//     map <source> <dest> {
+//         [default <default>] - used if not match is found
+//         [<regexp> <replacement>] - regular expression to match against the sourceo find and the matching replacement
+//         ...
 //     }
 //
 func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
@@ -45,8 +50,8 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 
 		// load the rules
 		for h.NextBlock(0) {
-			key := h.Val()
-			if key == "default" {
+			expression := h.Val()
+			if expression == "default" {
 				args := h.RemainingArgs()
 				if len(args) != 1 {
 					return m, h.ArgErr()
@@ -57,7 +62,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 				if len(args) != 1 {
 					return m, h.ArgErr()
 				}
-				m.Items = append(m.Items, Item{Key: key, Value: args[0]})
+				m.Items = append(m.Items, Item{Expression: expression, Value: args[0]})
 			}
 		}
 	}

--- a/modules/caddyhttp/map/caddyfile.go
+++ b/modules/caddyhttp/map/caddyfile.go
@@ -26,8 +26,8 @@ func init() {
 // parseCaddyfile sets up the handler for a map from
 // Caddyfile tokens. Syntax:
 //     The map takes a <source> variable and maps it into the <dest> variable. The mapping process
-//     will check the <source> variable for the first succesful match against a list of regular expressions.
-//     If a succesful match is found the <dest> variable will contain the <replacement> value.
+//     will check the <source> variable for the first successful match against a list of regular expressions.
+//     If a successful match is found the <dest> variable will contain the <replacement> value.
 //     If no successful match is found and the <default> is specified then the <dest> will contain the <default> value.
 //
 //     map <source> <dest> {

--- a/modules/caddyhttp/map/caddyfile.go
+++ b/modules/caddyhttp/map/caddyfile.go
@@ -23,18 +23,18 @@ func init() {
 	httpcaddyfile.RegisterHandlerDirective("map", parseCaddyfile)
 }
 
-// parseCaddyfile sets up the handler for a map from
-// Caddyfile tokens. Syntax:
-//     The map takes a <source> variable and maps it into the <dest> variable. The mapping process
-//     will check the <source> variable for the first successful match against a list of regular expressions.
-//     If a successful match is found the <dest> variable will contain the <replacement> value.
-//     If no successful match is found and the <default> is specified then the <dest> will contain the <default> value.
+// parseCaddyfile sets up the handler for a map from Caddyfile tokens. Syntax:
 //
 //     map <source> <dest> {
 //         [default <default>] - used if not match is found
-//         [<regexp> <replacement>] - regular expression to match against the sourceo find and the matching replacement
+//         [<regexp> <replacement>] - regular expression to match against the source find and the matching replacement value
 //         ...
 //     }
+//
+// The map takes a source variable and maps it into the dest variable. The mapping process
+// will check the source variable for the first successful match against a list of regular expressions.
+// If a successful match is found the dest variable will contain the replacement value.
+// If no successful match is found and the default is specified then the dest will contain the default value.
 //
 func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
 	m := new(Handler)

--- a/modules/caddyhttp/map/caddyfile.go
+++ b/modules/caddyhttp/map/caddyfile.go
@@ -1,0 +1,66 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mmap
+
+import (
+	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+func init() {
+	httpcaddyfile.RegisterHandlerDirective("map", parseCaddyfile)
+}
+
+// parseCaddyfile sets up the handler for a map from
+// Caddyfile tokens. Syntax:
+//
+//     map source dest {
+//         [[default] value]
+//         [+][<value|regexp> [<replacement>]]
+//     }
+//
+func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
+	m := new(Handler)
+
+	for h.Next() {
+		// first see if source and dest are configured
+		if h.NextArg() {
+			m.Source = h.Val()
+			if h.NextArg() {
+				m.Destination = h.Val()
+			}
+		}
+
+		// load the rules
+		for h.NextBlock(0) {
+			key := h.Val()
+			if key == "default" {
+				args := h.RemainingArgs()
+				if len(args) != 1 {
+					return m, h.ArgErr()
+				}
+				m.Default = args[0]
+			} else {
+				args := h.RemainingArgs()
+				if len(args) != 1 {
+					return m, h.ArgErr()
+				}
+				m.Items = append(m.Items, Item{Key: key, Value: args[0]})
+			}
+		}
+	}
+
+	return m, nil
+}

--- a/modules/caddyhttp/map/caddyfile.go
+++ b/modules/caddyhttp/map/caddyfile.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mmap
+package maphandler
 
 import (
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"

--- a/modules/caddyhttp/map/map.go
+++ b/modules/caddyhttp/map/map.go
@@ -76,18 +76,11 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhtt
 	// model to start with.
 	val, ok := repl.Get(h.Source)
 	if ok {
-		lookup := func(key string) (interface{}, bool) {
-			if v, ok := h.internalMap[val]; ok {
-				return v, true
-			}
-			if h.Default != "" {
-				return h.Default, true
-			}
-			return "", false
+		v, ok := h.internalMap[val]
+		if !ok && h.Default != "" {
+			v = h.Default
 		}
-
-		// add the lookup function
-		repl.Map(lookup)
+		repl.Set(h.Destination, v)
 	}
 
 	return next.ServeHTTP(w, r)
@@ -97,7 +90,6 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhtt
 type Item struct {
 	// Key
 	Key string `json:"key,omitempty"`
-
 	// Value
 	Value string `json:"value,omitempty"`
 }

--- a/modules/caddyhttp/map/map.go
+++ b/modules/caddyhttp/map/map.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mmap
+package maphandler
 
 import (
 	"net/http"

--- a/modules/caddyhttp/map/map.go
+++ b/modules/caddyhttp/map/map.go
@@ -26,14 +26,27 @@ func init() {
 	caddy.RegisterModule(Handler{})
 }
 
-// Handler - Map
+// Handler is a middleware that maps a source placeholder to a destination
+// placeholder.
 //
+// The mapping process happens early in the request handling lifecycle so that
+// the Destination placeholder is calculated and available for substitution.
+// The Items array contains pairs of regex expressions and values, the
+// Source is matched against the expression, if they match then the destination
+// placeholder is set to the value.
+//
+// The Default is optional, if no Item expression is matched then the value of
+// the Default will be used.
 //
 type Handler struct {
-	Source      string `json:"source,omitempty"`
+	// Source is a placeholder
+	Source string `json:"source,omitempty"`
+	// Destination is a new placeholder
 	Destination string `json:"destination,omitempty"`
-	Default     string `json:"default,omitempty"`
-	Items       []Item `json:"items,omitempty"`
+	// Default is an optional value to use if no other was found
+	Default string `json:"default,omitempty"`
+	// Items is an array of regex expressions and values
+	Items []Item `json:"items,omitempty"`
 }
 
 // CaddyModule returns the Caddy module information.
@@ -49,11 +62,6 @@ func (h *Handler) Provision(_ caddy.Context) error {
 	for i := 0; i < len(h.Items); i++ {
 		h.Items[i].compiled = regexp.MustCompile(h.Items[i].Expression)
 	}
-	return nil
-}
-
-// Validate ensures h's configuration is valid.
-func (h Handler) Validate() error {
 	return nil
 }
 

--- a/modules/caddyhttp/map/map.go
+++ b/modules/caddyhttp/map/map.go
@@ -1,0 +1,109 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mmap
+
+import (
+	"net/http"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+func init() {
+	caddy.RegisterModule(Handler{})
+}
+
+// Handler - Map
+//
+//
+type Handler struct {
+	Source      string `json:"source,omitempty"`
+	Destination string `json:"destination,omitempty"`
+	Default     string `json:"default,omitempty"`
+	Items       []Item `json:"items,omitempty"`
+	internalMap map[interface{}]string
+}
+
+// CaddyModule returns the Caddy module information.
+func (Handler) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "http.handlers.map",
+		New: func() caddy.Module { return new(Handler) },
+	}
+}
+
+// Provision -
+func (h *Handler) Provision(_ caddy.Context) error {
+	h.internalMap = make(map[interface{}]string)
+	return nil
+}
+
+// Validate ensures h's configuration is valid.
+func (h Handler) Validate() error {
+
+	//TODO: detect and compile regular expressions
+	//TODO: organise a data structure to determine the order in which
+	// the static keys and regular expressions can be deterministically
+	// evaluated. Static keys first then regular expressions in order?
+	// Or evaluated in order of appearance?
+
+	// load the values
+	for _, v := range h.Items {
+		h.internalMap[v.Key] = v.Value
+	}
+	return nil
+}
+
+func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
+	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+
+	// get the source value, if the source value was not found do no
+	// replacement.
+	//TODO: has the potential to miss changes in variables made later
+	// in the request pipeline but perhaps that is a simplier mental
+	// model to start with.
+	val, ok := repl.Get(h.Source)
+	if ok {
+		lookup := func(key string) (interface{}, bool) {
+			if v, ok := h.internalMap[val]; ok {
+				return v, true
+			}
+			if h.Default != "" {
+				return h.Default, true
+			}
+			return "", false
+		}
+
+		// add the lookup function
+		repl.Map(lookup)
+	}
+
+	return next.ServeHTTP(w, r)
+}
+
+// Item defines manipulations for HTTP headers.
+type Item struct {
+	// Key
+	Key string `json:"key,omitempty"`
+
+	// Value
+	Value string `json:"value,omitempty"`
+}
+
+// Interface guards
+var (
+	_ caddy.Provisioner           = (*Handler)(nil)
+	_ caddyhttp.MiddlewareHandler = (*Handler)(nil)
+)

--- a/modules/caddyhttp/standard/imports.go
+++ b/modules/caddyhttp/standard/imports.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/encode/zstd"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/fileserver"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/headers"
+	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/map"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/requestbody"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy/fastcgi"

--- a/replacer.go
+++ b/replacer.go
@@ -66,6 +66,17 @@ func (r *Replacer) Get(variable string) (interface{}, bool) {
 	return nil, false
 }
 
+// GetString gets a value from the replacer. It returns
+// the value and whether the variable was known.
+func (r *Replacer) GetString(variable string) (string, bool) {
+	for _, mapFunc := range r.providers {
+		if val, ok := mapFunc(variable); ok {
+			return toString(val), true
+		}
+	}
+	return "", false
+}
+
 // Delete removes a variable with a static value
 // that was created using Set.
 func (r *Replacer) Delete(variable string) {

--- a/replacer.go
+++ b/replacer.go
@@ -66,8 +66,8 @@ func (r *Replacer) Get(variable string) (interface{}, bool) {
 	return nil, false
 }
 
-// GetString gets a value from the replacer. It returns
-// the value and whether the variable was known.
+// GetString  is the same as Get, but coerces the value to a
+// string representation.
 func (r *Replacer) GetString(variable string) (string, bool) {
 	s, found := r.Get(variable)
 	return toString(s), found

--- a/replacer.go
+++ b/replacer.go
@@ -69,12 +69,8 @@ func (r *Replacer) Get(variable string) (interface{}, bool) {
 // GetString gets a value from the replacer. It returns
 // the value and whether the variable was known.
 func (r *Replacer) GetString(variable string) (string, bool) {
-	for _, mapFunc := range r.providers {
-		if val, ok := mapFunc(variable); ok {
-			return toString(val), true
-		}
-	}
-	return "", false
+	s, found := r.Get(variable)
+	return toString(s), found
 }
 
 // Delete removes a variable with a static value


### PR DESCRIPTION
Simple map implementation. #2824 

Open to suggestions around hybrid implementations or other data types.

Maps are resolved during request pipeline at the point in the pipeline, I did consider deferring evaluation to the point of substitution.

[edit]
A recurring idea I have for this feature is to make it more caddy-like, somehow taking the idea of matchers. It does make it more verbose specifying a matcher for each case.

```
map [dest_var] {
   [matcher] [value]
   ...
}

map $is_an_image {
   path /img/* true
   path /images/* true
   path_regexp *.[jpg|bmp] true
   default false
}
```