### PR TITLE
docs: Fix TOC/section header mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - [Build from source](#build-from-source)
 	- [For development](#for-development)
 	- [With version information and/or plugins](#with-version-information-andor-plugins)
-- [Getting started](#getting-started)
+- [Quick start](#quick-start)
 - [Overview](#overview)
 - [Full documentation](#full-documentation)
 - [Getting help](#getting-help)


### PR DESCRIPTION
Table of Contents says "Get Started"; Section Header says "Quick Start". Changed table of contents to align with section header.