### PR TITLE
reverseproxy: Caddyfile health check headers, host header support

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_health_headers.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_health_headers.txt
@@ -1,0 +1,49 @@
+:8884
+
+reverse_proxy 127.0.0.1:65535 {
+    health_headers {
+        Host example.com
+        X-Header-Keys VbG4NZwWnipo 335Q9/MhqcNU3s2TO
+    }
+}
+----------
+{
+    "apps": {
+        "http": {
+            "servers": {
+                "srv0": {
+                    "listen": [
+                        ":8884"
+                    ],
+                    "routes": [
+                        {
+                            "handle": [
+                                {
+                                    "handler": "reverse_proxy",
+                                    "health_checks": {
+                                        "active": {
+                                            "headers": {
+                                                "Host": [
+                                                    "example.com"
+                                                ],
+                                                "X-Header-Keys": [
+                                                    "VbG4NZwWnipo",
+                                                    "335Q9/MhqcNU3s2TO"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "upstreams": [
+                                        {
+                                            "dial": "127.0.0.1:65535"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_health_headers.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_health_headers.txt
@@ -3,7 +3,9 @@
 reverse_proxy 127.0.0.1:65535 {
 	health_headers {
 		Host example.com
+		X-Header-Key 95ca39e3cbe7
 		X-Header-Keys VbG4NZwWnipo 335Q9/MhqcNU3s2TO
+		X-Empty-Value
 	}
 }
 ----------
@@ -25,6 +27,12 @@ reverse_proxy 127.0.0.1:65535 {
 											"headers": {
 												"Host": [
 													"example.com"
+												],
+												"X-Empty-Value": [
+													""
+												],
+												"X-Header-Key": [
+													"95ca39e3cbe7"
 												],
 												"X-Header-Keys": [
 													"VbG4NZwWnipo",

--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_health_headers.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_health_headers.txt
@@ -1,49 +1,49 @@
 :8884
 
 reverse_proxy 127.0.0.1:65535 {
-    health_headers {
-        Host example.com
-        X-Header-Keys VbG4NZwWnipo 335Q9/MhqcNU3s2TO
-    }
+	health_headers {
+		Host example.com
+		X-Header-Keys VbG4NZwWnipo 335Q9/MhqcNU3s2TO
+	}
 }
 ----------
 {
-    "apps": {
-        "http": {
-            "servers": {
-                "srv0": {
-                    "listen": [
-                        ":8884"
-                    ],
-                    "routes": [
-                        {
-                            "handle": [
-                                {
-                                    "handler": "reverse_proxy",
-                                    "health_checks": {
-                                        "active": {
-                                            "headers": {
-                                                "Host": [
-                                                    "example.com"
-                                                ],
-                                                "X-Header-Keys": [
-                                                    "VbG4NZwWnipo",
-                                                    "335Q9/MhqcNU3s2TO"
-                                                ]
-                                            }
-                                        }
-                                    },
-                                    "upstreams": [
-                                        {
-                                            "dial": "127.0.0.1:65535"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            }
-        }
-    }
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8884"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "reverse_proxy",
+									"health_checks": {
+										"active": {
+											"headers": {
+												"Host": [
+													"example.com"
+												],
+												"X-Header-Keys": [
+													"VbG4NZwWnipo",
+													"335Q9/MhqcNU3s2TO"
+												]
+											}
+										}
+									},
+									"upstreams": [
+										{
+											"dial": "127.0.0.1:65535"
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
 }

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -63,7 +63,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 //         health_status <status>
 //         health_body <regexp>
 //         health_headers {
-//             <field> <value>
+//             <field> [<values...>]
 //         }
 //
 //         # passive health checking

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"runtime/debug"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/caddyserver/caddy/v2"
@@ -241,7 +242,11 @@ func (h *Handler) doActiveHealthCheck(dialInfo DialInfo, hostAddr string, host H
 		return fmt.Errorf("making request: %v", err)
 	}
 	for key, hdrs := range h.HealthChecks.Active.Headers {
-		req.Header[key] = hdrs
+		if strings.ToLower(key) == "host" {
+			req.Host = h.HealthChecks.Active.Headers.Get(key)
+		} else {
+			req.Header[key] = hdrs
+		}
 	}
 
 	// do the request, being careful to tame the response body


### PR DESCRIPTION
reverse_proxy:
health check headers can be set through Caddyfile using health_headers directive
health check header host can be set properly