### PR TITLE
httpcaddyfile: Support single-line matchers

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -964,7 +964,7 @@ func parseMatcherDefinitions(d *caddyfile.Dispenser, matchers map[string]caddy.M
 		// handle more than one segment); otherwise, we'd overwrite other
 		// instances of the matcher in this set
 		tokensByMatcherName := make(map[string][]caddyfile.Token)
-		for nesting := d.Nesting(); d.NextBlock(nesting); {
+		for nesting := d.Nesting(); d.NextArg() || d.NextBlock(nesting); {
 			matcherName := d.Val()
 			tokensByMatcherName[matcherName] = append(tokensByMatcherName[matcherName], d.NextSegment()...)
 		}

--- a/caddyconfig/httpcaddyfile/httptype_test.go
+++ b/caddyconfig/httpcaddyfile/httptype_test.go
@@ -50,6 +50,13 @@ func TestMatcherSyntax(t *testing.T) {
 			expectWarn:  false,
 			expectError: false,
 		},
+		{
+			input: `http://localhost
+			@debug not path /somepath*
+			`,
+			expectWarn:  false,
+			expectError: false,
+		},
 	} {
 
 		adapter := caddyfile.Adapter{

--- a/caddytest/integration/caddyfile_adapt_test.go
+++ b/caddytest/integration/caddyfile_adapt_test.go
@@ -283,3 +283,83 @@ func TestHttpOnlyOnNonStandardPort(t *testing.T) {
 	}
 }`)
 }
+
+func TestMatcherSyntax(t *testing.T) {
+	caddytest.AssertAdapt(t, ` 
+	:80 {
+		@matcher {
+			method GET
+		}
+		respond @matcher "get"
+
+		@matcher2 method POST
+		respond @matcher2 "post"
+
+		@matcher3 not method PUT
+		respond @matcher3 "not put"
+	}
+  `, "caddyfile", `{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"method": [
+										"GET"
+									]
+								}
+							],
+							"handle": [
+								{
+									"body": "get",
+									"handler": "static_response"
+								}
+							]
+						},
+						{
+							"match": [
+								{
+									"method": [
+										"POST"
+									]
+								}
+							],
+							"handle": [
+								{
+									"body": "post",
+									"handler": "static_response"
+								}
+							]
+						},
+						{
+							"match": [
+								{
+									"not": [
+										{
+											"method": [
+												"PUT"
+											]
+										}
+									]
+								}
+							],
+							"handle": [
+								{
+									"body": "not put",
+									"handler": "static_response"
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}`)
+}


### PR DESCRIPTION
I think this is a big win for readability. Almost identical implementation to #3228.

Caddyfile:

```
:80 {
    @matcher {
        method GET
    }
    respond @matcher "get"

    @matcher2 method POST
    respond @matcher2 "post"

    @matcher3 not method PUT
    respond @matcher3 "not put"
}
```

JSON:

```
{
  "apps": {
    "http": {
      "servers": {
        "srv0": {
          "listen": [
            ":80"
          ],
          "routes": [
            {
              "match": [
                {
                  "method": [
                    "GET"
                  ]
                }
              ],
              "handle": [
                {
                  "body": "get",
                  "handler": "static_response"
                }
              ]
            },
            {
              "match": [
                {
                  "method": [
                    "POST"
                  ]
                }
              ],
              "handle": [
                {
                  "body": "post",
                  "handler": "static_response"
                }
              ]
            },
            {
              "match": [
                {
                  "not": [
                    {
                      "method": [
                        "PUT"
                      ]
                    }
                  ]
                }
              ],
              "handle": [
                {
                  "body": "not put",
                  "handler": "static_response"
                }
              ]
            }
          ]
        }
      }
    }
  }
}
```