### PR TITLE
metrics: Always track method label in uppercase

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -125,7 +125,7 @@ func (admin AdminConfig) newAdminHandler(addr NetworkAddress) adminHandler {
 				labels := prometheus.Labels{
 					"path":    pattern,
 					"handler": handlerLabel,
-					"method":  sanitizeMethod(r.Method),
+					"method":  strings.ToUpper(r.Method),
 				}
 				adminMetrics.requestErrors.With(labels).Inc()
 			}

--- a/admin.go
+++ b/admin.go
@@ -36,7 +36,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 )
 
@@ -111,7 +110,7 @@ func (admin AdminConfig) newAdminHandler(addr NetworkAddress) adminHandler {
 
 	addRouteWithMetrics := func(pattern string, handlerLabel string, h http.Handler) {
 		labels := prometheus.Labels{"path": pattern, "handler": handlerLabel}
-		h = promhttp.InstrumentHandlerCounter(
+		h = instrumentHandlerCounter(
 			adminMetrics.requestCount.MustCurryWith(labels),
 			h,
 		)
@@ -126,7 +125,7 @@ func (admin AdminConfig) newAdminHandler(addr NetworkAddress) adminHandler {
 				labels := prometheus.Labels{
 					"path":    pattern,
 					"handler": handlerLabel,
-					"method":  r.Method,
+					"method":  sanitizeMethod(r.Method),
 				}
 				adminMetrics.requestErrors.With(labels).Inc()
 			}

--- a/metrics.go
+++ b/metrics.go
@@ -46,7 +46,7 @@ func instrumentHandlerCounter(counter *prometheus.CounterVec, next http.Handler)
 		next.ServeHTTP(d, r)
 		counter.With(prometheus.Labels{
 			"code":   sanitizeCode(d.status),
-			"method": sanitizeMethod(r.Method),
+			"method": strings.ToUpper(r.Method),
 		}).Inc()
 	})
 }
@@ -73,22 +73,5 @@ func sanitizeCode(s int) string {
 		return "200"
 	default:
 		return strconv.Itoa(s)
-	}
-}
-
-func sanitizeMethod(m string) string {
-	switch m {
-	case "GET", "get":
-		return "GET"
-	case "PUT", "put":
-		return "PUT"
-	case "HEAD", "head":
-		return "HEAD"
-	case "POST", "post":
-		return "POST"
-	case "DELETE", "delete":
-		return "DELETE"
-	default:
-		return strings.ToUpper(m)
 	}
 }


### PR DESCRIPTION
This is for consistency. The admin request counter always [sanitizes](https://github.com/prometheus/client_golang/blob/master/prometheus/promhttp/instrument_server.go#L292) the `method` label by lower-casing it, but the admin error counter and all of the HTTP metrics used the HTTP metric as-is.

This will not do:

```console
$ curl https://localhost/
$ curl -Xget https://localhost/
$ curl -s http://localhost:2019/metrics | grep ^caddy_http_request_duration_seconds_count | grep 'handler="file_server"'
caddy_http_request_duration_seconds_count{code="200",handler="file_server",method="GET",server="srv0"} 1
caddy_http_request_duration_seconds_count{code="200",handler="file_server",method="get",server="srv0"} 1
```

🤦‍♂️

This PR normalizes the method name. In `promhttp.InstrumentHandlerCounter`, the method is lower-cased, but that's contrary to the HTTP RFCs ([RFC 7230 s3.1.1](https://tools.ietf.org/html/rfc7230#section-3.1.1) and [RFC 7231 s4.1](https://tools.ietf.org/html/rfc7231#section-4.1)), and prevailing convention. So I've chosen to upper-case the methods instead.

Side note - I'm not actually sure why the methods are lower-cased instead of upper-cased in the `promhttp` code, but that's the way it's been for [the past ~3yrs](https://github.com/prometheus/client_golang/pull/285/commits/90dca5d416dd7e1fcbbb1238cddaf1a134f2720a#diff-9c0c00018610d6efebb26be9d72ed9d8R229). Maybe this is for a good reason and @stuartnelson3 or @beorn7 could enlighten me? 😅

Signed-off-by: Dave Henderson <dhenderson@gmail.com>