### PR TITLE
templates: Add support for dots to close yaml frontmatter

### DIFF
--- a/modules/caddyhttp/templates/frontmatter.go
+++ b/modules/caddyhttp/templates/frontmatter.go
@@ -34,25 +34,28 @@ func extractFrontMatter(input string) (map[string]interface{}, string, error) {
 	firstLine = strings.TrimSpace(firstLine)
 
 	// see what kind of front matter there is, if any
-	var closingFence string
+	var closingFence []string
 	var fmParser func([]byte) (map[string]interface{}, error)
-	switch firstLine {
-	case yamlFrontMatterFenceOpen:
-		fmParser = yamlFrontMatter
-		closingFence = yamlFrontMatterFenceClose
-	case tomlFrontMatterFenceOpen:
-		fmParser = tomlFrontMatter
-		closingFence = tomlFrontMatterFenceClose
-	case jsonFrontMatterFenceOpen:
-		fmParser = jsonFrontMatter
-		closingFence = jsonFrontMatterFenceClose
-	default:
+	for _, fmType := range supportedFrontMatterTypes {
+		if firstLine == fmType.FenceOpen {
+			closingFence = fmType.FenceClose
+			fmParser = fmType.ParseFunc
+		}
+	}
+
+	if fmParser == nil {
 		// no recognized front matter; whole document is body
 		return nil, input, nil
 	}
 
 	// find end of front matter
-	fmEndFenceStart := strings.Index(input[firstLineEnd:], "\n"+closingFence)
+	fmEndFenceStart := -1
+	for _, fence := range closingFence {
+		index := strings.Index(input[firstLineEnd:], "\n"+fence)
+		if index >= 0 {
+			fmEndFenceStart = index
+		}
+	}
 	if fmEndFenceStart < 0 {
 		return nil, "", fmt.Errorf("unterminated front matter")
 	}
@@ -96,8 +99,26 @@ type parsedMarkdownDoc struct {
 	Body string                 `json:"body,omitempty"`
 }
 
-const (
-	yamlFrontMatterFenceOpen, yamlFrontMatterFenceClose = "---", "---"
-	tomlFrontMatterFenceOpen, tomlFrontMatterFenceClose = "+++", "+++"
-	jsonFrontMatterFenceOpen, jsonFrontMatterFenceClose = "{", "}"
-)
+type frontMatterType struct {
+	FenceOpen  string
+	FenceClose []string
+	ParseFunc  func(input []byte) (map[string]interface{}, error)
+}
+
+var supportedFrontMatterTypes = []frontMatterType{
+	{
+		FenceOpen:  "---",
+		FenceClose: []string{"---", "..."},
+		ParseFunc:  yamlFrontMatter,
+	},
+	{
+		FenceOpen:  "+++",
+		FenceClose: []string{"+++"},
+		ParseFunc:  tomlFrontMatter,
+	},
+	{
+		FenceOpen:  "{",
+		FenceClose: []string{"}"},
+		ParseFunc:  jsonFrontMatter,
+	},
+}

--- a/modules/caddyhttp/templates/frontmatter.go
+++ b/modules/caddyhttp/templates/frontmatter.go
@@ -49,11 +49,13 @@ func extractFrontMatter(input string) (map[string]interface{}, string, error) {
 	}
 
 	// find end of front matter
+	var fmEndFence string
 	fmEndFenceStart := -1
 	for _, fence := range closingFence {
 		index := strings.Index(input[firstLineEnd:], "\n"+fence)
 		if index >= 0 {
 			fmEndFenceStart = index
+			fmEndFence = fence
 		}
 	}
 	if fmEndFenceStart < 0 {
@@ -69,7 +71,7 @@ func extractFrontMatter(input string) (map[string]interface{}, string, error) {
 	}
 
 	// the rest is the body
-	body := input[fmEndFenceStart+len(closingFence):]
+	body := input[fmEndFenceStart+len(fmEndFence):]
 
 	return fm, body, nil
 }

--- a/modules/caddyhttp/templates/tplcontext_test.go
+++ b/modules/caddyhttp/templates/tplcontext_test.go
@@ -290,11 +290,13 @@ func TestSplitFrontMatter(t *testing.T) {
 	for i, test := range []struct {
 		input  string
 		expect string
+		body   string
 	}{
 		{
 			// yaml with windows newline
 			input:  "---\r\ntitle: Welcome\r\n---\r\n# Test\\r\\n",
 			expect: `Welcome`,
+			body:   "\r\n# Test\\r\\n",
 		},
 		{
 			// yaml
@@ -303,6 +305,7 @@ title: Welcome
 ---
 ### Test`,
 			expect: `Welcome`,
+			body:   "\n### Test",
 		},
 		{
 			// yaml with dots for closer
@@ -311,6 +314,7 @@ title: Welcome
 ...
 ### Test`,
 			expect: `Welcome`,
+			body:   "\n### Test",
 		},
 		{
 			// toml
@@ -319,6 +323,7 @@ title = "Welcome"
 +++
 ### Test`,
 			expect: `Welcome`,
+			body:   "\n### Test",
 		},
 		{
 			// json
@@ -327,11 +332,15 @@ title = "Welcome"
 }
 ### Test`,
 			expect: `Welcome`,
+			body:   "\n### Test",
 		},
 	} {
 		result, _ := context.funcSplitFrontMatter(test.input)
 		if result.Meta["title"] != test.expect {
 			t.Errorf("Test %d: Expected %s, found %s. Input was SplitFrontMatter(%s)", i, test.expect, result.Meta["title"], test.input)
+		}
+		if result.Body != test.body {
+			t.Errorf("Test %d: Expected body %s, found %s. Input was SplitFrontMatter(%s)", i, test.body, result.Body, test.input)
 		}
 	}
 

--- a/modules/caddyhttp/templates/tplcontext_test.go
+++ b/modules/caddyhttp/templates/tplcontext_test.go
@@ -305,6 +305,14 @@ title: Welcome
 			expect: `Welcome`,
 		},
 		{
+			// yaml with dots for closer
+			input: `---
+title: Welcome
+...
+### Test`,
+			expect: `Welcome`,
+		},
+		{
 			// toml
 			input: `+++
 title = "Welcome"


### PR DESCRIPTION
Fixes #3497

Small refactor to the template frontmatter extraction code: 
- Now generalizes a frontmatter type into a struct which defines the fence delimiters and the parse function.
- Now loops over the supported types list instead of using a switch to detect the frontmatter type.
- Each type can now have more than one fence closing string, each are searched for in order they appear (currently only yaml supports more than one).