### PR TITLE
tls/client auth: verify all certificates in client request

### DIFF
--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -382,7 +382,7 @@ func (clientauth ClientAuthentication) verifyPeerCertificate(rawCerts [][]byte, 
 		return fmt.Errorf("no client certificate provided")
 	}
 
-	remoteLeafCert, err := x509.ParseCertificate(rawCerts[len(rawCerts)-1])
+	remoteLeafCert, err := x509.ParseCertificate(rawCerts[0])
 	if err != nil {
 		return fmt.Errorf("can't parse the given certificate: %s", err.Error())
 	}


### PR DESCRIPTION
Hi,
I have problem with certificate-based authentication. In my env Caddy can't authorized connection despite  correct certificates and configuration. After some debugging I notice that Caddy check only last certificate in request but client certificate is fist and second is CA cert.
This patch change this behavior - all certs from request are verified.

--------

When client certificate is enabled Caddy check only last certificate from
request. When this cert is not in list of trusted leaf certificates,
connection is rejected. But in some cases client certificate is not
last certificate in list; sometimes is first, before certificates of CA.

This patch add checking all sent certificates - if any match with trusted
certificates connection is accepted.