### PR TITLE
caddytls: Add Caddyfile support for key_type global option

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -307,6 +307,8 @@ func (ServerType) evaluateGlobalOptionsBlock(serverBlocks []serverBlock, options
 			val, err = parseOptOnDemand(disp)
 		case "local_certs":
 			val = true
+		case "key_type":
+			val, err = parseOptSingleString(disp)
 		default:
 			return nil, fmt.Errorf("unrecognized parameter name: %s", dir)
 		}

--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -322,8 +322,9 @@ func newBaseAutomationPolicy(options map[string]interface{}, warnings []caddycon
 	acmeCARoot, hasACMECARoot := options["acme_ca_root"]
 	email, hasEmail := options["email"]
 	localCerts, hasLocalCerts := options["local_certs"]
+	keyType, hasKeyType := options["key_type"]
 
-	hasGlobalAutomationOpts := hasACMECA || hasACMEDNS || hasACMECARoot || hasEmail || hasLocalCerts
+	hasGlobalAutomationOpts := hasACMECA || hasACMEDNS || hasACMECARoot || hasEmail || hasLocalCerts || hasKeyType
 
 	// if there are no global options related to automation policies
 	// set, then we can just return right away
@@ -362,6 +363,9 @@ func newBaseAutomationPolicy(options map[string]interface{}, warnings []caddycon
 		}
 		if acmeCARoot != nil {
 			mgr.TrustedRootsPEMFiles = []string{acmeCARoot.(string)}
+		}
+		if keyType != nil {
+			ap.KeyType = keyType.(string)
 		}
 		ap.Issuer = mgr // we'll encode it later
 	}


### PR DESCRIPTION
As per https://caddy.community/t/how-do-i-use-rsa-instead-of-ec-certificates/7448/3?u=francislavoie

```
{
    key_type rsa4096
}
```