### PR TITLE
fastcgi: Implement resolve symlinks feature

### DIFF
--- a/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
@@ -39,6 +39,7 @@ func init() {
 //         root <path>
 //         split <at>
 //         env <key> <value>
+//         resolve_root_symlink
 //     }
 //
 func (t *Transport) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
@@ -66,6 +67,9 @@ func (t *Transport) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					t.EnvVars = make(map[string]string)
 				}
 				t.EnvVars[args[0]] = args[1]
+
+			case "resolve_root_symlink":
+				t.ResolveRootSymlink = true
 
 			default:
 				return d.Errf("unrecognized subdirective %s", d.Val())
@@ -196,6 +200,14 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 					return nil, dispenser.ArgErr()
 				}
 				indexFile = args[0]
+
+			case "resolve_root_symlink":
+				args := dispenser.RemainingArgs()
+				dispenser.Delete()
+				for range args {
+					dispenser.Delete()
+				}
+				fcgiTransport.ResolveRootSymlink = true
 			}
 		}
 	}


### PR DESCRIPTION
This PR will enable resolving real path on symlinked releases.
When using a symlink based directory schema PHP, through Caddy, will serve old symlinked directory instead of resolving the actual real path of new released code: due to the nature of PHP opcache the new release path is not read by PHP because it’s cached and symlink path doesn’t change form PHP prospective.
Adding the new `resolverootsymlink` subdirective on php_fastcgi will enable resolution of real path, thus permitting Caddy to server the actual codebase instead of the old one.

See [this forum post](https://caddy.community/t/resolve-real-path-on-symlinked-releases/8963) to further details.

Example Caddyfile:
```
http://example.test {
    root * /var/www/deploy/current
    php_fastcgi 127.0.0.1:9000 {
        resolverootsymlink
    }
}
```

Where `/var/www/deploy/current` is a symlink to real directory