### PR TITLE
metrics: Fixing panic while observing with bad exemplars

### DIFF
--- a/caddytest/integration/autohttps_test.go
+++ b/caddytest/integration/autohttps_test.go
@@ -1,0 +1,22 @@
+package integration
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/caddytest"
+)
+
+func TestAutoHTTPtoHTTPSRedirects(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		http_port     9080
+		https_port    9443
+	}
+	localhost:9443
+	respond "Yahaha! You found me!"
+  `, "caddyfile")
+
+	tester.AssertRedirect("http://localhost:9080/", "https://localhost/", http.StatusPermanentRedirect)
+}

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -155,6 +155,7 @@ func (app *App) Provision(ctx caddy.Context) error {
 
 	// prepare each server
 	for srvName, srv := range app.Servers {
+		srv.name = srvName
 		srv.tlsApp = app.tlsApp
 		srv.logger = app.logger.Named("log")
 		srv.errorLogger = app.logger.Named("log.error")

--- a/modules/caddyhttp/metrics.go
+++ b/modules/caddyhttp/metrics.go
@@ -82,20 +82,14 @@ func initHTTPMetrics() {
 	}, httpLabels)
 }
 
-type ctxKeyServerName struct{}
-
 // serverNameFromContext extracts the current server name from the context.
-// Returns "UNKNOWN" if none is available (should probably never happen?)
+// Returns "UNKNOWN" if none is available (should probably never happen).
 func serverNameFromContext(ctx context.Context) string {
-	srvName, ok := ctx.Value(ctxKeyServerName{}).(string)
-	if !ok {
+	srv, ok := ctx.Value(ServerCtxKey).(*Server)
+	if !ok || srv == nil || srv.name == "" {
 		return "UNKNOWN"
 	}
-	return srvName
-}
-
-func contextWithServerName(ctx context.Context, serverName string) context.Context {
-	return context.WithValue(ctx, ctxKeyServerName{}, serverName)
+	return srv.name
 }
 
 type metricsInstrumentedHandler struct {

--- a/modules/caddyhttp/metrics.go
+++ b/modules/caddyhttp/metrics.go
@@ -94,31 +94,31 @@ func serverNameFromContext(ctx context.Context) string {
 	return srvName
 }
 
-type metricsInstrumentedHandler struct {
-	labels       prometheus.Labels
-	statusLabels prometheus.Labels
-	mh           MiddlewareHandler
+func contextWithServerName(ctx context.Context, serverName string) context.Context {
+	return context.WithValue(ctx, ctxKeyServerName{}, serverName)
 }
 
-func newMetricsInstrumentedHandler(server, handler string, mh MiddlewareHandler) *metricsInstrumentedHandler {
+type metricsInstrumentedHandler struct {
+	handler string
+	mh      MiddlewareHandler
+}
+
+func newMetricsInstrumentedHandler(handler string, mh MiddlewareHandler) *metricsInstrumentedHandler {
 	httpMetrics.init.Do(func() {
 		initHTTPMetrics()
 	})
 
-	labels := prometheus.Labels{"server": server, "handler": handler}
-	statusLabels := prometheus.Labels{"server": server, "handler": handler, "code": "", "method": ""}
-	return &metricsInstrumentedHandler{labels, statusLabels, mh}
+	return &metricsInstrumentedHandler{handler, mh}
 }
 
 func (h *metricsInstrumentedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next Handler) error {
-	inFlight := httpMetrics.requestInFlight.With(h.labels)
+	server := serverNameFromContext(r.Context())
+	labels := prometheus.Labels{"server": server, "handler": h.handler}
+	statusLabels := prometheus.Labels{"server": server, "handler": h.handler, "method": r.Method}
+
+	inFlight := httpMetrics.requestInFlight.With(labels)
 	inFlight.Inc()
 	defer inFlight.Dec()
-
-	statusLabels := prometheus.Labels{"method": r.Method}
-	for k, v := range h.labels {
-		statusLabels[k] = v
-	}
 
 	start := time.Now()
 
@@ -128,33 +128,23 @@ func (h *metricsInstrumentedHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 	writeHeaderRecorder := ShouldBufferFunc(func(status int, header http.Header) bool {
 		statusLabels["code"] = sanitizeCode(status)
 		ttfb := time.Since(start).Seconds()
-		observeWithExemplar(statusLabels, httpMetrics.responseDuration, ttfb)
+		httpMetrics.responseDuration.With(statusLabels).Observe(ttfb)
 		return false
 	})
 	wrec := NewResponseRecorder(w, nil, writeHeaderRecorder)
 	err := h.mh.ServeHTTP(wrec, r, next)
 	dur := time.Since(start).Seconds()
-	httpMetrics.requestCount.With(h.labels).Inc()
+	httpMetrics.requestCount.With(labels).Inc()
 	if err != nil {
-		httpMetrics.requestErrors.With(h.labels).Inc()
+		httpMetrics.requestErrors.With(labels).Inc()
 		return err
 	}
 
-	observeWithExemplar(statusLabels, httpMetrics.requestDuration, dur)
-	observeWithExemplar(statusLabels, httpMetrics.requestSize, float64(computeApproximateRequestSize(r)))
+	httpMetrics.requestDuration.With(statusLabels).Observe(dur)
+	httpMetrics.requestSize.With(statusLabels).Observe(float64(computeApproximateRequestSize(r)))
 	httpMetrics.responseSize.With(statusLabels).Observe(float64(wrec.Size()))
 
 	return nil
-}
-
-func observeWithExemplar(l prometheus.Labels, o *prometheus.HistogramVec, value float64) {
-	obs := o.With(l)
-	if oe, ok := obs.(prometheus.ExemplarObserver); ok {
-		oe.ObserveWithExemplar(value, l)
-		return
-	}
-	// _should_ be a noop, but here just in case...
-	obs.Observe(value)
 }
 
 func sanitizeCode(code int) string {

--- a/modules/caddyhttp/metrics_test.go
+++ b/modules/caddyhttp/metrics_test.go
@@ -18,7 +18,7 @@ func TestServerNameFromContext(t *testing.T) {
 	}
 
 	in := "foo"
-	ctx = contextWithServerName(ctx, in)
+	ctx = context.WithValue(ctx, ServerCtxKey, &Server{name: in})
 	if actual := serverNameFromContext(ctx); actual != in {
 		t.Errorf("Not equal: expected %q, but got %q", in, actual)
 	}

--- a/modules/caddyhttp/metrics_test.go
+++ b/modules/caddyhttp/metrics_test.go
@@ -1,6 +1,7 @@
 package caddyhttp
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,20 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
+
+func TestServerNameFromContext(t *testing.T) {
+	ctx := context.Background()
+	expected := "UNKNOWN"
+	if actual := serverNameFromContext(ctx); actual != expected {
+		t.Errorf("Not equal: expected %q, but got %q", expected, actual)
+	}
+
+	in := "foo"
+	ctx = contextWithServerName(ctx, in)
+	if actual := serverNameFromContext(ctx); actual != in {
+		t.Errorf("Not equal: expected %q, but got %q", in, actual)
+	}
+}
 
 func TestMetricsInstrumentedHandler(t *testing.T) {
 	handlerErr := errors.New("oh noes")
@@ -26,7 +41,7 @@ func TestMetricsInstrumentedHandler(t *testing.T) {
 		return h.ServeHTTP(w, r)
 	})
 
-	ih := newMetricsInstrumentedHandler("foo", "bar", mh)
+	ih := newMetricsInstrumentedHandler("bar", mh)
 
 	r := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()

--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -243,11 +243,9 @@ func wrapRoute(route Route) Middleware {
 // pointer into its own stack frame to preserve it so it
 // won't be overwritten in future loop iterations.
 func wrapMiddleware(ctx caddy.Context, mh MiddlewareHandler) Middleware {
-	// first, wrap the middleware with metrics instrumentation
-	metricsHandler := newMetricsInstrumentedHandler(
-		caddy.GetModuleName(mh),
-		mh,
-	)
+	// wrap the middleware with metrics instrumentation
+	metricsHandler := newMetricsInstrumentedHandler(caddy.GetModuleName(mh), mh)
+
 	return func(next Handler) Handler {
 		// copy the next handler (it's an interface, so it's
 		// just a very lightweight copy of a pointer); this

--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -245,7 +245,6 @@ func wrapRoute(route Route) Middleware {
 func wrapMiddleware(ctx caddy.Context, mh MiddlewareHandler) Middleware {
 	// first, wrap the middleware with metrics instrumentation
 	metricsHandler := newMetricsInstrumentedHandler(
-		serverNameFromContext(ctx.Context),
 		caddy.GetModuleName(mh),
 		mh,
 	)

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -132,6 +132,8 @@ type Server struct {
 	errorLogger  *zap.Logger
 
 	h3server *http3.Server
+
+	name string
 }
 
 // ServeHTTP is the entry point for all HTTP requests.
@@ -499,6 +501,8 @@ func PrepareRequest(r *http.Request, repl *caddy.Replacer, w http.ResponseWriter
 	ctx = context.WithValue(ctx, routeGroupCtxKey, make(map[string]struct{}))
 	var url2 url.URL // avoid letting this escape to the heap
 	ctx = context.WithValue(ctx, OriginalRequestCtxKey, originalRequest(r, &url2))
+	// inject the server name for observability purposes
+	ctx = contextWithServerName(ctx, s.name)
 	r = r.WithContext(ctx)
 
 	// once the pointer to the request won't change

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -122,6 +122,8 @@ type Server struct {
 	// ⚠️ Experimental feature; subject to change or removal.
 	AllowH2C bool `json:"allow_h2c,omitempty"`
 
+	name string
+
 	primaryHandlerChain Handler
 	errorHandlerChain   Handler
 	listenerWrappers    []caddy.ListenerWrapper
@@ -132,8 +134,6 @@ type Server struct {
 	errorLogger  *zap.Logger
 
 	h3server *http3.Server
-
-	name string
 }
 
 // ServeHTTP is the entry point for all HTTP requests.
@@ -501,8 +501,6 @@ func PrepareRequest(r *http.Request, repl *caddy.Replacer, w http.ResponseWriter
 	ctx = context.WithValue(ctx, routeGroupCtxKey, make(map[string]struct{}))
 	var url2 url.URL // avoid letting this escape to the heap
 	ctx = context.WithValue(ctx, OriginalRequestCtxKey, originalRequest(r, &url2))
-	// inject the server name for observability purposes
-	ctx = contextWithServerName(ctx, s.name)
 	r = r.WithContext(ctx)
 
 	// once the pointer to the request won't change


### PR DESCRIPTION
This fixes a bug that I introduced in #3709, that @mholt patched in c82c231ba7ec7c400e4d48ab943f57a6b29a2a2a.

The behaviour was that with this `Caddyfile`:

```
localhost
respond "Hello, world!"
```

This happened:

```console
$ curl -v http://localhost
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 80 (#0)
> GET / HTTP/1.1
> Host: localhost
> User-Agent: curl/7.64.1
> Accept: */*
> 
* Empty reply from server
* Connection #0 to host localhost left intact
curl: (52) Empty reply from server
* Closing connection 0
```

Effectively, the headers were sent, but then the connection was closed. Based on the metrics now exposed, I discovered that in the `metricsInstrumentedHandler.ServeHTTP` function, the call to `h.mh.ServeHTTP` was not returning at all, since neither the request counter nor the error counter were incrementing. This lead me to believe that there was a panic which was later being swallowed. A quick `defer func() { fmt.Printf(recover()) }()` showed me that the `ObserveWithExemplar` call was failing:

```
exemplar labels have 74 runes, exceeding the limit of 64
```

Effectively, I misunderstood the purpose of the labels in the [ObserveWithExemplar](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#ExemplarObserver), and simply added the same labels being observed.

The reason we didn't get hit by this earlier is that the `server` label was usually quite short, but in the case of HTTP-to-HTTPS redirection, the server is named `remaining_auto_https_redirects`, just pushing the total length of labels past the limit.

To solve this, for now I've simply switched back to using `Observe` instead of `ObserveWithExemplar`. However, once we get tracing added to Caddy, we should consider using this to track a span ID in an exemplar (with appropriate length safeguards, naturally).

Based on conversation with @mholt, I've also changed how the server name is injected into the labels. Instead of being done at provision-time, it's now done at request-time. This isn't strictly necessary, but it's slightly cleaner.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>