### PR TITLE
caddyfile: reject cyclic imports

### DIFF
--- a/caddyconfig/caddyfile/importgraph.go
+++ b/caddyconfig/caddyfile/importgraph.go
@@ -1,0 +1,128 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddyfile
+
+import (
+	"fmt"
+	"log"
+)
+
+type adjacency map[string][]string
+
+type importGraph struct {
+	nodes map[string]bool
+	edges adjacency
+}
+
+func (i *importGraph) addNode(name string) {
+	if i.nodes == nil {
+		i.nodes = make(map[string]bool)
+	}
+	if _, exists := i.nodes[name]; exists {
+		return
+	}
+	i.nodes[name] = true
+}
+func (i *importGraph) addNodes(names []string) {
+	for _, name := range names {
+		i.addNode(name)
+	}
+}
+
+func (i *importGraph) removeNode(name string) {
+	delete(i.nodes, name)
+}
+func (i *importGraph) removeNodes(names []string) {
+	for _, name := range names {
+		i.removeNode(name)
+	}
+}
+
+func (i *importGraph) addEdge(from, to string) error {
+	if !i.exists(from) || !i.exists(to) {
+		return fmt.Errorf("one of the nodes does not exist")
+	}
+
+	if i.willCycle(to, from) {
+		return fmt.Errorf("a cycle of imports exists between %s and %s", from, to)
+	}
+
+	if i.areConnected(from, to) {
+		log.Printf("adjacency: %+v", i.edges)
+		return fmt.Errorf("the nodes (%s -> %s) are already connected", from, to)
+	}
+
+	if i.nodes == nil {
+		i.nodes = make(map[string]bool)
+	}
+	if i.edges == nil {
+		i.edges = make(adjacency)
+	}
+
+	i.edges[from] = append(i.edges[from], to)
+	return nil
+}
+func (i *importGraph) addEdges(from string, tos []string) error {
+	for _, to := range tos {
+		err := i.addEdge(from, to)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (i *importGraph) areConnected(from, to string) bool {
+	al, ok := i.edges[from]
+	if !ok {
+		return false
+	}
+	for _, v := range al {
+		if v == to {
+			return true
+		}
+	}
+	return false
+}
+
+func (i *importGraph) willCycle(from, to string) bool {
+	collector := make(map[string]bool)
+
+	var visit func(string)
+	visit = func(start string) {
+		if !collector[start] {
+			collector[start] = true
+			for _, v := range i.edges[start] {
+				visit(v)
+			}
+		}
+	}
+
+	for _, v := range i.edges[from] {
+		visit(v)
+	}
+	for k := range collector {
+		if to == k {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (i *importGraph) exists(key string) bool {
+	_, exists := i.nodes[key]
+	return exists
+}

--- a/caddyconfig/caddyfile/importgraph.go
+++ b/caddyconfig/caddyfile/importgraph.go
@@ -16,7 +16,6 @@ package caddyfile
 
 import (
 	"fmt"
-	"log"
 )
 
 type adjacency map[string][]string
@@ -60,8 +59,8 @@ func (i *importGraph) addEdge(from, to string) error {
 	}
 
 	if i.areConnected(from, to) {
-		log.Printf("adjacency: %+v", i.edges)
-		return fmt.Errorf("the nodes (%s -> %s) are already connected", from, to)
+		// if connected, there's nothing to do
+		return nil
 	}
 
 	if i.nodes == nil {

--- a/caddyconfig/caddyfile/lexer.go
+++ b/caddyconfig/caddyfile/lexer.go
@@ -38,8 +38,8 @@ type (
 		File        string
 		Line        int
 		Text        string
-		InSnippet   bool
-		SnippetName string
+		inSnippet   bool
+		snippetName string
 	}
 )
 

--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -355,6 +355,9 @@ func (p *parser) doImport() error {
 		// collect all the imported tokens
 
 		for _, importFile := range matches {
+			if absFile == importFile {
+				return p.Errf("Recursive self-import found: %s", absFile)
+			}
 			newTokens, err := p.doSingleImport(importFile)
 			if err != nil {
 				return err

--- a/caddyconfig/caddyfile/parse_test.go
+++ b/caddyconfig/caddyfile/parse_test.go
@@ -193,6 +193,9 @@ func TestParseOneAndImport(t *testing.T) {
 		{`import testdata/import_args1.txt a b`, false, []string{"a", "b"}, []int{}},
 		{`import testdata/import_args*.txt a b`, false, []string{"a"}, []int{2}},
 
+		// recursive self-import
+		{`import testdata/import_recursive0.txt`, true, []string{}, []int{}},
+
 		// test cases found by fuzzing!
 		{`import }{$"`, true, []string{}, []int{}},
 		{`import /*/*.txt`, true, []string{}, []int{}},

--- a/caddyconfig/caddyfile/parse_test.go
+++ b/caddyconfig/caddyfile/parse_test.go
@@ -450,7 +450,7 @@ func TestParseAll(t *testing.T) {
 		{`import testdata/import_recursive3.txt
 		import testdata/import_recursive1.txt`, true, [][]string{}},
 
-		// TODO: enable the tests once we figure out how to detect cyclic snippets
+		// cyclic imports
 		{`(A) {
 			import A
 		}

--- a/caddyconfig/caddyfile/parse_test.go
+++ b/caddyconfig/caddyfile/parse_test.go
@@ -193,9 +193,6 @@ func TestParseOneAndImport(t *testing.T) {
 		{`import testdata/import_args1.txt a b`, false, []string{"a", "b"}, []int{}},
 		{`import testdata/import_args*.txt a b`, false, []string{"a"}, []int{2}},
 
-		// recursive self-import
-		{`import testdata/import_recursive0.txt`, true, []string{}, []int{}},
-
 		// test cases found by fuzzing!
 		{`import }{$"`, true, []string{}, []int{}},
 		{`import /*/*.txt`, true, []string{}, []int{}},
@@ -447,6 +444,28 @@ func TestParseAll(t *testing.T) {
 
 		{`import notfound/*`, false, [][]string{}},        // glob needn't error with no matches
 		{`import notfound/file.conf`, true, [][]string{}}, // but a specific file should
+
+		// recursive self-import
+		{`import testdata/import_recursive0.txt`, true, [][]string{}},
+		{`import testdata/import_recursive3.txt
+		import testdata/import_recursive1.txt`, true, [][]string{}},
+
+		// TODO: enable the tests once we figure out how to detect cyclic snippets
+		{`(A) {
+			import A
+		}
+		:80
+		import A
+		`, true, [][]string{}},
+		{`(A) {
+			import B
+		}
+		(B) {
+			import A
+		}
+		:80
+		import A
+		`, true, [][]string{}},
 	} {
 		p := testParser(test.input)
 		blocks, err := p.parseAll()

--- a/caddyconfig/caddyfile/testdata/import_recursive0.txt
+++ b/caddyconfig/caddyfile/testdata/import_recursive0.txt
@@ -1,0 +1,1 @@
+import import_recursive0.txt

--- a/caddyconfig/caddyfile/testdata/import_recursive1.txt
+++ b/caddyconfig/caddyfile/testdata/import_recursive1.txt
@@ -1,0 +1,1 @@
+import import_recursive2.txt

--- a/caddyconfig/caddyfile/testdata/import_recursive2.txt
+++ b/caddyconfig/caddyfile/testdata/import_recursive2.txt
@@ -1,0 +1,1 @@
+import import_recursive3.txt

--- a/caddyconfig/caddyfile/testdata/import_recursive3.txt
+++ b/caddyconfig/caddyfile/testdata/import_recursive3.txt
@@ -1,0 +1,1 @@
+import import_recursive1.txt

--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -354,8 +354,11 @@ func cmdBuildInfo(fl Flags) (int, error) {
 		return caddy.ExitCodeFailedStartup, fmt.Errorf("no build information")
 	}
 
-	fmt.Printf("path: %s\n", bi.Path)
-	fmt.Printf("main: %s %s %s\n", bi.Main.Path, bi.Main.Version, bi.Main.Sum)
+	fmt.Printf("go_version: %s\n", runtime.Version())
+	fmt.Printf("go_os:      %s\n", runtime.GOOS)
+	fmt.Printf("go_arch:    %s\n", runtime.GOARCH)
+	fmt.Printf("path:       %s\n", bi.Path)
+	fmt.Printf("main:       %s %s %s\n", bi.Main.Path, bi.Main.Version, bi.Main.Sum)
 	fmt.Println("dependencies:")
 
 	for _, goMod := range bi.Deps {
@@ -670,6 +673,7 @@ func cmdUpgrade(_ Flags) (int, error) {
 		defer destFile.Close()
 
 		l.Info("downloading binary", zap.String("source", urlStr), zap.String("destination", thisExecPath))
+
 		_, err = io.Copy(destFile, resp.Body)
 		if err != nil {
 			return fmt.Errorf("unable to download file: %v", err)
@@ -686,6 +690,8 @@ func cmdUpgrade(_ Flags) (int, error) {
 	if err != nil {
 		return caddy.ExitCodeFailedStartup, err
 	}
+
+	l.Info("download successful; displaying new binary details", zap.String("location", thisExecPath))
 
 	// use the new binary to print out version and module info
 	fmt.Print("\nModule versions:\n\n")


### PR DESCRIPTION
Fix an edge case of Caddyfile import itself. I don't imagine anyone deliberately self-importing a Caddyfile but could happen if glob expansion wasn't vetted by the user.