### PR TITLE
httpcaddyfile: Support `compression` in http transport config

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_h2c.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_h2c.txt
@@ -1,0 +1,96 @@
+
+https://example.com {
+	reverse_proxy /path http://localhost:54321 {
+		header_up Host {host}
+		header_up X-Real-IP {remote}
+		header_up X-Forwarded-For {remote}
+		header_up X-Forwarded-Port {server_port}
+		header_up X-Forwarded-Proto "http"
+		transport http {
+			versions h2c 2
+			compression off
+		}
+	}
+}
+
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"handler": "reverse_proxy",
+													"headers": {
+														"request": {
+															"set": {
+																"Host": [
+																	"{http.request.host}"
+																],
+																"X-Forwarded-For": [
+																	"{http.request.remote}"
+																],
+																"X-Forwarded-Port": [
+																	"{server_port}"
+																],
+																"X-Forwarded-Proto": [
+																	"http"
+																],
+																"X-Real-Ip": [
+																	"{http.request.remote}"
+																]
+															}
+														}
+													},
+													"transport": {
+														"compression": false,
+														"protocol": "http",
+														"versions": [
+															"h2c",
+															"2"
+														]
+													},
+													"upstreams": [
+														{
+															"dial": "localhost:54321"
+														}
+													]
+												}
+											],
+											"match": [
+												{
+													"path": [
+														"/path"
+													]
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -719,6 +719,14 @@ func (h *HTTPTransport) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.ArgErr()
 				}
 
+			case "compression":
+				if d.NextArg() {
+					if d.Val() == "off" {
+						var disable bool
+						h.Compression = &disable
+					}
+				}
+
 			default:
 				return d.Errf("unrecognized subdirective %s", d.Val())
 			}


### PR DESCRIPTION
I have successfully established h2c connection between caddy and my local service with the commits in https://github.com/caddyserver/caddy/pull/3561. 

But the json config in https://github.com/caddyserver/caddy/issues/3556#issuecomment-655274156 cannot be simply ported to caddyfile because of the absence of `compression` field in `reverse_proxy -> transport http` config. This PR is just a minor modification to make this field available to caddyfile's http transport config.

Config example:
```
    transport http {
      versions h2c 2
      compression off
    }
```