### PR TITLE
caddyhttp: Implement status_code handler

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -35,6 +35,7 @@ func init() {
 	RegisterHandlerDirective("root", parseRoot)
 	RegisterHandlerDirective("redir", parseRedir)
 	RegisterHandlerDirective("respond", parseRespond)
+	RegisterHandlerDirective("status_code", parseStatusCode)
 	RegisterHandlerDirective("route", parseRoute)
 	RegisterHandlerDirective("handle", parseHandle)
 	RegisterDirective("handle_errors", parseHandleErrors)
@@ -386,6 +387,16 @@ func parseRedir(h Helper) (caddyhttp.MiddlewareHandler, error) {
 // parseRespond parses the respond directive.
 func parseRespond(h Helper) (caddyhttp.MiddlewareHandler, error) {
 	sr := new(caddyhttp.StaticResponse)
+	err := sr.UnmarshalCaddyfile(h.Dispenser)
+	if err != nil {
+		return nil, err
+	}
+	return sr, nil
+}
+
+// parseStatusCode parses the status_code directive.
+func parseStatusCode(h Helper) (caddyhttp.MiddlewareHandler, error) {
+	sr := new(caddyhttp.StatusCode)
 	err := sr.UnmarshalCaddyfile(h.Dispenser)
 	if err != nil {
 		return nil, err

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -52,6 +52,7 @@ var directiveOrder = []string{
 	"basicauth",
 	"request_header",
 	"encode",
+	"status_code",
 	"templates",
 
 	// special routing directives

--- a/modules/caddyhttp/statuscode.go
+++ b/modules/caddyhttp/statuscode.go
@@ -1,0 +1,84 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddyhttp
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+)
+
+func init() {
+	caddy.RegisterModule(StatusCode{})
+}
+
+// StaticResponse implements a simple responder for static responses.
+type StatusCode struct {
+	// The HTTP status code to respond with. Can be an integer or,
+	// if needing to use a placeholder, a string.
+	StatusCode WeakString `json:"status_code,omitempty"`
+}
+
+// CaddyModule returns the Caddy module information.
+func (StatusCode) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "http.handlers.status_code",
+		New: func() caddy.Module { return new(StatusCode) },
+	}
+}
+
+// UnmarshalCaddyfile sets up the handler from Caddyfile tokens. Syntax:
+//
+//     status_code [<matcher>] <status>
+//
+func (s *StatusCode) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		args := d.RemainingArgs()
+		switch len(args) {
+		case 1:
+			s.StatusCode = WeakString(args[0])
+		default:
+			return d.ArgErr()
+		}
+	}
+	return nil
+}
+
+func (s StatusCode) ServeHTTP(w http.ResponseWriter, r *http.Request, _ Handler) error {
+	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+
+	// get the status code
+	statusCode := http.StatusOK
+	if codeStr := s.StatusCode.String(); codeStr != "" {
+		intVal, err := strconv.Atoi(repl.ReplaceAll(codeStr, ""))
+		if err != nil {
+			return Error(http.StatusInternalServerError, err)
+		}
+		statusCode = intVal
+	}
+
+	// write headers
+	w.WriteHeader(statusCode)
+
+	return nil
+}
+
+// Interface guards
+var (
+	_ MiddlewareHandler     = (*StatusCode)(nil)
+	_ caddyfile.Unmarshaler = (*StatusCode)(nil)
+)

--- a/modules/caddyhttp/statuscode_test.go
+++ b/modules/caddyhttp/statuscode_test.go
@@ -29,7 +29,7 @@ func TestStatusCodeHandler(t *testing.T) {
 		StatusCode: WeakString(strconv.Itoa(http.StatusNotFound)),
 	}
 
-	err := s.ServeHTTP(w, r, nil)
+	err := s.ServeHTTP(w, r, emptyHandler)
 	if err != nil {
 		t.Errorf("did not expect an error, but got: %v", err)
 	}

--- a/modules/caddyhttp/statuscode_test.go
+++ b/modules/caddyhttp/statuscode_test.go
@@ -1,0 +1,41 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddyhttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+)
+
+func TestStatusCodeHandler(t *testing.T) {
+	r := fakeRequest()
+	w := httptest.NewRecorder()
+
+	s := StatusCode{
+		StatusCode: WeakString(strconv.Itoa(http.StatusNotFound)),
+	}
+
+	err := s.ServeHTTP(w, r, nil)
+	if err != nil {
+		t.Errorf("did not expect an error, but got: %v", err)
+	}
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected status %d but got %d", http.StatusNotFound, resp.StatusCode)
+	}
+}


### PR DESCRIPTION
Closes #3312 

Adds a simple `status_code` handler which simply modifies the HTTP status code of a response.

JSON:
```
{
    "handler": "status_code",
    "status_code": 404
}
```

Caddyfile:
```
status_code [<matcher>] <status>
```

---

### Example usecase:

Caddyfile:
```
:8884

root .

try_files {path} /404.html
status_code /404.html 404

file_server
```

Request:
```
$ curl -v localhost:8884/nope
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8884 (#0)
> GET /nope HTTP/1.1
> Host: localhost:8884
> User-Agent: curl/7.58.0
> Accept: */*
>
< HTTP/1.1 404 Not Found
< Server: Caddy
< Date: Mon, 27 Apr 2020 06:21:34 GMT
< Content-Length: 4
< Content-Type: text/plain; charset=utf-8
<
This is a 404 response page.
* Connection #0 to host localhost left intact
```