### PR TITLE
reverseproxy: fix breakage in handling SRV lookup introduced by d55d50b

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -132,7 +132,7 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 	// get validation out of the way
 	for i, v := range h.Upstreams {
 		// Having LookupSRV non-empty conflicts with 2 other config parameters: active health checks, and upstream dial address.
-		// Therefore if LookupSRV is empty, then there are no immediately apparent config conflict and the iteration can be skipped.
+		// Therefore if LookupSRV is empty, then there are no immediately apparent config conflicts, and the iteration can be skipped.
 		if v.LookupSRV == "" {
 			continue
 		}

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -131,7 +131,8 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 
 	// get validation out of the way
 	for i, v := range h.Upstreams {
-		// the special cases arise with LookupSRV present, so skip the iteration if it's empty.
+		// Having LookupSRV non-empty conflicts with 2 other config parameters: active health checks, and upstream dial address.
+		// Therefore if LookupSRV is empty, then there are no immediately apparent config conflict and the iteration can be skipped.
 		if v.LookupSRV == "" {
 			continue
 		}


### PR DESCRIPTION
This is the naive fix. I still need to test it some more and figure whether this fix is the best.
@waiyip-aquabyte and @danlsgiga, is it possible to test using the CI artifacts? You can find them [here](https://github.com/caddyserver/caddy/actions/runs/273408022).

Fixes #3753