### PR TITLE
file-server: add flag to enable the access log

### DIFF
--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -33,7 +33,7 @@ func init() {
 	caddycmd.RegisterCommand(caddycmd.Command{
 		Name:  "file-server",
 		Func:  cmdFileServer,
-		Usage: "[--domain <example.com>] [--root <path>] [--listen <addr>] [--browse]",
+		Usage: "[--domain <example.com>] [--root <path>] [--listen <addr>] [--browse] [--access-log]",
 		Short: "Spins up a production-ready file server",
 		Long: `
 A simple but production-ready file server. Useful for quick deployments,
@@ -55,6 +55,7 @@ respond with a file listing.`,
 			fs.String("listen", "", "The address to which to bind the listener")
 			fs.Bool("browse", false, "Enable directory browsing")
 			fs.Bool("templates", false, "Enable template rendering")
+			fs.Bool("access-log", false, "Enable the access log")
 			return fs
 		}(),
 	})
@@ -68,6 +69,7 @@ func cmdFileServer(fs caddycmd.Flags) (int, error) {
 	listen := fs.String("listen")
 	browse := fs.Bool("browse")
 	templates := fs.Bool("templates")
+	accessLog := fs.Bool("access-log")
 
 	var handlers []json.RawMessage
 
@@ -107,6 +109,9 @@ func cmdFileServer(fs caddycmd.Flags) (int, error) {
 		}
 	}
 	server.Listen = []string{listen}
+	if accessLog {
+		server.Logs = &caddyhttp.ServerLogConfig{}
+	}
 
 	httpApp := caddyhttp.App{
 		Servers: map[string]*caddyhttp.Server{"static": server},


### PR DESCRIPTION
This closes #3452.

Using `--access-log` as-in:

```bash
./caddy file-server --access-log
```

Will enable the default access log and caddy will start showing the http access log in the console:

```json
2020/05/26 20:44:49.126	INFO	http.log.access	handled request	{"request": {"method": "GET", "uri": "/", "proto": "HTTP/1.1", "remote_addr": "[::1]:38556", "host": "localhost:8000", "headers": {"Accept": ["text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"], "Sec-Fetch-Mode": ["navigate"], "Sec-Fetch-Dest": ["document"], "Accept-Encoding": ["gzip, deflate, br"], "Accept-Language": ["en-US,en;q=0.9,pt-PT;q=0.8,pt;q=0.7"], "Connection": ["keep-alive"], "Upgrade-Insecure-Requests": ["1"], "User-Agent": ["Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"], "Sec-Fetch-User": ["?1"], "Cache-Control": ["max-age=0"], "Sec-Fetch-Site": ["cross-site"]}}, "common_log": "::1 - - [26/May/2020:21:44:49 +0100] \"GET / HTTP/1.1\" 200 15129", "duration": 0.001489366, "size": 15129, "status": 200, "resp_headers": {"Content-Type": ["text/html; charset=utf-8"], "Server": ["Caddy"]}}
2020/05/26 20:44:49.387	ERROR	http.log.access	handled request	{"request": {"method": "GET", "uri": "/favicon.ico", "proto": "HTTP/1.1", "remote_addr": "[::1]:38556", "host": "localhost:8000", "headers": {"Sec-Fetch-Dest": ["image"], "Referer": ["http://localhost:8000/"], "Accept-Encoding": ["gzip, deflate, br"], "Accept-Language": ["en-US,en;q=0.9,pt-PT;q=0.8,pt;q=0.7"], "Pragma": ["no-cache"], "Accept": ["image/webp,image/apng,image/*,*/*;q=0.8"], "Sec-Fetch-Site": ["same-origin"], "Sec-Fetch-Mode": ["no-cors"], "Connection": ["keep-alive"], "Cache-Control": ["no-cache"], "User-Agent": ["Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"]}}, "common_log": "::1 - - [26/May/2020:21:44:49 +0100] \"GET /favicon.ico HTTP/1.1\" 404 0", "duration": 0.000366389, "size": 0, "status": 404, "resp_headers": {"Server": ["Caddy"]}}
```
