### PR TITLE
chore: simplify goreleaser flow, add bash completions to .deb

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -82,9 +82,9 @@ nfpms:
       ./caddy-dist/init/caddy.service: /lib/systemd/system/caddy.service
       ./caddy-dist/init/caddy-api.service: /lib/systemd/system/caddy-api.service
       ./caddy-dist/welcome/index.html: /usr/share/caddy/index.html
+      ./caddy-dist/scripts/completions/bash-completion: /etc/bash_completion.d/caddy
     config_files:
       ./caddy-dist/config/Caddyfile: /etc/caddy/Caddyfile
-      ./caddy-dist/scripts/completions/bash-completion: /etc/bash_completion.d/caddy
 
     scripts:
       postinstall: ./caddy-dist/scripts/postinstall.sh

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,12 +1,10 @@
 before:
   hooks:
-    - mkdir -p caddy-build
-    - cp cmd/caddy/main.go caddy-build/main.go
-    - cp ./go.mod caddy-build/go.mod
-    - sed -i.bkp 's|github.com/caddyserver/caddy/v2|caddy|g' ./caddy-build/go.mod
+    - cp ./go.mod ./cmd/caddy/go.mod
+    - sed -i.bkp 's|github.com/caddyserver/caddy/v2|caddy|g' ./cmd/caddy/go.mod
     # GoReleaser doesn't seem to offer {{.Tag}} at this stage, so we have to embed it into the env
     # so we run: TAG=$(git describe --abbrev=0) goreleaser release --rm-dist --skip-publish --skip-validate
-    - go mod edit -require=github.com/caddyserver/caddy/v2@{{.Env.TAG}} ./caddy-build/go.mod
+    - go mod edit -require=github.com/caddyserver/caddy/v2@{{.Env.TAG}} ./cmd/caddy/go.mod
     - git clone --depth 1 https://github.com/caddyserver/dist caddy-dist
     - go mod download
 
@@ -15,7 +13,7 @@ builds:
   - CGO_ENABLED=0
   - GO111MODULE=on
   main: main.go
-  dir: ./caddy-build
+  dir: ./cmd/caddy
   binary: caddy
   goos:
   - darwin
@@ -86,6 +84,7 @@ nfpms:
       ./caddy-dist/welcome/index.html: /usr/share/caddy/index.html
     config_files:
       ./caddy-dist/config/Caddyfile: /etc/caddy/Caddyfile
+      ./caddy-dist/scripts/completions/bash-completion: /etc/bash_completion.d/caddy
 
     scripts:
       postinstall: ./caddy-dist/scripts/postinstall.sh


### PR DESCRIPTION
There's no need to create a whole new directory and copy `main.go` into it. It's already there, so just re-purpose it. Also, let's package bash-completions now that we have them.