### PR TITLE
support function map for custom template of browse

### DIFF
--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Masterminds/sprig/v3"
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"go.uber.org/zap"
@@ -106,7 +107,9 @@ func (fsrv *FileServer) Provision(ctx caddy.Context) error {
 		var tpl *template.Template
 		var err error
 		if fsrv.Browse.TemplateFile != "" {
-			tpl, err = template.ParseFiles(fsrv.Browse.TemplateFile)
+			tpl = template.New("custom_listing")
+			tpl.Funcs(sprig.HtmlFuncMap())
+			tpl, err = tpl.ParseFiles(fsrv.Browse.TemplateFile)
 			if err != nil {
 				return fmt.Errorf("parsing browse template file: %v", err)
 			}


### PR DESCRIPTION
I have a requirement to use `github.com/Masterminds/sprig/v3.hasSuffix` function in my custom static browse template file.