### PR TITLE
httpcaddyfile: Add shorthands for parameterized placeholders

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -109,7 +109,7 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 		{regexp.MustCompile(`{labels\.([\w-]*)}`), "{http.request.host.labels.$1}"},
 		{regexp.MustCompile(`{header\.([\w-]*)}`), "{http.request.header.$1}"},
 		{regexp.MustCompile(`{path\.([\w-]*)}`), "{http.request.uri.path.$1}"},
-		{regexp.MustCompile(`{r\.([\w-]*)\.([\w-]*)}`), "{http.regexp.$1.$2}"},
+		{regexp.MustCompile(`{re\.([\w-]*)\.([\w-]*)}`), "{http.regexp.$1.$2}"},
 	}
 
 	for _, sb := range originalServerBlocks {

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -71,34 +72,55 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 		return nil, warnings, err
 	}
 
+	// replace shorthand placeholders (which are
+	// convenient when writing a Caddyfile) with
+	// their actual placeholder identifiers or
+	// variable names
+	replacer := strings.NewReplacer(
+		"{dir}", "{http.request.uri.path.dir}",
+		"{file}", "{http.request.uri.path.file}",
+		"{host}", "{http.request.host}",
+		"{hostport}", "{http.request.hostport}",
+		"{port}", "{http.request.port}",
+		"{method}", "{http.request.method}",
+		"{path}", "{http.request.uri.path}",
+		"{query}", "{http.request.uri.query}",
+		"{remote}", "{http.request.remote}",
+		"{remote_host}", "{http.request.remote.host}",
+		"{remote_port}", "{http.request.remote.port}",
+		"{scheme}", "{http.request.scheme}",
+		"{uri}", "{http.request.uri}",
+		"{tls_cipher}", "{http.request.tls.cipher_suite}",
+		"{tls_version}", "{http.request.tls.version}",
+		"{tls_client_fingerprint}", "{http.request.tls.client.fingerprint}",
+		"{tls_client_issuer}", "{http.request.tls.client.issuer}",
+		"{tls_client_serial}", "{http.request.tls.client.serial}",
+		"{tls_client_subject}", "{http.request.tls.client.subject}",
+	)
+
+	// these are placeholders that allow a user-defined final
+	// parameters, but we still want to provide a shorthand
+	// for those, so we use a regexp to replace
+	regexpReplacements := []struct {
+		search  *regexp.Regexp
+		replace string
+	}{
+		{regexp.MustCompile(`{query\.([\w-]*)}`), "{http.request.uri.query.$1}"},
+		{regexp.MustCompile(`{labels\.([\w-]*)}`), "{http.request.host.labels.$1}"},
+		{regexp.MustCompile(`{header\.([\w-]*)}`), "{http.request.header.$1}"},
+		{regexp.MustCompile(`{path\.([\w-]*)}`), "{http.request.uri.path.$1}"},
+		{regexp.MustCompile(`{r\.([\w-]*)\.([\w-]*)}`), "{http.regexp.$1.$2}"},
+	}
+
 	for _, sb := range originalServerBlocks {
-		// replace shorthand placeholders (which are
-		// convenient when writing a Caddyfile) with
-		// their actual placeholder identifiers or
-		// variable names
-		replacer := strings.NewReplacer(
-			"{dir}", "{http.request.uri.path.dir}",
-			"{file}", "{http.request.uri.path.file}",
-			"{host}", "{http.request.host}",
-			"{hostport}", "{http.request.hostport}",
-			"{method}", "{http.request.method}",
-			"{path}", "{http.request.uri.path}",
-			"{query}", "{http.request.uri.query}",
-			"{remote}", "{http.request.remote}",
-			"{remote_host}", "{http.request.remote.host}",
-			"{remote_port}", "{http.request.remote.port}",
-			"{scheme}", "{http.request.scheme}",
-			"{uri}", "{http.request.uri}",
-			"{tls_cipher}", "{http.request.tls.cipher_suite}",
-			"{tls_version}", "{http.request.tls.version}",
-			"{tls_client_fingerprint}", "{http.request.tls.client.fingerprint}",
-			"{tls_client_issuer}", "{http.request.tls.client.issuer}",
-			"{tls_client_serial}", "{http.request.tls.client.serial}",
-			"{tls_client_subject}", "{http.request.tls.client.subject}",
-		)
 		for _, segment := range sb.block.Segments {
 			for i := 0; i < len(segment); i++ {
+				// simple string replacements
 				segment[i].Text = replacer.Replace(segment[i].Text)
+				// complex regexp replacements
+				for _, r := range regexpReplacements {
+					segment[i].Text = r.search.ReplaceAllString(segment[i].Text, r.replace)
+				}
 			}
 		}
 

--- a/caddytest/integration/caddyfile_adapt_test.go
+++ b/caddytest/integration/caddyfile_adapt_test.go
@@ -543,7 +543,7 @@ func TestLogRollDays(t *testing.T) {
 func TestShorthandParameterizedPlaceholders(t *testing.T) {
 	caddytest.AssertAdapt(t, `
 	localhost:80
-	respond * "{header.content-type} {labels.0} {query.p} {path.0} {r.name.0}"
+	respond * "{header.content-type} {labels.0} {query.p} {path.0} {re.name.0}"
 	`, "caddyfile", `{
 	"apps": {
 		"http": {

--- a/caddytest/integration/caddyfile_adapt_test.go
+++ b/caddytest/integration/caddyfile_adapt_test.go
@@ -539,3 +539,49 @@ func TestLogRollDays(t *testing.T) {
 	}
 }`)
 }
+
+func TestShorthandParameterizedPlaceholders(t *testing.T) {
+	caddytest.AssertAdapt(t, `
+	localhost:80
+	respond * "{header.content-type} {labels.0} {query.p} {path.0} {r.name.0}"
+	`, "caddyfile", `{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"localhost"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "{http.request.header.content-type} {http.request.host.labels.0} {http.request.uri.query.p} {http.request.uri.path.0} {http.regexp.name.0}",
+													"handler": "static_response"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		}
+	}
+}`)
+}


### PR DESCRIPTION
Adds the following new placeholder shorthands to the Caddyfile (plus one non-`*` placeholder):

```
{port}      ->  {http.request.port}
{query.*}   ->  {http.request.uri.query.*}
{labels.*}  ->  {http.request.host.labels.*}
{header.*}  ->  {http.request.header.*}
{path.*}    ->  {http.request.uri.path.*}
{re.*.*}    ->  {http.regexp.*.*}
```

These are quite commonly used placeholders. Because they're relatively long, it's hard to remember the exact syntax on the fly, requiring frequent referencing of the docs to verify.

~Currently I implemented this via just a quick prefix replacement, it's unlikely users would use these string patterns on their own. Probably the most concerning would be `{r.` because it's such a short sequence.~

~I chose the very short `{r.*.*}` as the syntax for the regexp placeholder, because when users provide a name argument, it's pretty obvious what `r` is referencing, since the name will be associated with a `path_regexp` or `header_regexp` matcher. It's easy to trace in the Caddyfile.~

Edit: Switched to `{re.*.*}` for some added clarity.

~As an improvement to this, in second iteration I think we could implement this via regexp replacements instead, it would probably be safer as well because we'd verify the final `}` is actually present. Just wanted to get out a quick proof of concept first.~

Edit: Done, implemented using regexp. Pretty easy.