### PR TITLE
caddyauth: Add realm support to basicauth Caddyfile directive

### DIFF
--- a/modules/caddyhttp/caddyauth/caddyfile.go
+++ b/modules/caddyhttp/caddyauth/caddyfile.go
@@ -46,6 +46,9 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 			hashName = "bcrypt"
 		case 1:
 			hashName = args[0]
+		case 2:
+			hashName = args[0]
+			ba.Realm = args[1]
 		default:
 			return nil, h.ArgErr()
 		}


### PR DESCRIPTION
Closes #3252

Old syntax:
```
basicauth [<matcher>] [<hash_algorithm>]
```

New syntax:
```
basicauth [<matcher>] [<hash_algorithm> [<realm>]]
```

Caddyfile example:
```
:80

basicauth /protected* bcrypt restricted {
    Bob JDJhJDEwJEVCNmdaNEg2Ti5iejRMYkF3MFZhZ3VtV3E1SzBWZEZ5Q3VWc0tzOEJwZE9TaFlZdEVkZDhX
}
```

Adapted JSON:
```
{
  "apps": {
    "http": {
      "servers": {
        "srv0": {
          "listen": [
            ":80"
          ],
          "routes": [
            {
              "match": [
                {
                  "path": [
                    "/protected*"
                  ]
                }
              ],
              "handle": [
                {
                  "handler": "authentication",
                  "providers": {
                    "http_basic": {
                      "accounts": [
                        {
                          "password": "JDJhJDEwJEVCNmdaNEg2Ti5iejRMYkF3MFZhZ3VtV3E1SzBWZEZ5Q3VWc0tzOEJwZE9TaFlZdEVkZDhX",
                          "username": "Bob"
                        }
                      ],
                      "hash": {
                        "algorithm": "bcrypt"
                      },
                      "realm": "restricted"
                    }
                  }
                }
              ]
            }
          ]
        }
      }
    }
  }
}
```