### PR TITLE
feat: add support for placeholders in query matcher keys & values

### DIFF
--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -374,10 +374,13 @@ func (m *MatchQuery) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 
 // Match returns true if r matches m. An empty m matches an empty query string.
 func (m MatchQuery) Match(r *http.Request) bool {
+	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 	for param, vals := range m {
+		param = repl.ReplaceAll(param, "")
 		paramVal, found := r.URL.Query()[param]
 		if found {
 			for _, v := range vals {
+				v = repl.ReplaceAll(v, "")
 				if paramVal[0] == v || v == "*" {
 					return true
 				}


### PR DESCRIPTION
Adds the ability to use placeholders in query matchers (both key and value) as described/requested in #3520