### PR TITLE
reverseproxy: Implement health_uri, replaces health_path, supports query

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_health_path_query.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_health_path_query.txt
@@ -1,0 +1,75 @@
+# Health with query in the uri
+:8443 {
+	reverse_proxy localhost:54321 {
+		health_uri /health?ready=1
+		health_status 2xx
+	}
+}
+
+# Health without query in the uri
+:8444 {
+	reverse_proxy localhost:54321 {
+		health_uri /health
+		health_status 200
+	}
+}
+
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8443"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "reverse_proxy",
+									"health_checks": {
+										"active": {
+											"expect_status": 2,
+											"uri": "/health?ready=1"
+										}
+									},
+									"upstreams": [
+										{
+											"dial": "localhost:54321"
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				"srv1": {
+					"listen": [
+						":8444"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "reverse_proxy",
+									"health_checks": {
+										"active": {
+											"expect_status": 200,
+											"uri": "/health"
+										}
+									},
+									"upstreams": [
+										{
+											"dial": "localhost:54321"
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -298,7 +298,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if h.HealthChecks.Active == nil {
 					h.HealthChecks.Active = new(ActiveHealthChecks)
 				}
-				h.HealthChecks.Active.Uri = d.Val()
+				h.HealthChecks.Active.URI = d.Val()
 
 			case "health_path":
 				if !d.NextArg() {
@@ -311,7 +311,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					h.HealthChecks.Active = new(ActiveHealthChecks)
 				}
 				h.HealthChecks.Active.Path = d.Val()
-				caddy.Log().Warn("the 'health_path' subdirective is deprecated, please use 'health_uri' instead!")
+				caddy.Log().Named("config.adapter.caddyfile").Warn("the 'health_path' subdirective is deprecated, please use 'health_uri' instead!")
 
 			case "health_port":
 				if !d.NextArg() {

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -288,6 +288,18 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				}
 				h.LoadBalancing.TryInterval = caddy.Duration(dur)
 
+			case "health_uri":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				if h.HealthChecks == nil {
+					h.HealthChecks = new(HealthChecks)
+				}
+				if h.HealthChecks.Active == nil {
+					h.HealthChecks.Active = new(ActiveHealthChecks)
+				}
+				h.HealthChecks.Active.Uri = d.Val()
+
 			case "health_path":
 				if !d.NextArg() {
 					return d.ArgErr()
@@ -299,6 +311,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					h.HealthChecks.Active = new(ActiveHealthChecks)
 				}
 				h.HealthChecks.Active.Path = d.Val()
+				caddy.Log().Warn("the 'health_path' subdirective is deprecated, please use 'health_uri' instead!")
 
 			case "health_port":
 				if !d.NextArg() {
@@ -382,7 +395,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if len(val) == 3 && strings.HasSuffix(val, "xx") {
 					val = val[:1]
 				}
-				statusNum, err := strconv.Atoi(val[:1])
+				statusNum, err := strconv.Atoi(val)
 				if err != nil {
 					return d.Errf("bad status value '%s': %v", d.Val(), err)
 				}
@@ -463,7 +476,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					if len(arg) == 3 && strings.HasSuffix(arg, "xx") {
 						arg = arg[:1]
 					}
-					statusNum, err := strconv.Atoi(arg[:1])
+					statusNum, err := strconv.Atoi(arg)
 					if err != nil {
 						return d.Errf("bad status value '%s': %v", d.Val(), err)
 					}

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -56,7 +56,7 @@ type ActiveHealthChecks struct {
 	Path string `json:"path,omitempty"`
 
 	// The URI (path and query) to use for health checks
-	Uri string `json:"uri,omitempty"`
+	URI string `json:"uri,omitempty"`
 
 	// The port to use (if different from the upstream's dial
 	// address) for health checks.

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -275,7 +275,7 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 
 		// if active health checks are enabled, configure them and start a worker
 		if h.HealthChecks.Active != nil && (h.HealthChecks.Active.Path != "" ||
-			h.HealthChecks.Active.Uri != "" ||
+			h.HealthChecks.Active.URI != "" ||
 			h.HealthChecks.Active.Port != 0) {
 
 			h.HealthChecks.Active.logger = h.logger.Named("health_checker.active")
@@ -285,13 +285,17 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 				timeout = 5 * time.Second
 			}
 
-			// parse the Uri string (supports path and query)
-			if h.HealthChecks.Active.Uri != "" {
-				url, err := url.Parse(h.HealthChecks.Active.Uri)
+			if h.HealthChecks.Active.Path != "" {
+				h.HealthChecks.Active.logger.Warn("the 'path' option is deprecated, please use 'uri' instead!")
+			}
+
+			// parse the URI string (supports path and query)
+			if h.HealthChecks.Active.URI != "" {
+				parsedURI, err := url.Parse(h.HealthChecks.Active.URI)
 				if err != nil {
 					return err
 				}
-				h.HealthChecks.Active.uri = url
+				h.HealthChecks.Active.uri = parsedURI
 			}
 
 			h.HealthChecks.Active.httpClient = &http.Client{


### PR DESCRIPTION
Closes #4049

```
reverse_proxy localhost:54321 {
	health_uri /health?ready=1
	health_status 2xx
}
```

Also fixes a bug with `health_status` Caddyfile parsing, it would always only take the first character of the status code even if it didn't end with "xx". I fixed the same bug in #4021 but it's relevant here too because it affects the adapt test I wrote (will rebase #4021 after and remove the redundant fix)