### PR TITLE
caddyauth: fix unbuffered channel passed to signal.Notify

### DIFF
--- a/modules/caddyhttp/caddyauth/command.go
+++ b/modules/caddyhttp/caddyauth/command.go
@@ -70,7 +70,7 @@ func cmdHashPassword(fs caddycmd.Flags) (int, error) {
 		if terminal.IsTerminal(fd) {
 			// ensure the terminal state is restored on SIGINT
 			state, _ := terminal.GetState(fd)
-			c := make(chan os.Signal)
+			c := make(chan os.Signal, 1)
 			signal.Notify(c, os.Interrupt)
 			go func() {
 				<-c


### PR DESCRIPTION
The docs at os/signal.Notify warn about this signal delivery loss bug at
https://golang.org/pkg/os/signal/#Notify, which says:

    Package signal will not block sending to c: the caller must ensure
    that c has sufficient buffer space to keep up with the expected signal
    rate. For a channel used for notification of just one signal value,
    a buffer of size 1 is sufficient.

Caught by a static analysis tool from Orijtech, Inc. called "sigchanyzer"