### PR TITLE
reverseproxy: Add `buffer_requests` option to `reverse_proxy` directive

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_h2c.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_h2c.txt
@@ -10,6 +10,7 @@ https://example.com {
 			versions h2c 2
 			compression off
 		}
+		buffer_requests
 	}
 }
 
@@ -38,6 +39,7 @@ https://example.com {
 										{
 											"handle": [
 												{
+													"buffer_requests": true,
 													"handler": "reverse_proxy",
 													"headers": {
 														"request": {

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -467,6 +467,12 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					h.FlushInterval = caddy.Duration(dur)
 				}
 
+			case "buffer_requests":
+				if d.NextArg() {
+					return d.ArgErr()
+				}
+				h.BufferRequests = true
+
 			case "header_up":
 				if h.Headers == nil {
 					h.Headers = new(headers.Handler)


### PR DESCRIPTION
https://caddy.community/t/adding-buffer-requests-to-caddyfile-for-reverse-proxy/9675/2