### PR TITLE
caddyhttp: Support single-line not matcher shortcut

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype_test.go
+++ b/caddyconfig/httpcaddyfile/httptype_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
-func TestServerType(t *testing.T) {
+func TestMatcherSyntax(t *testing.T) {
 	for i, tc := range []struct {
 		input       string
 		expectWarn  bool
@@ -15,7 +15,7 @@ func TestServerType(t *testing.T) {
 		{
 			input: `http://localhost
 			@debug {
-			  query showdebug=1
+				query showdebug=1
 			}
 			`,
 			expectWarn:  false,
@@ -24,11 +24,31 @@ func TestServerType(t *testing.T) {
 		{
 			input: `http://localhost
 			@debug {
-			  query bad format
+				query bad format
 			}
 			`,
 			expectWarn:  false,
 			expectError: true,
+		},
+		{
+			input: `http://localhost
+			@debug {
+				not {
+					path /somepath*
+				}
+			}
+			`,
+			expectWarn:  false,
+			expectError: false,
+		},
+		{
+			input: `http://localhost
+			@debug {
+				not path /somepath*
+			}
+			`,
+			expectWarn:  false,
+			expectError: false,
 		},
 	} {
 

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -559,7 +559,7 @@ func (m *MatchNot) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		var mp matcherPair
 		matcherMap := make(map[string]RequestMatcher)
-		for d.NextBlock(0) {
+		for d.NextArg() || d.NextBlock(0) {
 			matcherName := d.Val()
 			mod, err := caddy.GetModule("http.matchers." + matcherName)
 			if err != nil {


### PR DESCRIPTION
Simple addition to make it possible to have `not` negate a matcher on the same line instead of requiring it to be contained in a block.

E.g. before:

```
@notStatic {
    not {
        path /static*
    }
}
```

after:

```
@notStatic {
    not path /static*
}
```

![easy](https://media1.tenor.com/images/bb190864406b96d5ccb6071770a649c1/tenor.gif)