### PR TITLE
goreleaser: add s390x and ppc64le builds for linux

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,12 +26,21 @@ builds:
   - amd64
   - arm
   - arm64
+  - s390x
+  - ppc64le
   goarm:
   - 6
   - 7
   ignore:
     - goos: darwin
       goarch: arm
+    - goarch:
+      - ppc64le
+      - s390x
+      goos: 
+        - darwin
+        - windows
+        - freebsd
   flags:
   - -trimpath
   ldflags:


### PR DESCRIPTION
dan@fstn4-p1:~/go/src/github.com/caddyserver/caddy/cmd/caddy$ file ./caddy 
./caddy: ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), dynamically linked, interpreter /lib64/l, for GNU/Linux 3.10.0, BuildID[sha1]=1fc956e7b143268aec43dd6850e6af65562ed412, not stripped

dan@fstn4-p1:~/go/src/github.com/caddyserver/caddy/cmd/caddy$ ./caddy version
(devel)

dan@fstn4-p1:~/go/src/github.com/caddyserver/caddy/cmd/caddy$ ./caddy build-info
path: github.com/caddyserver/caddy/v2/cmd/caddy
main: github.com/caddyserver/caddy/v2 (devel) 
dependencies:
cloud.google.com/go v0.54.0 h1:3ithwDMr7/3vpAMXiH+ZQnYbuIsh+OPhUPMFC9enmn0=
...

Builds and runs seamlessly here (ppc64le, haven't tested s390x).