### PR TITLE
fastcgi: Fix php_fastcgi matcher regression

### DIFF
--- a/caddytest/integration/caddyfile_adapt/php_fastcgi_matcher.txt
+++ b/caddytest/integration/caddyfile_adapt/php_fastcgi_matcher.txt
@@ -1,0 +1,112 @@
+:8884
+
+@api host example.com
+php_fastcgi @api localhost:9000
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8884"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"handler": "static_response",
+													"headers": {
+														"Location": [
+															"{http.request.uri.path}/"
+														]
+													},
+													"status_code": 308
+												}
+											],
+											"match": [
+												{
+													"file": {
+														"try_files": [
+															"{http.request.uri.path}/index.php"
+														]
+													},
+													"not": [
+														{
+															"path": [
+																"*/"
+															]
+														}
+													]
+												}
+											]
+										},
+										{
+											"handle": [
+												{
+													"handler": "rewrite",
+													"uri": "{http.matchers.file.relative}"
+												}
+											],
+											"match": [
+												{
+													"file": {
+														"split_path": [
+															".php"
+														],
+														"try_files": [
+															"{http.request.uri.path}",
+															"{http.request.uri.path}/index.php",
+															"index.php"
+														]
+													}
+												}
+											]
+										},
+										{
+											"handle": [
+												{
+													"handler": "reverse_proxy",
+													"transport": {
+														"protocol": "fastcgi",
+														"split_path": [
+															".php"
+														]
+													},
+													"upstreams": [
+														{
+															"dial": "localhost:9000"
+														}
+													]
+												}
+											],
+											"match": [
+												{
+													"path": [
+														"*.php"
+													]
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
@@ -132,6 +132,16 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 	// set the default index file for the try_files rewrites
 	indexFile := "index.php"
 
+	// if the user specified a matcher token, use that
+	// matcher in a route that wraps both of our routes;
+	// either way, strip the matcher token and pass
+	// the remaining tokens to the unmarshaler so that
+	// we can gain the rest of the reverse_proxy syntax
+	userMatcherSet, err := h.ExtractMatcherSet()
+	if err != nil {
+		return nil, err
+	}
+
 	// make a new dispenser from the remaining tokens so that we
 	// can reset the dispenser back to this point for the
 	// reverse_proxy unmarshaler to read from it as well
@@ -250,16 +260,6 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 	}
 	rpMatcherSet := caddy.ModuleMap{
 		"path": h.JSON(pathList),
-	}
-
-	// if the user specified a matcher token, use that
-	// matcher in a route that wraps both of our routes;
-	// either way, strip the matcher token and pass
-	// the remaining tokens to the unmarshaler so that
-	// we can gain the rest of the reverse_proxy syntax
-	userMatcherSet, err := h.ExtractMatcherSet()
-	if err != nil {
-		return nil, err
 	}
 
 	// create the reverse proxy handler which uses our FastCGI transport


### PR DESCRIPTION
Fixes #3511

The order of operations for parsing `php_fastcgi` was wrong when I did the refactor to allow for subdirectives.

When we call `h.NewFromNextSegment()`, it will consume the matcher token (because it does `d.NextSegment()` which calls `d.NextArg()`). We need to grab the matcher token earlier before it gets dropped.