### PR TITLE
caddyhttp: Wrap http.Server logging with zap

### DIFF
--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -281,6 +281,12 @@ func (app *App) Validate() error {
 // Start runs the app. It finishes automatic HTTPS if enabled,
 // including management of certificates.
 func (app *App) Start() error {
+	// get a logger compatible with http.Server
+	serverLogger, err := zap.NewStdLogAt(app.logger.Named("stdlib"), zap.DebugLevel)
+	if err != nil {
+		return fmt.Errorf("failed to set up server logger: %v", err)
+	}
+
 	for srvName, srv := range app.Servers {
 		s := &http.Server{
 			ReadTimeout:       time.Duration(srv.ReadTimeout),
@@ -289,6 +295,7 @@ func (app *App) Start() error {
 			IdleTimeout:       time.Duration(srv.IdleTimeout),
 			MaxHeaderBytes:    srv.MaxHeaderBytes,
 			Handler:           srv,
+			ErrorLog:          serverLogger,
 		}
 
 		// enable h2c if configured
@@ -344,6 +351,7 @@ func (app *App) Start() error {
 								Addr:      hostport,
 								Handler:   srv,
 								TLSConfig: tlsCfg,
+								ErrorLog:  serverLogger,
 							},
 						}
 						go h3srv.Serve(h3ln)
@@ -382,7 +390,7 @@ func (app *App) Start() error {
 
 	// finish automatic HTTPS by finally beginning
 	// certificate management
-	err := app.automaticHTTPSPhase2()
+	err = app.automaticHTTPSPhase2()
 	if err != nil {
 		return fmt.Errorf("finalizing automatic HTTPS: %v", err)
 	}


### PR DESCRIPTION
Well this was way simpler than I expected... went way down the rabbithole in the wrong direction then realized all we needed was this one liner.

See https://pkg.go.dev/go.uber.org/zap?tab=doc#NewStdLog

Right now, this will log all errors from `http.Server` as INFO level, but we can easily change that by using `NewStdLogAt` instead to specify the level. Not sure what level you think we should use. Warn? Error?

This is how it looks before:

```
...
2020/08/20 04:10:27.647 INFO    serving initial configuration
2020/08/20 00:10:33 http: TLS handshake error from [::1]:65239: EOF
2020/08/20 04:11:32.551 INFO    shutting down   {"signal": "SIGINT"}
...
```

And after this change:

```
...
2020/08/20 04:32:52.059 INFO    serving initial configuration
2020/08/20 04:32:55.226 INFO    http    http: TLS handshake error from [::1]:49685: EOF
2020/08/20 04:33:48.299 INFO    shutting down   {"signal": "SIGINT"}
...
```

We may also want to make this change in other places like `admin.go` and the `h3` server, i.e. where other `http.Server`s are created. This is the important one though.