### PR TITLE
Fix html redir code, improve flow

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -490,7 +490,7 @@ func parseRedir(h Helper) (caddyhttp.MiddlewareHandler, error) {
 		if err != nil {
 			return nil, h.Errf("Not a supported redir code type or not valid integer: '%s'", code)
 		}
-		if codeInt < 300 && codeInt > 399 {
+		if codeInt < 300 || codeInt > 399 {
 			return nil, h.Errf("Redir code not in the 3xx range: '%v'", codeInt)
 		}
 	}

--- a/caddyconfig/httpcaddyfile/builtins_test.go
+++ b/caddyconfig/httpcaddyfile/builtins_test.go
@@ -51,3 +51,125 @@ func TestLogDirectiveSyntax(t *testing.T) {
 		}
 	}
 }
+
+func TestRedirDirectiveSyntax(t *testing.T) {
+	for i, tc := range []struct {
+		input       string
+		expectError bool
+	}{
+		{
+			input: `:8080 {
+				redir :8081
+			}`,
+			expectError: false,
+		},
+		{
+			input: `:8080 {
+				redir * :8081
+			}`,
+			expectError: false,
+		},
+		{
+			input: `:8080 {
+				redir /api/* :8081 300
+			}`,
+			expectError: false,
+		},
+		{
+			input: `:8080 {
+				redir :8081 300
+			}`,
+			expectError: false,
+		},
+		{
+			input: `:8080 {
+				redir /api/* :8081 399
+			}`,
+			expectError: false,
+		},
+		{
+			input: `:8080 {
+				redir :8081 399
+			}`,
+			expectError: false,
+		},
+		{
+			input: `:8080 {
+				redir /old.html /new.html
+			}`,
+			expectError: false,
+		},
+		{
+			input: `:8080 {
+				redir /old.html /new.html temporary
+			}`,
+			expectError: false,
+		},
+		{
+			input: `:8080 {
+				redir https://example.com{uri} permanent
+			}`,
+			expectError: false,
+		},
+		{
+			input: `:8080 {
+				redir /old.html /new.html permanent
+			}`,
+			expectError: false,
+		},
+		{
+			input: `:8080 {
+				redir /old.html /new.html html
+			}`,
+			expectError: false,
+		},
+		{
+			input: `:8080 {
+				redir /old.html /new.html htlm
+			}`,
+			expectError: true,
+		},
+		{
+			input: `:8080 {
+				redir * :8081 200
+			}`,
+			expectError: true,
+		},
+		{
+			input: `:8080 {
+				redir * :8081 400
+			}`,
+			expectError: true,
+		},
+		{
+			input: `:8080 {
+				redir * :8081 temp
+			}`,
+			expectError: true,
+		},
+		{
+			input: `:8080 {
+				redir * :8081 perm
+			}`,
+			expectError: true,
+		},
+		{
+			input: `:8080 {
+				redir * :8081 php
+			}`,
+			expectError: true,
+		},
+	} {
+
+		adapter := caddyfile.Adapter{
+			ServerType: ServerType{},
+		}
+
+		_, _, err := adapter.Adapt([]byte(tc.input), nil)
+
+		if err != nil != tc.expectError {
+			t.Errorf("Test %d error expectation failed Expected: %v, got %s", i, tc.expectError, err)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3979

Changes confirmed working with `html` redir code.

```
user@pc ~ $ curl -i -G https://hostname.com/
HTTP/2 302
location: https://www.hostname.com/
server: Caddy
content-length: 334
date: Sat, 23 Jan 2021 04:28:18 GMT

<!DOCTYPE html>
<html>
	<head>
		<title>Redirecting...</title>
		<script>window.location.replace("https://www.hostname.com/");</script>
		<meta http-equiv="refresh" content="0; URL='https://www.hostname.com/'">
	</head>
	<body>Redirecting to <a href="https://www.hostname.com/">https://www.hostname.com/</a>...</body>
</html>
```