### PR TITLE
reverseproxy: Improve error message when using scheme+placeholder

### DIFF
--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -103,6 +103,13 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		var network, scheme, host, port string
 
 		if strings.Contains(upstreamAddr, "://") {
+			// we get a parsing error if a placeholder is specified
+			// so we return a more user-friendly error message instead
+			// to explain what to do instead
+			if strings.Contains(upstreamAddr, "{") {
+				return "", d.Err("for now, placeholders are not allowed when specifying a scheme; instead, omit the scheme and use the transport subdirective if you need tls support")
+			}
+
 			toURL, err := url.Parse(upstreamAddr)
 			if err != nil {
 				return "", d.Errf("parsing upstream URL: %v", err)

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -107,7 +107,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			// so we return a more user-friendly error message instead
 			// to explain what to do instead
 			if strings.Contains(upstreamAddr, "{") {
-				return "", d.Err("for now, placeholders are not allowed when specifying a scheme; instead, omit the scheme and use the transport subdirective if you need tls support")
+				return "", d.Err("due to parsing difficulties, placeholders are not allowed when an upstream address contains a scheme")
 			}
 
 			toURL, err := url.Parse(upstreamAddr)


### PR DESCRIPTION
See the discussion here: https://caddy.community/t/proxy-upstream-placeholders/8085

So as it turns out, if you try to use a placeholder as a proxy address, it works fine, unless you also specify a scheme (i.e. the address containing `://`), which uses a different code path.

For example with this Caddyfile:

```
:8080
reverse_proxy http://{host}:8081
```

The error message when adapting looks like this:

> `adapt: parsing caddyfile tokens for 'reverse_proxy': Caddyfile:2 - Error during parsing: parsing upstream URL: parse "http://{http.request.host}:8081": invalid character "{" in host name`

This doesn't really explain why it doesn't work. This PR adds a condition ahead of the call to `url.Parse` (which triggers that error) which gives a more useful message:

> `adapt: parsing caddyfile tokens for 'reverse_proxy': Caddyfile:2 - Error during parsing: for now, placeholders are not allowed when specifying a scheme; instead, omit the scheme and use the transport subdirective if you need tls support`

Essentially this just means "omit `http://` and it'll work, or omit `https://` and use `transport { tls }` if you need HTTPS".

Also as a note, currently it's impossible to use a SRV address from the Caddyfile and also use placeholders. We could add a `srv` subdirective that basically skips the parsing checks. Currently, we must parse the scheme to allow SRV because it's set as a different field in the JSON than non-SRV addresses (i.e. `dial` for non-SRV, and `lookup_srv` for SRV addresses). With a separate subdirective we could skip the parse step to allow placeholders to pass though... but the use-case for that is so thin that I don't think it's worth the bother for now unless someone specifically shows a valid use-case for it.