### PR TITLE
ci: goreleaser: Drop some platforms and replacements

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,15 +23,12 @@ builds:
   - freebsd
   goarch:
   - amd64
-  - 386
   - arm
   - arm64
   goarm:
   - 6
   - 7
   ignore:
-    - goos: darwin
-      goarch: 386
     - goos: darwin
       goarch: arm
   flags:
@@ -43,11 +40,7 @@ archives:
       - goos: windows
         format: zip
     replacements:
-      darwin: macOS
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+      darwin: mac
 checksum:
   algorithm: sha512
 release:
@@ -60,8 +53,8 @@ changelog:
   sort: asc
   filters:
     exclude:
-    - '^ci:'
-    - '^docs:'
-    - '^test:'
     - '^chore:'
+    - '^ci:'
+    - '^docs?:'
+    - '^test:'
     - '^\w+\s+' # a hack to remove commit messages without colons thus don't correspond to a package


### PR DESCRIPTION
Based on download stats, demand for 32-bit binaries these days is
extremely low. Also unify some of the filename conventions; just a
few bikeshedding changes :)