### PR TITLE
reverseproxy: construct active health-check transport from scratch (Fixes #3691)

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -256,8 +256,15 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 			}
 
 			h.HealthChecks.Active.httpClient = &http.Client{
-				Timeout:   timeout,
-				Transport: h.Transport,
+				Timeout: timeout,
+			}
+
+			if h.TransportRaw != nil {
+				mod, err := ctx.LoadModule(h, "TransportRaw")
+				if err != nil {
+					return fmt.Errorf("loading transport: %v", err)
+				}
+				h.HealthChecks.Active.httpClient.Transport = mod.(http.RoundTripper)
 			}
 
 			if h.HealthChecks.Active.Interval == 0 {


### PR DESCRIPTION
The fix basically checks if custom transport config is available and creates the transport using the custom transport values. This works in my local manual tests. Tests can be added and the code can be deduplicated.

Fixes #3691