### PR TITLE
fastcgi: Set PATH_INFO to file matcher remainder as fallback

### DIFF
--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -182,13 +182,13 @@ func (m MatchFile) selectFile(r *http.Request) (matched bool) {
 	}
 
 	// common preparation of the file into parts
-	prepareFilePath := func(file string) (string, string, string) {
-		suffix, remainder := m.firstSplit(path.Clean(repl.ReplaceAll(file, "")))
+	prepareFilePath := func(file string) (suffix, fullpath, remainder string) {
+		suffix, remainder = m.firstSplit(path.Clean(repl.ReplaceAll(file, "")))
 		if strings.HasSuffix(file, "/") {
 			suffix += "/"
 		}
-		fullpath := sanitizedPathJoin(root, suffix)
-		return suffix, fullpath, remainder
+		fullpath = sanitizedPathJoin(root, suffix)
+		return
 	}
 
 	// sets up the placeholders for the matched file
@@ -307,10 +307,11 @@ func strictFileExists(file string) (os.FileInfo, bool) {
 
 // firstSplit returns the first result where the path
 // can be split in two by a value in m.SplitPath. The
-// result is the first piece of the path that ends with
-// in the split value, and the remainder. Returns the
-// path as-is if the path cannot be split.
-func (m MatchFile) firstSplit(path string) (string, string) {
+// return values are the first piece of the path that
+// ends with the split substring and the remainder.
+// If the path cannot be split, the path is returned
+// as-is (with no remainder).
+func (m MatchFile) firstSplit(path string) (splitPart, remainder string) {
 	for _, split := range m.SplitPath {
 		if idx := indexFold(path, split); idx > -1 {
 			pos := idx + len(split)

--- a/modules/caddyhttp/fileserver/matcher_test.go
+++ b/modules/caddyhttp/fileserver/matcher_test.go
@@ -206,9 +206,13 @@ func TestPHPFileMatcher(t *testing.T) {
 
 func TestFirstSplit(t *testing.T) {
 	m := MatchFile{SplitPath: []string{".php"}}
-	actual := m.firstSplit("index.PHP/somewhere")
+	actual, remainder := m.firstSplit("index.PHP/somewhere")
 	expected := "index.PHP"
+	expectedRemainder := "/somewhere"
 	if actual != expected {
-		t.Errorf("Expected %s but got %s", expected, actual)
+		t.Errorf("Expected split %s but got %s", expected, actual)
+	}
+	if remainder != expectedRemainder {
+		t.Errorf("Expected remainder %s but got %s", expectedRemainder, remainder)
 	}
 }

--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -212,8 +212,8 @@ func (t Transport) buildEnv(r *http.Request) (map[string]string, error) {
 	// if we didn't get a split result here.
 	// See https://github.com/caddyserver/caddy/issues/3718
 	if pathInfo == "" {
-		if remainder, ok := repl.Get("http.matchers.file.remainder"); ok {
-			pathInfo = remainder.(string)
+		if remainder, ok := repl.GetString("http.matchers.file.remainder"); ok {
+			pathInfo = remainder
 		}
 	}
 

--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -206,6 +206,15 @@ func (t Transport) buildEnv(r *http.Request) (map[string]string, error) {
 	}
 	scriptName := fpath
 
+	// Try to grab the path remainder from a file matcher if we didn't
+	// get a split result here.
+	// See https://github.com/caddyserver/caddy/issues/3718
+	if pathInfo == "" {
+		if remainder, ok := repl.Get("http.matchers.file.remainder"); ok {
+			pathInfo = remainder.(string)
+		}
+	}
+
 	// Strip PATH_INFO from SCRIPT_NAME
 	scriptName = strings.TrimSuffix(scriptName, pathInfo)
 

--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -195,28 +195,27 @@ func (t Transport) buildEnv(r *http.Request) (map[string]string, error) {
 	}
 
 	fpath := r.URL.Path
+	scriptName := fpath
 
+	docURI := fpath
 	// split "actual path" from "path info" if configured
-	var docURI, pathInfo string
+	var pathInfo string
 	if splitPos := t.splitPos(fpath); splitPos > -1 {
 		docURI = fpath[:splitPos]
 		pathInfo = fpath[splitPos:]
-	} else {
-		docURI = fpath
-	}
-	scriptName := fpath
 
-	// Try to grab the path remainder from a file matcher if we didn't
-	// get a split result here.
+		// Strip PATH_INFO from SCRIPT_NAME
+		scriptName = strings.TrimSuffix(scriptName, pathInfo)
+	}
+
+	// Try to grab the path remainder from a file matcher
+	// if we didn't get a split result here.
 	// See https://github.com/caddyserver/caddy/issues/3718
 	if pathInfo == "" {
 		if remainder, ok := repl.Get("http.matchers.file.remainder"); ok {
 			pathInfo = remainder.(string)
 		}
 	}
-
-	// Strip PATH_INFO from SCRIPT_NAME
-	scriptName = strings.TrimSuffix(scriptName, pathInfo)
 
 	// SCRIPT_FILENAME is the absolute path of SCRIPT_NAME
 	scriptFilename := filepath.Join(root, scriptName)


### PR DESCRIPTION
Fixes #3718

This isn't perfect, because if the `SplitPath` value is different between the `fastcgi` transport and a `file` matcher, then unexpected behaviour could happen... but this should work correctly for the `php_fastcgi` shortcut we provide.