### PR TITLE
reverseproxy: return validation error if upstream address has port range size of more than 1

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -204,6 +204,16 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 
 	// set up upstreams
 	for _, upstream := range h.Upstreams {
+		addr, err := caddy.ParseNetworkAddress(upstream.Dial)
+		if err != nil {
+			return err
+		}
+		if addr.PortRangeSize() != 1 {
+			h.logger.Error("multiple addresses (upstream must map to only one address)",
+				zap.String("address", upstream.Dial),
+			)
+			return fmt.Errorf("multiple addresses (upstream must map to only one address): %v", addr)
+		}
 		// create or get the host representation for this upstream
 		var host Host = new(upstreamHost)
 		existingHost, loaded := hosts.LoadOrStore(upstream.String(), host)

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -209,9 +209,6 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 			return err
 		}
 		if addr.PortRangeSize() != 1 {
-			h.logger.Error("multiple addresses (upstream must map to only one address)",
-				zap.String("address", upstream.Dial),
-			)
 			return fmt.Errorf("multiple addresses (upstream must map to only one address): %v", addr)
 		}
 		// create or get the host representation for this upstream


### PR DESCRIPTION
Currently the Provision-er of the reverse proxy handler accepts upstream network address with range size more than 1. This means the following Caddyfile is accepted and validates successfully:

```
localhost
reverse_proxy localhost:2000-2020
```

This is despite the comment on the `Dial` field of the `Upstream` struct saying only a single socket is accepted:

https://github.com/caddyserver/caddy/blob/e2f913bb7f813ac2f79cd3644066eff3815accd4/modules/caddyhttp/reverseproxy/hosts.go#L68-L78

The code doesn't validate that until request time, when the method `fillDialInfo` is called:

https://github.com/caddyserver/caddy/blob/e2f913bb7f813ac2f79cd3644066eff3815accd4/modules/caddyhttp/reverseproxy/hosts.go#L161-L164

This PR adds validation of the port range size of an upstream address to the `Provision` step. We can sugar the Caddyfile upstream to accept port range and convert it to the JSON array for the entire specified range.