### PR TITLE
caddyfile: Add support for env var defaults, tests

### DIFF
--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -60,21 +60,31 @@ func replaceEnvVars(input []byte) ([]byte, error) {
 		end += begin + len(spanOpen) // make end relative to input, not begin
 
 		// get the name; if there is no name, skip it
-		envVarName := input[begin+len(spanOpen) : end]
-		if len(envVarName) == 0 {
+		envString := input[begin+len(spanOpen) : end]
+		if len(envString) == 0 {
 			offset = end + len(spanClose)
 			continue
 		}
 
+		// split the string into a key and an optional default
+		envParts := strings.SplitN(string(envString), ":-", 2)
+
+		// do a lookup for the env var, replace with the default if not found
+		envVarValue, found := os.LookupEnv(string(envParts[0]))
+		if !found && len(envParts) == 2 {
+			envVarValue = envParts[1]
+		}
+
 		// get the value of the environment variable
-		envVarValue := []byte(os.ExpandEnv(os.Getenv(string(envVarName))))
+		// note that this causes one-level deep chaining
+		envVarBytes := []byte(os.ExpandEnv(envVarValue))
 
 		// splice in the value
 		input = append(input[:begin],
-			append(envVarValue, input[end+len(spanClose):]...)...)
+			append(envVarBytes, input[end+len(spanClose):]...)...)
 
 		// continue at the end of the replacement
-		offset = begin + len(envVarValue)
+		offset = begin + len(envVarBytes)
 	}
 	return input, nil
 }

--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -67,17 +67,17 @@ func replaceEnvVars(input []byte) ([]byte, error) {
 		}
 
 		// split the string into a key and an optional default
-		envParts := strings.SplitN(string(envString), ":-", 2)
+		envParts := strings.SplitN(string(envString), envVarDefaultDelimiter, 2)
 
 		// do a lookup for the env var, replace with the default if not found
-		envVarValue, found := os.LookupEnv(string(envParts[0]))
+		envVarValue, found := os.LookupEnv(envParts[0])
 		if !found && len(envParts) == 2 {
 			envVarValue = envParts[1]
 		}
 
 		// get the value of the environment variable
 		// note that this causes one-level deep chaining
-		envVarBytes := []byte(os.ExpandEnv(envVarValue))
+		envVarBytes := []byte(envVarValue)
 
 		// splice in the value
 		input = append(input[:begin],
@@ -558,4 +558,7 @@ func (s Segment) Directive() string {
 
 // spanOpen and spanClose are used to bound spans that
 // contain the name of an environment variable.
-var spanOpen, spanClose = []byte{'{', '$'}, []byte{'}'}
+var (
+	spanOpen, spanClose    = []byte{'{', '$'}, []byte{'}'}
+	envVarDefaultDelimiter = "??"
+)

--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -560,5 +560,5 @@ func (s Segment) Directive() string {
 // contain the name of an environment variable.
 var (
 	spanOpen, spanClose    = []byte{'{', '$'}, []byte{'}'}
-	envVarDefaultDelimiter = "??"
+	envVarDefaultDelimiter = ":"
 )

--- a/caddyconfig/caddyfile/parse_test.go
+++ b/caddyconfig/caddyfile/parse_test.go
@@ -526,19 +526,19 @@ func TestEnvironmentReplacement(t *testing.T) {
 		},
 		{
 			input:  "{$CHAINED}",
-			expect: "foobar",
+			expect: "$FOOBAR", // should not chain env expands
 		},
 		{
-			input:  "{$FOO:-default}",
+			input:  "{$FOO??default}",
 			expect: "default",
 		},
 		{
-			input:  "foo{$BAR:-bar}baz",
+			input:  "foo{$BAR??bar}baz",
 			expect: "foobarbaz",
 		},
 		{
-			input:  "foo{$BAR:-$FOOBAR}baz",
-			expect: "foofoobarbaz",
+			input:  "foo{$BAR??$FOOBAR}baz",
+			expect: "foo$FOOBARbaz", // should not chain env expands
 		},
 		{
 			input:  "{$FOOBAR",

--- a/caddyconfig/caddyfile/parse_test.go
+++ b/caddyconfig/caddyfile/parse_test.go
@@ -478,6 +478,7 @@ func TestParseAll(t *testing.T) {
 
 func TestEnvironmentReplacement(t *testing.T) {
 	os.Setenv("FOOBAR", "foobar")
+	os.Setenv("CHAINED", "$FOOBAR")
 
 	for i, test := range []struct {
 		input  string
@@ -522,6 +523,22 @@ func TestEnvironmentReplacement(t *testing.T) {
 		{
 			input:  "{$FOOBAR}{$FOOBAR}",
 			expect: "foobarfoobar",
+		},
+		{
+			input:  "{$CHAINED}",
+			expect: "foobar",
+		},
+		{
+			input:  "{$FOO:-default}",
+			expect: "default",
+		},
+		{
+			input:  "foo{$BAR:-bar}baz",
+			expect: "foobarbaz",
+		},
+		{
+			input:  "foo{$BAR:-$FOOBAR}baz",
+			expect: "foofoobarbaz",
 		},
 		{
 			input:  "{$FOOBAR",

--- a/caddyconfig/caddyfile/parse_test.go
+++ b/caddyconfig/caddyfile/parse_test.go
@@ -529,15 +529,15 @@ func TestEnvironmentReplacement(t *testing.T) {
 			expect: "$FOOBAR", // should not chain env expands
 		},
 		{
-			input:  "{$FOO??default}",
+			input:  "{$FOO:default}",
 			expect: "default",
 		},
 		{
-			input:  "foo{$BAR??bar}baz",
+			input:  "foo{$BAR:bar}baz",
 			expect: "foobarbaz",
 		},
 		{
-			input:  "foo{$BAR??$FOOBAR}baz",
+			input:  "foo{$BAR:$FOOBAR}baz",
 			expect: "foo$FOOBARbaz", // should not chain env expands
 		},
 		{


### PR DESCRIPTION
Closes #2313

This adds support for an optional default in Caddyfile environment variable placeholders with a `:` separator. This is specifically for the ones like `{$FOO}`, not the ones like `{env.FOO}` which are replaced at runtime.

For example:

```
{$DOMAIN:localhost} {
	respond "Hello world!"
}
```

If the `DOMAIN` environment variable exists, the site label will be set to the value of that environment variable, but if not set, will be set to `localhost`.

FYI @mholt I also noticed while working on this that we were doing `os.GetEnv` and feeding that into `os.ExpandEnv`, which actually means that the env var will be replaced twice in chain. I retained this behaviour for now and added a test for it, but it feels like that wasn't intentional. It would technically be a minor breaking change to fix it so I want to wait for your input.