### PR TITLE
caddyfile: Allow empty files to be imported

### DIFF
--- a/caddyconfig/caddyfile/lexer.go
+++ b/caddyconfig/caddyfile/lexer.go
@@ -49,6 +49,9 @@ func (l *lexer) load(input io.Reader) error {
 	// discard byte order mark, if present
 	firstCh, _, err := l.reader.ReadRune()
 	if err != nil {
+		if err == io.EOF {
+			return nil
+		}
 		return err
 	}
 	if firstCh != 0xFEFF {

--- a/caddyconfig/caddyfile/parse_test.go
+++ b/caddyconfig/caddyfile/parse_test.go
@@ -23,21 +23,47 @@ import (
 )
 
 func TestAllTokens(t *testing.T) {
-	input := []byte("a b c\nd e")
-	expected := []string{"a", "b", "c", "d", "e"}
-	tokens, err := allTokens("TestAllTokens", input)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "not-empty",
+			input:    "a b c\nd e",
+			expected: []string{"a", "b", "c", "d", "e"},
+		}, {
+			name:  "empty",
+			input: "",
+		}, {
+			name:  "newline",
+			input: "\n",
+		}, {
+			name:  "space",
+			input: " ",
+		}, {
+			name:  "tab and newline",
+			input: "\t\n",
+		},
 	}
-	if len(tokens) != len(expected) {
-		t.Fatalf("Expected %d tokens, got %d", len(expected), len(tokens))
-	}
 
-	for i, val := range expected {
-		if tokens[i].Text != val {
-			t.Errorf("Token %d should be '%s' but was '%s'", i, val, tokens[i].Text)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokens, err := allTokens("TestAllTokens", []byte(tt.input))
+
+			if err != nil {
+				t.Fatalf("Expected no error, got %v", err)
+			}
+			if len(tokens) != len(tt.expected) {
+				t.Fatalf("Expected %d tokens, got %d", len(tt.expected), len(tokens))
+			}
+
+			for i, val := range tt.expected {
+				if tokens[i].Text != val {
+					t.Errorf("Token %d should be '%s' but was '%s'", i, val, tokens[i].Text)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Allow empty files to be imported.

This may not be the right change to make. It's possible that you'd rather the io.EOF be handled at https://github.com/caddyserver/caddy/blob/master/caddyconfig/caddyfile/parse.go#L380-L382