### PR TITLE
(v2.3.0 base, temporary) Allow Caddyfile configuration of arbitrary loggers, add new replace log filter

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins_test.go
+++ b/caddyconfig/httpcaddyfile/builtins_test.go
@@ -33,7 +33,39 @@ func TestLogDirectiveSyntax(t *testing.T) {
 		},
 		{
 			input: `:8080 {
-				log /foo {
+				log {
+					format filter {
+						wrap console
+						fields {
+							common_log delete
+							request>remote_addr ip_mask {
+								ipv4 24
+								ipv6 32
+							}
+						}
+					}
+				}
+			}
+			`,
+			expectWarn:  false,
+			expectError: false,
+		},
+		{
+			input: `:8080 {
+				log {
+					output file foo.log
+				}
+				log default {
+					format json
+				}
+			}
+			`,
+			expectWarn:  false,
+			expectError: false,
+		},
+		{
+			input: `:8080 {
+				log example /foo {
 					output file foo.log
 				}
 			}

--- a/caddytest/integration/caddyfile_adapt/log_filters.txt
+++ b/caddytest/integration/caddyfile_adapt/log_filters.txt
@@ -5,7 +5,7 @@ log {
 	format filter {
 		wrap console
 		fields {
-			request>headers>Authorization delete
+			request>headers>Authorization replace REDACTED
 			request>headers>Server delete
 			request>remote_addr ip_mask {
 				ipv4 24
@@ -30,7 +30,8 @@ log {
 				"encoder": {
 					"fields": {
 						"request\u003eheaders\u003eAuthorization": {
-							"filter": "delete"
+							"filter": "replace",
+							"value": "REDACTED"
 						},
 						"request\u003eheaders\u003eServer": {
 							"filter": "delete"

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -25,6 +25,7 @@ import (
 
 func init() {
 	caddy.RegisterModule(DeleteFilter{})
+	caddy.RegisterModule(ReplaceFilter{})
 	caddy.RegisterModule(IPMaskFilter{})
 }
 
@@ -54,6 +55,37 @@ func (DeleteFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 // Filter filters the input field.
 func (DeleteFilter) Filter(in zapcore.Field) zapcore.Field {
 	in.Type = zapcore.SkipType
+	return in
+}
+
+// ReplaceFilter is a Caddy log field filter that
+// replaces the field with the indicated string.
+type ReplaceFilter struct {
+	Value string `json:"value,omitempty"`
+}
+
+// CaddyModule returns the Caddy module information.
+func (ReplaceFilter) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "caddy.logging.encoders.filter.replace",
+		New: func() caddy.Module { return new(ReplaceFilter) },
+	}
+}
+
+// UnmarshalCaddyfile sets up the module from Caddyfile tokens.
+func (f *ReplaceFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		if d.NextArg() {
+			f.Value = d.Val()
+		}
+	}
+	return nil
+}
+
+// Filter filters the input field with the replacement value.
+func (f *ReplaceFilter) Filter(in zapcore.Field) zapcore.Field {
+	in.Type = zapcore.StringType
+	in.String = f.Value
 	return in
 }
 


### PR DESCRIPTION
This is a temporary PR to keep track of a branch with the same changes as https://github.com/caddyserver/caddy/pull/3968, except for that it is based off of the v2.3.0 tag so that it can be tested against other systems without incorporating unreleased changes in that testing process.