### PR TITLE
httpcaddyfile: Improve error on matcher declared outside site block

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -54,6 +54,9 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 	originalServerBlocks := make([]serverBlock, 0, len(inputServerBlocks))
 	for i, sblock := range inputServerBlocks {
 		for j, k := range sblock.Keys {
+			if j == 0 && strings.HasPrefix(k, "@") {
+				return nil, warnings, fmt.Errorf("cannot define a matcher outside of a site block: '%s'", k)
+			}
 			if _, ok := sbKeys[k]; ok {
 				return nil, warnings, fmt.Errorf("duplicate site address not allowed: '%s' in %v (site block %d, key %d)", k, sblock.Keys, i, j)
 			}

--- a/caddyconfig/httpcaddyfile/httptype_test.go
+++ b/caddyconfig/httpcaddyfile/httptype_test.go
@@ -57,6 +57,15 @@ func TestMatcherSyntax(t *testing.T) {
 			expectWarn:  false,
 			expectError: false,
 		},
+		{
+			input: `@matcher {
+				path /matcher-not-allowed/outside-of-site-block/*
+			}
+			http://localhost
+			`,
+			expectWarn:  false,
+			expectError: true,
+		},
 	} {
 
 		adapter := caddyfile.Adapter{


### PR DESCRIPTION
We don't support defining matchers outside of site blocks. Some users try it, but get confusing error messaging because it still gets read as a site address. Instead, we can improve the error message in those cases because a site address starting with `@` isn't valid anyways.

Consider this Caddyfile:
```
@foo {
	path /bar/*
}

localhost {
	respond "hello"
}
```

Before:
```
$ ./caddy adapt --config Caddyfile
adapt: Caddyfile:2: unrecognized directive: path
```

After:
```
$ ./caddy adapt --config Caddyfile
adapt: cannot define a matcher outside of a site block: '@foo'
```