### PR TITLE
caddyauth: Fix hash-password broken terminal state on SIGINT

### DIFF
--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -148,6 +148,8 @@ func cmdStart(fl Flags) (int, error) {
 }
 
 func cmdRun(fl Flags) (int, error) {
+	caddy.TrapSignals()
+
 	runCmdConfigFlag := fl.String("config")
 	runCmdConfigAdapterFlag := fl.String("adapter")
 	runCmdResumeFlag := fl.Bool("resume")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,8 +51,6 @@ func init() {
 // Main implements the main function of the caddy command.
 // Call this if Caddy is to be the main() if your program.
 func Main() {
-	caddy.TrapSignals()
-
 	switch len(os.Args) {
 	case 0:
 		fmt.Printf("[FATAL] no arguments provided by OS; args[0] must be command\n")

--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -61,6 +61,8 @@ respond with a file listing.`,
 }
 
 func cmdFileServer(fs caddycmd.Flags) (int, error) {
+	caddy.TrapSignals()
+
 	domain := fs.String("domain")
 	root := fs.String("root")
 	listen := fs.String("listen")

--- a/modules/caddyhttp/reverseproxy/command.go
+++ b/modules/caddyhttp/reverseproxy/command.go
@@ -66,6 +66,8 @@ default, all incoming headers are passed through unmodified.)
 }
 
 func cmdReverseProxy(fs caddycmd.Flags) (int, error) {
+	caddy.TrapSignals()
+
 	from := fs.String("from")
 	to := fs.String("to")
 	changeHost := fs.Bool("change-host-header")


### PR DESCRIPTION
If you run `caddy hash-password` then hit `^C` to interrupt, the terminal would get stuck in a broken state. Not good.

This fixes that by storing the state before starting to read passwords (which modifies the terminal state) and restores it if `SIGINT` is caught.

This also has the side-effect of avoiding the default cleanup handling from Caddy which prints out some log lines that aren't helpful in this situation, e.g.:

```
2020/05/15 14:52:47.348	INFO	shutting down	{"signal": "SIGINT"}
2020/05/15 14:52:47.349	ERROR	stopping admin endpoint	{"signal": "SIGINT", "error": "no admin server"}
2020/05/15 14:52:47.349	INFO	shutdown done	{"signal": "SIGINT"}
```

And also, I changed the prompts to be printed to STDERR instead of STDOUT, so now you can do `caddy hash-password > hashed.txt` and it works as expected.

/cc @0az FYI