### PR TITLE
caddytls: Add support for ZeroSSL; add Caddyfile support for issuers

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -405,7 +405,7 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 		}
 		configVals = append(configVals, ConfigValue{
 			Class: "tls.cert_issuer",
-			Value: acmeIssuer,
+			Value: disambiguateACMEIssuer(acmeIssuer),
 		})
 	}
 

--- a/caddytest/integration/caddyfile_adapt/global_options.txt
+++ b/caddytest/integration/caddyfile_adapt/global_options.txt
@@ -56,7 +56,8 @@
 					{
 						"issuer": {
 							"module": "internal"
-						}
+						},
+						"key_type": "ed25519"
 					}
 				],
 				"on_demand": {

--- a/caddytest/integration/caddyfile_adapt/global_options_admin.txt
+++ b/caddytest/integration/caddyfile_adapt/global_options_admin.txt
@@ -64,7 +64,8 @@
 					{
 						"issuer": {
 							"module": "internal"
-						}
+						},
+						"key_type": "ed25519"
 					}
 				],
 				"on_demand": {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.1.0
 	github.com/alecthomas/chroma v0.7.4-0.20200517063913-500529fd43c1
 	github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a
-	github.com/caddyserver/certmagic v0.11.3-0.20200808143826-2e100d6d0bcf
+	github.com/caddyserver/certmagic v0.11.3-0.20200810220624-10a8b5c72339
 	github.com/dustin/go-humanize v1.0.1-0.20200219035652-afde56e7acac
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/google/cel-go v0.5.1
@@ -14,7 +14,7 @@ require (
 	github.com/klauspost/compress v1.10.10
 	github.com/klauspost/cpuid v1.2.5
 	github.com/lucas-clemente/quic-go v0.17.3
-	github.com/mholt/acmez v0.1.0
+	github.com/mholt/acmez v0.1.1-0.20200810215816-dbe88fc6cf09
 	github.com/naoina/go-stringutil v0.1.0 // indirect
 	github.com/naoina/toml v0.1.1
 	github.com/smallstep/certificates v0.14.6
@@ -25,7 +25,7 @@ require (
 	github.com/yuin/goldmark-highlighting v0.0.0-20200307114337-60d527fdb691
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
-	golang.org/x/net v0.0.0-20200625001655-4c5254603344
+	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 	google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.1.0
 	github.com/alecthomas/chroma v0.7.4-0.20200517063913-500529fd43c1
 	github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a
-	github.com/caddyserver/certmagic v0.11.3-0.20200730200704-7d9dfc3fe638
+	github.com/caddyserver/certmagic v0.11.3-0.20200804205533-c6afa6e7a22e
 	github.com/dustin/go-humanize v1.0.1-0.20200219035652-afde56e7acac
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/google/cel-go v0.5.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.1.0
 	github.com/alecthomas/chroma v0.7.4-0.20200517063913-500529fd43c1
 	github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a
-	github.com/caddyserver/certmagic v0.11.3-0.20200804205533-c6afa6e7a22e
+	github.com/caddyserver/certmagic v0.11.3-0.20200808143826-2e100d6d0bcf
 	github.com/dustin/go-humanize v1.0.1-0.20200219035652-afde56e7acac
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/google/cel-go v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTK
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
-github.com/caddyserver/certmagic v0.11.3-0.20200730200704-7d9dfc3fe638 h1:yG2XwuzF6kQni6HscKZRj6Qr6mrpXsRTUzl0m+zH6o0=
-github.com/caddyserver/certmagic v0.11.3-0.20200730200704-7d9dfc3fe638/go.mod h1:z0loWzjr6Sr8rOG2pdsiwajDpAcck2wfF8E7hTV0qT4=
+github.com/caddyserver/certmagic v0.11.3-0.20200804205533-c6afa6e7a22e h1:R/EmX2RTXml60AI685PL+eXA+q5w0HKZDHEXYhIIlR8=
+github.com/caddyserver/certmagic v0.11.3-0.20200804205533-c6afa6e7a22e/go.mod h1:z0loWzjr6Sr8rOG2pdsiwajDpAcck2wfF8E7hTV0qT4=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTK
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
-github.com/caddyserver/certmagic v0.11.3-0.20200804205533-c6afa6e7a22e h1:R/EmX2RTXml60AI685PL+eXA+q5w0HKZDHEXYhIIlR8=
-github.com/caddyserver/certmagic v0.11.3-0.20200804205533-c6afa6e7a22e/go.mod h1:z0loWzjr6Sr8rOG2pdsiwajDpAcck2wfF8E7hTV0qT4=
+github.com/caddyserver/certmagic v0.11.3-0.20200808143826-2e100d6d0bcf h1:Srcj7CdiavYImKMLDj8sSJKS3htwwwJB3bjPRTXh+P0=
+github.com/caddyserver/certmagic v0.11.3-0.20200808143826-2e100d6d0bcf/go.mod h1:z0loWzjr6Sr8rOG2pdsiwajDpAcck2wfF8E7hTV0qT4=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTK
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
-github.com/caddyserver/certmagic v0.11.3-0.20200808143826-2e100d6d0bcf h1:Srcj7CdiavYImKMLDj8sSJKS3htwwwJB3bjPRTXh+P0=
-github.com/caddyserver/certmagic v0.11.3-0.20200808143826-2e100d6d0bcf/go.mod h1:z0loWzjr6Sr8rOG2pdsiwajDpAcck2wfF8E7hTV0qT4=
+github.com/caddyserver/certmagic v0.11.3-0.20200810220624-10a8b5c72339 h1:wTD+Y63XoBtiTJhe/Xn7WLrwKenmjkt2WxH3FP+Y0DM=
+github.com/caddyserver/certmagic v0.11.3-0.20200810220624-10a8b5c72339/go.mod h1:mqOzOvKa7UcC+TWbBLcP0ZLRut/xaaQBw0hRGWHBIkY=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
@@ -384,8 +384,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/mholt/acmez v0.1.0 h1:LL7WQVCjZvwbo3pjAUdsqEao5kI8nyHubAGtCzrTS5g=
-github.com/mholt/acmez v0.1.0/go.mod h1:rNLSzYu5VR6ggyarXDKDCNefo06cOkJn+VObTDJCk0U=
+github.com/mholt/acmez v0.1.1-0.20200810215816-dbe88fc6cf09 h1:J7NVJ46iBFeWsUc5aeVv8QNO2mLhI6rJKIbpAsH7d7g=
+github.com/mholt/acmez v0.1.1-0.20200810215816-dbe88fc6cf09/go.mod h1:8qnn8QA/Ewx8E3ZSsmscqsIjhhpxuy9vqdgbX2ceceM=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/miekg/dns v1.1.30 h1:Qww6FseFn8PRfw07jueqIXqodm0JKiiKuK0DeXSqfyo=
 github.com/miekg/dns v1.1.30/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
@@ -710,8 +710,8 @@ golang.org/x/net v0.0.0-20191002035440-2ec189313ef0/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
-golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
+golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/modules/caddytls/acmeissuer.go
+++ b/modules/caddytls/acmeissuer.go
@@ -87,7 +87,7 @@ func (ACMEIssuer) CaddyModule() caddy.ModuleInfo {
 	}
 }
 
-// Provision sets up m.
+// Provision sets up iss.
 func (iss *ACMEIssuer) Provision(ctx caddy.Context) error {
 	iss.logger = ctx.Logger(iss)
 

--- a/modules/caddytls/internalissuer.go
+++ b/modules/caddytls/internalissuer.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddypki"
 	"github.com/caddyserver/certmagic"
 	"github.com/smallstep/certificates/authority/provisioner"
@@ -63,25 +64,25 @@ func (InternalIssuer) CaddyModule() caddy.ModuleInfo {
 }
 
 // Provision sets up the issuer.
-func (li *InternalIssuer) Provision(ctx caddy.Context) error {
+func (iss *InternalIssuer) Provision(ctx caddy.Context) error {
 	// get a reference to the configured CA
 	appModule, err := ctx.App("pki")
 	if err != nil {
 		return err
 	}
 	pkiApp := appModule.(*caddypki.PKI)
-	if li.CA == "" {
-		li.CA = caddypki.DefaultCAID
+	if iss.CA == "" {
+		iss.CA = caddypki.DefaultCAID
 	}
-	ca, ok := pkiApp.CAs[li.CA]
+	ca, ok := pkiApp.CAs[iss.CA]
 	if !ok {
-		return fmt.Errorf("no certificate authority configured with id: %s", li.CA)
+		return fmt.Errorf("no certificate authority configured with id: %s", iss.CA)
 	}
-	li.ca = ca
+	iss.ca = ca
 
 	// set any other default values
-	if li.Lifetime == 0 {
-		li.Lifetime = caddy.Duration(defaultInternalCertLifetime)
+	if iss.Lifetime == 0 {
+		iss.Lifetime = caddy.Duration(defaultInternalCertLifetime)
 	}
 
 	return nil
@@ -89,38 +90,38 @@ func (li *InternalIssuer) Provision(ctx caddy.Context) error {
 
 // IssuerKey returns the unique issuer key for the
 // confgured CA endpoint.
-func (li InternalIssuer) IssuerKey() string {
-	return li.ca.ID()
+func (iss InternalIssuer) IssuerKey() string {
+	return iss.ca.ID()
 }
 
 // Issue issues a certificate to satisfy the CSR.
-func (li InternalIssuer) Issue(ctx context.Context, csr *x509.CertificateRequest) (*certmagic.IssuedCertificate, error) {
+func (iss InternalIssuer) Issue(ctx context.Context, csr *x509.CertificateRequest) (*certmagic.IssuedCertificate, error) {
 	// prepare the signing authority
 	authCfg := caddypki.AuthorityConfig{
-		SignWithRoot: li.SignWithRoot,
+		SignWithRoot: iss.SignWithRoot,
 	}
-	auth, err := li.ca.NewAuthority(authCfg)
+	auth, err := iss.ca.NewAuthority(authCfg)
 	if err != nil {
 		return nil, err
 	}
 
 	// get the cert (public key) that will be used for signing
 	var issuerCert *x509.Certificate
-	if li.SignWithRoot {
-		issuerCert = li.ca.RootCertificate()
+	if iss.SignWithRoot {
+		issuerCert = iss.ca.RootCertificate()
 	} else {
-		issuerCert = li.ca.IntermediateCertificate()
+		issuerCert = iss.ca.IntermediateCertificate()
 	}
 
 	// ensure issued certificate does not expire later than its issuer
-	lifetime := time.Duration(li.Lifetime)
+	lifetime := time.Duration(iss.Lifetime)
 	if time.Now().Add(lifetime).After(issuerCert.NotAfter) {
 		// TODO: log this
 		lifetime = issuerCert.NotAfter.Sub(time.Now())
 	}
 
 	certChain, err := auth.Sign(csr, provisioner.Options{},
-		profileDefaultDuration(li.Lifetime),
+		profileDefaultDuration(iss.Lifetime),
 	)
 	if err != nil {
 		return nil, err
@@ -137,6 +138,26 @@ func (li InternalIssuer) Issue(ctx context.Context, csr *x509.CertificateRequest
 	return &certmagic.IssuedCertificate{
 		Certificate: buf.Bytes(),
 	}, nil
+}
+
+// UnmarshalCaddyfile deserializes Caddyfile tokens into iss.
+//
+//     ... internal {
+//         ca <name>
+//     }
+//
+func (iss *InternalIssuer) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		for d.NextBlock(0) {
+			switch d.Val() {
+			case "ca":
+				if !d.AllArgs(&iss.CA) {
+					return d.ArgErr()
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // profileDefaultDuration is a wrapper against x509util.WithOption to conform

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -313,8 +313,10 @@ func (t *TLS) HandleHTTPChallenge(w http.ResponseWriter, r *http.Request) bool {
 	if ap.magic.Issuer == nil {
 		return false
 	}
-	if am, ok := ap.magic.Issuer.(*ACMEIssuer); ok {
-		return certmagic.NewACMEManager(am.magic, am.template).HandleHTTPChallenge(w, r)
+	type acmeCapable interface{ GetACMEIssuer() *ACMEIssuer }
+	if am, ok := ap.magic.Issuer.(acmeCapable); ok {
+		iss := am.GetACMEIssuer()
+		return certmagic.NewACMEManager(iss.magic, iss.template).HandleHTTPChallenge(w, r)
 	}
 	return false
 }

--- a/modules/caddytls/zerosslissuer.go
+++ b/modules/caddytls/zerosslissuer.go
@@ -1,0 +1,212 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddytls
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/certmagic"
+	"github.com/mholt/acmez/acme"
+	"go.uber.org/zap"
+)
+
+func init() {
+	caddy.RegisterModule(new(ZeroSSLIssuer))
+}
+
+// ZeroSSLIssuer makes an ACME manager
+// for managing certificates using ACME.
+type ZeroSSLIssuer struct {
+	*ACMEIssuer
+
+	// The API key (or "access key") for using the ZeroSSL
+	// API (required).
+	APIKey string `json:"api_key,omitempty"`
+
+	mu     sync.Mutex
+	logger *zap.Logger
+}
+
+// CaddyModule returns the Caddy module information.
+func (*ZeroSSLIssuer) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "tls.issuance.zerossl",
+		New: func() caddy.Module { return new(ZeroSSLIssuer) },
+	}
+}
+
+// Provision sets up iss.
+func (iss *ZeroSSLIssuer) Provision(ctx caddy.Context) error {
+	iss.logger = ctx.Logger(iss)
+
+	if iss.ACMEIssuer == nil {
+		iss.ACMEIssuer = new(ACMEIssuer)
+	}
+	err := iss.ACMEIssuer.Provision(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (iss *ZeroSSLIssuer) newAccountCallback(ctx context.Context, am *certmagic.ACMEManager, _ acme.Account) error {
+	if am.ExternalAccount != nil {
+		return nil
+	}
+	var err error
+	am.ExternalAccount, err = iss.generateEABCredentials(ctx)
+	return err
+}
+
+func (iss *ZeroSSLIssuer) generateEABCredentials(ctx context.Context) (*acme.EAB, error) {
+	apiKey := caddy.NewReplacer().ReplaceAll(iss.APIKey, "")
+	if apiKey == "" {
+		return nil, fmt.Errorf("missing API key: '%v'", iss.APIKey)
+	}
+
+	qs := url.Values{"access_key": []string{apiKey}}
+	endpoint := fmt.Sprintf("%s/eab-credentials?%s", zerosslAPIBase, qs.Encode())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("forming request: %v", err)
+	}
+	req.Header.Set("User-Agent", certmagic.UserAgent)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("performing EAB credentials request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Success bool `json:"success"`
+		Error   struct {
+			Code int    `json:"code"`
+			Type string `json:"type"`
+		} `json:"error"`
+		EABKID     string `json:"eab_kid"`
+		EABHMACKey string `json:"eab_hmac_key"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	if err != nil {
+		return nil, fmt.Errorf("decoding API response: %v", err)
+	}
+	if result.Error.Code != 0 {
+		return nil, fmt.Errorf("failed getting EAB credentials: HTTP %d: %s (code %d)",
+			resp.StatusCode, result.Error.Type, result.Error.Code)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed getting EAB credentials: HTTP %d", resp.StatusCode)
+	}
+
+	iss.logger.Info("generated EAB credentials", zap.String("key_id", result.EABKID))
+
+	return &acme.EAB{
+		KeyID:  result.EABKID,
+		MACKey: result.EABHMACKey,
+	}, nil
+}
+
+// initialize modifies the template for the underlying ACMEManager
+// values by setting the CA endpoint to the ZeroSSL directory and
+// setting the NewAccountFunc callback to one which allows us to
+// generate EAB credentials only if a new account is being made.
+// Since it modifies the stored template, its effect should only
+// be needed once, but it is fine to call it repeatedly.
+func (iss *ZeroSSLIssuer) initialize() {
+	iss.mu.Lock()
+	defer iss.mu.Unlock()
+	if iss.template.CA == "" {
+		iss.template.CA = zerosslACMEDirectory
+	}
+	if iss.template.NewAccountFunc == nil {
+		iss.template.NewAccountFunc = iss.newAccountCallback
+	}
+}
+
+// PreCheck implements the certmagic.PreChecker interface.
+func (iss *ZeroSSLIssuer) PreCheck(ctx context.Context, names []string, interactive bool) error {
+	iss.initialize()
+	return certmagic.NewACMEManager(iss.magic, iss.template).PreCheck(ctx, names, interactive)
+}
+
+// Issue obtains a certificate for the given csr.
+func (iss *ZeroSSLIssuer) Issue(ctx context.Context, csr *x509.CertificateRequest) (*certmagic.IssuedCertificate, error) {
+	iss.initialize()
+	return certmagic.NewACMEManager(iss.magic, iss.template).Issue(ctx, csr)
+}
+
+// IssuerKey returns the unique issuer key for the configured CA endpoint.
+func (iss *ZeroSSLIssuer) IssuerKey() string {
+	return certmagic.NewACMEManager(iss.magic, iss.template).IssuerKey()
+}
+
+// Revoke revokes the given certificate.
+func (iss *ZeroSSLIssuer) Revoke(ctx context.Context, cert certmagic.CertificateResource, reason int) error {
+	iss.initialize()
+	return certmagic.NewACMEManager(iss.magic, iss.template).Revoke(ctx, cert, reason)
+}
+
+// UnmarshalCaddyfile deserializes Caddyfile tokens into iss.
+//
+//     ... zerossl <api_key> {
+//         ...
+//     }
+//
+// Any of the subdirectives for the ACME issuer can be used in the block.
+func (iss *ZeroSSLIssuer) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		if !d.AllArgs(&iss.APIKey) {
+			return d.ArgErr()
+		}
+
+		if iss.ACMEIssuer == nil {
+			iss.ACMEIssuer = new(ACMEIssuer)
+		}
+		err := iss.ACMEIssuer.UnmarshalCaddyfile(d.NewFromNextSegment())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+const (
+	zerosslACMEDirectory = "https://acme.zerossl.com/v2/DV90"
+	zerosslAPIBase       = "https://api.zerossl.com/acme"
+)
+
+// Interface guards
+var (
+	_ certmagic.PreChecker = (*ZeroSSLIssuer)(nil)
+	_ certmagic.Issuer     = (*ZeroSSLIssuer)(nil)
+	_ certmagic.Revoker    = (*ZeroSSLIssuer)(nil)
+	_ caddy.Provisioner    = (*ZeroSSLIssuer)(nil)
+	_ ConfigSetter         = (*ZeroSSLIssuer)(nil)
+
+	// a type which properly embeds an ACMEIssuer should implement
+	// this interface so it can be treated as an ACMEIssuer
+	_ interface{ GetACMEIssuer() *ACMEIssuer } = (*ZeroSSLIssuer)(nil)
+)

--- a/modules/caddytls/zerosslissuer.go
+++ b/modules/caddytls/zerosslissuer.go
@@ -166,24 +166,25 @@ func (iss *ZeroSSLIssuer) initialize() {
 // PreCheck implements the certmagic.PreChecker interface.
 func (iss *ZeroSSLIssuer) PreCheck(ctx context.Context, names []string, interactive bool) error {
 	iss.initialize()
-	return certmagic.NewACMEManager(iss.magic, iss.template).PreCheck(ctx, names, interactive)
+	return iss.ACMEIssuer.PreCheck(ctx, names, interactive)
 }
 
 // Issue obtains a certificate for the given csr.
 func (iss *ZeroSSLIssuer) Issue(ctx context.Context, csr *x509.CertificateRequest) (*certmagic.IssuedCertificate, error) {
 	iss.initialize()
-	return certmagic.NewACMEManager(iss.magic, iss.template).Issue(ctx, csr)
+	return iss.ACMEIssuer.Issue(ctx, csr)
 }
 
 // IssuerKey returns the unique issuer key for the configured CA endpoint.
 func (iss *ZeroSSLIssuer) IssuerKey() string {
-	return certmagic.NewACMEManager(iss.magic, iss.template).IssuerKey()
+	iss.initialize()
+	return iss.ACMEIssuer.IssuerKey()
 }
 
 // Revoke revokes the given certificate.
 func (iss *ZeroSSLIssuer) Revoke(ctx context.Context, cert certmagic.CertificateResource, reason int) error {
 	iss.initialize()
-	return certmagic.NewACMEManager(iss.magic, iss.template).Revoke(ctx, cert, reason)
+	return iss.ACMEIssuer.Revoke(ctx, cert, reason)
 }
 
 // UnmarshalCaddyfile deserializes Caddyfile tokens into iss.


### PR DESCRIPTION
Configuring issuers explicitly in a Caddyfile is not easily compatible
with existing ACME-specific parameters such as email or acme_ca which
infer the kind of issuer it creates (this is complicated now because
the ZeroSSL issuer wraps the ACME issuer)... oh well, we can revisit
that later if we need to.

New Caddyfile global option:

    {
        cert_issuer <name> ...
    }

Or, alternatively, as a tls subdirective:

    tls {
        issuer <name> ...
    }

For example, to use ZeroSSL with an API key:

    {
        cert_issuser zerossl API_KEY
    }

For now, that still uses ZeroSSL's ACME endpoint; it fetches EAB
credentials for you. You can also provide the EAB credentials directly
just like any other ACME endpoint:

    {
        cert_issuer acme {
            eab KEY_ID MAC_KEY
        }
    }

All these examples use the new global option (or tls subdirective). You
can still use traditional/existing options with ZeroSSL, since it's
just another ACME endpoint:

    {
        acme_ca  https://acme.zerossl.com/v2/DV90
        acme_eab KEY_ID MAC_KEY
    }

That's all there is to it. You just can't mix-and-match acme_* options
with cert_issuer, because it becomes confusing/ambiguous/complicated to
merge the settings.

----

The latest commits on this PR make it possible to implicitly configure the ZeroSSL issuer by specifying a CA endpoint containing `acme.zerossl.com` and an email address; no API key required:

```
{
    acme_ca https://acme.zerossl.com/v2/DV90
    email   you@yours.com
}
```

(And similarly for with the `tls` directive.)

In other words, even though using ZeroSSL (the first time) requires the `ZeroSSLIssuer` type (to generate the EAB credentials when making an ACME account), it's very easy to configure ZeroSSL: Caddy will mostly auto-detect it and wrap the ACMEIssuer properly with ZeroSSLIssuer. You can also explicitly configure ZeroSSL as shown above.

No issuer defaults are changed with this PR.

----

With version 2.3 (to clarify: not 2.2, the release for which this change is slated), we can then work on making one CA a fallback of another. For example, if ZeroSSL is the primary CA but is down, then switch to Let's Encrypt. Or vice-versa, if LE is down (or you've hit rate limits), switch to ZeroSSL.