### PR TITLE
Fix to HTTP/2.- and Chrome coalescing issue

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -289,7 +289,7 @@ func (s *Server) enforcementHandler(w http.ResponseWriter, r *http.Request, next
 			err := fmt.Errorf("strict host matching: TLS ServerName (%s) and HTTP Host (%s) values differ",
 				r.TLS.ServerName, hostname)
 			r.Close = true
-			return Error(http.StatusForbidden, err)
+			return Error(http.StatusMisdirectedRequest, err)
 		}
 	}
 	return next.ServeHTTP(w, r)


### PR DESCRIPTION
Made change to return status code 421 instead of 403 when StrictSNIHost matching is on.


This is related to:
https://github.com/caddyserver/caddy/issues/4017

I'm not suggesting this is the complete fix.  I just know it fixes a critical issue with Chrome (and presumable Firefox).