### PR TITLE
caddyhttp: support X-Forwarded-Host

### DIFF
--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -169,10 +169,16 @@ func (m *MatchHost) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 
 // Match returns true if r matches m.
 func (m MatchHost) Match(r *http.Request) bool {
-	reqHost, _, err := net.SplitHostPort(r.Host)
+	var hostPort string
+	if fwdHost := r.Header.Get("X-Forwarded-Host"); fwdHost != "" {
+		hostPort = fwdHost
+	} else {
+		hostPort = r.Host
+	}
+	reqHost, _, err := net.SplitHostPort(hostPort)
 	if err != nil {
 		// OK; probably didn't have a port
-		reqHost = r.Host
+		reqHost = hostPort
 
 		// make sure we strip the brackets from IPv6 addresses
 		reqHost = strings.TrimPrefix(reqHost, "[")


### PR DESCRIPTION
Adds support for the `X-Forwarded-Host` header in host matching. Should satisfy #3599.

This only checks either the header or the request host with preference to former.

Should we check both?