### PR TITLE
reverseproxy: Logging for streaming and upgrades

### DIFF
--- a/modules/caddyhttp/reverseproxy/streaming.go
+++ b/modules/caddyhttp/reverseproxy/streaming.go
@@ -32,8 +32,7 @@ func (h Handler) handleUpgradeResponse(rw http.ResponseWriter, req *http.Request
 	reqUpType := upgradeType(req.Header)
 	resUpType := upgradeType(res.Header)
 	if reqUpType != resUpType {
-		// TODO: figure out our own error handling
-		// p.getErrorHandler()(rw, req, fmt.Errorf("backend tried to switch protocol %q when %q was requested", resUpType, reqUpType))
+		h.logger.Sugar().Errorf("backend tried to switch protocol %q when %q was requested", resUpType, reqUpType)
 		return
 	}
 
@@ -41,12 +40,12 @@ func (h Handler) handleUpgradeResponse(rw http.ResponseWriter, req *http.Request
 
 	hj, ok := rw.(http.Hijacker)
 	if !ok {
-		// p.getErrorHandler()(rw, req, fmt.Errorf("can't switch protocols using non-Hijacker ResponseWriter type %T", rw))
+		h.logger.Sugar().Errorf("can't switch protocols using non-Hijacker ResponseWriter type %T", rw)
 		return
 	}
 	backConn, ok := res.Body.(io.ReadWriteCloser)
 	if !ok {
-		// p.getErrorHandler()(rw, req, fmt.Errorf("internal error: 101 switching protocols response with non-writable body"))
+		h.logger.Sugar().Errorf("internal error: 101 switching protocols response with non-writable body")
 		return
 	}
 
@@ -65,17 +64,17 @@ func (h Handler) handleUpgradeResponse(rw http.ResponseWriter, req *http.Request
 
 	conn, brw, err := hj.Hijack()
 	if err != nil {
-		// p.getErrorHandler()(rw, req, fmt.Errorf("Hijack failed on protocol switch: %v", err))
+		h.logger.Sugar().Errorf("Hijack failed on protocol switch: %v", err)
 		return
 	}
 	defer conn.Close()
 	res.Body = nil // so res.Write only writes the headers; we have res.Body in backConn above
 	if err := res.Write(brw); err != nil {
-		// p.getErrorHandler()(rw, req, fmt.Errorf("response write: %v", err))
+		h.logger.Sugar().Errorf("response write: %v", err)
 		return
 	}
 	if err := brw.Flush(); err != nil {
-		// p.getErrorHandler()(rw, req, fmt.Errorf("response flush: %v", err))
+		h.logger.Sugar().Errorf("response flush: %v", err)
 		return
 	}
 	errc := make(chan error, 1)

--- a/modules/caddyhttp/reverseproxy/streaming.go
+++ b/modules/caddyhttp/reverseproxy/streaming.go
@@ -32,7 +32,9 @@ func (h Handler) handleUpgradeResponse(rw http.ResponseWriter, req *http.Request
 	reqUpType := upgradeType(req.Header)
 	resUpType := upgradeType(res.Header)
 	if reqUpType != resUpType {
-		h.logger.Sugar().Debugf("backend tried to switch protocol %q when %q was requested", resUpType, reqUpType)
+		h.logger.Debug("backend tried to switch to unexpected protocol via Upgrade header",
+			zap.String("backend_upgrade", resUpType),
+			zap.String("requested_upgrade", reqUpType))
 		return
 	}
 


### PR DESCRIPTION
https://caddy.community/t/caddy-reverse-proxy-to-another-domain/9589/6

Looks like we forgot to set up logging here. I'm not sure if using the sugared logger is ideal, but it's the easiest way to get this working as similarly to the stdlib implementation I think.