### PR TITLE
reverseproxy: Add support for `Host` header selection policy

### DIFF
--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -362,6 +362,13 @@ func (s HeaderHashSelection) Select(pool UpstreamPool, req *http.Request) *Upstr
 	if s.Field == "" {
 		return nil
 	}
+
+	// The Host header should be obtained from the req.Host field
+	// since net/http removes it from the header map.
+	if s.Field == "Host" && req.Host != "" {
+		return hostByHashing(pool, req.Host)
+	}
+
 	val := req.Header.Get(s.Field)
 	if val == "" {
 		return RandomSelection{}.Select(pool, req)


### PR DESCRIPTION
Super simple fix to allow `lb_policy header Host` to work.

See https://caddy.community/t/v2-lb-policy-testing/9441