### PR TITLE
Small improvements to avoid possible panics and inform users about the actual error

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -471,7 +471,7 @@ func stopAndCleanup() error {
 	}
 	certmagic.CleanUpOwnLocks()
 	if pidfile != "" {
-		os.Remove(pidfile)
+		return os.Remove(pidfile)
 	}
 	return nil
 }

--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -401,6 +401,9 @@ func leastRequests(upstreams []*Upstream) *Upstream {
 			best = append(best, upstream)
 		}
 	}
+	if len(best) == 0 {
+		return nil
+	}
 	return best[weakrand.Intn(len(best))]
 }
 

--- a/modules/caddyhttp/templates/tplcontext_test.go
+++ b/modules/caddyhttp/templates/tplcontext_test.go
@@ -90,7 +90,7 @@ func TestCookie(t *testing.T) {
 		},
 		{
 			// cookie with optional fields
-			cookie:     &http.Cookie{Name: "cookie", Value: "cookieValue", Path: "/path", Domain: "https://localhost", Expires: (time.Now().Add(10 * time.Minute)), MaxAge: 120},
+			cookie:     &http.Cookie{Name: "cookie", Value: "cookieValue", Path: "/path", Domain: "https://localhost", Expires: time.Now().Add(10 * time.Minute), MaxAge: 120},
 			cookieName: "cookie",
 			expect:     "cookieValue",
 		},


### PR DESCRIPTION
- Added additional checks to make sure the code will not panic.
- Removed redundant parentheses
- Log the error whenever an unexpected error occurs when running the admin server (improved feedback for end user)