### PR TITLE
Fix a typo in modules.go

### DIFF
--- a/modules.go
+++ b/modules.go
@@ -212,7 +212,6 @@ func GetModules(scope string) []ModuleInfo {
 	}
 
 	var mods []ModuleInfo
-iterateModules:
 	for id, m := range modules {
 		modParts := strings.Split(id, ".")
 


### PR DESCRIPTION
Hello 👋 

While diving into the `modules` code, I've found this weird typo.

As far as I know, it appears to be an error, but I might be wrong. 🤔 