### PR TITLE
httpcaddyfile: Fix panic when parsing route with matchers

### DIFF
--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -304,13 +304,17 @@ func parseSegmentAsConfig(h Helper) ([]ConfigValue, error) {
 		}
 
 		// find and extract any embedded matcher definitions in this scope
-		for i, seg := range segments {
+		for i := 0; i < len(segments); i++ {
+			seg := segments[i]
 			if strings.HasPrefix(seg.Directive(), matcherPrefix) {
+				// parse, then add the matcher to matcherDefs
 				err := parseMatcherDefinitions(caddyfile.NewDispenser(seg), matcherDefs)
 				if err != nil {
 					return nil, err
 				}
+				// remove the matcher segment (consumed), then step back the loop
 				segments = append(segments[:i], segments[i+1:]...)
+				i--
 			}
 		}
 

--- a/caddytest/integration/caddyfile_adapt/matchers_in_route.txt
+++ b/caddytest/integration/caddyfile_adapt/matchers_in_route.txt
@@ -1,0 +1,31 @@
+:80 {
+    route {
+        # unused matchers should not panic
+        # see https://github.com/caddyserver/caddy/issues/3745
+        @matcher1 path /path1
+        @matcher2 path /path2
+    }
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "subroute"
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/caddyserver/caddy/issues/3745

Basically I was doing `range segments` then modifying `segments` so we had a couple of bugs going on. Panic if a matcher segment was ever the last thing in a route, and bad parsing (skipped segments) in other situations.

Fixed by using a regular step loop and rewinding one step every time we splice a segment out.