### PR TITLE
httpcaddyfile: allow modules to customize listener wrappers

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -438,7 +438,6 @@ func (st *ServerType) serversFromPairings(
 					"wrapper",
 					listenerWrapper.(caddy.Module).CaddyModule().ID.Name(),
 					warnings)
-
 				srv.ListenerWrappersRaw = append(srv.ListenerWrappersRaw, jsonListenerWrapper)
 			}
 

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -425,8 +425,7 @@ func (st *ServerType) serversFromPairings(
 					(addr.Port == httpsPort || (addr.Port != httpPort && addr.Host != ""))
 			}
 
-			// Look for any config values that provide listener wrappers on the
-			// server block
+			// Look for any config values that provide listener wrappers on the server block
 			for _, listenerConfig := range sblock.pile["listener_wrapper"] {
 				listenerWrapper, ok := listenerConfig.Value.(caddy.ListenerWrapper)
 				if !ok {

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -425,6 +425,24 @@ func (st *ServerType) serversFromPairings(
 					(addr.Port == httpsPort || (addr.Port != httpPort && addr.Host != ""))
 			}
 
+			// Look for any config values that provide listener wrappers on the
+			// server block
+			for _, listenerConfig := range sblock.pile["listener_wrapper"] {
+				listenerWrapper, ok := listenerConfig.Value.(caddy.ListenerWrapper)
+
+				if !ok {
+					return nil, fmt.Errorf("config for a listener wrapper did not provide a value that implements caddy.ListenerWrapper")
+				}
+
+				jsonListenerWrapper := caddyconfig.JSONModuleObject(
+					listenerWrapper,
+					"wrapper",
+					listenerWrapper.(caddy.Module).CaddyModule().ID.Name(),
+					warnings)
+
+				srv.ListenerWrappersRaw = append(srv.ListenerWrappersRaw, jsonListenerWrapper)
+			}
+
 			// set up each handler directive, making sure to honor directive order
 			dirRoutes := sblock.pile["route"]
 			siteSubroute, err := buildSubroute(dirRoutes, groupCounter)

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -429,7 +429,6 @@ func (st *ServerType) serversFromPairings(
 			// server block
 			for _, listenerConfig := range sblock.pile["listener_wrapper"] {
 				listenerWrapper, ok := listenerConfig.Value.(caddy.ListenerWrapper)
-
 				if !ok {
 					return nil, fmt.Errorf("config for a listener wrapper did not provide a value that implements caddy.ListenerWrapper")
 				}

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -432,7 +432,6 @@ func (st *ServerType) serversFromPairings(
 				if !ok {
 					return nil, fmt.Errorf("config for a listener wrapper did not provide a value that implements caddy.ListenerWrapper")
 				}
-
 				jsonListenerWrapper := caddyconfig.JSONModuleObject(
 					listenerWrapper,
 					"wrapper",


### PR DESCRIPTION
This changes grants modules the ability to customize the listener wrapppers by introducing a new server block pile called listener_wrappers.
For example directives can now return `ConfigValue`s like so:

```go
package custom

type CustomModule struct {}

func init() {
	caddy.RegisterModule(CustomModule{})
	httpcaddyfile.RegisterDirective("custom_listener", parseCaddyfile)
}

var (
	_ caddy.Module          = (*CustomModule)(nil)
	_ caddy.ListenerWrapper = (*CustomModule)(nil)
)

func (c *CustomModule) WrapListener(listener net.Listener) net.Listener {
	// omitted to keep the example short but you probably want to wrap this
	// incoming listener with your own customised one
	return listener
}

func parseCaddyfile(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error) {
	var mod CustomModule

	// initialize your custom module from by parsing the directive

	return []ConfigValue{{
		Class: "listener_wrapper",
		Value: &mod,
	}}
}
```

Closes #3394 