### PR TITLE
fastcgi: Make sure splitPos handles empty SplitPath correctly

### DIFF
--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -303,6 +303,10 @@ func (t Transport) splitPos(path string) int {
 	// if httpserver.CaseSensitivePath {
 	// 	return strings.Index(path, r.SplitPath)
 	// }
+	if len(t.SplitPath) == 0 {
+		return 0
+	}
+
 	lowerPath := strings.ToLower(path)
 	for _, split := range t.SplitPath {
 		if idx := strings.Index(lowerPath, strings.ToLower(split)); idx > -1 {


### PR DESCRIPTION
In commit f2ce81c, support for multiple path splitters was added. The
type of SplitPath changed from string to []string, and splitPos was
changed to loop through all values in SplitPath.

Before that commit, if SplitPath was empty, strings.Index returned 0 and
PATH_INFO was set correctly in buildEnv.

Currently, however, splitPos returns -1 for empty values of SplitPath,
behaving as if a split position could not be found at all. PATH_INFO is
then never set in buildEnv and remains empty.

Restore the old behaviour by explicitly checking whether SplitPath is
empty and returning 0 in splitPos.

Closes #3490