### PR TITLE
admin: lower log level to Debug for /metrics requests

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -311,11 +311,13 @@ type adminHandler struct {
 // ServeHTTP is the external entry point for API requests.
 // It will only be called once per request.
 func (h adminHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	log := Log().Named("admin.api").With(zap.String("method", r.Method),
+	log := Log().Named("admin.api").With(
+		zap.String("method", r.Method),
 		zap.String("host", r.Host),
 		zap.String("uri", r.RequestURI),
 		zap.String("remote_addr", r.RemoteAddr),
-		zap.Reflect("headers", r.Header))
+		zap.Reflect("headers", r.Header),
+	)
 	if r.RequestURI == "/metrics" {
 		log.Debug("received request")
 	} else {

--- a/admin.go
+++ b/admin.go
@@ -311,13 +311,16 @@ type adminHandler struct {
 // ServeHTTP is the external entry point for API requests.
 // It will only be called once per request.
 func (h adminHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	Log().Named("admin.api").Info("received request",
-		zap.String("method", r.Method),
+	log := Log().Named("admin.api").With(zap.String("method", r.Method),
 		zap.String("host", r.Host),
 		zap.String("uri", r.RequestURI),
 		zap.String("remote_addr", r.RemoteAddr),
-		zap.Reflect("headers", r.Header),
-	)
+		zap.Reflect("headers", r.Header))
+	if r.RequestURI == "/metrics" {
+		log.Debug("received request")
+	} else {
+		log.Info("received request")
+	}
 	h.serveHTTP(w, r)
 }
 


### PR DESCRIPTION
When monitoring Caddy with Prometheus pointed at the default endpoint (http://localhost:2019/metrics), things can get a little verbose:

```
2020/09/24 00:17:00.484 INFO    admin.api       received request        {"method": "GET", "host": "localhost:2019", "uri": "/metrics", "remote_addr": "127.0.0.1:52404", "headers": {"Accept":["application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1"],"Accept-Encoding":["gzip"],"User-Agent":["Prometheus/2.21.0"],"X-Prometheus-Scrape-Timeout-Seconds":["10.000000"]}}
2020/09/24 00:17:15.485 INFO    admin.api       received request        {"method": "GET", "host": "localhost:2019", "uri": "/metrics", "remote_addr": "127.0.0.1:52404", "headers": {"Accept":["application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1"],"Accept-Encoding":["gzip"],"User-Agent":["Prometheus/2.21.0"],"X-Prometheus-Scrape-Timeout-Seconds":["10.000000"]}}
2020/09/24 00:17:30.483 INFO    admin.api       received request        {"method": "GET", "host": "localhost:2019", "uri": "/metrics", "remote_addr": "127.0.0.1:52404", "headers": {"Accept":["application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1"],"Accept-Encoding":["gzip"],"User-Agent":["Prometheus/2.21.0"],"X-Prometheus-Scrape-Timeout-Seconds":["10.000000"]}}
[... ad nauseum ...]
```

I'm not _ecstatic_ about this solution, but I feel like it's good enough until we can figure out a better approach. Ideally an admin module would be able to control its own logging in some way. This'll at least make monitoring Caddy with Prometheus a less _noisy_ activity for the 2.2 release...

Signed-off-by: Dave Henderson <dhenderson@gmail.com>