### PR TITLE
add adaption tests. fix load failure not failing tests

### DIFF
--- a/caddytest/caddytest.go
+++ b/caddytest/caddytest.go
@@ -351,11 +351,9 @@ func AssertAdapt(t *testing.T, rawConfig string, adapterName string, expectedRes
 	// scan for failure
 	failed := false
 	for _, d := range diff {
-		switch d.Delta {
-		case difflib.LeftOnly:
+		if d.Delta != difflib.Common {
 			failed = true
-		case difflib.RightOnly:
-			failed = true
+			break
 		}
 	}
 
@@ -365,10 +363,8 @@ func AssertAdapt(t *testing.T, rawConfig string, adapterName string, expectedRes
 			case difflib.Common:
 				fmt.Printf("  %s\n", d.Payload)
 			case difflib.LeftOnly:
-				failed = true
 				fmt.Printf(" - %s\n", d.Payload)
 			case difflib.RightOnly:
-				failed = true
 				fmt.Printf(" + %s\n", d.Payload)
 			}
 		}

--- a/caddytest/integration/caddyfile_adapt_test.go
+++ b/caddytest/integration/caddyfile_adapt_test.go
@@ -1,0 +1,285 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/caddytest"
+)
+
+func TestHttpOnlyOnLocalhost(t *testing.T) {
+	caddytest.AssertAdapt(t, ` 
+	localhost:80 {
+		respond /version 200 {
+			body "hello from localhost"
+		}
+	}
+  `, "caddyfile", `{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"localhost"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "hello from localhost",
+													"handler": "static_response",
+													"status_code": 200
+												}
+											],
+											"match": [
+												{
+													"path": [
+														"/version"
+													]
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		}
+	}
+}`)
+}
+
+func TestHttpOnlyOnAnyAddress(t *testing.T) {
+	caddytest.AssertAdapt(t, ` 
+	:80 {
+		respond /version 200 {
+			body "hello from localhost"
+		}
+	}
+  `, "caddyfile", `{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"path": [
+										"/version"
+									]
+								}
+							],
+							"handle": [
+								{
+									"body": "hello from localhost",
+									"handler": "static_response",
+									"status_code": 200
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}`)
+}
+
+func TestHttpsOnDomain(t *testing.T) {
+	caddytest.AssertAdapt(t, ` 
+	a.caddy.localhost {
+		respond /version 200 {
+			body "hello from localhost"
+		}
+	}
+  `, "caddyfile", `{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"a.caddy.localhost"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "hello from localhost",
+													"handler": "static_response",
+													"status_code": 200
+												}
+											],
+											"match": [
+												{
+													"path": [
+														"/version"
+													]
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		}
+	}
+}`)
+}
+
+func TestHttpOnlyOnDomain(t *testing.T) {
+	caddytest.AssertAdapt(t, ` 
+	http://a.caddy.localhost {
+		respond /version 200 {
+			body "hello from localhost"
+		}
+	}
+  `, "caddyfile", `{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"a.caddy.localhost"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "hello from localhost",
+													"handler": "static_response",
+													"status_code": 200
+												}
+											],
+											"match": [
+												{
+													"path": [
+														"/version"
+													]
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					],
+					"automatic_https": {
+						"skip": [
+							"a.caddy.localhost"
+						]
+					}
+				}
+			}
+		}
+	}
+}`)
+}
+
+func TestHttpOnlyOnNonStandardPort(t *testing.T) {
+	caddytest.AssertAdapt(t, ` 
+	http://a.caddy.localhost:81 {
+		respond /version 200 {
+			body "hello from localhost"
+		}
+	}
+  `, "caddyfile", `{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":81"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"a.caddy.localhost"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "hello from localhost",
+													"handler": "static_response",
+													"status_code": 200
+												}
+											],
+											"match": [
+												{
+													"path": [
+														"/version"
+													]
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					],
+					"automatic_https": {
+						"skip": [
+							"a.caddy.localhost"
+						]
+					}
+				}
+			}
+		}
+	}
+}`)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/Masterminds/sprig/v3 v3.0.2
 	github.com/alecthomas/chroma v0.7.2-0.20200305040604-4f3623dce67a
+	github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a
 	github.com/caddyserver/certmagic v0.10.8
 	github.com/cenkalti/backoff/v4 v4.0.2 // indirect
 	github.com/dustin/go-humanize v1.0.1-0.20200219035652-afde56e7acac

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/antlr/antlr4 v0.0.0-20190819145818-b43a4c3a8015 h1:StuiJFxQUsxSCzcby6
 github.com/antlr/antlr4 v0.0.0-20190819145818-b43a4c3a8015/go.mod h1:T7PbCXFs94rrTttyxjbyT5+/1V8T2TYDejxUfHJjw1Y=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a h1:pv34s756C4pEXnjgPfGYgdhg/ZdajGhyOvzx8k+23nw=
+github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
 github.com/asaskevich/govalidator v0.0.0-20180315120708-ccb8e960c48f/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=


### PR DESCRIPTION
Pulled test harness fix and base test cases from #3193 

Incorporated feedback from #3193 

None of the sorting code is needed yet as these tests deal with single hostnames.

Example diffing output, when changing the port number from the expected output.
```
  {
  	"apps": {
  		"http": {
  			"servers": {
  				"srv0": {
  					"listen": [
 - 						":80"
 + 						":81"
  					],
  					"routes": [
  						{
.. (truncation is mine)
```