### PR TITLE
ci: Add pushing to cloudsmith

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,9 @@ jobs:
         TAG: ${{ steps.vars.outputs.version_tag }}
 
     # Only publish on non-special tags (e.g. non-beta)
+    # We will continue to push to Gemfury for the forseeable future, although
+    # Cloudsmith is probably better, to not break things for existing users of Gemfury.
+    # See https://gemfury.com/caddy/deb:caddy
     - name: Publish .deb to Gemfury
       if: ${{ steps.vars.outputs.tag_special == '' }}
       env:
@@ -106,8 +109,7 @@ jobs:
     - name: Publish .deb to Cloudsmith (special tags)
       if: ${{ steps.vars.outputs.tag_special != '' }}
       env:
-        # TODO:
-        # CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+        CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
       run: |
         for filename in dist/*.deb; do
           # armv6 and armv7 are both "armhf" so we can skip the duplicate
@@ -125,8 +127,7 @@ jobs:
     - name: Publish .deb to Cloudsmith (stable tags)
       if: ${{ steps.vars.outputs.tag_special == '' }}
       env:
-        # TODO:
-        # CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+        CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
       run: |
         for filename in dist/*.deb; do
           # armv6 and armv7 are both "armhf" so we can skip the duplicate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,6 @@ jobs:
     - name: Unshallowify the repo clone
       run: git fetch --prune --unshallow
 
-    # Cloudsmith CLI tooling for pushing releases
-    - name: Install Cloudsmith CLI
-      run: pip install --upgrade cloudsmith-cli
-
     # https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
     - name: Print Go version and environment
       id: vars
@@ -45,6 +41,9 @@ jobs:
         echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
         echo "::set-output name=go_cache::$(go env GOCACHE)"
 
+        # Add "pip install" CLI tools to PATH
+        echo ~/.local/bin >> $GITHUB_PATH
+
         # Parse semver
         TAG=${GITHUB_REF/refs\/tags\//}
         SEMVER_RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z\.-]*\)'
@@ -56,6 +55,11 @@ jobs:
         echo "::set-output name=tag_minor::${TAG_MINOR}"
         echo "::set-output name=tag_patch::${TAG_PATCH}"
         echo "::set-output name=tag_special::${TAG_SPECIAL}"
+
+    # Cloudsmith CLI tooling for pushing releases
+    # See https://help.cloudsmith.io/docs/cli
+    - name: Install Cloudsmith CLI
+      run: pip install --upgrade cloudsmith-cli
 
     - name: Validate commits and tag signatures
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ jobs:
     - name: Unshallowify the repo clone
       run: git fetch --prune --unshallow
 
+    # Cloudsmith CLI tooling for pushing releases
+    - name: Install Cloudsmith CLI
+      run: pip install --upgrade cloudsmith-cli
+
     # https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
     - name: Print Go version and environment
       id: vars
@@ -88,6 +92,52 @@ jobs:
         GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}
       run: |
         for filename in dist/*.deb; do
+          # armv6 and armv7 are both "armhf" so we can skip the duplicate
+          if [[ "$filename" == *"armv7"* ]]; then
+            echo "Skipping $filename"
+            continue
+          fi
+
           curl -F package=@"$filename" https://${GEMFURY_PUSH_TOKEN}:@push.fury.io/caddy/
         done
 
+    # Publish only special tags (unstable/beta/rc) to the "testing" repo
+    # See https://cloudsmith.io/~caddy/repos/testing/
+    - name: Publish .deb to Cloudsmith (special tags)
+      if: ${{ steps.vars.outputs.tag_special != '' }}
+      env:
+        # TODO:
+        # CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+      run: |
+        for filename in dist/*.deb; do
+          # armv6 and armv7 are both "armhf" so we can skip the duplicate
+          if [[ "$filename" == *"armv7"* ]]; then
+            echo "Skipping $filename"
+            continue
+          fi
+
+          echo "Pushing $filename to 'testing'"
+          cloudsmith push deb caddy/testing/any-distro/any-version $filename
+        done
+
+    # Publish stable tags to Cloudsmith to both repos, "stable" and "testing"
+    # See https://cloudsmith.io/~caddy/repos/stable/
+    - name: Publish .deb to Cloudsmith (stable tags)
+      if: ${{ steps.vars.outputs.tag_special == '' }}
+      env:
+        # TODO:
+        # CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+      run: |
+        for filename in dist/*.deb; do
+          # armv6 and armv7 are both "armhf" so we can skip the duplicate
+          if [[ "$filename" == *"armv7"* ]]; then
+            echo "Skipping $filename"
+            continue
+          fi
+
+          echo "Pushing $filename to 'stable'"
+          cloudsmith push deb caddy/stable/any-distro/any-version $filename
+
+          echo "Pushing $filename to 'testing'"
+          cloudsmith push deb caddy/testing/any-distro/any-version $filename
+        done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
       run: |
         for filename in dist/*.deb; do
           # armv6 and armv7 are both "armhf" so we can skip the duplicate
-          if [[ "$filename" == *"armv7"* ]]; then
+          if [[ "$filename" == *"armv6"* ]]; then
             echo "Skipping $filename"
             continue
           fi
@@ -117,7 +117,7 @@ jobs:
       run: |
         for filename in dist/*.deb; do
           # armv6 and armv7 are both "armhf" so we can skip the duplicate
-          if [[ "$filename" == *"armv7"* ]]; then
+          if [[ "$filename" == *"armv6"* ]]; then
             echo "Skipping $filename"
             continue
           fi
@@ -135,7 +135,7 @@ jobs:
       run: |
         for filename in dist/*.deb; do
           # armv6 and armv7 are both "armhf" so we can skip the duplicate
-          if [[ "$filename" == *"armv7"* ]]; then
+          if [[ "$filename" == *"armv6"* ]]; then
             echo "Skipping $filename"
             continue
           fi

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 	<br>
 	<a href="https://twitter.com/caddyserver" title="@caddyserver on Twitter"><img src="https://img.shields.io/badge/twitter-@caddyserver-55acee.svg" alt="@caddyserver on Twitter"></a>
 	<a href="https://caddy.community" title="Caddy Forum"><img src="https://img.shields.io/badge/community-forum-ff69b4.svg" alt="Caddy Forum"></a>
+	<br>
 	<a href="https://sourcegraph.com/github.com/caddyserver/caddy?badge" title="Caddy on Sourcegraph"><img src="https://sourcegraph.com/github.com/caddyserver/caddy/-/badge.svg" alt="Caddy on Sourcegraph"></a>
+	<a href="https://cloudsmith.io/~caddy/repos/"><img src="https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith" alt="Cloudsmith"></a>
 </p>
 <p align="center">
 	<a href="https://github.com/caddyserver/caddy/releases">Releases</a> ·
@@ -188,3 +190,5 @@ Please use our [issue tracker](https://github.com/caddyserver/caddy/issues) only
 - _Author on Twitter: [@mholt6](https://twitter.com/mholt6)_
 
 Caddy is a project of [ZeroSSL](https://zerossl.com), an [apilayer](https://apilayer.com) company.
+
+Debian package repository hosting is graciously provided by [Cloudsmith](https://cloudsmith.com). Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that enables your organization to create, store and share packages in any format, to any place, with total confidence.


### PR DESCRIPTION
See https://github.com/caddyserver/dist/issues/49

Still needs `CLOUDSMITH_API_KEY` to be added to the repo/org @mholt, I don't remember if you've done it already? Please let me know 😄 leaving as draft until that's confirmed and my TODO is fixed.

Also adds a condition to skip the `caddy_<version>_linux_armv7.deb` because Cloudsmith would complain and Gemfury would have it override the `armv6` one, because apparently they're both `armhf`. But maybe we should skip the `armv6` one instead of `armv7`? I don't know. I assume the `armv6` one would be more compatible 🤷‍♂️ but I don't know anything about ARM arch differences.