### PR TITLE
caddyconfig: Error on extra args for route and handle directive family

### DIFF
--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -285,6 +285,11 @@ func parseSegmentAsConfig(h Helper) ([]ConfigValue, error) {
 	var allResults []ConfigValue
 
 	for h.Next() {
+		// don't allow non-matcher args on the first line
+		if h.NextArg() {
+			return nil, h.ArgErr()
+		}
+
 		// slice the linear list of tokens into top-level segments
 		var segments []caddyfile.Segment
 		for nesting := h.Nesting(); h.NextBlock(nesting); {


### PR DESCRIPTION
Brought up here: https://caddy.community/t/v2-how-do-i-selectively-rewrite-multiple-times/9854

Basically, this disallows extra args on the line after the matcher for `route`, `handle`, `handle_errors` and `handle_path`. For example, these are now errors:

```
route @foo bar {
	respond "Foo"
}
```

```
handle bar {
	respond "Foo"
}
```

This is purely an adapter change to be stricter so that users don't have args in their config that do nothing useful (like thinking some args act like a matcher).