### PR TITLE
caddycmd: check file exists before validate

### DIFF
--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -506,6 +506,15 @@ func cmdValidateConfig(fl Flags) (int, error) {
 	validateCmdConfigFlag := fl.String("config")
 	validateCmdAdapterFlag := fl.String("adapter")
 
+	if validateCmdConfigFlag == "" {
+		validateCmdConfigFlag = "Caddyfile"
+	}
+	_, err := os.Stat(validateCmdConfigFlag)
+	if err != nil {
+		return caddy.ExitCodeFailedStartup,
+			fmt.Errorf("file doesn't exist: %v", err)
+	}
+
 	input, _, err := loadConfig(validateCmdConfigFlag, validateCmdAdapterFlag)
 	if err != nil {
 		return caddy.ExitCodeFailedStartup, err


### PR DESCRIPTION
Calling `validate` if the config file doesn't exist has a misleading error:

```
./caddy validate
validate: decoding config: unexpected end of JSON input
```

This PR adds a validation to output a better error

```
./caddy validate
validate: file doesn't exist: stat Caddyfile: no such file or directory
```

The check is done on `cmdValidate` because `loadConfig` shouldn't error if the file doesn't exist (https://github.com/caddyserver/caddy/blob/master/cmd/main.go#L139).  The func `loadConfig` is used by `run` and `start`,  if the config file doesn't exist, it will boot with blank config.