### PR TITLE
file_server: Accept files args in one-liner of Caddyfile matcher

### DIFF
--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -80,7 +80,7 @@ func (MatchFile) CaddyModule() caddy.ModuleInfo {
 
 // UnmarshalCaddyfile sets up the matcher from Caddyfile tokens. Syntax:
 //
-//     file {
+//     file <files...> {
 //         root <path>
 //         try_files <files...>
 //         try_policy first_exist|smallest_size|largest_size|most_recently_modified
@@ -88,6 +88,7 @@ func (MatchFile) CaddyModule() caddy.ModuleInfo {
 //
 func (m *MatchFile) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
+		m.TryFiles = append(m.TryFiles, d.RemainingArgs()...)
 		for d.NextBlock(0) {
 			switch d.Val() {
 			case "root":
@@ -96,7 +97,7 @@ func (m *MatchFile) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				}
 				m.Root = d.Val()
 			case "try_files":
-				m.TryFiles = d.RemainingArgs()
+				m.TryFiles = append(m.TryFiles, d.RemainingArgs()...)
 				if len(m.TryFiles) == 0 {
 					return d.ArgErr()
 				}


### PR DESCRIPTION
Previously, matching by trying files other than the actual path of the URI was:

    file {
        try_files <files...>
    }

Now, the same can be done in one line:

    file <files...>

As before, an empty file matcher:

    file

still matches if the request URI exists as a file in the site root.

Inspired by: https://caddy.community/t/why-caddy-2-is-not-able-to-serve-static-brotli-files/7653/19?u=matt