### PR TITLE
cmd: Organize list-modules output; add --packages flag

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -191,10 +191,11 @@ config file; otherwise the default is assumed.`,
 	RegisterCommand(Command{
 		Name:  "list-modules",
 		Func:  cmdListModules,
-		Usage: "[--versions]",
+		Usage: "[--packages] [--versions]",
 		Short: "Lists the installed Caddy modules",
 		Flags: func() *flag.FlagSet {
 			fs := flag.NewFlagSet("list-modules", flag.ExitOnError)
+			fs.Bool("packages", false, "Print package paths")
 			fs.Bool("versions", false, "Print version information")
 			return fs
 		}(),


### PR DESCRIPTION
One thing that I always found kinda difficult was inspecting the output of `caddy list-modules` manually/visually.

I often want to know at a glance which non-standard modules a binary contains so that I can upgrade that Caddy instance without forgetting any of the modules it uses when I create its build.

This output is much easier to scan. It lists the standard modules first, then non-standard ones separately. It even counts them. I also added a `--packages` flag so you can see what Go package the module comes from.

(In the future, there should be a way to easily download the same build configuration but at the latest version, or a specified version.)