### PR TITLE
caddyfile: Make NewTestDispenser accessible for plugin authors

### DIFF
--- a/caddyconfig/caddyfile/dispenser.go
+++ b/caddyconfig/caddyfile/dispenser.go
@@ -17,6 +17,8 @@ package caddyfile
 import (
 	"errors"
 	"fmt"
+	"io"
+	"log"
 	"strings"
 )
 
@@ -35,6 +37,16 @@ func NewDispenser(tokens []Token) *Dispenser {
 		tokens: tokens,
 		cursor: -1,
 	}
+}
+
+// NewTestDispenser parses input into tokens and creates a new
+// Disenser for test purposes only; any errors are fatal.
+func NewTestDispenser(input string) *Dispenser {
+	tokens, err := allTokens("Testfile", []byte(input))
+	if err != nil && err != io.EOF {
+		log.Fatalf("getting all tokens from input: %v", err)
+	}
+	return NewDispenser(tokens)
 }
 
 // Next loads the next token. Returns true if a token

--- a/caddyconfig/caddyfile/dispenser_test.go
+++ b/caddyconfig/caddyfile/dispenser_test.go
@@ -15,8 +15,6 @@
 package caddyfile
 
 import (
-	"io"
-	"log"
 	"reflect"
 	"strings"
 	"testing"
@@ -305,14 +303,4 @@ func TestDispenser_ArgErr_Err(t *testing.T) {
 	if !strings.Contains(err.Error(), "foobar") {
 		t.Errorf("Expected error message with custom message in it ('foobar'); got '%v'", err)
 	}
-}
-
-// NewTestDispenser parses input into tokens and creates a new
-// Disenser for test purposes only; any errors are fatal.
-func NewTestDispenser(input string) *Dispenser {
-	tokens, err := allTokens("Testfile", []byte(input))
-	if err != nil && err != io.EOF {
-		log.Fatalf("getting all tokens from input: %v", err)
-	}
-	return NewDispenser(tokens)
 }


### PR DESCRIPTION
See discussion in #3402, we've had a couple suggestions to move this out of the `_test` file to make it usable for plugin authors in their own tests.