### PR TITLE
ci: Enable GoReleaser .deb support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,9 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ${{ steps.vars.outputs.go_cache }}
-        key: ${{ runner.os }}-go-gocache-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-ci-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-go-ci
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Unshallowify the repo clone
       run: git fetch --prune --unshallow
 
+    # https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
     - name: Print Go version and environment
       id: vars
       run: |
@@ -39,11 +40,6 @@ jobs:
         go env
         printf "\n\nSystem environment:\n\n"
         env
-    
-    # https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
-    - name: Get the version
-      id: vars
-      run: |
         echo "::set-output name=version_tag::${GITHUB_REF/refs\/tags\//}"
         echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
         echo "::set-output name=go_cache::$(go env GOCACHE)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,9 @@ jobs:
     # https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
     - name: Get the version
       id: get_version
-      run: echo "::set-output name=version_tag::${GITHUB_REF/refs\/tags\//}"
+      run: |
+        echo "::set-output name=version_tag::${GITHUB_REF/refs\/tags\//}"
+        echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
 
     # GoReleaser will take care of publishing those artifacts into the release
     - name: Run GoReleaser
@@ -55,3 +57,10 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: v2.0.0-rc.3
         # TAG: ${{ steps.get_version.outputs.version_tag }}
+
+    - name: Publish Build Artifact
+      uses: actions/upload-artifact@v2-preview
+      with:
+        name: caddy_v2_${{ steps.get_version.outputs.short_sha }}
+        path: dist/caddy*.deb
+        # path: dist/caddy_v2.0.0-rc.3-SNAPSHOT-${{ steps.vars.outputs.short_sha }}_linux_amd64.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,5 +75,5 @@ jobs:
         GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}
       run: |
         for filename in dist/*.deb; do
-          curl -F package=@"$filename" https://${GEMFURY_PUSH_TOKEN}@push.fury.io/caddy/
+          curl -F package=@"$filename" https://${GEMFURY_PUSH_TOKEN}:@push.fury.io/caddy/
         done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,4 +53,5 @@ jobs:
         args: release --rm-dist --skip-publish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TAG: ${{ steps.get_version.outputs.version_tag }}
+        TAG: v2.0.0-rc.3
+        # TAG: ${{ steps.get_version.outputs.version_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,7 @@ jobs:
       env:
         GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}
       run: |
+        echo "Token length: ${#GEMFURY_PUSH_TOKEN}"
         for filename in dist/*.deb; do
           curl -F package=@"$filename" https://${GEMFURY_PUSH_TOKEN}:@push.fury.io/caddy/
         done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,6 @@ on:
   push:
     tags:
       - 'v*.*.*'
-  pull_request:
-    branches:
-      - master
 
 jobs:
   release:
@@ -57,24 +54,15 @@ jobs:
       uses: goreleaser/goreleaser-action@v1
       with:
         version: latest
-        args: release --rm-dist --skip-publish
+        args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TAG: v2.0.0-rc.3
-        # TAG: ${{ steps.vars.outputs.version_tag }}
-
-    - name: Publish Build Artifact
-      uses: actions/upload-artifact@v2-preview
-      with:
-        name: caddy_v2_${{ steps.vars.outputs.short_sha }}
-        path: dist/caddy*.deb
-        # path: dist/caddy_v2.0.0-rc.3-SNAPSHOT-${{ steps.vars.outputs.short_sha }}_linux_amd64.deb
+        TAG: ${{ steps.vars.outputs.version_tag }}
 
     - name: Publish .deb to Gemfury
       env:
         GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}
       run: |
-        echo "Token length: ${#GEMFURY_PUSH_TOKEN}"
         for filename in dist/*.deb; do
           curl -F package=@"$filename" https://${GEMFURY_PUSH_TOKEN}:@push.fury.io/caddy/
         done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,9 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ${{ steps.vars.outputs.go_cache }}
-        key: ${{ runner.os }}-go-gocache-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-release-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-go-release
 
     # GoReleaser will take care of publishing those artifacts into the release
     - name: Run GoReleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,3 +69,12 @@ jobs:
         name: caddy_v2_${{ steps.vars.outputs.short_sha }}
         path: dist/caddy*.deb
         # path: dist/caddy_v2.0.0-rc.3-SNAPSHOT-${{ steps.vars.outputs.short_sha }}_linux_amd64.deb
+
+    - name: Publish .deb to Gemfury
+      env:
+        GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}
+      run: |
+        curl -F package=@dist/caddy*linux_armv6.deb https://{$GEMFURY_PUSH_TOKEN}@push.fury.io/caddy/
+        curl -F package=@dist/caddy*linux_armv7.deb https://{$GEMFURY_PUSH_TOKEN}@push.fury.io/caddy/
+        curl -F package=@dist/caddy*linux_arm64.deb https://{$GEMFURY_PUSH_TOKEN}@push.fury.io/caddy/
+        curl -F package=@dist/caddy*linux_amd64.deb https://{$GEMFURY_PUSH_TOKEN}@push.fury.io/caddy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v1
       with:
         version: latest
-        args: release --rm-dist --snapshot --skip-publish
+        args: release --rm-dist --skip-publish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ steps.get_version.outputs.version_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,6 @@ jobs:
       env:
         GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}
       run: |
-        curl -F package=@dist/caddy*linux_armv6.deb https://{$GEMFURY_PUSH_TOKEN}@push.fury.io/caddy/
-        curl -F package=@dist/caddy*linux_armv7.deb https://{$GEMFURY_PUSH_TOKEN}@push.fury.io/caddy/
-        curl -F package=@dist/caddy*linux_arm64.deb https://{$GEMFURY_PUSH_TOKEN}@push.fury.io/caddy/
-        curl -F package=@dist/caddy*linux_amd64.deb https://{$GEMFURY_PUSH_TOKEN}@push.fury.io/caddy/
+        for filename in dist/*.deb; do
+          curl -F package=@"$filename" https://${GEMFURY_PUSH_TOKEN}@push.fury.io/caddy/
+        done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  pull_request:
+    branches:
+      - master
 
 jobs:
   release:
@@ -47,7 +50,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v1
       with:
         version: latest
-        args: release --rm-dist
+        args: release --rm-dist --snapshot --skip-publish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ steps.get_version.outputs.version_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,19 @@ jobs:
     
     # https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
     - name: Get the version
-      id: get_version
+      id: vars
       run: |
         echo "::set-output name=version_tag::${GITHUB_REF/refs\/tags\//}"
         echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
+        echo "::set-output name=go_cache::$(go env GOCACHE)"
+
+    - name: Cache the build cache
+      uses: actions/cache@v1
+      with:
+        path: ${{ steps.vars.outputs.go_cache }}
+        key: ${{ runner.os }}-go-gocache-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     # GoReleaser will take care of publishing those artifacts into the release
     - name: Run GoReleaser
@@ -56,11 +65,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: v2.0.0-rc.3
-        # TAG: ${{ steps.get_version.outputs.version_tag }}
+        # TAG: ${{ steps.vars.outputs.version_tag }}
 
     - name: Publish Build Artifact
       uses: actions/upload-artifact@v2-preview
       with:
-        name: caddy_v2_${{ steps.get_version.outputs.short_sha }}
+        name: caddy_v2_${{ steps.vars.outputs.short_sha }}
         path: dist/caddy*.deb
         # path: dist/caddy_v2.0.0-rc.3-SNAPSHOT-${{ steps.vars.outputs.short_sha }}_linux_amd64.deb

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -72,9 +72,9 @@ nfpms:
       ./caddy-dist/config/Caddyfile: /etc/caddy/Caddyfile
 
     scripts:
-      preinstall: ./caddy-dist/scripts/preinstall.sh
       postinstall: ./caddy-dist/scripts/postinstall.sh
       preremove: ./caddy-dist/scripts/preremove.sh
+      postremove: ./caddy-dist/scripts/postremove.sh
 
 
 release:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,8 +50,6 @@ nfpms:
   - id: default
     package_name: caddy
 
-    # file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
-
     vendor: Light Code Labs
     homepage: https://caddyserver.com
     maintainer: Matthew Holt <mholt@users.noreply.github.com>

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,6 +66,7 @@ nfpms:
     bindir: /usr/local/bin
     files:
       ./caddy-dist/init/caddy.service: /lib/systemd/system/caddy.service
+      ./caddy-dist/init/caddy-api.service: /lib/systemd/system/caddy-api.service
       ./caddy-dist/welcome/index.html: /usr/share/caddy/index.html
     config_files:
       ./caddy-dist/config/Caddyfile: /etc/caddy/Caddyfile

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,7 @@ archives:
 checksum:
   algorithm: sha512
 
-nfpm:
+nfpms:
   - id: default
     package_name: caddy
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,8 +51,6 @@ nfpms:
     package_name: caddy
 
     # file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
-    replacements:
-      darwin: mac
 
     vendor: Light Code Labs
     homepage: https://caddyserver.com

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,7 +63,7 @@ nfpms:
       - deb
       # - rpm
 
-    bindir: /usr/local/bin
+    bindir: /usr/bin
     files:
       ./caddy-dist/init/caddy.service: /lib/systemd/system/caddy.service
       ./caddy-dist/init/caddy-api.service: /lib/systemd/system/caddy-api.service

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,12 +3,13 @@ before:
     - mkdir -p caddy-build
     - cp cmd/caddy/main.go caddy-build/main.go
     - cp ./go.mod caddy-build/go.mod
-    - sed -i.bkp s/github.com\/caddyserver\/caddy\/v2/caddy/g ./caddy-build/go.mod
+    - sed -i.bkp 's|github.com/caddyserver/caddy/v2|caddy|g' ./caddy-build/go.mod
     # GoReleaser doesn't seem to offer {{.Tag}} at this stage, so we have to embed it into the env
     # so we run: TAG=$(git describe --abbrev=0) goreleaser release --rm-dist --skip-publish --skip-validate
     - go mod edit -require=github.com/caddyserver/caddy/v2@{{.Env.TAG}} ./caddy-build/go.mod
     - git clone --depth 1 https://github.com/caddyserver/dist caddy-dist
     - go mod download
+
 builds:
 - env:
   - CGO_ENABLED=0
@@ -35,6 +36,7 @@ builds:
   - -trimpath
   ldflags:
   - -s -w
+
 archives:
   - format_overrides:
       - goos: windows
@@ -43,12 +45,46 @@ archives:
       darwin: mac
 checksum:
   algorithm: sha512
+
+nfpm:
+  - id: default
+    package_name: caddy
+
+    # file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+    replacements:
+      darwin: mac
+
+    vendor: Light Code Labs
+    homepage: https://caddyserver.com
+    maintainer: Matthew Holt <mholt@users.noreply.github.com>
+    description: |
+      Powerful, enterprise-ready, open source web server with automatic HTTPS written in Go
+    license: Apache 2.0
+
+    formats:
+      - deb
+      # - rpm
+
+    bindir: /usr/local/bin
+    files:
+      ./caddy-dist/init/caddy.service: /lib/systemd/system/caddy.service
+      ./caddy-dist/welcome/index.html: /usr/share/caddy/index.html
+    config_files:
+      ./caddy-dist/config/Caddyfile: /etc/caddy/Caddyfile
+
+    scripts:
+      preinstall: ./caddy-dist/scripts/preinstall.sh
+      postinstall: ./caddy-dist/scripts/postinstall.sh
+      preremove: ./caddy-dist/scripts/preremove.sh
+
+
 release:
   github:
     owner: caddyserver
     name: caddy
   draft: true
   prerelease: auto
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
Replaces #3280

I need to do this from a branch on this repo to be able to test using secrets, i.e. for gemfury.

~Work in progress.~

~TODO:~
- [x] Set up uploading to https://gemfury.com
- [x] Improve scripts to deal with `caddy-api` service file
  - In postinstall:
    - if `caddy` is enabled, restart that one
    - if `caddy-api` is enabled, then restart that one
    - else enable and start `caddy`
  - In preremove:
    - if `caddy` is enabled, then stop and disable that one
    - if `caddy-api` is enabled, then stop and disable that one
- [x] Clean up CI config afterwards to put it back in "release mode"
  - Turn off the PR trigger
  - Remove `--skip-publish` in GoReleaser
  - Remove publishing the `.deb` as Github artifacts