### PR TITLE
chore: make the linter happier

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,6 @@
 linters-settings:
+  maligned:
+    suggest-new: true
   errcheck:
     ignore: fmt:.*,io/ioutil:^Read.*,github.com/caddyserver/caddy/v2/caddyconfig:RegisterAdapter,github.com/caddyserver/caddy/v2:RegisterModule
     ignoretests: true
@@ -8,6 +10,8 @@ linters-settings:
 linters:
   enable:
     - bodyclose
+    - prealloc
+    - unconvert
     - errcheck
     - gofmt
     - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,4 @@
 linters-settings:
-  maligned:
-    suggest-new: true
   errcheck:
     ignore: fmt:.*,io/ioutil:^Read.*,github.com/caddyserver/caddy/v2/caddyconfig:RegisterAdapter,github.com/caddyserver/caddy/v2:RegisterModule
     ignoretests: true

--- a/admin.go
+++ b/admin.go
@@ -149,7 +149,7 @@ func (admin AdminConfig) allowedOrigins(listen string) []string {
 	if admin.Origins == nil {
 		uniqueOrigins[listen] = struct{}{}
 	}
-	var allowed []string
+	allowed := make([]string, 0, len(uniqueOrigins))
 	for origin := range uniqueOrigins {
 		allowed = append(allowed, origin)
 	}

--- a/caddyconfig/httpcaddyfile/addresses.go
+++ b/caddyconfig/httpcaddyfile/addresses.go
@@ -138,7 +138,7 @@ func (st *ServerType) mapAddressToServerBlocks(originalServerBlocks []serverBloc
 // association from multiple addresses to multiple server blocks; i.e. each element of
 // the returned slice) becomes a server definition in the output JSON.
 func (st *ServerType) consolidateAddrMappings(addrToServerBlocks map[string][]serverBlock) []sbAddrAssociation {
-	var sbaddrs []sbAddrAssociation
+	sbaddrs := make([]sbAddrAssociation, 0, len(addrToServerBlocks))
 	for addr, sblocks := range addrToServerBlocks {
 		// we start with knowing that at least this address
 		// maps to these server blocks
@@ -199,7 +199,7 @@ func (st *ServerType) listenerAddrsForServerBlockKey(sblock serverBlock, key str
 	}
 
 	// the bind directive specifies hosts, but is optional
-	var lnHosts []string
+	lnHosts := make([]string, 0, len(sblock.pile))
 	for _, cfgVal := range sblock.pile["bind"] {
 		lnHosts = append(lnHosts, cfgVal.Value.([]string)...)
 	}
@@ -219,7 +219,7 @@ func (st *ServerType) listenerAddrsForServerBlockKey(sblock serverBlock, key str
 	}
 
 	// now turn map into list
-	var listenersList []string
+	listenersList := make([]string, 0, len(listeners))
 	for lnStr := range listeners {
 		listenersList = append(listenersList, lnStr)
 	}

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -50,7 +50,7 @@ func (st ServerType) Setup(originalServerBlocks []caddyfile.ServerBlock,
 	// chosen to handle a request - we actually will make each
 	// server block's route terminal so that only one will run
 	sbKeys := make(map[string]struct{})
-	var serverBlocks []serverBlock
+	serverBlocks := make([]serverBlock, 0, len(originalServerBlocks))
 	for i, sblock := range originalServerBlocks {
 		for j, k := range sblock.Keys {
 			if _, ok := sbKeys[k]; ok {
@@ -935,7 +935,7 @@ func (st *ServerType) compileEncodedMatcherSets(sblock serverBlock) ([]caddy.Mod
 	}
 
 	// finally, encode each of the matcher sets
-	var matcherSetsEnc []caddy.ModuleMap
+	matcherSetsEnc := make([]caddy.ModuleMap, 0, len(matcherSets))
 	for _, ms := range matcherSets {
 		msEncoded, err := encodeMatcherSet(ms)
 		if err != nil {

--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -245,7 +245,7 @@ func (st ServerType) buildTLSApp(
 				}
 				clVal := reflect.ValueOf(cl)
 				for i := 0; i < clVal.Len(); i++ {
-					combined = reflect.Append(reflect.Value(combined), clVal.Index(i))
+					combined = reflect.Append(combined, clVal.Index(i))
 				}
 				loadersByName[name] = combined.Interface().(caddytls.CertificateLoader)
 			}

--- a/caddytest/caddytest.go
+++ b/caddytest/caddytest.go
@@ -255,7 +255,7 @@ func AssertGetResponse(t *testing.T, requestURI string, statusCode int, expected
 	if !strings.Contains(body, expectedBody) {
 		t.Errorf("requesting \"%s\" expected response body \"%s\" but got \"%s\"", requestURI, expectedBody, body)
 	}
-	return resp, string(body)
+	return resp, body
 }
 
 // AssertGetResponseBody request a URI and assert the status code matches

--- a/logging.go
+++ b/logging.go
@@ -217,7 +217,7 @@ func (logging *Logging) Logger(mod Module) *zap.Logger {
 
 	multiCore := zapcore.NewTee(cores...)
 
-	return zap.New(multiCore).Named(string(modID))
+	return zap.New(multiCore).Named(modID)
 }
 
 // openWriter opens a writer using opener, and returns true if
@@ -458,7 +458,7 @@ func (cl *CustomLog) buildCore() {
 }
 
 func (cl *CustomLog) matchesModule(moduleID string) bool {
-	return cl.loggerAllowed(string(moduleID), true)
+	return cl.loggerAllowed(moduleID, true)
 }
 
 // loggerAllowed returns true if name is allowed to emit

--- a/modules.go
+++ b/modules.go
@@ -210,7 +210,7 @@ func GetModules(scope string) []ModuleInfo {
 	var mods []ModuleInfo
 iterateModules:
 	for id, m := range modules {
-		modParts := strings.Split(string(id), ".")
+		modParts := strings.Split(id, ".")
 
 		// match only the next level of nesting
 		if len(modParts) != len(scopeParts)+1 {
@@ -241,9 +241,9 @@ func Modules() []string {
 	modulesMu.RLock()
 	defer modulesMu.RUnlock()
 
-	var names []string
+	names := make([]string, 0, len(modules))
 	for name := range modules {
-		names = append(names, string(name))
+		names = append(names, name)
 	}
 
 	sort.Strings(names)

--- a/modules/caddyhttp/caddyauth/basicauth.go
+++ b/modules/caddyhttp/caddyauth/basicauth.go
@@ -77,8 +77,8 @@ func (hba *HTTPBasicAuth) Provision(ctx caddy.Context) error {
 		}
 
 		acct.Username = repl.ReplaceAll(acct.Username, "")
-		acct.Password = repl.ReplaceAll(string(acct.Password), "")
-		acct.Salt = repl.ReplaceAll(string(acct.Salt), "")
+		acct.Password = repl.ReplaceAll(acct.Password, "")
+		acct.Salt = repl.ReplaceAll(acct.Salt, "")
 
 		if acct.Username == "" || acct.Password == "" {
 			return fmt.Errorf("account %d: username and password are required", i)

--- a/modules/caddyhttp/caddyauth/command.go
+++ b/modules/caddyhttp/caddyauth/command.go
@@ -76,7 +76,7 @@ func cmdHashPassword(fs caddycmd.Flags) (int, error) {
 		return caddy.ExitCodeFailedStartup, err
 	}
 
-	hashBase64 := base64.StdEncoding.EncodeToString([]byte(hash))
+	hashBase64 := base64.StdEncoding.EncodeToString(hash)
 
 	fmt.Println(hashBase64)
 

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -146,7 +146,7 @@ func parseTryFiles(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error) 
 	// if there are query strings in the list, we have to split into
 	// a separate route for each item with a query string, because
 	// the rewrite is different for that item
-	var try []string
+	try := make([]string, 0, len(tryFiles))
 	for _, item := range tryFiles {
 		if idx := strings.Index(item, "?"); idx >= 0 {
 			if len(try) > 0 {

--- a/modules/caddyhttp/replacer.go
+++ b/modules/caddyhttp/replacer.go
@@ -188,7 +188,7 @@ func addHTTPVarsToReplacer(repl *caddy.Replacer, req *http.Request, w http.Respo
 			if strings.HasPrefix(key, varsReplPrefix) {
 				varName := key[len(varsReplPrefix):]
 				tbl := req.Context().Value(VarsCtxKey).(map[string]interface{})
-				raw, _ := tbl[varName]
+				raw := tbl[varName]
 				// variables can be dynamic, so always return true
 				// even when it may not be set; treat as empty then
 				return raw, true

--- a/modules/caddyhttp/responsewriter.go
+++ b/modules/caddyhttp/responsewriter.go
@@ -74,17 +74,6 @@ type HTTPInterfaces interface {
 // ResponseWriter does not implement the required method.
 var ErrNotImplemented = fmt.Errorf("method not implemented")
 
-/*
-struct of size 64 bytes could be of size 56 bytes:
-	ResponseWriterWrapper	*github.com/caddyserver/caddy/v2/modules/caddyhttp.ResponseWriterWrapper,
-	statusCode           	int,
-	buf                  	*bytes.Buffer,
-	shouldBuffer         	github.com/caddyserver/caddy/v2/modules/caddyhttp.ShouldBufferFunc,
-	size                 	int,
-	header               	net/http.Header,
-	wroteHeader          	bool,
-	stream               	bool,
-*/
 type responseRecorder struct {
 	*ResponseWriterWrapper
 	statusCode   int

--- a/modules/caddyhttp/responsewriter.go
+++ b/modules/caddyhttp/responsewriter.go
@@ -74,15 +74,26 @@ type HTTPInterfaces interface {
 // ResponseWriter does not implement the required method.
 var ErrNotImplemented = fmt.Errorf("method not implemented")
 
+/*
+struct of size 64 bytes could be of size 56 bytes:
+	ResponseWriterWrapper	*github.com/caddyserver/caddy/v2/modules/caddyhttp.ResponseWriterWrapper,
+	statusCode           	int,
+	buf                  	*bytes.Buffer,
+	shouldBuffer         	github.com/caddyserver/caddy/v2/modules/caddyhttp.ShouldBufferFunc,
+	size                 	int,
+	header               	net/http.Header,
+	wroteHeader          	bool,
+	stream               	bool,
+*/
 type responseRecorder struct {
 	*ResponseWriterWrapper
-	wroteHeader  bool
 	statusCode   int
 	buf          *bytes.Buffer
 	shouldBuffer ShouldBufferFunc
-	stream       bool
 	size         int
 	header       http.Header
+	wroteHeader  bool
+	stream       bool
 }
 
 // NewResponseRecorder returns a new ResponseRecorder that can be

--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -167,7 +167,7 @@ func (routes RouteList) ProvisionHandlers(ctx caddy.Context) error {
 // This should only be done once: after all the routes have
 // been provisioned, and before serving requests.
 func (routes RouteList) Compile(next Handler) Handler {
-	var mid []Middleware
+	mid := make([]Middleware, 0, len(routes))
 	for _, route := range routes {
 		mid = append(mid, wrapRoute(route))
 	}

--- a/modules/caddyhttp/templates/frontmatter.go
+++ b/modules/caddyhttp/templates/frontmatter.go
@@ -33,7 +33,7 @@ func extractFrontMatter(input string) (map[string]interface{}, string, error) {
 	// see what kind of front matter there is, if any
 	var closingFence string
 	var fmParser func([]byte) (map[string]interface{}, error)
-	switch string(firstLine) {
+	switch firstLine {
 	case yamlFrontMatterFenceOpen:
 		fmParser = yamlFrontMatter
 		closingFence = yamlFrontMatterFenceClose

--- a/modules/caddytls/automation.go
+++ b/modules/caddytls/automation.go
@@ -148,7 +148,7 @@ func (ap *AutomationPolicy) Provision(tlsApp *TLS) error {
 	// none of the subjects qualify for a public certificate,
 	// set the issuer to internal so that these names can all
 	// get certificates; critically, we can only do this if an
-	// issuer is not explictly configured (IssuerRaw, vs. just
+	// issuer is not explicitly configured (IssuerRaw, vs. just
 	// Issuer) AND if the list of subjects is non-empty
 	if ap.IssuerRaw == nil && len(ap.Subjects) > 0 {
 		var anyPublic bool

--- a/modules/caddytls/fileloader.go
+++ b/modules/caddytls/fileloader.go
@@ -57,7 +57,7 @@ type CertKeyFilePair struct {
 
 // LoadCertificates returns the certificates to be loaded by fl.
 func (fl FileLoader) LoadCertificates() ([]Certificate, error) {
-	var certs []Certificate
+	certs := make([]Certificate, 0, len(fl))
 	for _, pair := range fl {
 		certData, err := ioutil.ReadFile(pair.Certificate)
 		if err != nil {

--- a/modules/caddytls/pemloader.go
+++ b/modules/caddytls/pemloader.go
@@ -54,7 +54,7 @@ type CertKeyPEMPair struct {
 
 // LoadCertificates returns the certificates contained in pl.
 func (pl PEMLoader) LoadCertificates() ([]Certificate, error) {
-	var certs []Certificate
+	certs := make([]Certificate, 0, len(pl))
 	for i, pair := range pl {
 		cert, err := tls.X509KeyPair([]byte(pair.CertificatePEM), []byte(pair.KeyPEM))
 		if err != nil {

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -457,7 +457,7 @@ func (t *TLS) moveCertificates() error {
 	}
 
 	// get list of used CAs
-	var oldCANames []string
+	oldCANames := make([]string, 0, len(oldAcmeCas))
 	for _, fi := range oldAcmeCas {
 		if !fi.IsDir() {
 			continue


### PR DESCRIPTION
This PR enables 2 additional linters:
- [prealloc](https://github.com/alexkohler/prealloc), which finds slices that can be preallocated and subsequently [leads to better performance and fewer allocations](https://github.com/alexkohler/prealloc#purpose)
- [unconvert](https://github.com/mdempsky/unconvert), which removes unnecessary conversions

I've taken action on all of `unconvert` and most of `prealloc`.  [`maligned`](https://github.com/mdempsky/maligned) reports 4 structs whose size can be reduced:
- 64 B -> 56 B: AdminConfig, AutoHTTPSConfig, responseRecorder
- 152 B -> 144 B: AutomationPolicy