### PR TITLE
httpcaddyfile: Add `error` directive for the existing handler

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -42,6 +42,7 @@ func init() {
 	RegisterHandlerDirective("redir", parseRedir)
 	RegisterHandlerDirective("respond", parseRespond)
 	RegisterHandlerDirective("abort", parseAbort)
+	RegisterHandlerDirective("error", parseError)
 	RegisterHandlerDirective("route", parseRoute)
 	RegisterHandlerDirective("handle", parseHandle)
 	RegisterDirective("handle_errors", parseHandleErrors)
@@ -564,6 +565,16 @@ func parseAbort(h Helper) (caddyhttp.MiddlewareHandler, error) {
 		return nil, h.ArgErr()
 	}
 	return &caddyhttp.StaticResponse{Abort: true}, nil
+}
+
+// parseError parses the error directive.
+func parseError(h Helper) (caddyhttp.MiddlewareHandler, error) {
+	se := new(caddyhttp.StaticError)
+	err := se.UnmarshalCaddyfile(h.Dispenser)
+	if err != nil {
+		return nil, err
+	}
+	return se, nil
 }
 
 // parseRoute parses the route directive.

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -63,6 +63,7 @@ var directiveOrder = []string{
 	"push",
 
 	// handlers that typically respond to requests
+	"error",
 	"respond",
 	"metrics",
 	"reverse_proxy",

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -63,7 +63,6 @@ var directiveOrder = []string{
 	"push",
 
 	// handlers that typically respond to requests
-	"error",
 	"respond",
 	"metrics",
 	"reverse_proxy",
@@ -71,6 +70,7 @@ var directiveOrder = []string{
 	"file_server",
 	"acme_server",
 	"abort",
+	"error",
 }
 
 // directiveIsOrdered returns true if dir is


### PR DESCRIPTION
Closes https://github.com/caddyserver/caddy/issues/3782

Just adds Caddyfile support for the static `error` handler that already exists: https://caddyserver.com/docs/json/apps/http/servers/routes/handle/error/

Syntax:
```
error [<matcher>] <status>|<message> [<status>] {
    message <text>
}
```