### PR TITLE
reverseproxy: always set the req.URL.Host with the upstream

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -613,19 +613,17 @@ func (lb LoadBalancing) tryAgain(start time.Time, proxyErr error, req *http.Requ
 // directRequest modifies only req.URL so that it points to the upstream
 // in the given DialInfo. It must modify ONLY the request URL.
 func (h Handler) directRequest(req *http.Request, di DialInfo) {
-	if req.URL.Host == "" {
-		// we need a host, so set the upstream's host address
-		reqHost := di.Address
+	// we need a host, so set the upstream's host address
+	reqHost := di.Address
 
-		// if the port equates to the scheme, strip the port because
-		// it's weird to make a request like http://example.com:80/.
-		if (req.URL.Scheme == "http" && di.Port == "80") ||
-			(req.URL.Scheme == "https" && di.Port == "443") {
-			reqHost = di.Host
-		}
-
-		req.URL.Host = reqHost
+	// if the port equates to the scheme, strip the port because
+	// it's weird to make a request like http://example.com:80/.
+	if (req.URL.Scheme == "http" && di.Port == "80") ||
+		(req.URL.Scheme == "https" && di.Port == "443") {
+		reqHost = di.Host
 	}
+
+	req.URL.Host = reqHost
 }
 
 // shouldPanicOnCopyError reports whether the reverse proxy should


### PR DESCRIPTION
Issue Description: reverse proxy with round-robin policy always forwards the traffic to one upstream node.

How to Reproduce: 
1. set up upstream http service with two nodes(keep-alive enabled, on port 9010 and 9020)
2. set up caddy as a reverse proxy with config: 
:2015 {
    reverse_proxy /* 127.0.0.1:9010 127.0.0.1:9020 {
        lb_policy round_robin
        lb_try_duration 100ms
        lb_try_interval 250ms
    }
}
3. run the reverse proxy, and do a infinite loop test against :2015 to see the traffics are round-robin forwarded to 9010/9020
4. during the test, kill the service on 9010, and restart 9010
5. check the traffics will never forward to 9010, which always sticks to 9020

Test on macos