### PR TITLE
caddyfile: Add support for `vars` and `vars_regexp` matchers

### DIFF
--- a/caddytest/integration/caddyfile_adapt/matcher_syntax.txt
+++ b/caddytest/integration/caddyfile_adapt/matcher_syntax.txt
@@ -9,6 +9,15 @@
 
 	@matcher3 not method PUT
 	respond @matcher3 "not put"
+
+	@matcher4 vars "{http.request.uri}" "/vars-matcher"
+	respond @matcher4 "from vars matcher"
+
+	@matcher5 vars_regexp static "{http.request.uri}" `\.([a-f0-9]{6})\.(css|js)$`
+	respond @matcher5 "from vars_regexp matcher with name"
+
+	@matcher6 vars_regexp "{http.request.uri}" `\.([a-f0-9]{6})\.(css|js)$`
+	respond @matcher6 "from vars_regexp matcher without name"
 }
 ----------
 {
@@ -65,6 +74,56 @@
 							"handle": [
 								{
 									"body": "not put",
+									"handler": "static_response"
+								}
+							]
+						},
+						{
+							"match": [
+								{
+									"vars": {
+										"{http.request.uri}": "/vars-matcher"
+									}
+								}
+							],
+							"handle": [
+								{
+									"body": "from vars matcher",
+									"handler": "static_response"
+								}
+							]
+						},
+						{
+							"match": [
+								{
+									"vars_regexp": {
+										"{http.request.uri}": {
+											"name": "static",
+											"pattern": "\\.([a-f0-9]{6})\\.(css|js)$"
+										}
+									}
+								}
+							],
+							"handle": [
+								{
+									"body": "from vars_regexp matcher with name",
+									"handler": "static_response"
+								}
+							]
+						},
+						{
+							"match": [
+								{
+									"vars_regexp": {
+										"{http.request.uri}": {
+											"pattern": "\\.([a-f0-9]{6})\\.(css|js)$"
+										}
+									}
+								}
+							],
+							"handle": [
+								{
+									"body": "from vars_regexp matcher without name",
 									"handler": "static_response"
 								}
 							]

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -927,6 +927,8 @@ var (
 	_ caddyfile.Unmarshaler = (*MatchHeaderRE)(nil)
 	_ caddyfile.Unmarshaler = (*MatchProtocol)(nil)
 	_ caddyfile.Unmarshaler = (*MatchRemoteIP)(nil)
+	_ caddyfile.Unmarshaler = (*VarsMatcher)(nil)
+	_ caddyfile.Unmarshaler = (*MatchVarsRE)(nil)
 
 	_ json.Marshaler   = (*MatchNot)(nil)
 	_ json.Unmarshaler = (*MatchNot)(nil)

--- a/modules/caddyhttp/vars.go
+++ b/modules/caddyhttp/vars.go
@@ -17,7 +17,6 @@ package caddyhttp
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/caddyserver/caddy/v2"
@@ -148,7 +147,6 @@ func (m *MatchVarsRE) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		}
 
 		(*m)[field] = &MatchRegexp{Pattern: val, Name: name}
-		log.Printf("%+v\n\n", m)
 		if d.NextBlock(0) {
 			return d.Err("malformed vars_regexp matcher: blocks are not supported")
 		}

--- a/modules/caddyhttp/vars.go
+++ b/modules/caddyhttp/vars.go
@@ -17,9 +17,11 @@ package caddyhttp
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
 func init() {
@@ -64,6 +66,24 @@ func (VarsMatcher) CaddyModule() caddy.ModuleInfo {
 	}
 }
 
+// UnmarshalCaddyfile implements caddyfile.Unmarshaler.
+func (m *VarsMatcher) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	if *m == nil {
+		*m = make(map[string]string)
+	}
+	for d.Next() {
+		var field, val string
+		if !d.Args(&field, &val) {
+			return d.Errf("malformed vars matcher: expected both field and value")
+		}
+		(*m)[field] = val
+		if d.NextBlock(0) {
+			return d.Err("malformed vars matcher: blocks are not supported")
+		}
+	}
+	return nil
+}
+
 // Match matches a request based on variables in the context.
 func (m VarsMatcher) Match(r *http.Request) bool {
 	vars := r.Context().Value(VarsCtxKey).(map[string]interface{})
@@ -104,6 +124,36 @@ func (MatchVarsRE) CaddyModule() caddy.ModuleInfo {
 		ID:  "http.matchers.vars_regexp",
 		New: func() caddy.Module { return new(MatchVarsRE) },
 	}
+}
+
+// UnmarshalCaddyfile implements caddyfile.Unmarshaler.
+func (m *MatchVarsRE) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	if *m == nil {
+		*m = make(map[string]*MatchRegexp)
+	}
+	for d.Next() {
+		var first, second, third string
+		if !d.Args(&first, &second) {
+			return d.ArgErr()
+		}
+
+		var name, field, val string
+		if d.Args(&third) {
+			name = first
+			field = second
+			val = third
+		} else {
+			field = first
+			val = second
+		}
+
+		(*m)[field] = &MatchRegexp{Pattern: val, Name: name}
+		log.Printf("%+v\n\n", m)
+		if d.NextBlock(0) {
+			return d.Err("malformed vars_regexp matcher: blocks are not supported")
+		}
+	}
+	return nil
 }
 
 // Provision compiles m's regular expressions.


### PR DESCRIPTION
I noticed those were missing from the [Request Matcher docs of the Caddyfile](https://caddyserver.com/docs/caddyfile/matchers#path-regexp). I dug into the code and found they don't implement the necessary interface. Now they do.