### PR TITLE
acme_server: fix reload of acme database

### DIFF
--- a/modules/caddypki/acmeserver/acmeserver.go
+++ b/modules/caddypki/acmeserver/acmeserver.go
@@ -162,8 +162,7 @@ func (ash Handler) getDatabaseKey() string {
 	key := ash.CA
 	key = strings.ToLower(key)
 	key = strings.TrimSpace(key)
-	cleaner := regexp.MustCompile(`[^\w.-_]`)
-	return cleaner.ReplaceAllLiteralString(key, "")
+	return keyCleaner.ReplaceAllLiteralString(key, "")
 }
 
 // Cleanup implements caddy.CleanerUpper and closes any idle databases.
@@ -210,6 +209,7 @@ const (
 	defaultPathPrefix = "/acme/"
 )
 
+var keyCleaner = regexp.MustCompile(`[^\w.-_]`)
 var databasePool = caddy.NewUsagePool()
 
 type databaseCloser struct {

--- a/modules/caddypki/acmeserver/acmeserver.go
+++ b/modules/caddypki/acmeserver/acmeserver.go
@@ -66,6 +66,7 @@ type Handler struct {
 	PathPrefix string `json:"path_prefix,omitempty"`
 
 	acmeEndpoints http.Handler
+	logger        *zap.Logger
 }
 
 // CaddyModule returns the Caddy module information.
@@ -78,7 +79,7 @@ func (Handler) CaddyModule() caddy.ModuleInfo {
 
 // Provision sets up the ACME server handler.
 func (ash *Handler) Provision(ctx caddy.Context) error {
-	logger := ctx.Logger(ash)
+	ash.logger = ctx.Logger(ash)
 	// set some defaults
 	if ash.CA == "" {
 		ash.CA = caddypki.DefaultCAID
@@ -101,25 +102,10 @@ func (ash *Handler) Provision(ctx caddy.Context) error {
 		return fmt.Errorf("no certificate authority configured with id: %s", ash.CA)
 	}
 
-	dbFolder := filepath.Join(caddy.AppDataDir(), "acme_server")
-	dbPath := filepath.Join(dbFolder, "db")
-
-	// TODO: See https://github.com/smallstep/nosql/issues/7
-	err = os.MkdirAll(dbFolder, 0755)
+	database, err := ash.getDatabase(ash.CA)
 	if err != nil {
-		return fmt.Errorf("making folder for ACME server database: %v", err)
-	}
-
-	// Check to see if previous db exists
-	var stat os.FileInfo
-	stat, err = os.Stat(dbPath)
-	if stat != nil && err == nil {
-		// A badger db is found and should be removed
-		if stat.IsDir() {
-			logger.Warn("Found an old badger database and removing it",
-				zap.String("path", dbPath))
-			_ = os.RemoveAll(dbPath)
-		}
+		ash.logger.Error("Could not initialize CA database")
+		return err
 	}
 
 	authorityConfig := caddypki.AuthorityConfig{
@@ -136,10 +122,7 @@ func (ash *Handler) Provision(ctx caddy.Context) error {
 				},
 			},
 		},
-		DB: &db.Config{
-			Type:       "bbolt",
-			DataSource: dbPath,
-		},
+		DB: &database,
 	}
 
 	auth, err := ca.NewAuthority(authorityConfig)
@@ -173,6 +156,23 @@ func (ash Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyh
 		return nil
 	}
 	return next.ServeHTTP(w, r)
+}
+
+func (ash Handler) getDatabase(caID string) (db.AuthDB, error) {
+	dbFolder := filepath.Join(caddy.AppDataDir(), "acme_server", ash.CA)
+	dbPath := filepath.Join(dbFolder, "db")
+
+	err := os.MkdirAll(dbFolder, 0755)
+	if err != nil {
+		return nil, fmt.Errorf("making folder for ACME server database: %v", err)
+	}
+
+	dbConfig := &db.Config{
+		Type:       "bbolt",
+		DataSource: dbPath,
+	}
+	database, err := db.New(dbConfig)
+	return database, err
 }
 
 const (

--- a/modules/caddypki/ca.go
+++ b/modules/caddypki/ca.go
@@ -198,10 +198,10 @@ func (ca CA) NewAuthority(authorityConfig AuthorityConfig) (*authority.Authority
 	auth, err := authority.NewEmbedded(
 		authority.WithConfig(&authority.Config{
 			AuthorityConfig: authorityConfig.AuthConfig,
-			DB:              authorityConfig.DB,
 		}),
 		authority.WithX509Signer(issuerCert, issuerKey.(crypto.Signer)),
 		authority.WithX509RootCerts(rootCert),
+		authority.WithDatabase(*authorityConfig.DB),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("initializing certificate authority: %v", err)
@@ -382,7 +382,7 @@ type AuthorityConfig struct {
 	SignWithRoot bool
 
 	// TODO: should we just embed the underlying authority.Config struct type?
-	DB         *db.Config
+	DB         *db.AuthDB
 	AuthConfig *authority.AuthConfig
 }
 

--- a/modules/caddypki/ca.go
+++ b/modules/caddypki/ca.go
@@ -195,14 +195,18 @@ func (ca CA) NewAuthority(authorityConfig AuthorityConfig) (*authority.Authority
 		issuerKey = ca.IntermediateKey()
 	}
 
-	auth, err := authority.NewEmbedded(
+	opts := []authority.Option{
 		authority.WithConfig(&authority.Config{
 			AuthorityConfig: authorityConfig.AuthConfig,
 		}),
 		authority.WithX509Signer(issuerCert, issuerKey.(crypto.Signer)),
 		authority.WithX509RootCerts(rootCert),
-		authority.WithDatabase(*authorityConfig.DB),
-	)
+	}
+	// Add a database if we have one
+	if authorityConfig.DB != nil {
+		opts = append(opts, authority.WithDatabase(*authorityConfig.DB))
+	}
+	auth, err := authority.NewEmbedded(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("initializing certificate authority: %v", err)
 	}


### PR DESCRIPTION
Now using a UsagePool to manage database instances.

Verified with the following `Caddyfile`.

Verifying graceful change by toggling debug on and off and graceful destruction by toggling `acme_server` and `respond` directives.

```
{
    local_certs
    debug
}

acme.localhost {
    acme_server
    # respond "ok"
}
```

One thing to note, now that the database paths are not wholly predictable, this branch no longer deletes old db directories.

Fixes #3865 