### PR TITLE
chore: ci: fix release action script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,4 +50,4 @@ jobs:
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TAG: ${{ steps.vars.outputs.version_tag }}
+        TAG: ${{ steps.get_version.outputs.version_tag }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,6 +60,7 @@ changelog:
   sort: asc
   filters:
     exclude:
+    - '^ci:'
     - '^docs:'
     - '^test:'
     - '^chore:'


### PR DESCRIPTION
- The magical Github-y syntax was referencing the wrong step ID to get the tag
- Exclude commits prefixed with `ci:` from the changelog