### PR TITLE
httpcaddyfile: Ensure handle_path is sorted as equal to handle

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -862,7 +862,17 @@ func buildSubroute(routes []ConfigValue, groupCounter counter) (*caddyhttp.Subro
 		// root directives would overwrite previously-matched ones; they should not cascade
 		"root": {},
 	}
-	for meDir, info := range mutuallyExclusiveDirs {
+
+	// we want to deterministicly loop over the set of dirs
+	keys := make([]string, 0, len(mutuallyExclusiveDirs))
+	for k := range mutuallyExclusiveDirs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, meDir := range keys {
+		info := mutuallyExclusiveDirs[meDir]
+
 		// see how many instances of the directive there are
 		for _, r := range routes {
 			if r.directive == meDir {

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -864,7 +864,7 @@ func buildSubroute(routes []ConfigValue, groupCounter counter) (*caddyhttp.Subro
 		"root": {},
 	}
 
-	// we want to deterministicly loop over the set of dirs
+	// we need to deterministically loop over each of these directives
 	keys := make([]string, 0, len(mutuallyExclusiveDirs))
 	for k := range mutuallyExclusiveDirs {
 		keys = append(keys, k)

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -172,6 +172,14 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 			if err != nil {
 				return nil, warnings, fmt.Errorf("parsing caddyfile tokens for '%s': %v", dir, err)
 			}
+
+			// as a special case, we want "handle_path" to be sorted
+			// at the same level as "handle" so we force them to use
+			// the same directive name after their parsing is complete
+			if dir == "handle_path" {
+				dir = "handle"
+			}
+
 			for _, result := range results {
 				result.directive = dir
 				sb.pile[result.Class] = append(sb.pile[result.Class], result)

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -865,6 +865,7 @@ func buildSubroute(routes []ConfigValue, groupCounter counter) (*caddyhttp.Subro
 	}
 
 	// we need to deterministically loop over each of these directives
+	// in order to keep the group numbers consistent
 	keys := make([]string, 0, len(mutuallyExclusiveDirs))
 	for k := range mutuallyExclusiveDirs {
 		keys = append(keys, k)

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -173,9 +173,10 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 				return nil, warnings, fmt.Errorf("parsing caddyfile tokens for '%s': %v", dir, err)
 			}
 
-			// as a special case, we want "handle_path" to be sorted
-			// at the same level as "handle" so we force them to use
-			// the same directive name after their parsing is complete
+			// As a special case, we want "handle_path" to be sorted
+			// at the same level as "handle", so we force them to use
+			// the same directive name after their parsing is complete.
+			// See https://github.com/caddyserver/caddy/issues/3675#issuecomment-678042377
 			if dir == "handle_path" {
 				dir = "handle"
 			}

--- a/caddytest/integration/caddyfile_adapt/handle_path_sorting.txt
+++ b/caddytest/integration/caddyfile_adapt/handle_path_sorting.txt
@@ -1,0 +1,105 @@
+:80 {
+	handle /api/* {
+		respond "api"
+	}
+
+	handle_path /static/* {
+		respond "static"
+	}
+
+	handle {
+		respond "handle"
+	}
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"group": "group4",
+							"match": [
+								{
+									"path": [
+										"/static/*"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"handler": "rewrite",
+													"strip_path_prefix": "/static"
+												}
+											]
+										},
+										{
+											"handle": [
+												{
+													"body": "static",
+													"handler": "static_response"
+												}
+											]
+										}
+									]
+								}
+							]
+						},
+						{
+							"group": "group4",
+							"match": [
+								{
+									"path": [
+										"/api/*"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "api",
+													"handler": "static_response"
+												}
+											]
+										}
+									]
+								}
+							]
+						},
+						{
+							"group": "group4",
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "handle",
+													"handler": "static_response"
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/caddytest/integration/caddyfile_adapt/handle_path_sorting.txt
+++ b/caddytest/integration/caddyfile_adapt/handle_path_sorting.txt
@@ -22,7 +22,7 @@
 					],
 					"routes": [
 						{
-							"group": "group4",
+							"group": "group3",
 							"match": [
 								{
 									"path": [
@@ -55,7 +55,7 @@
 							]
 						},
 						{
-							"group": "group4",
+							"group": "group3",
 							"match": [
 								{
 									"path": [
@@ -80,7 +80,7 @@
 							]
 						},
 						{
-							"group": "group4",
+							"group": "group3",
 							"handle": [
 								{
 									"handler": "subroute",


### PR DESCRIPTION
Fixes an issue found in #3675

I don't love this fix frankly, any hard-coded logic is 😬 but I'm not sure of a better way to do this. We want `handle` and `handle_path` to have different `dirFunc` logic, but we need them to sort equivalently because they are both just handles, where one is just a shortcut to the other.

Having done this, I think we could probably remove `handle_path` from the directive order since it'll never actually be seen by the sort function.