### PR TITLE
ci: Add release tagged event triggers to sister repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,15 @@ jobs:
     #     go get -u github.com/jstemmer/go-junit-report
     #     echo "::add-path::$(go env GOPATH)/bin"
 
+    # See https://github.com/peter-evans/repository-dispatch
+    - name: Trigger event on caddyserver/caddy-docker
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.REPO_DISPATCH_TOKEN }}
+        repository: caddyserver/caddy-docker
+        event-type: release-tagged
+        client-payload: '{"tag": "v2.0.0-rc3"}'
+
     - name: Print Go version and environment
       id: vars
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,15 +55,6 @@ jobs:
     #     go get -u github.com/jstemmer/go-junit-report
     #     echo "::add-path::$(go env GOPATH)/bin"
 
-    # See https://github.com/peter-evans/repository-dispatch
-    - name: Trigger event on caddyserver/caddy-docker
-      uses: peter-evans/repository-dispatch@v1
-      with:
-        token: ${{ secrets.REPO_DISPATCH_TOKEN }}
-        repository: caddyserver/caddy-docker
-        event-type: release-tagged
-        client-payload: '{"tag": "v2.0.0-rc3"}'
-
     - name: Print Go version and environment
       id: vars
       run: |
@@ -154,3 +145,12 @@ jobs:
           args: check
         env:
           TAG: ${{ steps.vars.outputs.version_tag }}
+
+      # See https://github.com/peter-evans/repository-dispatch
+      - name: Trigger event on caddyserver/caddy-docker
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_DISPATCH_TOKEN }}
+          repository: caddyserver/caddy-docker
+          event-type: release-tagged
+          client-payload: '{"tag": "v2.0.0-rc3"}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,12 +145,3 @@ jobs:
           args: check
         env:
           TAG: ${{ steps.vars.outputs.version_tag }}
-
-      # See https://github.com/peter-evans/repository-dispatch
-      - name: Trigger event on caddyserver/caddy-docker
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token: ${{ secrets.REPO_DISPATCH_TOKEN }}
-          repository: caddyserver/caddy-docker
-          event-type: release-tagged
-          client-payload: '{"tag": "v2.0.0-rc.3"}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,4 +153,4 @@ jobs:
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
           repository: caddyserver/caddy-docker
           event-type: release-tagged
-          client-payload: '{"tag": "v2.0.0-rc3"}'
+          client-payload: '{"tag": "v2.0.0-rc.3"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Trigger event on caddyserver/dist
       uses: peter-evans/repository-dispatch@v1
       with:
-        token: ${{ secrets.CADDYSERVER_DIST_TOKEN }}
+        token: ${{ secrets.REPO_DISPATCH_TOKEN }}
         repository: caddyserver/dist
         event-type: release-tagged
         client-payload: '{"tag": "${{ steps.vars.outputs.version_tag }}"}'
@@ -79,7 +79,7 @@ jobs:
     - name: Trigger event on caddyserver/caddy-docker
       uses: peter-evans/repository-dispatch@v1
       with:
-        token: ${{ secrets.CADDYSERVER_DOCKER_TOKEN }}
+        token: ${{ secrets.REPO_DISPATCH_TOKEN }}
         repository: caddyserver/caddy-docker
         event-type: release-tagged
         client-payload: '{"tag": "${{ steps.vars.outputs.version_tag }}"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,3 +66,22 @@ jobs:
         for filename in dist/*.deb; do
           curl -F package=@"$filename" https://${GEMFURY_PUSH_TOKEN}:@push.fury.io/caddy/
         done
+
+    # See https://github.com/peter-evans/repository-dispatch
+    - name: Trigger event on caddyserver/dist
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.CADDYSERVER_DIST_TOKEN }}
+        repository: caddyserver/dist
+        event-type: release-tagged
+        client-payload: '{"tag": "${{ steps.vars.outputs.version_tag }}"}'
+
+    - name: Trigger event on caddyserver/caddy-docker
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.CADDYSERVER_DOCKER_TOKEN }}
+        repository: caddyserver/caddy-docker
+        event-type: release-tagged
+        client-payload: '{"tag": "${{ steps.vars.outputs.version_tag }}"}'
+
+


### PR DESCRIPTION
@mholt We'll need two new secrets added:

- `CADDYSERVER_DIST_TOKEN`
- `CADDYSERVER_DOCKER_TOKEN`

Both of these should be personal access tokens for their respective repos with the `repo` permissions scope.

Once those are added, I can try to trigger these by putting it in `ci.yml` temporarily. We'll need to add a CI config to one of the other repos to accept the triggers to test that it works as expected.

See https://github.com/peter-evans/repository-dispatch for docs.

We'll likely also use https://github.com/peter-evans/create-pull-request on the sister repos to do the work.

/cc @hairyhenderson @Mohammed90 