### PR TITLE
ci: add CI on s390x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
     #     exit 1
 
   s390x-test:
-    name: Test IBM Linux on Z
+    name: test (s390x on IBM Z)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code into the Go module directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,25 +126,25 @@ jobs:
     steps:
       - name: Checkout code into the Go module directory
         uses: actions/checkout@v2
-      # - name: Run Tests
-      #   run: |
-      #     mkdir -p ~/.ssh && echo -e "${SSH_KEY//_/\\n}" > ~/.ssh/id_rsa && chmod og-rwx ~/.ssh/id_rsa
+      - name: Run Tests
+        run: |
+          mkdir -p ~/.ssh && echo -e "${SSH_KEY//_/\\n}" > ~/.ssh/id_ecdsa && chmod og-rwx ~/.ssh/id_ecdsa
 
-      #     # short sha is enough?
-      #     short_sha=$(git rev-parse --short HEAD)
+          # short sha is enough?
+          short_sha=$(git rev-parse --short HEAD)
 
-      #     # The environment is fresh, so there's no point in keeping accepting and adding the key.
-      #     rsync -arz -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --progress --delete --exclude '.git' . caddy-ci@test-server:/var/tmp/"$short_sha"
-      #     ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -t caddy-ci@test-server "cd /var/tmp/$short_sha; CGO_ENABLED=0 /usr/local/go/bin/go test -v ./..."
-      #     test_result=$?
+          # The environment is fresh, so there's no point in keeping accepting and adding the key.
+          rsync -arz -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --progress --delete --exclude '.git' . caddy-ci@ci-s390x.caddyserver.com:/var/tmp/"$short_sha"
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -t caddy-ci@ci-s390x.caddyserver.com "cd /var/tmp/$short_sha; CGO_ENABLED=0 /usr/local/go/bin/go test -v ./..."
+          test_result=$?
 
-      #     # There's no need leaving the files around
-      #     ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null caddy-ci@test-server "rm -rf /var/tmp/'$short_sha'"
+          # There's no need leaving the files around
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null caddy-ci@ci-s390x.caddyserver.com "rm -rf /var/tmp/'$short_sha'"
 
-      #     echo "Test exit code: $test_result"
-      #     exit $test_result
-      #   with:
-      #     SSH_KEY: ${{ secrets.ssh_key }}
+          echo "Test exit code: $test_result"
+          exit $test_result
+        env:
+          SSH_KEY: ${{ secrets.S390X_SSH_KEY }}
 
   # From https://github.com/reviewdog/action-golangci-lint
   golangci-lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,32 @@ jobs:
     #     echo "step_test ${{ steps.step_test.outputs.status }}\n"
     #     exit 1
 
+  s390x-test:
+    name: Test IBM Linux on Z
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v2
+      # - name: Run Tests
+      #   run: |
+      #     mkdir -p ~/.ssh && echo -e "${SSH_KEY//_/\\n}" > ~/.ssh/id_rsa && chmod og-rwx ~/.ssh/id_rsa
+
+      #     # short sha is enough?
+      #     short_sha=$(git rev-parse --short HEAD)
+
+      #     # The environment is fresh, so there's no point in keeping accepting and adding the key.
+      #     rsync -arz -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --progress --delete --exclude '.git' . caddy-ci@test-server:/var/tmp/"$short_sha"
+      #     ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -t caddy-ci@test-server "cd /var/tmp/$short_sha; CGO_ENABLED=0 /usr/local/go/bin/go test -v ./..."
+      #     test_result=$?
+
+      #     # There's no need leaving the files around
+      #     ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null caddy-ci@test-server "rm -rf /var/tmp/'$short_sha'"
+
+      #     echo "Test exit code: $test_result"
+      #     exit $test_result
+      #   with:
+      #     SSH_KEY: ${{ secrets.ssh_key }}
+
   # From https://github.com/reviewdog/action-golangci-lint
   golangci-lint:
     name: runner / golangci-lint


### PR DESCRIPTION
I tried to make it as simple as possible and as minimal as possible. The flow is:
- Read the current short-sha of git HEAD
- rsync the repo to the remote server into a directory whose name is the short-sha
- Store the exit code
- Delete the remote directory
- Exit with the exit code of the test run

