### PR TITLE
reverseproxy: Make conns per host configurable, fix godocs

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_options.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_options.txt
@@ -6,11 +6,15 @@ https://example.com {
 		header_up X-Forwarded-For {remote}
 		header_up X-Forwarded-Port {server_port}
 		header_up X-Forwarded-Proto "http"
+
+		buffer_requests
+
 		transport http {
 			versions h2c 2
 			compression off
+			max_conns_per_host 5
+			max_idle_conns_per_host 2
 		}
-		buffer_requests
 	}
 }
 
@@ -64,6 +68,8 @@ https://example.com {
 													},
 													"transport": {
 														"compression": false,
+														"max_conns_per_host": 5,
+														"max_idle_conns_per_host": 2,
 														"protocol": "http",
 														"versions": [
 															"h2c",

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -72,6 +72,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 //
 //         # streaming
 //         flush_interval <duration>
+//         buffer_requests
 //
 //         # header manipulation
 //         header_up   [+|-]<field> [<value|regexp> [<replacement>]]
@@ -588,13 +589,18 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 //         read_buffer  <size>
 //         write_buffer <size>
 //         dial_timeout <duration>
-//         tls_client_auth <cert_file> <key_file>
+//         tls
+//         tls_client_auth <automate_name> | <cert_file> <key_file>
 //         tls_insecure_skip_verify
 //         tls_timeout <duration>
 //         tls_trusted_ca_certs <cert_files...>
+//         tls_server_name <sni>
 //         keepalive [off|<duration>]
 //         keepalive_idle_conns <max_count>
 //         versions <versions...>
+//         compression off
+//         max_conns_per_host <count>
+//         max_idle_conns_per_host <count>
 //     }
 //
 func (h *HTTPTransport) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
@@ -737,6 +743,26 @@ func (h *HTTPTransport) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 						h.Compression = &disable
 					}
 				}
+
+			case "max_conns_per_host":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				num, err := strconv.Atoi(d.Val())
+				if err != nil {
+					return d.Errf("bad integer value '%s': %v", d.Val(), err)
+				}
+				h.MaxConnsPerHost = num
+
+			case "max_idle_conns_per_host":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				num, err := strconv.Atoi(d.Val())
+				if err != nil {
+					return d.Errf("bad integer value '%s': %v", d.Val(), err)
+				}
+				h.MaxIdleConnsPerHost = num
 
 			default:
 				return d.Errf("unrecognized subdirective %s", d.Val())

--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -62,6 +62,9 @@ type HTTPTransport struct {
 	// Maximum number of connections per host. Default: 0 (no limit)
 	MaxConnsPerHost int `json:"max_conns_per_host,omitempty"`
 
+	// Maximum number of idle connections per host. Default: 0 (uses Go's default of 2)
+	MaxIdleConnsPerHost int `json:"max_idle_conns_per_host,omitempty"`
+
 	// How long to wait before timing out trying to connect to
 	// an upstream.
 	DialTimeout caddy.Duration `json:"dial_timeout,omitempty"`
@@ -193,6 +196,7 @@ func (h *HTTPTransport) NewTransport(ctx caddy.Context) (*http.Transport, error)
 			return conn, nil
 		},
 		MaxConnsPerHost:        h.MaxConnsPerHost,
+		MaxIdleConnsPerHost:    h.MaxIdleConnsPerHost,
 		ResponseHeaderTimeout:  time.Duration(h.ResponseHeaderTimeout),
 		ExpectContinueTimeout:  time.Duration(h.ExpectContinueTimeout),
 		MaxResponseHeaderBytes: h.MaxResponseHeaderSize,


### PR DESCRIPTION
- Makes `max_conns_per_host` configurable in Caddyfile
- Adds new `max_idle_conns_per_host` option which is passed through to `http.Transport`, plus Caddyfile support
- Fix godoc for `buffer_requests` (was in the wrong place) and add other missing options from http transport

This stuff came up after I read https://caddy.community/t/caddy-container-500-mb-ram-within-10h-1-gb-at-some-point/10070/13 which made me dig into this

I'll make a website PR as well after merged (unless you want me to do it asap?)