### PR TITLE
httpcaddyfile: Support inline path prefix matcher tokens

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -890,8 +890,8 @@ func matcherSetFromMatcherToken(
 	if tkn.Text == "*" {
 		// match all requests == no matchers, so nothing to do
 		return nil, true, nil
-	} else if strings.HasPrefix(tkn.Text, "/") {
-		// convenient way to specify a single path match
+	} else if strings.HasPrefix(tkn.Text, "/") || strings.HasPrefix(tkn.Text, "*") {
+		// convenient way to specify a single prefix or suffix path match
 		return caddy.ModuleMap{
 			"path": caddyconfig.JSON(caddyhttp.MatchPath{tkn.Text}, warnings),
 		}, true, nil

--- a/caddytest/integration/caddyfile_adapt/matcher_syntax.txt
+++ b/caddytest/integration/caddyfile_adapt/matcher_syntax.txt
@@ -9,6 +9,8 @@
 
 	@matcher3 not method PUT
 	respond @matcher3 "not put"
+
+	respond *.txt "text"
 }
 ----------
 {
@@ -20,6 +22,21 @@
 						":80"
 					],
 					"routes": [
+						{
+							"match": [
+								{
+									"path": [
+										"*.txt"
+									]
+								}
+							],
+							"handle": [
+								{
+									"body": "text",
+									"handler": "static_response"
+								}
+							]
+						},
 						{
 							"match": [
 								{


### PR DESCRIPTION
This makes it possible to use a suffix matcher like `*.txt` inline wherever you can have a `/prefix/*` matcher as well. We already use `*` as the wildcard, so expanding that to also allow a suffix isn't a bit stretch. Example:

```
respond *.txt "yep it's a text file"
```

I think the likelihood of this breaking someone's config is pretty low, but there is a slight chance if they rely on it as the first argument to some directive. Not sure I have anything but contrived examples here.

I think we just need to update https://caddyserver.com/docs/caddyfile/matchers#syntax to mention another option for the inline syntax.

I'll probably need to update my syntax highlighter for this :sweat_smile: and the caddy-docker-proxy will probably need a slight update as well to support this. No big deal though.