### PR TITLE
log: implement `formatted` log encoder which accepts custom template for log lines

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.1.0
 	github.com/alecthomas/chroma v0.7.4-0.20200517063913-500529fd43c1
 	github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a
+	github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23
 	github.com/caddyserver/certmagic v0.10.13
 	github.com/dustin/go-humanize v1.0.1-0.20200219035652-afde56e7acac
 	github.com/go-acme/lego/v3 v3.7.0

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,7 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
+github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23 h1:D21IyuvjDCshj1/qq+pCNd3VZOAEI9jy6Bi131YlXgI=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/caddyserver/certmagic v0.10.13 h1:wfyYpXVXSSYMS1ZFpSr7HptwsC+j7elda5PUERrHtRc=
 github.com/caddyserver/certmagic v0.10.13/go.mod h1:Yz6cSRUdddGy6Ut5JfrvcqBwrm1BqXxJRqJq2TwjPnA=

--- a/modules/logging/formattedencoder.go
+++ b/modules/logging/formattedencoder.go
@@ -1,0 +1,147 @@
+package logging
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/buger/jsonparser"
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"go.uber.org/zap/buffer"
+	"go.uber.org/zap/zapcore"
+)
+
+func init() {
+	caddy.RegisterModule(FormattedEncoder{})
+}
+
+const commonLogFormat = `{http.common_log}`
+
+// FormattedEncoder allows the user to provide custom template for log prints. The
+// encoder builds atop the json encoder, thus it follows its message structure. The placeholders
+// are namespaced by the name of the app logging the message.
+type FormattedEncoder struct {
+	zapcore.Encoder `json:"-"`
+	LogEncoderConfig
+	Template string `json:"template,omitempty"`
+}
+
+func (FormattedEncoder) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID: "caddy.logging.encoders.formatted",
+		New: func() caddy.Module {
+			return &FormattedEncoder{
+				Encoder: new(JSONEncoder),
+			}
+		},
+	}
+}
+
+// Provision sets up the encoder.
+func (se *FormattedEncoder) Provision(ctx caddy.Context) error {
+	if se.Template == "" {
+		return fmt.Errorf("missing template for formatted log encoder")
+	}
+	se.Encoder = zapcore.NewJSONEncoder(se.ZapcoreEncoderConfig())
+	return nil
+}
+
+// Clone wraps the underlying encoder's Clone. This is
+// necessary because we implement our own EncodeEntry,
+// and if we simply let the embedded encoder's Clone
+// be promoted, it would return a clone of that, and
+// we'd lose our FormattedEncoder's EncodeEntry.
+func (se FormattedEncoder) Clone() zapcore.Encoder {
+	return FormattedEncoder{
+		Encoder:  se.Encoder.Clone(),
+		Template: se.Template,
+	}
+}
+
+// EncodeEntry partially implements the zapcore.Encoder interface.
+func (se FormattedEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field) (*buffer.Buffer, error) {
+	repl := caddy.NewReplacer()
+	buf, err := se.Encoder.EncodeEntry(ent, fields)
+	if err != nil {
+		return nil, err
+	}
+	appName := strings.SplitN(ent.LoggerName, ".", 2)[0]
+	// set the vals in the replacer
+	err = jsonparser.ObjectEach(buf.Bytes(), visitor(appName, repl))
+	buf.Reset() // the buffer is only used to collect placeholders' values anyway
+	buf.Free()
+	if err != nil {
+		return nil, err
+	}
+
+	out := repl.ReplaceKnown(se.Template, "")
+	// Unescape escaped quotes
+	buf.AppendString(strings.Replace(out, `\"`, `"`, -1))
+	if !strings.HasSuffix(out, "\n") {
+		buf.AppendByte('\n')
+	}
+
+	return buf, err
+}
+
+func visitor(prefix string, repl *caddy.Replacer) func(key []byte, value []byte, dataType jsonparser.ValueType, offset int) error {
+	format := fmt.Sprintf("%s.%%s", prefix)
+	keyFormat := func(itemKey string) string {
+		return fmt.Sprintf(format, itemKey)
+	}
+	return func(key []byte, value []byte, dataType jsonparser.ValueType, offset int) error {
+		switch dataType {
+		case jsonparser.NotExist:
+			panic("unimplemented jsonparser visitor for NotExist")
+		case jsonparser.String:
+			repl.Set(keyFormat(string(key)), string(value))
+		case jsonparser.Number:
+			// see: https://github.com/buger/jsonparser/issues/85
+			if bytes.IndexByte(value, '.') > -1 {
+				v, _ := strconv.ParseFloat(string(value), 64)
+				repl.Set(keyFormat(string(key)), v)
+			} else {
+				v, _ := strconv.ParseUint(string(value), 10, 64)
+				repl.Set(keyFormat(string(key)), v)
+			}
+		case jsonparser.Object:
+			// recurse
+			err := jsonparser.ObjectEach(value, visitor(keyFormat(string(key)), repl))
+			if err != nil {
+				return err
+			}
+		case jsonparser.Array:
+			repl.Set(keyFormat(string(key)), value)
+		case jsonparser.Boolean:
+			v, _ := strconv.ParseBool(string(value))
+			repl.Set(keyFormat(string(key)), v)
+		case jsonparser.Null:
+			panic("unimplemented jsonparser visitor for Null")
+		case jsonparser.Unknown:
+			panic("unimplemented jsonparser visitor for Unknown")
+		default:
+			panic("completely unknown dataType")
+		}
+		return nil
+	}
+}
+
+// UnmarshalCaddyfile sets up the module from Caddyfile tokens. Syntax:
+//
+//     formatted <template>
+//
+// If the value of "template" is omitted, Common Log Format is assumed.
+// See the godoc on the LogEncoderConfig type for the syntax of
+// subdirectives that are common to most/all encoders.
+func (se *FormattedEncoder) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		var template string
+		if !d.AllArgs(&template) {
+			template = commonLogFormat
+		}
+		se.Template = template
+	}
+	return nil
+}

--- a/modules/logging/formattedencoder.go
+++ b/modules/logging/formattedencoder.go
@@ -65,15 +65,14 @@ func (se FormattedEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field
 	repl := caddy.NewReplacer()
 	buf, err := se.Encoder.EncodeEntry(ent, fields)
 	if err != nil {
-		return nil, err
+		return buf, err
 	}
 	appName := strings.SplitN(ent.LoggerName, ".", 2)[0]
 	// set the vals in the replacer
 	err = jsonparser.ObjectEach(buf.Bytes(), visitor(appName, repl))
 	buf.Reset() // the buffer is only used to collect placeholders' values anyway
-	buf.Free()
 	if err != nil {
-		return nil, err
+		return buf, err
 	}
 
 	out := repl.ReplaceKnown(se.Template, "")
@@ -82,7 +81,6 @@ func (se FormattedEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field
 	if !strings.HasSuffix(out, "\n") {
 		buf.AppendByte('\n')
 	}
-
 	return buf, err
 }
 

--- a/modules/logging/formattedencoder.go
+++ b/modules/logging/formattedencoder.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package logging
 
 import (


### PR DESCRIPTION
This implements a logger that accepts custom format. I picked `template` for the format because the encoder name is determined by an existing `format` key. This is extremely an inefficient implementation. It takes the request to encode the entries, encodes it as JSON, parses the JSON and collects keys/values (using [buger/jsonparser](https://github.com/)) and sets them in a new replacer, then runs the replacer against the provided template. The placeholders are namespaced by the calling app name followed by the series of keys traversed to reach the designated value. For example, the below is the JSON structure logged by the HTTP app in response to handling a request. To log the protocol, the placeholder would be `{http.request.proto}`.

In the Caddyfile, the absence of template implies configuring the template as Common Log Format.

```
{
	"request": {
		"method": "GET",
		"uri": "/",
		"proto": "HTTP/2.0",
		"remote_addr": "[::1]:50257",
		"host": "localhost",
		"headers": {
			"Te": [
				"trailers"
			],
			"User-Agent": [
				"Mozilla/5.0 (Windows NT 10.0; rv:68.0) Gecko/20100101 Firefox/68.0"
			],
			"Accept-Language": [
				"en-US,en;q=0.5"
			],
			"Accept-Encoding": [
				"gzip, deflate, br"
			],
			"Referer": [
				"https://localhost/"
			],
			"Cache-Control": [
				"max-age=0"
			],
			"Accept": [
				"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
			],
			"Dnt": [
				"1"
			],
			"Upgrade-Insecure-Requests": [
				"1"
			]
		},
		"tls": {
			"resumed": false,
			"version": 772,
			"ciphersuite": 4865,
			"proto": "h2",
			"proto_mutual": true,
			"server_name": "localhost"
		}
	},
	"common_log": "::1 - - [25/May/2020:10:03:00 +0300] \"GET /.tooling/ HTTP/2.0\" 200 12851",
	"duration": 0.008519377,
	"size": 12851,
	"status": 200,
	"resp_headers": {
		"Server": [
			"Caddy"
		],
		"Content-Type": [
			"text/html; charset=utf-8"
		]
	}
}
```

Closes #3417 