### PR TITLE
docs: Mention {http.auth.user.id} placeholder in basicauth JSON docs

### DIFF
--- a/modules/caddyhttp/caddyauth/basicauth.go
+++ b/modules/caddyhttp/caddyauth/basicauth.go
@@ -39,8 +39,6 @@ type HTTPBasicAuth struct {
 	HashRaw json.RawMessage `json:"hash,omitempty" caddy:"namespace=http.authentication.hashes inline_key=algorithm"`
 
 	// The list of accounts to authenticate.
-	// After a successful authentication, the placeholder
-	// `{http.auth.user.id}` will be set to the username.
 	AccountList []Account `json:"accounts,omitempty"`
 
 	// The name of the realm. Default: restricted

--- a/modules/caddyhttp/caddyauth/basicauth.go
+++ b/modules/caddyhttp/caddyauth/basicauth.go
@@ -39,6 +39,8 @@ type HTTPBasicAuth struct {
 	HashRaw json.RawMessage `json:"hash,omitempty" caddy:"namespace=http.authentication.hashes inline_key=algorithm"`
 
 	// The list of accounts to authenticate.
+	// After a successful authentication, the placeholder
+	// `{http.auth.user.id}` will be set to the username.
 	AccountList []Account `json:"accounts,omitempty"`
 
 	// The name of the realm. Default: restricted

--- a/modules/caddyhttp/caddyauth/caddyauth.go
+++ b/modules/caddyhttp/caddyauth/caddyauth.go
@@ -30,6 +30,11 @@ func init() {
 // Authentication is a middleware which provides user authentication.
 // Rejects requests with HTTP 401 if the request is not authenticated.
 //
+// After a successful authentication, the placeholder
+// `{http.auth.user.id}` will be set to the username, and also
+// `{http.auth.user.*}` placeholders may be set for any authentication
+// modules that provide user metadata.
+//
 // Its API is still experimental and may be subject to change.
 type Authentication struct {
 	// A set of authentication providers. If none are specified,


### PR DESCRIPTION
https://caddy.community/t/placeholder-for-username-of-basicauth-user/10606

See also https://github.com/caddyserver/website/pull/117