### PR TITLE
caddytest: add AssertPostResponse and test client struct

### DIFF
--- a/caddytest/caddytest.go
+++ b/caddytest/caddytest.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/http/cookiejar"
 	"os"
 	"path"
 	"regexp"
@@ -30,6 +31,7 @@ import (
 // Tester represents an instance of a test client.
 type Tester struct {
 	Client *http.Client
+	Jar    *cookiejar.Jar
 	t      *testing.T
 }
 

--- a/caddytest/caddytest_test.go
+++ b/caddytest/caddytest_test.go
@@ -1,6 +1,7 @@
 package caddytest
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 )
@@ -30,4 +31,84 @@ func TestReplaceCertificatePaths(t *testing.T) {
 	if !strings.Contains(r, "https://b.caddy.localhost:9443/version") {
 		t.Error("expected redirect uri to be unchanged")
 	}
+}
+
+func TestAssertPostResponse(t *testing.T) {
+	rawConfig := `{
+	  "logging": {
+		"logs": {
+		  "default": {
+			"level": "DEBUG"
+		  }
+		}
+	  },
+	  "apps": {
+		"http": {
+		  "https_port": 9443,
+		  "servers": {
+			"srv0": {
+			  "listen": [
+				":9443"
+			  ],
+			  "routes": [
+				{
+				  "handle": [
+					{
+					  "body": "OK",
+					  "handler": "static_response",
+					  "status_code": 200
+					}
+				  ],
+				  "match": [
+					{
+					  "path": [
+						"/health"
+					  ]
+					}
+				  ],
+				  "terminal": true
+				}
+			  ],
+			  "tls_connection_policies": [
+				{
+				  "certificate_selection": {
+					"any_tag": [
+					  "cert0"
+					]
+				  }
+				}
+			  ]
+			}
+		  }
+		},
+		"tls": {
+		  "certificates": {
+			"load_files": [
+			  {
+				"certificate": "/caddy.localhost.crt",
+				"key": "/caddy.localhost.key",
+				"tags": [
+				  "cert0"
+				]
+			  }
+			]
+		  }
+		},
+		"pki": {
+		  "certificate_authorities": {
+			"local": {
+			  "install_trust": false
+			}
+		  }
+		}
+	  }
+	}`
+	baseURL := "https://localhost:9443"
+	InitServer(t, rawConfig, "json")
+	AssertGetResponse(t, baseURL+"/health", 200, "OK")
+	reqHeaders := []string{
+		"Content-Type: application/x-www-form-urlencoded",
+	}
+	reqPayload := bytes.NewBufferString("foo=bar")
+	AssertPostResponse(t, baseURL+"/health", reqHeaders, reqPayload, 200, "OK")
 }


### PR DESCRIPTION
Changes per my comment here: https://github.com/caddyserver/caddy/pull/3285#pullrequestreview-396450281