### PR TITLE
headers: Fix Caddyfile parsing with request matcher

### DIFF
--- a/caddytest/integration/caddyfile_adapt/header.txt
+++ b/caddytest/integration/caddyfile_adapt/header.txt
@@ -9,6 +9,10 @@
 		?Tim "Berners-Lee"
 		defer
 	}
+	@images path /images/*
+	header @images {
+		Cache-Control "public, max-age=3600, stale-while-revalidate=86400"
+	}
 }
 ----------
 {
@@ -20,6 +24,27 @@
 						":80"
 					],
 					"routes": [
+						{
+							"match": [
+								{
+									"path": [
+										"/images/*"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "headers",
+									"response": {
+										"set": {
+											"Cache-Control": [
+												"public, max-age=3600, stale-while-revalidate=86400"
+											]
+										}
+									}
+								}
+							]
+						},
 						{
 							"handle": [
 								{

--- a/modules/caddyhttp/headers/caddyfile.go
+++ b/modules/caddyhttp/headers/caddyfile.go
@@ -46,6 +46,10 @@ func init() {
 // and ? conditionally sets a value only if the header field is not already
 // set.
 func parseCaddyfile(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error) {
+	if !h.Next() {
+		return nil, h.ArgErr()
+	}
+
 	matcherSet, err := h.ExtractMatcherSet()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Closes #3891

Fixes regression from b0d5c2c8ae076393e7a3ad59ce875027f4c29304

The problem is that `RegisterHandlerDirective` also calls `h.Next()` to consume the directive name from the dispenser before calling `h.MatcherToken()`. When this was changed to use `RegisterDirective` instead and use `h.ExtractMatcherSet()`, this was forgotten, so it broke request matchers because it would first see `headers` instead of `@foo` when trying to extract the matcher.

I confirmed it still rejects the config if non-matcher args are given at the same time as block ones.