### PR TITLE
caddyhttp: Add Caddyfile support for merging header matchers

### DIFF
--- a/caddytest/integration/caddyfile_adapt/matcher_syntax.txt
+++ b/caddytest/integration/caddyfile_adapt/matcher_syntax.txt
@@ -18,6 +18,13 @@
 
 	@matcher6 vars_regexp "{http.request.uri}" `\.([a-f0-9]{6})\.(css|js)$`
 	respond @matcher6 "from vars_regexp matcher without name"
+
+	@matcher7 {
+		header Foo bar
+		header Foo foobar
+		header Bar foo
+	}
+	respond @matcher7 "header matcher merging values of the same field"
 }
 ----------
 {
@@ -124,6 +131,27 @@
 							"handle": [
 								{
 									"body": "from vars_regexp matcher without name",
+									"handler": "static_response"
+								}
+							]
+						},
+						{
+							"match": [
+								{
+									"header": {
+										"Bar": [
+											"foo"
+										],
+										"Foo": [
+											"bar",
+											"foobar"
+										]
+									}
+								}
+							],
+							"handle": [
+								{
+									"body": "header matcher merging values of the same field",
 									"handler": "static_response"
 								}
 							]


### PR DESCRIPTION
Adds support for adding multiple headers values to match to the same field, from the Caddyfile.

This was something that was already possible in JSON, but in the Caddyfile, it was only keeping the last defined field-value pair, and not merging it into the list.

Example:
```
	@matcher7 {
		header Foo bar
		header Foo foobar
		header Bar foo
	}
	respond @matcher7 "header matcher merging values of the same field"
```

Now gives this JSON matcher (would only have `"Foo": ["foobar"]` before):
```json
"header": {
	"Bar": [
		"foo"
	],
	"Foo": [
		"bar",
		"foobar"
	]
}
```