### PR TITLE
fileserver: First attempt to fix failing test on Linux

### DIFF
--- a/modules/caddyhttp/fileserver/matcher_test.go
+++ b/modules/caddyhttp/fileserver/matcher_test.go
@@ -39,6 +39,11 @@ func TestPHPFileMatcher(t *testing.T) {
 			matched:      true,
 		},
 		{
+			path:         "/index.PHP/somewhere",
+			expectedPath: "/index.PHP",
+			matched:      true,
+		},
+		{
 			path:         "/remote.php",
 			expectedPath: "/remote.php",
 			matched:      true,
@@ -69,11 +74,6 @@ func TestPHPFileMatcher(t *testing.T) {
 		{
 			path:         "/foo.php.php/index.php",
 			expectedPath: "/foo.php.php/index.php",
-			matched:      true,
-		},
-		{
-			path:         "/foo.php.PHP/index.php",
-			expectedPath: "/foo.php.PHP/index.php",
 			matched:      true,
 		},
 		{

--- a/modules/caddyhttp/fileserver/matcher_test.go
+++ b/modules/caddyhttp/fileserver/matcher_test.go
@@ -39,11 +39,6 @@ func TestPHPFileMatcher(t *testing.T) {
 			matched:      true,
 		},
 		{
-			path:         "/index.PHP/somewhere",
-			expectedPath: "/index.PHP",
-			matched:      true,
-		},
-		{
 			path:         "/remote.php",
 			expectedPath: "/remote.php",
 			matched:      true,
@@ -113,5 +108,14 @@ func TestPHPFileMatcher(t *testing.T) {
 		if rel != tc.expectedPath {
 			t.Fatalf("Test %d: actual path: %v, expected: %v", i, rel, tc.expectedPath)
 		}
+	}
+}
+
+func TestFirstSplit(t *testing.T) {
+	m := MatchFile{SplitPath: []string{".php"}}
+	actual := m.firstSplit("index.PHP/somewhere")
+	expected := "index.PHP"
+	if actual != expected {
+		t.Errorf("Expected %s but got %s", expected, actual)
 	}
 }


### PR DESCRIPTION
I think I updated the wrong test case before. I don't have Linux handy so it's going to be trial-and-error until we can figure this out.

This is a new test case. If I recall correctly, we had problems with `.PHP` (non-lowercased path splits) that led to unfavorable handling of those requests in the past.