### PR TITLE
caddyhttp: Restore original request params before error handlers

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -209,6 +209,13 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// restore original request before invoking error handler chain (issue #3717)
+	origReq := r.Context().Value(OriginalRequestCtxKey).(http.Request)
+	r.Method = origReq.Method
+	r.RemoteAddr = origReq.RemoteAddr
+	r.RequestURI = origReq.RequestURI
+	cloneURL(origReq.URL, r.URL)
+
 	// prepare the error log
 	logger := errLog
 	if s.Logs != nil {


### PR DESCRIPTION
Fixes #3717

If the primary handler chain rewrote the request, it needs to be restored before the error handler chain gets invoked.

Right now the actual specifics of how this should work are undefined, but I think it makes sense that the primary chain, upon returning an error, should invoke the error handler chain without side-effects on the request. Works well for me.

@aitva could you please try this out? You can get build artifacts from CI.