### PR TITLE
caddyhttp: Add placeholder for domains that should have HTTPS redirects

### DIFF
--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -157,6 +157,13 @@ func (app *App) Provision(ctx caddy.Context) error {
 			srv.accessLogger = app.logger.Named("log.access")
 		}
 
+		// add the redirect domains list to be added to the replacer
+		redirDomains, ok := repl.Get("http.autohttps.redir_domains")
+		if !ok {
+			return fmt.Errorf("failed to get redir_domains")
+		}
+		srv.redirDomains = redirDomains.([]string)
+
 		// if not explicitly configured by the user, disallow TLS
 		// client auth bypass (domain fronting) which could
 		// otherwise be exploited by sending an unprotected SNI

--- a/modules/caddyhttp/autohttps.go
+++ b/modules/caddyhttp/autohttps.go
@@ -275,6 +275,15 @@ uniqueDomainsLoop:
 		return err
 	}
 
+	// add the redir domains as an array to the replacer so that
+	// users may choose to handle the redirects themselves
+	// if they have a server block that overrides the redirects
+	domainsArray := []string{}
+	for k := range redirDomains {
+		domainsArray = append(domainsArray, k)
+	}
+	repl.Set("http.autohttps.redir_domains", domainsArray)
+
 	// we need to reduce the mapping, i.e. group domains by address
 	// since new routes are appended to servers by their address
 	domainsByAddr := make(map[string][]string)

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -112,8 +112,11 @@ func (m *MatchExpression) Provision(_ caddy.Context) error {
 
 	// request matching is a boolean operation, so we don't really know
 	// what to do if the expression returns a non-boolean type
-	if !proto.Equal(checked.ResultType(), decls.Bool) {
-		return fmt.Errorf("CEL request matcher expects return type of bool, not %s", checked.ResultType())
+	// TODO: for now, we're allowing Dyn because certain expressions can't have
+	// their type inferred if there's ambiguity.
+	// See https://github.com/caddyserver/caddy/pull/3246#issuecomment-611256387
+	if !proto.Equal(checked.ResultType(), decls.Bool) && !proto.Equal(checked.ResultType(), decls.Dyn) {
+		return fmt.Errorf("CEL request matcher expects return type of bool or dyn, not %s", checked.ResultType())
 	}
 
 	// compile the "program"

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -112,11 +112,8 @@ func (m *MatchExpression) Provision(_ caddy.Context) error {
 
 	// request matching is a boolean operation, so we don't really know
 	// what to do if the expression returns a non-boolean type
-	// TODO: for now, we're allowing Dyn because certain expressions can't have
-	// their type inferred if there's ambiguity.
-	// See https://github.com/caddyserver/caddy/pull/3246#issuecomment-611256387
-	if !proto.Equal(checked.ResultType(), decls.Bool) && !proto.Equal(checked.ResultType(), decls.Dyn) {
-		return fmt.Errorf("CEL request matcher expects return type of bool or dyn, not %s", checked.ResultType())
+	if !proto.Equal(checked.ResultType(), decls.Bool) {
+		return fmt.Errorf("CEL request matcher expects return type of bool, not %s", checked.ResultType())
 	}
 
 	// compile the "program"

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -144,7 +144,6 @@ func (m MatchExpression) Match(r *http.Request) bool {
 		return outBool
 	}
 	return false
-
 }
 
 // UnmarshalCaddyfile implements caddyfile.Unmarshaler.

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -132,6 +132,8 @@ type Server struct {
 	errorLogger  *zap.Logger
 
 	h3server *http3.Server
+
+	redirDomains []string
 }
 
 // ServeHTTP is the entry point for all HTTP requests.
@@ -147,6 +149,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	repl := caddy.NewReplacer()
 	r = PrepareRequest(r, repl, w, s)
+
+	repl.Set("http.autohttps.redir_domains", s.redirDomains)
 
 	// encode the request for logging purposes before
 	// it enters any handler chain; this is necessary


### PR DESCRIPTION
WIP implementation of https://github.com/caddyserver/caddy/issues/3212#issuecomment-611229153

This isn't working yet, when I try to compile the CEL expression, it fails with this message:

```
validate: loading http app module: provision http: server srv1: setting up route matchers: route 0: loading matcher modules: module name 'expression': provis
ion http.matchers.expression: CEL request matcher expects return type of bool, not dyn:<>
```

Using this Caddyfile as a testcase:

```
abc.com {
  respond "HTTPS"
}

bcd.com {
  respond "HTTPS"
}

cde.com {
  respond "HTTPS"
}

http:// {
  @shouldRedir {
    expression {host} in {http.autohttps.redir_domains}
  }
  redir @shouldRedir https://{host}{uri} 308

  respond "HTTP"
}
```

```
$ ./caddy validate --config Caddyfile
```