### PR TITLE
httpcaddyfile: Make third-party app modules configurable via globals

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -36,6 +36,17 @@ func init() {
 	caddyconfig.RegisterAdapter("caddyfile", caddyfile.Adapter{ServerType: ServerType{}})
 }
 
+// App represents the configuration for a non-standard
+// Caddy app module (e.g. third-party plugin) which was
+// parsed from a global options block.
+type App struct {
+	// The JSON key for the app being configured
+	Name string
+
+	// The raw app config as JSON
+	Value json.RawMessage
+}
+
 // ServerType can set up a config from an HTTP Caddyfile.
 type ServerType struct {
 }
@@ -260,6 +271,17 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 
 	// annnd the top-level config, then we're done!
 	cfg := &caddy.Config{AppsRaw: make(caddy.ModuleMap)}
+
+	// loop through the configured options, and if any of
+	// them are an httpcaddyfile App, then we insert them
+	// into the config as raw Caddy apps
+	for _, opt := range options {
+		if app, ok := opt.(App); ok {
+			cfg.AppsRaw[app.Name] = app.Value
+		}
+	}
+
+	// insert the standard Caddy apps into the config
 	if len(httpApp.Servers) > 0 {
 		cfg.AppsRaw["http"] = caddyconfig.JSON(httpApp, &warnings)
 	}


### PR DESCRIPTION
This is an attempt at solving #3634 in the simplest way I can think of.

/cc @abiosoft and @vrongmeal since you both have Caddy apps (`exec` and `git` respectively) which could make use of this.

So the idea here is that to make a third-party Caddy app configurable via the Caddyfile, it would be in global options. For example, take this Caddyfile config (taking inspiration from the https://github.com/abiosoft/caddy-exec README):

```
{
	exec {
		command hugo {
			args "generate" "--destination=/home/user/site/public"
			at startup
			foreground
			timeout 10s
		}
		command echo {
			args "foobar"
			at startup
		}
	}
}
```

A package would invoke `App("exec", parseExec)`, where `parseExec` has the signature `func parseExec(d *caddyfile.Dispenser, _ interface{}) (interface{}, error)`, but actually returns a `httpcaddyfile.App{AppKey: "exec", Value: json.RawMessage}`, where the json.RawMessage is the marshaled app module config struct.

Then, when the Caddyfile adapter nears the end, it'll grab any options that are `httpcaddyfile.App`, and insert them as-is into the config.

~~This _should_ do the trick, but I haven't tested it yet. Do you guys think this makes sense as an API?~~

Tested it with the `caddy-exec` lib in https://github.com/abiosoft/caddy-exec/pull/8 and it works!