### PR TITLE
httpcaddyfile: Only append TLS conn policy if it's non-empty

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -402,7 +402,10 @@ func (st *ServerType) serversFromPairings(
 						hasCatchAllTLSConnPolicy = true
 					}
 
-					srv.TLSConnPolicies = append(srv.TLSConnPolicies, cp)
+					// only append this policy if it actually changes something
+					if !cp.SettingsEmpty() {
+						srv.TLSConnPolicies = append(srv.TLSConnPolicies, cp)
+					}
 				}
 			}
 

--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -264,6 +264,19 @@ func (p *ConnectionPolicy) buildStandardTLSConfig(ctx caddy.Context) error {
 	return nil
 }
 
+// SettingsEmpty returns true if p's settings (fields
+// except the matchers) are all empty/unset.
+func (p ConnectionPolicy) SettingsEmpty() bool {
+	return p.CertSelection == nil &&
+		p.CipherSuites == nil &&
+		p.Curves == nil &&
+		p.ALPN == nil &&
+		p.ProtocolMin == "" &&
+		p.ProtocolMax == "" &&
+		p.ClientAuthentication == nil &&
+		p.DefaultSNI == ""
+}
+
 // ClientAuthentication configures TLS client auth.
 type ClientAuthentication struct {
 	// A list of base64 DER-encoded CA certificates


### PR DESCRIPTION
This can lead to nicer, smaller JSON output for Caddyfiles like this:

	a {
		tls internal
	}
	b {
		tls foo@bar.com
	}

i.e. where the tls directive only configures automation policies, and
is merely meant to enable TLS on a server block (if it wasn't implied).
This helps keeps implicit config implicit.

Needs a little more testing to ensure it doesn't break anything
important.

Diff: https://www.diffchecker.com/U9uyyjkT

JSON before:

```json
{
  "apps": {
    "http": {
      "servers": {
        "srv0": {
          "listen": [
            ":443"
          ],
          "routes": [
            {
              "match": [
                {
                  "host": [
                    "a"
                  ]
                }
              ],
              "terminal": true
            },
            {
              "match": [
                {
                  "host": [
                    "b"
                  ]
                }
              ],
              "terminal": true
            }
          ],
          "tls_connection_policies": [
            {
              "match": {
                "sni": [
                  "a"
                ]
              }
            },
            {
              "match": {
                "sni": [
                  "b"
                ]
              }
            },
            {}
          ]
        }
      }
    },
    "tls": {
      "automation": {
        "policies": [
          {
            "subjects": [
              "a"
            ],
            "issuer": {
              "module": "internal"
            }
          },
          {
            "subjects": [
              "b"
            ],
            "issuer": {
              "email": "foo@bar.com",
              "module": "acme"
            }
          }
        ]
      }
    }
  }
}
```

JSON after:

```json
{
  "apps": {
    "http": {
      "servers": {
        "srv0": {
          "listen": [
            ":443"
          ],
          "routes": [
            {
              "match": [
                {
                  "host": [
                    "a"
                  ]
                }
              ],
              "terminal": true
            },
            {
              "match": [
                {
                  "host": [
                    "b"
                  ]
                }
              ],
              "terminal": true
            }
          ]
        }
      }
    },
    "tls": {
      "automation": {
        "policies": [
          {
            "subjects": [
              "a"
            ],
            "issuer": {
              "module": "internal"
            }
          },
          {
            "subjects": [
              "b"
            ],
            "issuer": {
              "email": "foo@bar.com",
              "module": "acme"
            }
          }
        ]
      }
    }
  }
}
```

17 line savings in this case.