### PR TITLE
fileserver: Improve and clarify file hiding logic

### DIFF
--- a/caddytest/integration/caddyfile_adapt/sort_directives_with_any_matcher_first.txt
+++ b/caddytest/integration/caddyfile_adapt/sort_directives_with_any_matcher_first.txt
@@ -32,7 +32,7 @@ file_server @untrusted
 								{
 									"handler": "file_server",
 									"hide": [
-										"Caddyfile"
+										"./Caddyfile"
 									]
 								}
 							]
@@ -42,7 +42,7 @@ file_server @untrusted
 								{
 									"handler": "file_server",
 									"hide": [
-										"Caddyfile"
+										"./Caddyfile"
 									]
 								}
 							]

--- a/caddytest/integration/caddyfile_adapt/sort_directives_with_any_matcher_first.txt
+++ b/caddytest/integration/caddyfile_adapt/sort_directives_with_any_matcher_first.txt
@@ -1,9 +1,9 @@
 :80
 
-file_server
+respond 200
 
 @untrusted not remote_ip 10.1.1.0/24
-file_server @untrusted
+respond @untrusted 401
 ----------
 {
 	"apps": {
@@ -30,20 +30,16 @@ file_server @untrusted
 							],
 							"handle": [
 								{
-									"handler": "file_server",
-									"hide": [
-										"./Caddyfile"
-									]
+									"handler": "static_response",
+									"status_code": 401
 								}
 							]
 						},
 						{
 							"handle": [
 								{
-									"handler": "file_server",
-									"hide": [
-										"./Caddyfile"
-									]
+									"handler": "static_response",
+									"status_code": 200
 								}
 							]
 						}

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -15,6 +15,7 @@
 package fileserver
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/caddyserver/caddy/v2"
@@ -85,7 +86,14 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 	// hide the Caddyfile (and any imported Caddyfiles)
 	if configFiles := h.Caddyfiles(); len(configFiles) > 0 {
 		for _, file := range configFiles {
+			file = filepath.Clean(file)
 			if !fileHidden(file, fsrv.Hide) {
+				// if there's no path separator, the file server module will hide all
+				// files by that name, rather than a specific one; but we want to hide
+				// only this specific file, so ensure there's always a path separator
+				if !strings.Contains(file, separator) {
+					file = "." + separator + file
+				}
 				fsrv.Hide = append(fsrv.Hide, file)
 			}
 		}

--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -286,7 +285,7 @@ func strictFileExists(file string) (os.FileInfo, bool) {
 		// https://stackoverflow.com/a/12518877/1048862
 		return nil, false
 	}
-	if strings.HasSuffix(file, string(filepath.Separator)) {
+	if strings.HasSuffix(file, separator) {
 		// by convention, file paths ending
 		// in a path separator must be a directory
 		return stat, stat.IsDir()

--- a/modules/caddyhttp/fileserver/staticfiles_test.go
+++ b/modules/caddyhttp/fileserver/staticfiles_test.go
@@ -44,7 +44,7 @@ func TestSanitizedPathJoin(t *testing.T) {
 		},
 		{
 			inputPath: "/foo/",
-			expect:    "foo" + string(filepath.Separator),
+			expect:    "foo" + separator,
 		},
 		{
 			inputPath: "/foo/bar",
@@ -77,7 +77,7 @@ func TestSanitizedPathJoin(t *testing.T) {
 		{
 			inputRoot: "/a/b",
 			inputPath: "/%2e%2e%2f%2e%2e%2f",
-			expect:    filepath.Join("/", "a", "b") + string(filepath.Separator),
+			expect:    filepath.Join("/", "a", "b") + separator,
 		},
 		{
 			inputRoot: "C:\\www",
@@ -155,6 +155,26 @@ func TestFileHidden(t *testing.T) {
 			expect:    true,
 		},
 		{
+			inputHide: []string{"*.txt"},
+			inputPath: "/foo/bar.txt",
+			expect:    true,
+		},
+		{
+			inputHide: []string{"/foo/bar/*.txt"},
+			inputPath: "/foo/bar/baz.txt",
+			expect:    true,
+		},
+		{
+			inputHide: []string{"/foo/bar/*.txt"},
+			inputPath: "/foo/bar.txt",
+			expect:    false,
+		},
+		{
+			inputHide: []string{"/foo/bar/*.txt"},
+			inputPath: "/foo/bar/index.html",
+			expect:    false,
+		},
+		{
 			inputHide: []string{"/foo"},
 			inputPath: "/foo",
 			expect:    true,
@@ -163,6 +183,11 @@ func TestFileHidden(t *testing.T) {
 			inputHide: []string{"/foo"},
 			inputPath: "/foobar",
 			expect:    false,
+		},
+		{
+			inputHide: []string{"first", "second"},
+			inputPath: "/second",
+			expect:    true,
 		},
 	} {
 		// for Windows' sake
@@ -173,8 +198,8 @@ func TestFileHidden(t *testing.T) {
 
 		actual := fileHidden(tc.inputPath, tc.inputHide)
 		if actual != tc.expect {
-			t.Errorf("Test %d: Is %s hidden in %v? Got %t but expected %t",
-				i, tc.inputPath, tc.inputHide, actual, tc.expect)
+			t.Errorf("Test %d: Does %v hide %s? Got %t but expected %t",
+				i, tc.inputHide, tc.inputPath, actual, tc.expect)
 		}
 	}
 }

--- a/modules/caddyhttp/fileserver/staticfiles_test.go
+++ b/modules/caddyhttp/fileserver/staticfiles_test.go
@@ -17,6 +17,8 @@ package fileserver
 import (
 	"net/url"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -190,10 +192,17 @@ func TestFileHidden(t *testing.T) {
 			expect:    true,
 		},
 	} {
-		// for Windows' sake
-		tc.inputPath = filepath.FromSlash(tc.inputPath)
-		for i := range tc.inputHide {
-			tc.inputHide[i] = filepath.FromSlash(tc.inputHide[i])
+		if runtime.GOOS == "windows" {
+			if strings.HasPrefix(tc.inputPath, "/") {
+				tc.inputPath, _ = filepath.Abs(tc.inputPath)
+			}
+			tc.inputPath = filepath.FromSlash(tc.inputPath)
+			for i := range tc.inputHide {
+				if strings.HasPrefix(tc.inputPath, "/") {
+					tc.inputHide[i], _ = filepath.Abs(tc.inputHide[i])
+				}
+				tc.inputHide[i] = filepath.FromSlash(tc.inputHide[i])
+			}
 		}
 
 		actual := fileHidden(tc.inputPath, tc.inputHide)

--- a/modules/caddyhttp/fileserver/staticfiles_test.go
+++ b/modules/caddyhttp/fileserver/staticfiles_test.go
@@ -198,7 +198,7 @@ func TestFileHidden(t *testing.T) {
 			}
 			tc.inputPath = filepath.FromSlash(tc.inputPath)
 			for i := range tc.inputHide {
-				if strings.HasPrefix(tc.inputPath, "/") {
+				if strings.HasPrefix(tc.inputHide[i], "/") {
 					tc.inputHide[i], _ = filepath.Abs(tc.inputHide[i])
 				}
 				tc.inputHide[i] = filepath.FromSlash(tc.inputHide[i])


### PR DESCRIPTION
Improvements to file hiding logic, but mostly to documentation to make it clear that hide paths are _file system paths_, NOT request paths, and that any relative paths are relative to the current working directory, NOT the site root (because site roots can be dynamic).

Hopefully these tests pass on Windows :man_shrugging: 