### PR TITLE
logging: add replace filter for static value replacement

### DIFF
--- a/caddytest/integration/caddyfile_adapt/log_filters.txt
+++ b/caddytest/integration/caddyfile_adapt/log_filters.txt
@@ -5,7 +5,7 @@ log {
 	format filter {
 		wrap console
 		fields {
-			request>headers>Authorization delete
+			request>headers>Authorization replace REDACTED
 			request>headers>Server delete
 			request>remote_addr ip_mask {
 				ipv4 24
@@ -30,7 +30,8 @@ log {
 				"encoder": {
 					"fields": {
 						"request\u003eheaders\u003eAuthorization": {
-							"filter": "delete"
+							"filter": "replace",
+							"value": "REDACTED"
 						},
 						"request\u003eheaders\u003eServer": {
 							"filter": "delete"

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -25,6 +25,7 @@ import (
 
 func init() {
 	caddy.RegisterModule(DeleteFilter{})
+	caddy.RegisterModule(ReplaceFilter{})
 	caddy.RegisterModule(IPMaskFilter{})
 }
 
@@ -54,6 +55,37 @@ func (DeleteFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 // Filter filters the input field.
 func (DeleteFilter) Filter(in zapcore.Field) zapcore.Field {
 	in.Type = zapcore.SkipType
+	return in
+}
+
+// ReplaceFilter is a Caddy log field filter that
+// replaces the field with the indicated string.
+type ReplaceFilter struct {
+	Value string `json:"value,omitempty"`
+}
+
+// CaddyModule returns the Caddy module information.
+func (ReplaceFilter) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "caddy.logging.encoders.filter.replace",
+		New: func() caddy.Module { return new(ReplaceFilter) },
+	}
+}
+
+// UnmarshalCaddyfile sets up the module from Caddyfile tokens.
+func (f *ReplaceFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		if d.NextArg() {
+			f.Value = d.Val()
+		}
+	}
+	return nil
+}
+
+// Filter filters the input field with the replacement value.
+func (f *ReplaceFilter) Filter(in zapcore.Field) zapcore.Field {
+	in.Type = zapcore.StringType
+	in.String = f.Value
 	return in
 }
 


### PR DESCRIPTION
This filter is intended to be useful in scenarios where you may want to
redact a value with a static string, giving you information that the
field did previously exist and was present, but not revealing the value
itself in the logs.

This was inspired by work on adding more complete support for removing
sensitive values from logs [1]. An example use case would be the
Authorization header in request log output, for which the value should
usually not be logged, but it may be quite useful for debugging to
confirm that the header was present in the request.

This PR was split out from https://github.com/caddyserver/caddy/pull/4028

[1] https://github.com/caddyserver/caddy/issues/3958