### PR TITLE
caddyconfig: Only parse `#` as the start of a comment if preceded by whitespace

### DIFF
--- a/caddyconfig/caddyfile/formatter.go
+++ b/caddyconfig/caddyfile/formatter.go
@@ -131,9 +131,6 @@ func Format(input []byte) []byte {
 		//////////////////////////////////////////////////////////
 
 		if ch == '#' {
-			if !spacePrior && !beginningOfLine {
-				write(' ')
-			}
 			comment = true
 		}
 

--- a/caddyconfig/caddyfile/formatter_test.go
+++ b/caddyconfig/caddyfile/formatter_test.go
@@ -201,7 +201,7 @@ c
 }
 
 d {
-	e #f
+	e#f
 	# g
 }
 
@@ -229,7 +229,7 @@ bar"
 j {
 "\"k\" l m"
 }`,
-			expect: `"a \"b\" " #c
+			expect: `"a \"b\" "#c
 d
 
 e {
@@ -304,6 +304,11 @@ bar "{\"key\":34}"`,
 }
 
 baz`,
+		},
+		{
+			description: "hash within string is not a comment",
+			input:       `redir / /some/#/path`,
+			expect:      `redir / /some/#/path`,
 		},
 	} {
 		// the formatter should output a trailing newline,

--- a/caddyconfig/caddyfile/lexer.go
+++ b/caddyconfig/caddyfile/lexer.go
@@ -74,7 +74,6 @@ func (l *lexer) load(input io.Reader) error {
 func (l *lexer) next() bool {
 	var val []rune
 	var comment, quoted, escaped bool
-	var spacePrior = true
 
 	makeToken := func() bool {
 		l.token.Text = string(val)
@@ -120,7 +119,6 @@ func (l *lexer) next() bool {
 		}
 
 		if unicode.IsSpace(ch) {
-			spacePrior = true
 			if ch == '\r' {
 				continue
 			}
@@ -140,12 +138,9 @@ func (l *lexer) next() bool {
 			continue
 		}
 
-		if ch == '#' && spacePrior {
+		if ch == '#' && len(val) == 0 {
 			comment = true
 		}
-
-		spacePrior = false
-
 		if comment {
 			continue
 		}

--- a/caddyconfig/caddyfile/lexer.go
+++ b/caddyconfig/caddyfile/lexer.go
@@ -74,6 +74,7 @@ func (l *lexer) load(input io.Reader) error {
 func (l *lexer) next() bool {
 	var val []rune
 	var comment, quoted, escaped bool
+	var spacePrior = true
 
 	makeToken := func() bool {
 		l.token.Text = string(val)
@@ -119,6 +120,7 @@ func (l *lexer) next() bool {
 		}
 
 		if unicode.IsSpace(ch) {
+			spacePrior = true
 			if ch == '\r' {
 				continue
 			}
@@ -138,9 +140,12 @@ func (l *lexer) next() bool {
 			continue
 		}
 
-		if ch == '#' {
+		if ch == '#' && spacePrior {
 			comment = true
 		}
+
+		spacePrior = false
+
 		if comment {
 			continue
 		}

--- a/caddyconfig/caddyfile/lexer_test.go
+++ b/caddyconfig/caddyfile/lexer_test.go
@@ -92,6 +92,12 @@ func TestLexer(t *testing.T) {
 			},
 		},
 		{
+			input: "# comment at beginning of file\n# comment at beginning of line\nhost:123",
+			expected: []Token{
+				{Line: 3, Text: "host:123"},
+			},
+		},
+		{
 			input: `a "quoted value" b
 					foobar`,
 			expected: []Token{

--- a/caddyconfig/caddyfile/lexer_test.go
+++ b/caddyconfig/caddyfile/lexer_test.go
@@ -78,6 +78,20 @@ func TestLexer(t *testing.T) {
 			},
 		},
 		{
+			input: `host:123 {
+						# hash inside string is not a comment
+						redir / /some/#/path
+					}`,
+			expected: []Token{
+				{Line: 1, Text: "host:123"},
+				{Line: 1, Text: "{"},
+				{Line: 3, Text: "redir"},
+				{Line: 3, Text: "/"},
+				{Line: 3, Text: "/some/#/path"},
+				{Line: 4, Text: "}"},
+			},
+		},
+		{
 			input: `a "quoted value" b
 					foobar`,
 			expected: []Token{


### PR DESCRIPTION
See discussion in https://caddy.community/t/example-for-redir/7475

Also updated `caddy fmt` to skip adding a space before `#` when it shouldn't