### PR TITLE
reverseproxy: Fix dial placeholders, SRV, active health checks

### DIFF
--- a/caddytest/integration/reverseproxy_test.go
+++ b/caddytest/integration/reverseproxy_test.go
@@ -79,6 +79,244 @@ func TestSRVWithDial(t *testing.T) {
 	`, "json", `upstream: specifying dial address is incompatible with lookup_srv: 0: {\"dial\": \"tcp/address.to.upstream:80\", \"lookup_srv\": \"srv.host.service.consul\"}`)
 }
 
+func TestDialWithPlaceholderUnix(t *testing.T) {
+
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
+
+	f, err := ioutil.TempFile("", "*.sock")
+	if err != nil {
+		t.Errorf("failed to create TempFile: %s", err)
+		return
+	}
+	// a hack to get a file name within a valid path to use as socket
+	socketName := f.Name()
+	os.Remove(f.Name())
+
+	server := http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.Write([]byte("Hello, World!"))
+		}),
+	}
+
+	unixListener, err := net.Listen("unix", socketName)
+	if err != nil {
+		t.Errorf("failed to listen on the socket: %s", err)
+		return
+	}
+	go server.Serve(unixListener)
+	t.Cleanup(func() {
+		server.Close()
+	})
+	runtime.Gosched() // Allow other goroutines to run
+
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		"apps": {
+		  "http": {
+			"servers": {
+			  "srv0": {
+				"listen": [
+				  ":8080"
+				],
+				"routes": [
+				  {
+					"handle": [
+					  {
+						"handler": "reverse_proxy",
+						"upstreams": [
+						  {
+							"dial": "unix/{http.request.header.X-Caddy-Upstream-Dial}"
+						  }
+						]
+					  }
+					]
+				  }
+				]
+			  }
+			}
+		  }
+		}
+	  }
+	`, "json")
+
+	req, err := http.NewRequest(http.MethodGet, "http://localhost:8080", nil)
+	if err != nil {
+		t.Fail()
+		return
+	}
+	req.Header.Set("X-Caddy-Upstream-Dial", socketName)
+	tester.AssertResponse(req, 200, "Hello, World!")
+}
+
+func TestReverseProxyWithPlaceholderDialAddress(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		"apps": {
+			"http": {
+				"servers": {
+					"srv0": {
+						"listen": [
+							":8080"
+						],
+						"routes": [
+							{
+								"match": [
+									{
+										"host": [
+											"localhost"
+										]
+									}
+								],
+								"handle": [
+									{
+										"handler": "static_response",
+										"body": "Hello, World!"
+									}
+								],
+								"terminal": true
+							}
+						],
+						"automatic_https": {
+							"skip": [
+								"localhost"
+							]
+						}
+					},
+					"srv1": {
+						"listen": [
+							":9080"
+						],
+						"routes": [
+							{
+								"match": [
+									{
+										"host": [
+											"localhost"
+										]
+									}
+								],
+								"handle": [
+									{
+	
+										"handler": "reverse_proxy",
+										"upstreams": [
+											{
+												"dial": "{http.request.header.X-Caddy-Upstream-Dial}"
+											}
+										]
+									}
+								],
+								"terminal": true
+							}
+						],
+						"automatic_https": {
+							"skip": [
+								"localhost"
+							]
+						}
+					}
+				}
+			}
+		}
+	}
+  	`, "json")
+
+	req, err := http.NewRequest(http.MethodGet, "http://localhost:9080", nil)
+	if err != nil {
+		t.Fail()
+		return
+	}
+	req.Header.Set("X-Caddy-Upstream-Dial", "localhost:8080")
+	tester.AssertResponse(req, 200, "Hello, World!")
+}
+
+func TestReverseProxyWithPlaceholderTCPDialAddress(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		"apps": {
+			"http": {
+				"servers": {
+					"srv0": {
+						"listen": [
+							":8080"
+						],
+						"routes": [
+							{
+								"match": [
+									{
+										"host": [
+											"localhost"
+										]
+									}
+								],
+								"handle": [
+									{
+										"handler": "static_response",
+										"body": "Hello, World!"
+									}
+								],
+								"terminal": true
+							}
+						],
+						"automatic_https": {
+							"skip": [
+								"localhost"
+							]
+						}
+					},
+					"srv1": {
+						"listen": [
+							":9080"
+						],
+						"routes": [
+							{
+								"match": [
+									{
+										"host": [
+											"localhost"
+										]
+									}
+								],
+								"handle": [
+									{
+	
+										"handler": "reverse_proxy",
+										"upstreams": [
+											{
+												"dial": "tcp/{http.request.header.X-Caddy-Upstream-Dial}:8080"
+											}
+										]
+									}
+								],
+								"terminal": true
+							}
+						],
+						"automatic_https": {
+							"skip": [
+								"localhost"
+							]
+						}
+					}
+				}
+			}
+		}
+	}
+  	`, "json")
+
+	req, err := http.NewRequest(http.MethodGet, "http://localhost:9080", nil)
+	if err != nil {
+		t.Fail()
+		return
+	}
+	req.Header.Set("X-Caddy-Upstream-Dial", "localhost")
+	tester.AssertResponse(req, 200, "Hello, World!")
+}
+
 func TestSRVWithActiveHealthcheck(t *testing.T) {
 	caddytest.AssertLoadError(t, `
 	{

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -92,7 +92,6 @@ type Upstream struct {
 	// HeaderAffinity string
 	// IPAffinity     string
 
-	networkAddress        caddy.NetworkAddress
 	activeHealthCheckPort int
 	healthCheckPolicy     *PassiveHealthChecks
 	cb                    CircuitBreaker

--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -182,9 +182,6 @@ func (h *HTTPTransport) NewTransport(ctx caddy.Context) (*http.Transport, error)
 			if dialInfo, ok := GetDialInfo(ctx); ok {
 				network = dialInfo.Network
 				address = dialInfo.Address
-				if dialInfo.Upstream.networkAddress.IsUnixNetwork() {
-					address = dialInfo.Host
-				}
 			}
 			conn, err := dialer.DialContext(ctx, network, address)
 			if err != nil {


### PR DESCRIPTION
Supersedes #3776
Partially reverts or updates #3756, #3693, and #3695

Please take a look @Mohammed90 @francislavoie and users we know to have been affected previously: @waiyip-aquabyte,  @danlsgiga, @markuswustenberg, and @yflau. Build artifacts are available in the CI / actions area.

My understanding is that fixing #3753 introduced regressions fixed by #3693 and #3695, which broke dynamic upstreams (using placeholders in dial addresses) as reported in #3768. Instead of piling more code on top to patch the regressions, this change causes the recently-added integration tests to pass without adding more complexity. I think the key is to just not parse the network address at provision-time, which we can't reliably do because we don't know whether it is a usable address (because it supports placeholders, the address might not be able to be evaluated until request-time).

@Mohammed90 I did bring over the new tests you wrote for #3776 and they pass, but I did not add them to this commit because I want you to get credit for those, so if you would like to push them to this branch before we merge, that would be great. One test did not pass (`TestDialWithPlaceholderActiveHealthcheck`) but I think that test is not really valid anyway, since we don't parse the addresses up front.