### PR TITLE
ci: Apparently only single-quote strings are supported

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
 
     # Only publish on non-special tags (e.g. non-beta)
     - name: Publish .deb to Gemfury
-      if: ${{ steps.vars.outputs.tag_special == "" }}
+      if: ${{ steps.vars.outputs.tag_special == '' }}
       env:
         GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}
       run: |


### PR DESCRIPTION
https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#literals

https://github.com/caddyserver/caddy/actions/runs/147953515