### PR TITLE
logging: fix/improve rounding logic for log rolling directives

### DIFF
--- a/modules/logging/filewriter.go
+++ b/modules/logging/filewriter.go
@@ -17,6 +17,7 @@ package logging
 import (
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -138,8 +139,15 @@ func (fw FileWriter) OpenWriter() (io.WriteCloser, error) {
 //         roll_keep_for <days>
 //     }
 //
-// The roll_size value will be rounded down to number of megabytes (MiB).
-// The roll_keep_for duration will be rounded down to number of days.
+// The roll_size value has megabyte resolution.
+// Fractional values are rounded up to the next whole megabyte (MiB).
+//
+// The roll_keep_for duration has day resolution.
+// Fractional values are rounded up to the next whole number of days.
+//
+// If any of the roll_size, roll_keep, or roll_keep_for subdirectives are
+// omitted or set to a zero value, then Caddy's default value for that
+// subdirective is used.
 func (fw *FileWriter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		if !d.NextArg() {
@@ -168,7 +176,7 @@ func (fw *FileWriter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if err != nil {
 					return d.Errf("parsing size: %v", err)
 				}
-				fw.RollSizeMB = int(size)/1024/1024 + 1
+				fw.RollSizeMB = int(math.Ceil(float64(size) / humanize.MiByte))
 
 			case "roll_keep":
 				var keepStr string
@@ -190,7 +198,10 @@ func (fw *FileWriter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if err != nil {
 					return d.Errf("parsing roll_keep_for duration: %v", err)
 				}
-				fw.RollKeepDays = int(keepFor.Hours()) / 24
+				if keepFor < 0 {
+					return d.Errf("negative roll_keep_for duration: %v", keepFor)
+				}
+				fw.RollKeepDays = int(math.Ceil(keepFor.Hours() / 24))
 			}
 		}
 	}


### PR DESCRIPTION
* For `roll_size` and `roll_keep_for` directives, round up instead of down.
  For example, if a user wants to be able to look back on 36 hours of logs,
  but you must round to a 24-hour multiple, then it's better to round up to
  48 hours (which includes the desired 36 hours) instead of down to 24 hours.

* `roll_size` had an off-by-one error that caused the size to be as much as
  1 MB larger than requested. For example, requests of `1MB` and `1.1MB`
  both became 2 MB. Now `1MB` means 1 MB, and `1.1MB` is rounded up to 2 MB.