### PR TITLE
reverseproxy: Change 500 error to 502 for lookup_srv config (#3763)

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -384,7 +384,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 		// DialInfo struct should have valid network address syntax
 		dialInfo, err := upstream.fillDialInfo(r)
 		if err != nil {
-			return fmt.Errorf("making dial info: %v", err)
+			err = fmt.Errorf("making dial info: %v", err)
+			return caddyhttp.Error(http.StatusBadGateway, err)
 		}
 
 		// attach to the request information about how to dial the upstream;


### PR DESCRIPTION
This should be checked with fix-srv-3753 branch due to #3753 bug.