### PR TITLE
chore: Fix typo in reverse-proxy subcommand help message

### DIFF
--- a/modules/caddyhttp/reverseproxy/command.go
+++ b/modules/caddyhttp/reverseproxy/command.go
@@ -55,7 +55,7 @@ from its original incoming value to the address of the upstream. (Otherwise, by
 default, all incoming headers are passed through unmodified.)
 `,
 		Flags: func() *flag.FlagSet {
-			fs := flag.NewFlagSet("file-server", flag.ExitOnError)
+			fs := flag.NewFlagSet("reverse-proxy", flag.ExitOnError)
 			fs.String("from", "localhost", "Address on which to receive traffic")
 			fs.String("to", "", "Upstream address to which to to proxy traffic")
 			fs.Bool("change-host-header", false, "Set upstream Host header to address of upstream")


### PR DESCRIPTION
Currently:
```
% caddy reverse-proxy --broken
flag provided but not defined: -broken
Usage of file-server:
...
```

Should be:
```
% caddy reverse-proxy --broken                    
flag provided but not defined: -broken
Usage of reverse-proxy:
```