### PR TITLE
reverseproxy: default to port 80 for port-less upstream dial addresses

### DIFF
--- a/caddytest/integration/caddyfile_adapt/portless_upstream.txt
+++ b/caddytest/integration/caddyfile_adapt/portless_upstream.txt
@@ -1,0 +1,113 @@
+whoami.example.com {
+	reverse_proxy whoami
+}
+
+app.example.com {
+	reverse_proxy app:80
+}
+unix.example.com {
+	reverse_proxy unix//path/to/socket
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"whoami.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"handler": "reverse_proxy",
+													"upstreams": [
+														{
+															"dial": "whoami:80"
+														}
+													]
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						},
+						{
+							"match": [
+								{
+									"host": [
+										"unix.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"handler": "reverse_proxy",
+													"upstreams": [
+														{
+															"dial": "unix//path/to/socket"
+														}
+													]
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						},
+						{
+							"match": [
+								{
+									"host": [
+										"app.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"handler": "reverse_proxy",
+													"upstreams": [
+														{
+															"dial": "app:80"
+														}
+													]
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/caddytest/integration/reverseproxy_test.go
+++ b/caddytest/integration/reverseproxy_test.go
@@ -13,6 +13,23 @@ import (
 	"github.com/caddyserver/caddy/v2/caddytest"
 )
 
+func TestBareUpstream(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		http_port     9080
+		https_port    9443
+	}
+	whoami.domain.me {
+		reverse_proxy whoami
+	}
+	
+	app.domain.me {
+		reverse_proxy app:80
+	}
+	`, "caddyfile")
+}
+
 func TestReverseProxyHealthCheck(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`

--- a/caddytest/integration/reverseproxy_test.go
+++ b/caddytest/integration/reverseproxy_test.go
@@ -13,23 +13,6 @@ import (
 	"github.com/caddyserver/caddy/v2/caddytest"
 )
 
-func TestBareUpstream(t *testing.T) {
-	tester := caddytest.NewTester(t)
-	tester.InitServer(`
-	{
-		http_port     9080
-		https_port    9443
-	}
-	whoami.domain.me {
-		reverse_proxy whoami
-	}
-	
-	app.domain.me {
-		reverse_proxy app:80
-	}
-	`, "caddyfile")
-}
-
 func TestReverseProxyHealthCheck(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -155,6 +155,9 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			if err != nil {
 				host = upstreamAddr
 			}
+			if port == "" {
+				port = "80"
+			}
 		}
 
 		// the underlying JSON does not yet support different


### PR DESCRIPTION
Fixes #3761