### PR TITLE
caddyhttp: Merge query matchers in Caddyfile

### DIFF
--- a/caddytest/integration/caddyfile_adapt/matcher_syntax.txt
+++ b/caddytest/integration/caddyfile_adapt/matcher_syntax.txt
@@ -25,6 +25,12 @@
 		header Bar foo
 	}
 	respond @matcher7 "header matcher merging values of the same field"
+
+	@matcher8 {
+		query foo=bar foo=baz bar=foo
+		query bar=baz
+	}
+	respond @matcher8 "query matcher merging pairs with the same keys"
 }
 ----------
 {
@@ -152,6 +158,28 @@
 							"handle": [
 								{
 									"body": "header matcher merging values of the same field",
+									"handler": "static_response"
+								}
+							]
+						},
+						{
+							"match": [
+								{
+									"query": {
+										"bar": [
+											"foo",
+											"baz"
+										],
+										"foo": [
+											"bar",
+											"baz"
+										]
+									}
+								}
+							],
+							"handle": [
+								{
+									"body": "query matcher merging pairs with the same keys",
 									"handler": "static_response"
 								}
 							]


### PR DESCRIPTION
I noticed this while revising the matcher docs, `query` wasn't adapting as advertised. It was only letting you have one value per key, and if you specified more tokens, it would fail because `d.Args(&query)` would end up hitting every 2nd token because it's in a `d.Next()` loop. Switches to `Add` from `Set` which will append the value (even if it's empty) instead of overwriting every time.

Also, turns out that `Add` on headers will work even if there's nothing there yet (because it's initialized already as an empty array), so we can remove the condition I introduced in #3832 (effectively we just switched from `Set` to `Add`)