### PR TITLE
caddyhttp: Implement better logic for inserting the HTTP->HTTPS redirs

### DIFF
--- a/caddytest/integration/autohttps_test.go
+++ b/caddytest/integration/autohttps_test.go
@@ -80,3 +80,26 @@ func TestAutoHTTPRedirectsWithHTTPListenerFirstInAddresses(t *testing.T) {
 `, "json")
 	tester.AssertRedirect("http://localhost:9080/", "https://localhost/", http.StatusPermanentRedirect)
 }
+
+func TestAutoHTTPRedirectsInsertedBeforeUserDefinedCatchAll(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		http_port     9080
+		https_port    9443
+		local_certs
+	}
+	http://:9080 {
+		respond "Foo"
+	}
+	http://baz.localhost:9080 {
+		respond "Baz"
+	}
+	bar.localhost {
+		respond "Bar"
+	}
+  `, "caddyfile")
+	tester.AssertRedirect("http://bar.localhost:9080/", "https://bar.localhost/", http.StatusPermanentRedirect)
+	tester.AssertGetResponse("http://foo.localhost:9080/", 200, "Foo")
+	tester.AssertGetResponse("http://baz.localhost:9080/", 200, "Baz")
+}


### PR DESCRIPTION
Taking a crack at implementing what I suggested in https://github.com/caddyserver/caddy/issues/3212

This is WIP, I haven't tested it yet, but wouldn't mind your 2c about this idea @mholt before I dive any deeper on the idea.

Basically, this should insert the redirect routes after any existing route with a host matcher but before any possibly existing user-defined catch-all route, then append our own catch-all at the end just in case as we already did before. I think this would better align with what users expect when they write a Caddyfile that has a `http://` route. This behaviour can be opted out of by setting `auto_https disable_redirects`.