### PR TITLE
acme_server: switch to bbolt storage

### DIFF
--- a/modules/caddypki/acmeserver/acmeserver.go
+++ b/modules/caddypki/acmeserver/acmeserver.go
@@ -99,13 +99,18 @@ func (ash *Handler) Provision(ctx caddy.Context) error {
 		return fmt.Errorf("no certificate authority configured with id: %s", ash.CA)
 	}
 
-	dbFolder := filepath.Join(caddy.AppDataDir(), "acme_server", "db")
+	dbFolder := filepath.Join(caddy.AppDataDir(), "acme_server")
+	dbPath := filepath.Join(dbFolder, "db2")
 
 	// TODO: See https://github.com/smallstep/nosql/issues/7
 	err = os.MkdirAll(dbFolder, 0755)
 	if err != nil {
 		return fmt.Errorf("making folder for ACME server database: %v", err)
 	}
+
+	// Clear old db paths out
+	legacyDbPath := filepath.Join(dbFolder, "db")
+	_ = os.RemoveAll(legacyDbPath)
 
 	authorityConfig := caddypki.AuthorityConfig{
 		AuthConfig: &authority.AuthConfig{
@@ -122,8 +127,8 @@ func (ash *Handler) Provision(ctx caddy.Context) error {
 			},
 		},
 		DB: &db.Config{
-			Type:       "badger",
-			DataSource: dbFolder,
+			Type:       "bbolt",
+			DataSource: dbPath,
 		},
 	}
 

--- a/modules/caddypki/acmeserver/acmeserver.go
+++ b/modules/caddypki/acmeserver/acmeserver.go
@@ -32,6 +32,7 @@ import (
 	"github.com/smallstep/certificates/authority/provisioner"
 	"github.com/smallstep/certificates/db"
 	"github.com/smallstep/nosql"
+	"go.uber.org/zap"
 )
 
 func init() {
@@ -77,6 +78,7 @@ func (Handler) CaddyModule() caddy.ModuleInfo {
 
 // Provision sets up the ACME server handler.
 func (ash *Handler) Provision(ctx caddy.Context) error {
+	logger := ctx.Logger(ash)
 	// set some defaults
 	if ash.CA == "" {
 		ash.CA = caddypki.DefaultCAID
@@ -100,7 +102,7 @@ func (ash *Handler) Provision(ctx caddy.Context) error {
 	}
 
 	dbFolder := filepath.Join(caddy.AppDataDir(), "acme_server")
-	dbPath := filepath.Join(dbFolder, "db2")
+	dbPath := filepath.Join(dbFolder, "db")
 
 	// TODO: See https://github.com/smallstep/nosql/issues/7
 	err = os.MkdirAll(dbFolder, 0755)
@@ -108,9 +110,17 @@ func (ash *Handler) Provision(ctx caddy.Context) error {
 		return fmt.Errorf("making folder for ACME server database: %v", err)
 	}
 
-	// Clear old db paths out
-	legacyDbPath := filepath.Join(dbFolder, "db")
-	_ = os.RemoveAll(legacyDbPath)
+	// Check to see if previous db exists
+	var stat os.FileInfo
+	stat, err = os.Stat(dbPath)
+	if stat != nil && err == nil {
+		// A badger db is found and should be removed
+		if stat.IsDir() {
+			logger.Warn("Found an old badger database and removing it",
+				zap.String("path", dbPath))
+			_ = os.RemoveAll(dbPath)
+		}
+	}
 
 	authorityConfig := caddypki.AuthorityConfig{
 		AuthConfig: &authority.AuthConfig{


### PR DESCRIPTION
There have been some issues with the badger storage engine being used by the embedded acme_server. This will replace the storage engine with bbolt.

Fixes #3847
Closes #3849
Closes #3867