### PR TITLE
Add new acme_server database options

### DIFF
--- a/modules/caddypki/acmeserver/acmeserver.go
+++ b/modules/caddypki/acmeserver/acmeserver.go
@@ -65,12 +65,12 @@ type Handler struct {
 	PathPrefix string `json:"path_prefix,omitempty"`
 
 	// Whether to store using FileIO rather than MemoryMap
-	// Deafult: false
-	NoMemoryMap bool `json:"no_memory_map,omitempty`
+	// Default: false
+	NoMemoryMap bool `json:"no_memory_map,omitempty"`
 
 	// Whether to use BadgerV2 storage
-	// Deafult: false
-	UseBadgerV2 bool `json:"use_badgerv2,omitempty`
+	// Default: false
+	UseBadgerV2 bool `json:"use_badger_v2,omitempty"`
 
 	acmeEndpoints http.Handler
 }

--- a/modules/caddypki/acmeserver/caddyfile.go
+++ b/modules/caddypki/acmeserver/caddyfile.go
@@ -40,7 +40,7 @@ func parseACMEServer(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error
 //
 //		acme_server [<matcher>] {
 //			[no_memory_map]
-//			[use_badgerv2]
+//			[use_badger_v2]
 //		}
 //
 func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
@@ -53,7 +53,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			switch subdirective {
 			case "no_memory_map":
 				h.NoMemoryMap = true
-			case "use_badgerv2":
+			case "use_badger_v2":
 				h.UseBadgerV2 = true
 			default:
 				return fmt.Errorf("unsupported subdirective %s", subdirective)


### PR DESCRIPTION
As described in #3847, the ACME server fails when run on ARM devices.
This is due to smallstep using `MemoryMap` log storage for it's Badger
database.

This patch allows one to either disable `MemoryMap` and switch to `FileIO`

    acme_server {
        no_memory_map
    }

or to explicitly switch to BadgerV2

    acme_server {
        use_badgerv2
    }

If you have no existing database state, you can simply use BadgerV2, as
it will eventually become the default.

If instead you have an existing state, this will give you a manifest
error. In that case you will need to disable `MemoryMap`.

Fixes #3847