### PR TITLE
reverseproxy: always set the req.URL.Host with the upstream

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -613,19 +613,17 @@ func (lb LoadBalancing) tryAgain(start time.Time, proxyErr error, req *http.Requ
 // directRequest modifies only req.URL so that it points to the upstream
 // in the given DialInfo. It must modify ONLY the request URL.
 func (h Handler) directRequest(req *http.Request, di DialInfo) {
-	if req.URL.Host == "" {
-		// we need a host, so set the upstream's host address
-		reqHost := di.Address
+	// we need a host, so set the upstream's host address
+	reqHost := di.Address
 
-		// if the port equates to the scheme, strip the port because
-		// it's weird to make a request like http://example.com:80/.
-		if (req.URL.Scheme == "http" && di.Port == "80") ||
-			(req.URL.Scheme == "https" && di.Port == "443") {
-			reqHost = di.Host
-		}
-
-		req.URL.Host = reqHost
+	// if the port equates to the scheme, strip the port because
+	// it's weird to make a request like http://example.com:80/.
+	if (req.URL.Scheme == "http" && di.Port == "80") ||
+		(req.URL.Scheme == "https" && di.Port == "443") {
+		reqHost = di.Host
 	}
+
+	req.URL.Host = reqHost
 }
 
 // shouldPanicOnCopyError reports whether the reverse proxy should


### PR DESCRIPTION
resubmit the PR of https://github.com/caddyserver/caddy/pull/3290

due to the CLA(I used a fake email address in my git config, sorry for the inconvenience for re-submit)