### PR TITLE
ci: skip s390x tests on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
   s390x-test:
     name: test (s390x on IBM Z)
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'caddyserver/caddy' }}
     steps:
       - name: Checkout code into the Go module directory
         uses: actions/checkout@v2


### PR DESCRIPTION
Forks don't have access to secrets, which are needed to access the ssh key.