### PR TITLE
Fixes logging filter for ip_mask with ipv4 adresses

### DIFF
--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -141,7 +141,7 @@ func (m IPMaskFilter) Filter(in zapcore.Field) zapcore.Field {
 		return in
 	}
 	mask := m.v4Mask
-	if ipAddr.To16() != nil {
+	if ipAddr.To4() == nil {
 		mask = m.v6Mask
 	}
 	masked := ipAddr.Mask(mask)


### PR DESCRIPTION
Addresses: #3820 
Related: https://caddy.community/t/use-ip-mask-in-caddyfile-v2/10173/11

IPv4 filter was not working correctly because `to16()` does always return a `true` value if it's an valid ip address. Independently if it's v4 or v6.

On the otherhand `to4()` does return nil when it's not an v4. So in this case it would correctly identify an IPv6 address and use the proper mask.

Logging before:

```
{
	"msg": "handled request",
	"request": {
		"remote_addr": "[::]:61671",
	},
}
```

Logging after

```
{
	"msg": "handled request",
	"request": {
		"remote_addr": "127.0.0.0:63058",
	},
}
```