### PR TITLE
httpcaddyfile: Add `auto_https` global option

### DIFF
--- a/caddyconfig/httpcaddyfile/options.go
+++ b/caddyconfig/httpcaddyfile/options.go
@@ -38,6 +38,7 @@ func init() {
 	RegisterGlobalOption("on_demand_tls", parseOptOnDemand)
 	RegisterGlobalOption("local_certs", parseOptTrue)
 	RegisterGlobalOption("key_type", parseOptSingleString)
+	RegisterGlobalOption("auto_https", parseOptAutoHTTPS)
 }
 
 func parseOptTrue(d *caddyfile.Dispenser) (interface{}, error) {
@@ -263,4 +264,19 @@ func parseOptOnDemand(d *caddyfile.Dispenser) (interface{}, error) {
 		return nil, d.Err("expected at least one config parameter for on_demand_tls")
 	}
 	return ond, nil
+}
+
+func parseOptAutoHTTPS(d *caddyfile.Dispenser) (interface{}, error) {
+	d.Next() // consume parameter name
+	if !d.Next() {
+		return "", d.ArgErr()
+	}
+	val := d.Val()
+	if d.Next() {
+		return "", d.ArgErr()
+	}
+	if val != "off" && val != "disable_redirects" {
+		return "", d.Errf("auto_https must be either 'off' or 'disable_redirects'")
+	}
+	return val, nil
 }

--- a/caddytest/integration/caddyfile_adapt/auto_https_disable_redirects.txt
+++ b/caddytest/integration/caddyfile_adapt/auto_https_disable_redirects.txt
@@ -1,0 +1,34 @@
+{
+	auto_https disable_redirects
+}
+
+localhost
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"localhost"
+									]
+								}
+							],
+							"terminal": true
+						}
+					],
+					"automatic_https": {
+						"disable_redirects": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/caddytest/integration/caddyfile_adapt/auto_https_off.txt
+++ b/caddytest/integration/caddyfile_adapt/auto_https_off.txt
@@ -1,0 +1,37 @@
+{
+	auto_https off
+}
+
+localhost
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"localhost"
+									]
+								}
+							],
+							"terminal": true
+						}
+					],
+					"tls_connection_policies": [
+						{}
+					],
+					"automatic_https": {
+						"disable": true
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3219 

Adds a new global option to the Caddyfile to configure Automatic HTTPS:

```
{
	auto_https [off|disable_redirects]
}
```

---

Disabling redirects from Caddyfile:
```
{
	auto_https disable_redirects
}

localhost
```

JSON:
```
{
	"apps": {
		"http": {
			"servers": {
				"srv0": {
					"listen": [
						":443"
					],
					"routes": [
						{
							"match": [
								{
									"host": [
										"localhost"
									]
								}
							],
							"terminal": true
						}
					],
					"automatic_https": {
						"disable_redirects": true
					}
				}
			}
		}
	}
}
```

---

Disabling Auto HTTPS completely from Caddyfile:
```
{
	auto_https off
}

localhost
```

JSON:
```
{
	"apps": {
		"http": {
			"servers": {
				"srv0": {
					"listen": [
						":443"
					],
					"routes": [
						{
							"match": [
								{
									"host": [
										"localhost"
									]
								}
							],
							"terminal": true
						}
					],
					"tls_connection_policies": [
						{}
					],
					"automatic_https": {
						"disable": true
					}
				}
			}
		}
	}
}
```