### PR TITLE
reverseproxy: ignore RFC 1521 parameters in mime type when checking the Content-Type header

### DIFF
--- a/modules/caddyhttp/reverseproxy/streaming.go
+++ b/modules/caddyhttp/reverseproxy/streaming.go
@@ -21,6 +21,7 @@ package reverseproxy
 import (
 	"context"
 	"io"
+	"mime"
 	"net/http"
 	"sync"
 	"time"
@@ -88,11 +89,12 @@ func (h Handler) handleUpgradeResponse(rw http.ResponseWriter, req *http.Request
 // flushInterval returns the p.FlushInterval value, conditionally
 // overriding its value for a specific request/response.
 func (h Handler) flushInterval(req *http.Request, res *http.Response) time.Duration {
-	resCT := res.Header.Get("Content-Type")
+	resCTHeader := res.Header.Get("Content-Type")
+	resCT, _, err := mime.ParseMediaType(resCTHeader)
 
 	// For Server-Sent Events responses, flush immediately.
 	// The MIME type is defined in https://www.w3.org/TR/eventsource/#text-event-stream
-	if resCT == "text/event-stream" {
+	if err == nil && resCT == "text/event-stream" {
 		return -1 // negative means immediately
 	}
 


### PR DESCRIPTION
Without this change, a Content-Type header like "text/event-stream;charset=utf-8"
would not trigger the immediate flushing.

Fixes #3765