### PR TITLE
windows newline issue withSplitFrontMatter, fix for #3386

### DIFF
--- a/modules/caddyhttp/templates/frontmatter.go
+++ b/modules/caddyhttp/templates/frontmatter.go
@@ -29,8 +29,10 @@ func extractFrontMatter(input string) (map[string]interface{}, string, error) {
 		lineEmpty = lineEmpty && unicode.IsSpace(b)
 	}
 	firstLine := input[firstLineStart:firstLineEnd]
-	//ensure residue windows newline is removed
+
+	// ensure residue windows newline is removed
 	firstLine = strings.Trim(firstLine, "\r")
+
 	// see what kind of front matter there is, if any
 	var closingFence string
 	var fmParser func([]byte) (map[string]interface{}, error)

--- a/modules/caddyhttp/templates/frontmatter.go
+++ b/modules/caddyhttp/templates/frontmatter.go
@@ -31,7 +31,7 @@ func extractFrontMatter(input string) (map[string]interface{}, string, error) {
 	firstLine := input[firstLineStart:firstLineEnd]
 
 	// ensure residue windows newline is removed
-	firstLine = strings.Trim(firstLine, "\r")
+	firstLine = strings.TrimSpace(firstLine)
 
 	// see what kind of front matter there is, if any
 	var closingFence string

--- a/modules/caddyhttp/templates/frontmatter.go
+++ b/modules/caddyhttp/templates/frontmatter.go
@@ -29,7 +29,8 @@ func extractFrontMatter(input string) (map[string]interface{}, string, error) {
 		lineEmpty = lineEmpty && unicode.IsSpace(b)
 	}
 	firstLine := input[firstLineStart:firstLineEnd]
-
+	//ensure residue windows newline is removed
+	firstLine = strings.Trim(firstLine, "\r")
 	// see what kind of front matter there is, if any
 	var closingFence string
 	var fmParser func([]byte) (map[string]interface{}, error)

--- a/modules/caddyhttp/templates/frontmatter.go
+++ b/modules/caddyhttp/templates/frontmatter.go
@@ -30,7 +30,7 @@ func extractFrontMatter(input string) (map[string]interface{}, string, error) {
 	}
 	firstLine := input[firstLineStart:firstLineEnd]
 
-	// ensure residue windows newline is removed
+	// ensure residue windows carriage return byte is removed
 	firstLine = strings.TrimSpace(firstLine)
 
 	// see what kind of front matter there is, if any

--- a/modules/caddyhttp/templates/tplcontext_test.go
+++ b/modules/caddyhttp/templates/tplcontext_test.go
@@ -284,6 +284,51 @@ func TestFileListing(t *testing.T) {
 	}
 }
 
+func TestSplitFrontMatter(t *testing.T) {
+	context := getContextOrFail(t)
+
+	for i, test := range []struct {
+		input  string
+		expect string
+	}{
+		{
+			// yaml with windows newline
+			input:  "---\r\ntitle: Welcome\r\n---\r\n# Test\\r\\n",
+			expect: `Welcome`,
+		},
+		{
+			// yaml
+			input: `---
+title: Welcome
+---
+### Test`,
+			expect: `Welcome`,
+		},
+		{
+			// toml
+			input: `+++
+title = "Welcome"
++++
+### Test`,
+			expect: `Welcome`,
+		},
+		{
+			// json
+			input: `{
+    "title": "Welcome"
+}
+### Test`,
+			expect: `Welcome`,
+		},
+	} {
+		result, _ := context.funcSplitFrontMatter(test.input)
+		if result.Meta["title"] != test.expect {
+			t.Errorf("Test %d: Expected %s, found %s. Input was SplitFrontMatter(%s)", i, test.expect, result.Meta["title"], test.input)
+		}
+	}
+
+}
+
 func getContextOrFail(t *testing.T) templateContext {
 	context, err := initTestContext()
 	if err != nil {


### PR DESCRIPTION
Had an issue with templates and SplitFrontMatter that did not work when on Windows.
Created an test case and found that the issue was in the way fronmatter was detected.

Due to the extra control characters in Windows newline it did not match correctly.

Fixed by removing the extra "\r" 

Fix for https://github.com/caddyserver/caddy/issues/3386

And to some degree cloud also add value to #3191