### PR TITLE
reverseproxy: Fix upstreams with placeholders with no port

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_upstream_placeholder.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_upstream_placeholder.txt
@@ -1,0 +1,102 @@
+:8884 {
+	map {host} {upstream} {
+		foo.example.com 1.2.3.4
+		default 2.3.4.5
+	}
+
+	# Upstream placeholder with a port should retain the port
+	reverse_proxy {upstream}:80
+}
+
+:8885 {
+	map {host} {upstream} {
+		foo.example.com 1.2.3.4:8080
+		default 2.3.4.5:8080
+	}
+
+	# Upstream placeholder with no port should not have a port joined
+	reverse_proxy {upstream}
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8884"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"defaults": [
+										"2.3.4.5"
+									],
+									"destinations": [
+										"{upstream}"
+									],
+									"handler": "map",
+									"mappings": [
+										{
+											"input": "foo.example.com",
+											"outputs": [
+												"1.2.3.4"
+											]
+										}
+									],
+									"source": "{http.request.host}"
+								},
+								{
+									"handler": "reverse_proxy",
+									"upstreams": [
+										{
+											"dial": "{upstream}:80"
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				"srv1": {
+					"listen": [
+						":8885"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"defaults": [
+										"2.3.4.5:8080"
+									],
+									"destinations": [
+										"{upstream}"
+									],
+									"handler": "map",
+									"mappings": [
+										{
+											"input": "foo.example.com",
+											"outputs": [
+												"1.2.3.4:8080"
+											]
+										}
+									],
+									"source": "{http.request.host}"
+								},
+								{
+									"handler": "reverse_proxy",
+									"upstreams": [
+										{
+											"dial": "{upstream}"
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -184,6 +184,13 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		if network != "" {
 			return caddy.JoinNetworkAddress(network, host, port), nil
 		}
+
+		// if the host is a placeholder, then we don't want to join with an empty port,
+		// because that would just append an extra ':' at the end of the address.
+		if port == "" && strings.Contains(host, "{") {
+			return host, nil
+		}
+
 		return net.JoinHostPort(host, port), nil
 	}
 


### PR DESCRIPTION
See https://caddy.community/t/migrate-to-using-a-wildcard-certificate/11679/21

Fixes a bug where an upstream with a placeholder would append a `:` in the JSON.

Before:

```json
{
	"handler":"reverse_proxy",
	"upstreams":[
		{
			"dial": "{upstream}:"
		}
	]
}
```

After:

```json
{
	"handler":"reverse_proxy",
	"upstreams":[
		{
			"dial": "{upstream}"
		}
	]
}
```