### PR TITLE
check if the upstream is a placeholder

### DIFF
--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -155,6 +155,8 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			if err != nil {
 				host = upstreamAddr
 			}
+			// we can assume a port if only a hostname is specified, but use of a
+			// placeholder without a port likely means a port will be filled in
 			if port == "" && !strings.Contains(host, "{") {
 				port = "80"
 			}

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -155,7 +155,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			if err != nil {
 				host = upstreamAddr
 			}
-			if port == "" {
+			if port == "" && !strings.Contains(host, "{") {
 				port = "80"
 			}
 		}


### PR DESCRIPTION
This removes the hard coded port 80 when the `reverse_proxy` upstream is using a placeholder.

Here is an example Caddyfile to reproduces the issue:

```
my.domain.com {
    encode zstd gzip

    some_module_that_sets_the_http_var

    respond /test 200 { # works as expected
    	body {http.vars.some_custom_var}
    	close
    }

    tls internal

    reverse_proxy / {
        to {http.vars.some_custom_var}
    }

    file_server
}
```

More detailed explanations are documented in this conversation: https://caddy.community/t/dynamically-set-reverse-proxy-upstreams-from-custom-module/10142/15