### PR TITLE
fmt: preserve the input config file permissions

### DIFF
--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -566,11 +566,15 @@ func cmdFmt(fl Flags) (int, error) {
 		return caddy.ExitCodeFailedStartup,
 			fmt.Errorf("reading input file: %v", err)
 	}
-
 	output := caddyfile.Format(input)
 
 	if overwrite {
-		err = ioutil.WriteFile(formatCmdConfigFile, output, 0644)
+		s, err := os.Stat(formatCmdConfigFile)
+		if err != nil {
+			return caddy.ExitCodeFailedStartup,
+				fmt.Errorf("reading input file permissions: %v", err)
+		}
+		err = ioutil.WriteFile(formatCmdConfigFile, output, s.Mode().Perm())
 		if err != nil {
 			return caddy.ExitCodeFailedStartup, nil
 		}


### PR DESCRIPTION
The earlier code set the permissions to 0644. It's possible the file has different permissions set by the file owner, so we don't want to alter anything beyond the content we're permitted and instructed to change.