### PR TITLE
caddyfile: Implement heredoc support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ vendor
 dist
 caddy-build
 caddy-dist
+
+# ide specific
+.vscode/

--- a/caddyconfig/caddyfile/dispenser.go
+++ b/caddyconfig/caddyfile/dispenser.go
@@ -378,7 +378,7 @@ func (d *Dispenser) numLineBreaks(tknIdx int) int {
 	if tknIdx < 0 || tknIdx >= len(d.tokens) {
 		return 0
 	}
-	return strings.Count(d.tokens[tknIdx].Text, "\n")
+	return strings.Count(d.tokens[tknIdx].Text, "\n") + d.tokens[tknIdx].Heredoc
 }
 
 // isNewLine determines whether the current token is on a different

--- a/caddyconfig/caddyfile/lexer.go
+++ b/caddyconfig/caddyfile/lexer.go
@@ -155,8 +155,9 @@ func (l *lexer) next() bool {
 						panic(fmt.Errorf("mismatched whitespace in heredoc on line #%d [%s], expected whitespace [%s]", i, line, paddingToStrip))
 					}
 
-					// strip, then append the line, with the newline, to the output
-					out += line[len(paddingToStrip):] + "\n"
+					// strip, then append the line, with the newline, to the output.
+					// also removes all "\r" because Windows.
+					out += strings.ReplaceAll(line[len(paddingToStrip):]+"\n", "\r", "")
 				}
 
 				// set the final value

--- a/caddyconfig/caddyfile/lexer.go
+++ b/caddyconfig/caddyfile/lexer.go
@@ -17,7 +17,9 @@ package caddyfile
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
+	"strings"
 	"unicode"
 )
 
@@ -35,9 +37,10 @@ type (
 
 	// Token represents a single parsable unit.
 	Token struct {
-		File string
-		Line int
-		Text string
+		File    string
+		Line    int
+		Text    string
+		Heredoc int
 	}
 )
 
@@ -74,7 +77,9 @@ func (l *lexer) load(input io.Reader) error {
 // a token was loaded; false otherwise.
 func (l *lexer) next() bool {
 	var val []rune
-	var comment, quoted, btQuoted, escaped bool
+	var comment, quoted, btQuoted, inHeredoc, escaped bool
+	var heredocMarker string
+	var heredocEscaped bool
 
 	makeToken := func() bool {
 		l.token.Text = string(val)
@@ -82,6 +87,10 @@ func (l *lexer) next() bool {
 	}
 
 	for {
+		// Read a character in; if err then if we had
+		// read some characters, make a token. If we
+		// reached EOF, then no more tokens to read.
+		// If no EOF, then we had a problem.
 		ch, _, err := l.reader.ReadRune()
 		if err != nil {
 			if len(val) > 0 {
@@ -93,6 +102,86 @@ func (l *lexer) next() bool {
 			panic(err)
 		}
 
+		// detect whether we have the start of a heredoc
+		if !inHeredoc && !heredocEscaped && len(val) > 1 && string(val[:2]) == "<<" {
+			if ch == '<' {
+				panic(fmt.Errorf("too many '<' for heredoc"))
+			}
+			if ch == '\r' {
+				continue
+			}
+			// after hitting a newline, we know that the heredoc marker
+			// is the characters after the two << and the newline.
+			// we reset the val because the heredoc is syntax we don't
+			// want to keep.
+			if ch == '\n' {
+				inHeredoc = true
+				heredocMarker = string(val[2:])
+				l.skippedLines++
+				val = nil
+				continue
+			}
+			val = append(val, ch)
+			continue
+		}
+
+		// if we're in a heredoc, all characters are read as-is
+		if inHeredoc {
+			val = append(val, ch)
+
+			if ch == '\n' {
+				l.skippedLines++
+			}
+
+			// check if we're done, i.e. that the last few characters are the marker
+			if len(val) > len(heredocMarker) && string(val[len(val)-len(heredocMarker):]) == heredocMarker {
+				// find the last newline of the heredoc, which is where the contents end
+				lastNewline := strings.LastIndex(string(val), "\n")
+
+				// figure out how much whitespace we need to strip from the front of every line
+				paddingToStrip := string(val[lastNewline+1 : len(val)-len(heredocMarker)])
+
+				// collapse the content, then split into separate lines
+				lines := strings.Split(string(val[:lastNewline+1]), "\n")
+
+				// iterate over each line and strip the whitespace from the front
+				var out string
+				for i, line := range lines[:len(lines)-1] {
+					// find an exact match for the padding
+					index := strings.Index(line, paddingToStrip)
+
+					// if the padding doesn't match exactly at the start then we can't safely strip
+					if index != 0 {
+						panic(fmt.Errorf("mismatched whitespace in heredoc on line #%d [%s], expected whitespace [%s]", i, line, paddingToStrip))
+					}
+
+					// strip, then append the line, with the newline, to the output
+					out += line[len(paddingToStrip):] + "\n"
+				}
+
+				// set the final value
+				val = []rune(out)
+
+				// set the line counter
+				l.line += l.skippedLines
+				l.skippedLines = 0
+
+				// adds +1 to the count of newlines in the token text
+				// for the parser to track whether we're still on
+				// the same directive; this is a hack, because we
+				// consume the first newline in the heredoc, so
+				// it throws off the line count.
+				l.token.Heredoc = 1
+
+				return makeToken()
+			}
+
+			// stay in the heredoc until we find the ending marker
+			continue
+		}
+
+		// track whether we found an escape '\' for the next
+		// iteration to be contextually aware
 		if !escaped && !btQuoted && ch == '\\' {
 			escaped = true
 			continue
@@ -107,26 +196,30 @@ func (l *lexer) next() bool {
 				}
 				escaped = false
 			} else {
-				if quoted && ch == '"' {
-					return makeToken()
-				}
-				if btQuoted && ch == '`' {
+				// check if we reached the end of the quoted token
+				if (quoted && ch == '"') || (btQuoted && ch == '`') {
 					return makeToken()
 				}
 			}
+			// allow quoted text to wrap continue on multiple lines
 			if ch == '\n' {
 				l.line += 1 + l.skippedLines
 				l.skippedLines = 0
 			}
+			// collect this character as part of the quoted token
 			val = append(val, ch)
 			continue
 		}
 
 		if unicode.IsSpace(ch) {
+			// ignore CR altogether, we only actually care about LF (\n)
 			if ch == '\r' {
 				continue
 			}
+			// end of the line
 			if ch == '\n' {
+				// newlines can be escaped to chain arguments
+				// onto multiple lines; else, increment the line count
 				if escaped {
 					l.skippedLines++
 					escaped = false
@@ -134,14 +227,18 @@ func (l *lexer) next() bool {
 					l.line += 1 + l.skippedLines
 					l.skippedLines = 0
 				}
+				// comments (#) are single-line only
 				comment = false
 			}
+			// any kind of space means we're at the end of this token
 			if len(val) > 0 {
 				return makeToken()
 			}
 			continue
 		}
 
+		// comments must be at the start of a token,
+		// in other words, preceded by space or newline
 		if ch == '#' && len(val) == 0 {
 			comment = true
 		}
@@ -162,7 +259,12 @@ func (l *lexer) next() bool {
 		}
 
 		if escaped {
-			val = append(val, '\\')
+			// allow escaping the first < to skip the heredoc syntax
+			if ch == '<' {
+				heredocEscaped = true
+			} else {
+				val = append(val, '\\')
+			}
 			escaped = false
 		}
 

--- a/caddytest/integration/caddyfile_adapt/heredoc.txt
+++ b/caddytest/integration/caddyfile_adapt/heredoc.txt
@@ -1,0 +1,50 @@
+example.com {
+    respond <<EOF
+    <html>
+      <head><title>Foo</title>
+      <body>Foo</body>
+    </html>
+    EOF 200
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "\u003chtml\u003e\n  \u003chead\u003e\u003ctitle\u003eFoo\u003c/title\u003e\n  \u003cbody\u003eFoo\u003c/body\u003e\n\u003c/html\u003e\n",
+													"handler": "static_response",
+													"status_code": 200
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds support for heredoc syntax to the Caddyfile, inspired by HCL (HashiCorp Config Language), and PHP 7.3's flexible syntax (trimming the front of every line based on the indentation of the ending marker: https://wiki.php.net/rfc/flexible_heredoc_nowdoc_syntaxes)

Here's an example:

```
example.com {
    respond <<EOF
    <html>
      <head><title>Foo</title>
      <body>Foo</body>
    </html>
    EOF 200
}
```

Adapted JSON:

```json
{
	"apps": {
		"http": {
			"servers": {
				"srv0": {
					"listen": [
						":443"
					],
					"routes": [
						{
							"match": [
								{
									"host": [
										"example.com"
									]
								}
							],
							"handle": [
								{
									"handler": "subroute",
									"routes": [
										{
											"handle": [
												{
													"body": "\u003chtml\u003e\n  \u003chead\u003e\u003ctitle\u003eFoo\u003c/title\u003e\n  \u003cbody\u003eFoo\u003c/body\u003e\n\u003c/html\u003e\n",
													"handler": "static_response",
													"status_code": 200
												}
											]
										}
									]
								}
							],
							"terminal": true
						}
					]
				}
			}
		}
	}
}
```

Notice that the response body has the leading whitespace on each line stripped away.

---

The implementation was a bit funky here, I don't like that I added a new field on the Token struct, but I couldn't think of a better way to handle it, frankly.

Basically, heredocs don't include the newline that counts as the starting point as part of the token contents. This is ideal, because then you don't have an extra newline at the start of every token, so it reads more like a file.

The problem is this: the logic for splitting the tokens into segments involves counting the amount of newlines inside of the token text, and checking whether it matches the line numbers on the tokens. Since we drop one newline from the heredoc, this doesn't match that expectation.

So basically my "hack" was to just add a "+1" marker on the token, with a field called "Heredoc" for the purposes of counting line breaks, while keeping the line numbers intact (because they're useful for debugging etc). Can you think of a better way?

I also went ahead and commented the shit out of the lexer, because I think it deserves it, since it's getting pretty involved. The heredoc stuff is admittedly quite chunky, and probably non-optimally written cause I'm by no means a Go expert... but I think the logic is sound.

I should add some more tests for this to `lexer_test.go` but I'm too tired right now :smile: I'll come back to it soon.