### PR TITLE
caddyhttp: Added `is_verified` placeholder for client cert

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -99,6 +99,8 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 		"{tls_client_issuer}", "{http.request.tls.client.issuer}",
 		"{tls_client_serial}", "{http.request.tls.client.serial}",
 		"{tls_client_subject}", "{http.request.tls.client.subject}",
+		"{tls_client_placeholder}", "{http.request.tls.client.certificate_pem}",
+		"{tls_client_is_verified}", "{http.request.tls.client.is_verified}",
 	)
 
 	// these are placeholders that allow a user-defined final

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -78,6 +78,8 @@ func init() {
 // `{http.request.tls.client.issuer}` | The issuer DN of the client certificate
 // `{http.request.tls.client.serial}` | The serial number of the client certificate
 // `{http.request.tls.client.subject}` | The subject DN of the client certificate
+// `{http.request.tls.client.certificate_pem}` | The PEM encoded value of certificate.
+// `{http.request.tls.client.is_verified}` | Boolean value indicating if certificate is verified.
 // `{http.request.tls.client.san.dns_names.*}` | SAN DNS names(index optional)
 // `{http.request.tls.client.san.emails.*}` | SAN email addresses (index optional)
 // `{http.request.tls.client.san.ips.*}` | SAN IP addresses (index optional)

--- a/modules/caddyhttp/replacer_test.go
+++ b/modules/caddyhttp/replacer_test.go
@@ -187,3 +187,67 @@ eqp31wM9il1n+guTNyxJd+FzVAH+hCZE5K+tCgVDdVFUlDEHHbS/wqb2PSIoouLV
 		}
 	}
 }
+
+// Use this command to generate the verified cert again if needed
+// `openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem`
+func TestVarsReplaceWithVerifiedCert(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/", nil)
+	repl := caddy.NewReplacer()
+	ctx := context.WithValue(req.Context(), caddy.ReplacerCtxKey, repl)
+	req = req.WithContext(ctx)
+	req.Host = "example.com:80"
+	req.RemoteAddr = "localhost:1234"
+
+	verifiedCert := []byte(`-----BEGIN CERTIFICATE-----
+MIIEBzCCAu+gAwIBAgIUF+cy33gANcV/6YSImPgx7o4X+QkwDQYJKoZIhvcNAQEL
+BQAwgZIxCzAJBgNVBAYTAklOMRIwEAYDVQQIDAlIWURFUkFCQUQxETAPBgNVBAcM
+CEJlZ3VtcGV0MQ4wDAYDVQQKDAVDYWRkeTEOMAwGA1UECwwFQ2FkZHkxGDAWBgNV
+BAMMD0dBVVJBViBESEFNRUVKQTEiMCAGCSqGSIb3DQEJARYTZ2RoYW1lZWphQGdt
+YWlsLmNvbTAeFw0yMDEwMDEwNzEyMzNaFw0zMDA5MjkwNzEyMzNaMIGSMQswCQYD
+VQQGEwJJTjESMBAGA1UECAwJSFlERVJBQkFEMREwDwYDVQQHDAhCZWd1bXBldDEO
+MAwGA1UECgwFQ2FkZHkxDjAMBgNVBAsMBUNhZGR5MRgwFgYDVQQDDA9HQVVSQVYg
+REhBTUVFSkExIjAgBgkqhkiG9w0BCQEWE2dkaGFtZWVqYUBnbWFpbC5jb20wggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7/Vh9qj/vk0KJAS334Hsh531M
+3tDkvY1S1mXI0/Xkh59AP9HZD2y18IjmwwwwPwS3cswabitd9DvYy5K230Hkmnkv
+UTM4PsC8rMRoA2NZl1D1KHEvmiBIixMyVQeyITd6XnrV72TlKtZy78o29xJzmv3U
+5Xqm9cizJmUyzzV9UWRAafhSOOdEDthzqdcqF/uuoFGSsnjMcDj6XuYjSY2nokl/
+vwXTGHCAvOkX+9GXdrtCYuIOfgU5nH+giCkYsN9e9YCg13PG1hwsxpDPDLPYvJMl
+djI+o8U/xkdGnvPmWp9r5hyqW4gzbC72PSZQM6+bQlq7bka7D8cw48HlAm0XAgMB
+AAGjUzBRMB0GA1UdDgQWBBQtMRVJXzm6F32dTpajXjFJW5/SVjAfBgNVHSMEGDAW
+gBQtMRVJXzm6F32dTpajXjFJW5/SVjAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
+DQEBCwUAA4IBAQCPl8V4vc8vujDDQ8pjGgLVA7JeXEGDbABtXPYnO0ALsgdhJWtu
+MGawVjUI402IE/0ffpohGNgXj2LHmml55sbRyFFD4EXMeX7NBm2YYn82oVm7rD+x
+oDoNd69Oz6jJPoZDEL/YKo2OXxYGmnc2Q3NfrCqr+XuytMZZQxNLXYcAK30Y6KxF
+7aMypwBRCnyrefpUKryWGPeJvYndkUoEee+acH9v3nANLoBqkoWNWfE56d/XlA+I
+xu6Qum6tNm1i6oOf+22bWwKxtVaXvW9fXmLjA2L6XVWVQtdo3o1FKUdUs0Ec/WPE
+poxsVrsicPcWHN+iYnVVoZm97MD6thAKQJ+N
+-----END CERTIFICATE-----`)
+	block, _ := pem.Decode(verifiedCert)
+	if block == nil {
+		t.Fatalf("failed to decode PEM certificate")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to decode PEM certificate: %v", err)
+	}
+	req.TLS = &tls.ConnectionState{
+		Version:                    tls.VersionTLS13,
+		HandshakeComplete:          true,
+		ServerName:                 "foo.com",
+		CipherSuite:                tls.TLS_AES_256_GCM_SHA384,
+		PeerCertificates:           []*x509.Certificate{cert},
+		NegotiatedProtocol:         "h2",
+		NegotiatedProtocolIsMutual: true,
+	}
+
+	res := httptest.NewRecorder()
+	addHTTPVarsToReplacer(repl, req, res)
+	placeholder := "{http.request.tls.client.is_verified}"
+	actual := repl.ReplaceAll(placeholder, "<empty>")
+	expectedValue := "true"
+	if actual != expectedValue {
+		t.Errorf("Test TestReplaceForVerifiedCert: Expected placeholder %s to be '%s' but got '%s'",
+			placeholder, expectedValue, actual)
+	}
+}

--- a/modules/caddyhttp/replacer_test.go
+++ b/modules/caddyhttp/replacer_test.go
@@ -250,4 +250,7 @@ poxsVrsicPcWHN+iYnVVoZm97MD6thAKQJ+N
 		t.Errorf("Test TestReplaceForVerifiedCert: Expected placeholder %s to be '%s' but got '%s'",
 			placeholder, expectedValue, actual)
 	}
+	if val, ok := repl.FromStatic(IS_CERT_VERIFIED); !ok || !val.(bool) {
+		t.Errorf("Test TestReplaceForVerifiedCert: Expected %s to be set in replacer", IS_CERT_VERIFIED)
+	}
 }

--- a/modules/caddyhttp/replacer_test.go
+++ b/modules/caddyhttp/replacer_test.go
@@ -173,7 +173,11 @@ eqp31wM9il1n+guTNyxJd+FzVAH+hCZE5K+tCgVDdVFUlDEHHbS/wqb2PSIoouLV
 		},
 		{
 			input:  "{http.request.tls.client.certificate_pem}",
-			expect: string(clientCert) + "\n",  // returned value comes with a newline appended to it
+			expect: string(clientCert) + "\n", // returned value comes with a newline appended to it
+		},
+		{
+			input:  "{http.request.tls.client.is_verified}",
+			expect: "false",
 		},
 	} {
 		actual := repl.ReplaceAll(tc.input, "<empty>")

--- a/replacer.go
+++ b/replacer.go
@@ -31,7 +31,7 @@ func NewReplacer() *Replacer {
 	}
 	rep.providers = []ReplacerFunc{
 		globalDefaultReplacements,
-		rep.fromStatic,
+		rep.FromStatic,
 	}
 	return rep
 }
@@ -79,8 +79,8 @@ func (r *Replacer) Delete(variable string) {
 	delete(r.static, variable)
 }
 
-// fromStatic provides values from r.static.
-func (r *Replacer) fromStatic(key string) (interface{}, bool) {
+// FromStatic provides values from r.static.
+func (r *Replacer) FromStatic(key string) (interface{}, bool) {
 	val, ok := r.static[key]
 	return val, ok
 }


### PR DESCRIPTION
Uses x509.Verify for verification.
For #3585 

Question: In the test, the certificate is not verified (expected value is `false`) because I'm assuming certificate used here is actually not verified right?