### PR TITLE
caddytls: add 'key_type' subdirective

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -87,7 +87,7 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 	var folderLoader caddytls.FolderLoader
 	var certSelector caddytls.CustomCertSelectionPolicy
 	var acmeIssuer *caddytls.ACMEIssuer
-	var autoPolicy *caddytls.AutomationPolicy
+	var keyType *string
 	var internalIssuer *caddytls.InternalIssuer
 	var issuers []certmagic.Issuer
 	var onDemand bool
@@ -273,10 +273,7 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 				if len(arg) != 1 {
 					return nil, h.ArgErr()
 				}
-				if autoPolicy == nil {
-					autoPolicy = new(caddytls.AutomationPolicy)
-				}
-				autoPolicy.KeyType = arg[0]
+				*keyType = arg[0]
 
 			case "eab":
 				arg := h.RemainingArgs()
@@ -395,10 +392,10 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 		})
 	}
 
-	if autoPolicy != nil {
+	if keyType != nil {
 		configVals = append(configVals, ConfigValue{
 			Class: "tls.key_type",
-			Value: autoPolicy.KeyType,
+			Value: *keyType,
 		})
 	}
 

--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -87,6 +87,7 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 	var folderLoader caddytls.FolderLoader
 	var certSelector caddytls.CustomCertSelectionPolicy
 	var acmeIssuer *caddytls.ACMEIssuer
+	var autoPolicy *caddytls.AutomationPolicy
 	var internalIssuer *caddytls.InternalIssuer
 	var issuers []certmagic.Issuer
 	var onDemand bool
@@ -267,6 +268,16 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 				}
 				acmeIssuer.CA = arg[0]
 
+			case "key_type":
+				arg := h.RemainingArgs()
+				if len(arg) != 1 {
+					return nil, h.ArgErr()
+				}
+				if autoPolicy == nil {
+					autoPolicy = new(caddytls.AutomationPolicy)
+				}
+				autoPolicy.KeyType = arg[0]
+
 			case "eab":
 				arg := h.RemainingArgs()
 				if len(arg) != 2 {
@@ -394,6 +405,13 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 		configVals = append(configVals, ConfigValue{
 			Class: "tls.cert_issuer",
 			Value: internalIssuer,
+		})
+	}
+
+	if autoPolicy != nil {
+		configVals = append(configVals, ConfigValue{
+			Class: "tls.key_type",
+			Value: autoPolicy.KeyType,
 		})
 	}
 

--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -87,7 +87,7 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 	var folderLoader caddytls.FolderLoader
 	var certSelector caddytls.CustomCertSelectionPolicy
 	var acmeIssuer *caddytls.ACMEIssuer
-	var keyType *string
+	var keyType string
 	var internalIssuer *caddytls.InternalIssuer
 	var issuers []certmagic.Issuer
 	var onDemand bool
@@ -273,7 +273,7 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 				if len(arg) != 1 {
 					return nil, h.ArgErr()
 				}
-				*keyType = arg[0]
+				keyType = arg[0]
 
 			case "eab":
 				arg := h.RemainingArgs()
@@ -392,10 +392,10 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 		})
 	}
 
-	if keyType != nil {
+	if keyType != "" {
 		configVals = append(configVals, ConfigValue{
 			Class: "tls.key_type",
-			Value: *keyType,
+			Value: keyType,
 		})
 	}
 

--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -108,6 +108,10 @@ func (st ServerType) buildTLSApp(
 				ap.OnDemand = true
 			}
 
+			if keyTypeVals, ok := sblock.pile["tls.key_type"]; ok {
+				ap.KeyType = keyTypeVals[0].Value.(string)
+			}
+
 			// certificate issuers
 			if issuerVals, ok := sblock.pile["tls.cert_issuer"]; ok {
 				var issuers []certmagic.Issuer

--- a/caddytest/integration/caddyfile_adapt/tls_automation_policies_2.txt
+++ b/caddytest/integration/caddyfile_adapt/tls_automation_policies_2.txt
@@ -7,6 +7,7 @@
 example.com {
 	tls {
 		on_demand
+		key_type rsa2048
 	}
 }
 
@@ -79,6 +80,7 @@ http://example.net {
 								"module": "zerossl"
 							}
 						],
+						"key_type": "rsa2048",
 						"on_demand": true
 					},
 					{


### PR DESCRIPTION
It seems that `key_type` subdirective it's not implemented in v2. I don't know if this is intentional but I needed this ASAP and I implemented it myself. Here is the code if you are interested