### PR TITLE
caddyhttp: Fix merging of matchers within a not block

### DIFF
--- a/caddytest/integration/caddyfile_adapt_test.go
+++ b/caddytest/integration/caddyfile_adapt_test.go
@@ -363,3 +363,55 @@ func TestMatcherSyntax(t *testing.T) {
 	}
 }`)
 }
+
+func TestNotBlockMerging(t *testing.T) {
+	caddytest.AssertAdapt(t, ` 
+	:80
+
+	@test {
+		not {
+			header Abc "123"
+			header Bcd "123"
+		}
+	}
+	respond @test 403
+  `, "caddyfile", `{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"not": [
+										{
+											"header": {
+												"Abc": [
+													"123"
+												],
+												"Bcd": [
+													"123"
+												]
+											}
+										}
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "static_response",
+									"status_code": 403
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}`)
+}


### PR DESCRIPTION
Found while discussing here: https://caddy.community/t/multiple-named-matchers-for-basicauth/8025

Consider the following Caddyfile:
```
:80

@test {
    not {
        header Abc "123"
        header Bcd "123"
    }
}
respond @test 403
```

And the following adapted JSON:
```
{
  "apps": {
    "http": {
      "servers": {
        "srv0": {
          "listen": [
            ":80"
          ],
          "routes": [
            {
              "match": [
                {
                  "not": [
                    {
                      "header": {
                        "Bcd": [
                          "123"
                        ]
                      }
                    }
                  ]
                }
              ],
              "handle": [
                {
                  "handler": "static_response",
                  "status_code": 403
                }
              ]
            }
          ]
        }
      }
    }
  }
}
```

Notice that only the 2nd header matcher is found within the `not` matcher in the JSON. This is incorrect.

The `not` matcher UnmarshalCaddyfile was just setting the matchers in its internal map by name, which means they would override eachother and only the last one would be kept.

This PR essentially just copies the logic from `httptype.go`'s `parseMatcherDefinitions` function which first collects all tokens for same-named matchers together, then for each matcher, unmarshals them using the full set of tokens. This makes sure they're correctly merged.

Example fixed JSON:
```
{
  "apps": {
    "http": {
      "servers": {
        "srv0": {
          "listen": [
            ":80"
          ],
          "routes": [
            {
              "match": [
                {
                  "not": [
                    {
                      "header": {
                        "Abc": [
                          "123"
                        ],
                        "Bcd": [
                          "123"
                        ]
                      }
                    }
                  ]
                }
              ],
              "handle": [
                {
                  "handler": "static_response",
                  "status_code": 403
                }
              ]
            }
          ]
        }
      }
    }
  }
}
```