### PR TITLE
caddyhttp: Add tls_server_name http transport option to Caddyfile

### DIFF
--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -669,6 +669,16 @@ func (h *HTTPTransport) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 
 				h.TLS.RootCAPEMFiles = args
 
+			case "tls_server_name":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				if h.TLS == nil {
+					h.TLS = new(TLSConfig)
+				}
+
+				h.TLS.ServerName = d.Val()
+
 			case "keepalive":
 				if !d.NextArg() {
 					return d.ArgErr()


### PR DESCRIPTION
See https://caddy.community/t/how-can-i-use-proxy-ssl-name-for-sni-in-caddy-2/7739

Caddyfile:

```
:8000

reverse_proxy https://mydomain.com {
	transport http {
		tls_server_name mydomain.com
	}
}
```

JSON:
```
{
  "apps": {
    "http": {
      "servers": {
        "srv0": {
          "listen": [
            ":8000"
          ],
          "routes": [
            {
              "handle": [
                {
                  "handler": "reverse_proxy",
                  "transport": {
                    "protocol": "http",
                    "tls": {
                      "server_name": "mydomain.com"
                    }
                  },
                  "upstreams": [
                    {
                      "dial": "mydomain.com:443"
                    }
                  ]
                }
              ]
            }
          ]
        }
      }
    }
  }
}
```