### PR TITLE
ci: fuzz: skip fuzz data that contains `import`

### DIFF
--- a/caddyconfig/caddyfile/parse_fuzz.go
+++ b/caddyconfig/caddyfile/parse_fuzz.go
@@ -16,7 +16,12 @@
 
 package caddyfile
 
+import "bytes"
+
 func FuzzParseCaddyfile(data []byte) (score int) {
+	if bytes.Contains(data, []byte("import")) {
+		return -1
+	}
 	sb, err := Parse("Caddyfile", data)
 	if err != nil {
 		// if both an error is received and some ServerBlocks,


### PR DESCRIPTION
Thus far the fuzzers have found a few crashers in the Caddyfile parser. However, the fuzzer have been stuck at import glob expansion after import glob expansion, which aren't reproducible.