### PR TITLE
ci: Fix release publish trigger

### DIFF
--- a/.github/workflows/release_published.yml
+++ b/.github/workflows/release_published.yml
@@ -22,7 +22,7 @@ jobs:
         token: ${{ secrets.REPO_DISPATCH_TOKEN }}
         repository: caddyserver/dist
         event-type: release-tagged
-        client-payload: '{"tag": "${{ github.release.tag_name }}"}'
+        client-payload: '{"tag": "${{ github.event.release.tag_name }}"}'
 
     - name: Trigger event on caddyserver/caddy-docker
       uses: peter-evans/repository-dispatch@v1


### PR DESCRIPTION
Didn't trigger correctly, the tag was empty: https://github.com/caddyserver/caddy/runs/812332740?check_suite_focus=true

Looks like event payloads need to be prefixed with `github.event` to get the actual payload contents. Didn't dig deep enough.

https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context