### PR TITLE
caddycmd: Add upgrade command

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -277,6 +277,15 @@ is always printed to stdout.`,
 		}(),
 	})
 
+	RegisterCommand(Command{
+		Name:  "upgrade",
+		Func:  cmdUpgrade,
+		Short: "Upgrade Caddy (EXPERIMENTAL)",
+		Long: `
+Downloads an updated Caddy binary with the same modules/plugins at the
+latest versions. EXPERIMENTAL: May be changed or removed.`,
+	})
+
 }
 
 // RegisterCommand registers the command cmd.

--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -14,10 +14,12 @@
 
 package caddycmd
 
+// NotifyReadiness notifies process manager of readiness.
 func NotifyReadiness() error {
 	return notifyReadiness()
 }
 
+// NotifyReloading notifies process manager of reloading.
 func NotifyReloading() error {
 	return notifyReloading()
 }


### PR DESCRIPTION
I was getting stuck/frustrated on another feature I have planned for Caddy 2.4, so I took a quick break and threw this together, from my own personal wishlist which I expressed in a tweet recently: https://twitter.com/mholt6/status/1349186705002151937

The `caddy upgrade` command replaces the current Caddy executable with a new one from the build server. It honors custom builds, as long as all the plugins are registered on the Caddy website. Of course, this requires permissions to replace current executable. You might have to run `sudo caddy upgrade`.

This is very experimental but I figure we can merge this in sooner or later and have people try it out and offer feedback.

There's more we could do here, like allowing the user to customize versions and/or just download the binary without replacing the current one, and/or just print the download URL, even.

Please give it a try!

Here's my log, for illustration:

```
$ go run main.go upgrade
2021/01/13 22:22:49.201 INFO    this executable will be replaced        {"path": "/tmp/go-build129556065/b001/exe/main"}
2021/01/13 22:22:49.201 INFO    found non-standard module       {"id": "http.handlers.webdav", "package": "github.com/mholt/caddy-webdav"}
2021/01/13 22:22:49.201 INFO    requesting build        {"os": "linux", "arch": "amd64", "packages": ["github.com/mholt/caddy-webdav"]}
2021/01/13 22:22:49.386 INFO    build acquired; backing up current executable   {"current_path": "/tmp/go-build129556065/b001/exe/main", "backup_path": "/tmp/go-build129556065/b001/exe/main.tmp"}
2021/01/13 22:22:49.386 INFO    downloading binary      {"source": "https://caddyserver.com/api/download?arch=amd64&os=linux&p=github.com%2Fmholt%2Fcaddy-webdav", "destination": "/tmp/go-build129556065/b001/exe/main"}

Module versions:

admin.api.load v2.3.0
admin.api.metrics v2.3.0
caddy.adapters.caddyfile v2.3.0
caddy.listeners.tls v2.3.0
caddy.logging.encoders.console v2.3.0
caddy.logging.encoders.filter v2.3.0
caddy.logging.encoders.filter.delete v2.3.0
caddy.logging.encoders.filter.ip_mask v2.3.0
caddy.logging.encoders.json v2.3.0
caddy.logging.encoders.logfmt v2.3.0
caddy.logging.encoders.single_field v2.3.0
caddy.logging.writers.discard v2.3.0
caddy.logging.writers.file v2.3.0
caddy.logging.writers.net v2.3.0
caddy.logging.writers.stderr v2.3.0
caddy.logging.writers.stdout v2.3.0
caddy.storage.file_system v2.3.0
http v2.3.0
http.authentication.hashes.bcrypt v2.3.0
http.authentication.hashes.scrypt v2.3.0
http.authentication.providers.http_basic v2.3.0
http.encoders.gzip v2.3.0
http.encoders.zstd v2.3.0
http.handlers.acme_server v2.3.0
http.handlers.authentication v2.3.0
http.handlers.encode v2.3.0
http.handlers.error v2.3.0
http.handlers.file_server v2.3.0
http.handlers.headers v2.3.0
http.handlers.map v2.3.0
http.handlers.metrics v2.3.0
http.handlers.push v2.3.0
http.handlers.request_body v2.3.0
http.handlers.reverse_proxy v2.3.0
http.handlers.rewrite v2.3.0
http.handlers.static_response v2.3.0
http.handlers.subroute v2.3.0
http.handlers.templates v2.3.0
http.handlers.vars v2.3.0
http.handlers.webdav v0.0.0-20200916200058-c949b3226234
http.matchers.expression v2.3.0
http.matchers.file v2.3.0
http.matchers.header v2.3.0
http.matchers.header_regexp v2.3.0
http.matchers.host v2.3.0
http.matchers.method v2.3.0
http.matchers.not v2.3.0
http.matchers.path v2.3.0
http.matchers.path_regexp v2.3.0
http.matchers.protocol v2.3.0
http.matchers.query v2.3.0
http.matchers.remote_ip v2.3.0
http.matchers.vars v2.3.0
http.matchers.vars_regexp v2.3.0
http.reverse_proxy.selection_policies.cookie v2.3.0
http.reverse_proxy.selection_policies.first v2.3.0
http.reverse_proxy.selection_policies.header v2.3.0
http.reverse_proxy.selection_policies.ip_hash v2.3.0
http.reverse_proxy.selection_policies.least_conn v2.3.0
http.reverse_proxy.selection_policies.random v2.3.0
http.reverse_proxy.selection_policies.random_choose v2.3.0
http.reverse_proxy.selection_policies.round_robin v2.3.0
http.reverse_proxy.selection_policies.uri_hash v2.3.0
http.reverse_proxy.transport.fastcgi v2.3.0
http.reverse_proxy.transport.http v2.3.0
pki v2.3.0
tls v2.3.0
tls.certificates.automate v2.3.0
tls.certificates.load_files v2.3.0
tls.certificates.load_folders v2.3.0
tls.certificates.load_pem v2.3.0
tls.handshake_match.sni v2.3.0
tls.issuance.acme v2.3.0
tls.issuance.internal v2.3.0
tls.issuance.zerossl v2.3.0
tls.stek.distributed v2.3.0
tls.stek.standard v2.3.0

Version:
v2.3.0 h1:fnrqJLa3G5vfxcxmOH/+kJOcunPLhSBnjgIvjXV/QTA=

2021/01/13 22:22:50.544 INFO    upgrade successful; please restart any running Caddy instances  {"executable": "/tmp/go-build129556065/b001/exe/main"}
```