### PR TITLE
caddyhttp: Implement handler abort; new 'abort' directive (close #3871)

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -40,6 +40,7 @@ func init() {
 	RegisterHandlerDirective("root", parseRoot)
 	RegisterHandlerDirective("redir", parseRedir)
 	RegisterHandlerDirective("respond", parseRespond)
+	RegisterHandlerDirective("abort", parseAbort)
 	RegisterHandlerDirective("route", parseRoute)
 	RegisterHandlerDirective("handle", parseHandle)
 	RegisterDirective("handle_errors", parseHandleErrors)
@@ -500,6 +501,15 @@ func parseRespond(h Helper) (caddyhttp.MiddlewareHandler, error) {
 		return nil, err
 	}
 	return sr, nil
+}
+
+// parseAbort parses the abort directive.
+func parseAbort(h Helper) (caddyhttp.MiddlewareHandler, error) {
+	h.Next() // consume directive
+	for h.Next() || h.NextBlock(0) {
+		return nil, h.ArgErr()
+	}
+	return &caddyhttp.StaticResponse{Abort: true}, nil
 }
 
 // parseRoute parses the route directive.

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -63,6 +63,7 @@ var directiveOrder = []string{
 	"push",
 
 	// handlers that typically respond to requests
+	"abort",
 	"respond",
 	"metrics",
 	"reverse_proxy",


### PR DESCRIPTION
This adds the `abort` option to the `static_response` handler, which immediately, forcefully closes a connection without wwriting a response.

It also adds a simple `abort` directive, instead of adding this functionality to the existing `respond` directive, because this behavior does not actually respond: it prevents a response.

Closes #3871

/cc @SvenDowideit and @segevfiner