### PR TITLE
reverseproxy: Avoid "operation was canceled" errors

### DIFF
--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -144,7 +144,7 @@ func (u *Upstream) fillDialInfo(r *http.Request) (DialInfo, error) {
 	if u.LookupSRV != "" {
 		// perform DNS lookup for SRV records and choose one
 		srvName := repl.ReplaceAll(u.LookupSRV, "")
-		_, records, err := net.DefaultResolver.LookupSRV(r.Context(), "", "", srvName)
+		_, records, err := net.LookupSRV("", "", srvName)
 		if err != nil {
 			return DialInfo{}, err
 		}

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -144,7 +144,7 @@ func (u *Upstream) fillDialInfo(r *http.Request) (DialInfo, error) {
 	if u.LookupSRV != "" {
 		// perform DNS lookup for SRV records and choose one
 		srvName := repl.ReplaceAll(u.LookupSRV, "")
-		_, records, err := net.LookupSRV("", "", srvName)
+		_, records, err := net.DefaultResolver.LookupSRV(r.Context(), "", "", srvName)
 		if err != nil {
 			return DialInfo{}, err
 		}

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -421,6 +421,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 			return nil
 		}
 
+		// detect connection timeout to the upstream and respond with 504
+		switch e, ok := proxyErr.(net.Error); ok {
+		case e.Timeout():
+			return caddyhttp.Error(http.StatusGatewayTimeout, proxyErr)
+		}
+
 		// if the roundtrip was successful, don't retry the request or
 		// ding the health status of the upstream (an error can still
 		// occur after the roundtrip if, for example, a response handler

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -421,12 +421,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 			return nil
 		}
 
-		// detect connection timeout to the upstream and respond with 504
-		switch e, ok := proxyErr.(net.Error); ok {
-		case e.Timeout():
-			return caddyhttp.Error(http.StatusGatewayTimeout, proxyErr)
-		}
-
 		// if the roundtrip was successful, don't retry the request or
 		// ding the health status of the upstream (an error can still
 		// occur after the roundtrip if, for example, a response handler

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -384,8 +385,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 		// DialInfo struct should have valid network address syntax
 		dialInfo, err := upstream.fillDialInfo(r)
 		if err != nil {
-			err = fmt.Errorf("making dial info: %v", err)
-			return caddyhttp.Error(http.StatusBadGateway, err)
+			return statusError(fmt.Errorf("making dial info: %v", err))
 		}
 
 		// attach to the request information about how to dial the upstream;
@@ -438,7 +438,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 		}
 	}
 
-	return caddyhttp.Error(http.StatusBadGateway, proxyErr)
+	return statusError(proxyErr)
 }
 
 // prepareRequest modifies req so that it is ready to be proxied,
@@ -781,6 +781,27 @@ func removeConnectionHeaders(h http.Header) {
 			}
 		}
 	}
+}
+
+// statusError returns an error value that has a status code.
+func statusError(err error) error {
+	// errors proxying usually mean there is a problem with the upstream(s)
+	statusCode := http.StatusBadGateway
+
+	// if the client canceled the request (usually this means they closed
+	// the connection, so they won't see any response), we can report it
+	// as a client error (4xx) and not a server error (5xx); unfortunately
+	// the Go standard library, at least at time of writing in late 2020,
+	// obnoxiously wraps the exported, standard context.Canceled error with
+	// an unexported garbage value that we have to do a substring check for:
+	// https://github.com/golang/go/blob/6965b01ea248cabb70c3749fd218b36089a21efb/src/net/net.go#L416-L430
+	if errors.Is(err, context.Canceled) || strings.Contains(err.Error(), "operation was canceled") {
+		// regrettably, there is no standard error code for "client closed connection", but
+		// for historical reasons we can use a code that a lot of people are already using;
+		// using 5xx is problematic for users; see #3748
+		statusCode = 499
+	}
+	return caddyhttp.Error(statusCode, err)
 }
 
 // LoadBalancing has parameters related to load balancing.


### PR DESCRIPTION
Related to #3748

Do not pass the request context to the LookupSRV call (no context is used for the dial call anyways). This avoids caddy from logging the "operation was cancelled" coming from the [net package](https://golang.org/src/net/net.go#L411) constantly when the client closes the connection and the request context is canceled, which also was misleading caddy to log these as `502` in the access logs

I've also added and additional error handling for when the upstream connection timesout and we return the `http.StatusGatewayTimeout` code (504) appropriately, instead of 502.