### PR TITLE
Allow Caddyfile configuration of arbitrary loggers, add new replace log filter

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -548,18 +548,32 @@ func parseHandleErrors(h Helper) ([]ConfigValue, error) {
 
 // parseLog parses the log directive. Syntax:
 //
-//     log {
-//         output <writer_module> ...
-//         format <encoder_module> ...
-//         level  <level>
+//     log [name] {
+//         output  <writer_module> ...
+//         format  <encoder_module> ...
+//         level   <level>
+//         include <namespaces...>
+//         exclude <namespaces...>
 //     }
+//
+// When the name argument is unspecified, this directive modifies the HTTP
+// access logs and adds an include for that namespace.
+//
+// Specifying the name "default" will modify the default logger used globally
+// within Caddy.
 //
 func parseLog(h Helper) ([]ConfigValue, error) {
 	var configValues []ConfigValue
 	for h.Next() {
-		// log does not currently support any arguments
+		var logName string
 		if h.NextArg() {
-			return nil, h.ArgErr()
+			// Allow for a log name to be specified,
+			logName = h.Val()
+
+			// Only a single argument is supported.
+			if h.NextArg() {
+				return nil, h.ArgErr()
+			}
 		}
 
 		cl := new(caddy.CustomLog)
@@ -623,19 +637,39 @@ func parseLog(h Helper) ([]ConfigValue, error) {
 					return nil, h.ArgErr()
 				}
 
+			case "include":
+				if !h.NextArg() {
+					return nil, h.ArgErr()
+				}
+				for h.NextArg() {
+					cl.Include = append(cl.Include, h.Val())
+				}
+
+			case "exclude":
+				if !h.NextArg() {
+					return nil, h.ArgErr()
+				}
+				for h.NextArg() {
+					cl.Exclude = append(cl.Exclude, h.Val())
+				}
+
 			default:
 				return nil, h.Errf("unrecognized subdirective: %s", h.Val())
 			}
 		}
 
 		var val namedCustomLog
-		if !reflect.DeepEqual(cl, new(caddy.CustomLog)) {
+		if logName != "" {
+			// If a target name is specified, use it.
+			val.name = logName
+			val.log = cl
+		} else if !reflect.DeepEqual(cl, new(caddy.CustomLog)) {
 			logCounter, ok := h.State["logCounter"].(int)
 			if !ok {
 				logCounter = 0
 			}
 			val.name = fmt.Sprintf("log%d", logCounter)
-			cl.Include = []string{"http.log.access." + val.name}
+			cl.Include = append(cl.Include, "http.log.access."+val.name)
 			val.log = cl
 			logCounter++
 			h.State["logCounter"] = logCounter

--- a/caddyconfig/httpcaddyfile/builtins_test.go
+++ b/caddyconfig/httpcaddyfile/builtins_test.go
@@ -30,7 +30,37 @@ func TestLogDirectiveSyntax(t *testing.T) {
 		},
 		{
 			input: `:8080 {
-				log /foo {
+				log {
+					format filter {
+						wrap console
+						fields {
+							common_log delete
+							request>remote_addr ip_mask {
+								ipv4 24
+								ipv6 32
+							}
+						}
+					}
+				}
+			}
+			`,
+			expectError: false,
+		},
+		{
+			input: `:8080 {
+				log {
+					output file foo.log
+				}
+				log default {
+					format json
+				}
+			}
+			`,
+			expectError: false,
+		},
+		{
+			input: `:8080 {
+				log example /foo {
 					output file foo.log
 				}
 			}

--- a/caddytest/integration/caddyfile_adapt/log_filters.txt
+++ b/caddytest/integration/caddyfile_adapt/log_filters.txt
@@ -5,7 +5,7 @@ log {
 	format filter {
 		wrap console
 		fields {
-			request>headers>Authorization delete
+			request>headers>Authorization replace REDACTED
 			request>headers>Server delete
 			request>remote_addr ip_mask {
 				ipv4 24
@@ -30,7 +30,8 @@ log {
 				"encoder": {
 					"fields": {
 						"request\u003eheaders\u003eAuthorization": {
-							"filter": "delete"
+							"filter": "replace",
+							"value": "REDACTED"
 						},
 						"request\u003eheaders\u003eServer": {
 							"filter": "delete"

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -25,6 +25,7 @@ import (
 
 func init() {
 	caddy.RegisterModule(DeleteFilter{})
+	caddy.RegisterModule(ReplaceFilter{})
 	caddy.RegisterModule(IPMaskFilter{})
 }
 
@@ -54,6 +55,37 @@ func (DeleteFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 // Filter filters the input field.
 func (DeleteFilter) Filter(in zapcore.Field) zapcore.Field {
 	in.Type = zapcore.SkipType
+	return in
+}
+
+// ReplaceFilter is a Caddy log field filter that
+// replaces the field with the indicated string.
+type ReplaceFilter struct {
+	Value string `json:"value,omitempty"`
+}
+
+// CaddyModule returns the Caddy module information.
+func (ReplaceFilter) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "caddy.logging.encoders.filter.replace",
+		New: func() caddy.Module { return new(ReplaceFilter) },
+	}
+}
+
+// UnmarshalCaddyfile sets up the module from Caddyfile tokens.
+func (f *ReplaceFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		if d.NextArg() {
+			f.Value = d.Val()
+		}
+	}
+	return nil
+}
+
+// Filter filters the input field with the replacement value.
+func (f *ReplaceFilter) Filter(in zapcore.Field) zapcore.Field {
+	in.Type = zapcore.StringType
+	in.String = f.Value
 	return in
 }
 


### PR DESCRIPTION
This PR follows up on discussion in https://github.com/caddyserver/caddy/issues/3958 about adding more functionality to the Caddyfile. I also added in another commit for a small new "replace" filter aimed at the same goal as I wrote up in the original ticket, providing more tools to remove sensitive data from logs.

Closes https://github.com/caddyserver/caddy/issues/3958