### PR TITLE
notify: Send all sd_notify signals from main caddy process

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -39,6 +39,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/caddyserver/caddy/v2/notify"
 	"github.com/caddyserver/certmagic"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -905,6 +906,11 @@ func handleStop(w http.ResponseWriter, r *http.Request) error {
 			Err:        fmt.Errorf("method not allowed"),
 		}
 	}
+
+	if err := notify.NotifyStopping(); err != nil {
+		Log().Error("unable to notify stopping to service manager", zap.Error(err))
+	}
+
 	exitProcess(Log().Named("admin.api"))
 	return nil
 }

--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -269,10 +269,6 @@ func cmdRun(fl Flags) (int, error) {
 		}
 	}
 
-	if err := NotifyReadiness(); err != nil {
-		caddy.Log().Error("unable to notify readiness to service manager", zap.Error(err))
-	}
-
 	select {}
 }
 
@@ -293,15 +289,6 @@ func cmdReload(fl Flags) (int, error) {
 	reloadCmdConfigAdapterFlag := fl.String("adapter")
 	reloadCmdAddrFlag := fl.String("address")
 	reloadCmdForceFlag := fl.Bool("force")
-
-	if err := NotifyReloading(); err != nil {
-		caddy.Log().Error("unable to notify reloading to service manager", zap.Error(err))
-	}
-	defer func() {
-		if err := NotifyReadiness(); err != nil {
-			caddy.Log().Error("unable to notify readiness to service manager", zap.Error(err))
-		}
-	}()
 
 	// get the config in caddy's native format
 	config, configFile, err := loadConfig(reloadCmdConfigFlag, reloadCmdConfigAdapterFlag)

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -12,14 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !linux
+package notify
 
-package caddycmd
-
-func notifyReadiness() error {
-	return nil
+// NotifyReadiness notifies process manager of readiness.
+func NotifyReadiness() error {
+	return notifyReadiness()
 }
 
-func notifyReloading() error {
-	return nil
+// NotifyReloading notifies process manager of reloading.
+func NotifyReloading() error {
+	return notifyReloading()
+}
+
+// NotifyStopping notifies process manager of stopping.
+func NotifyStopping() error {
+	return notifyStopping()
 }

--- a/notify/notify_linux.go
+++ b/notify/notify_linux.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package caddycmd
+package notify
 
 import (
 	"io"
@@ -42,7 +42,7 @@ func sdNotify(path, payload string) error {
 	return nil
 }
 
-// notifyReadiness notifies systemd caddy that has finished its
+// notifyReadiness notifies systemd that caddy has finished its
 // initialization routines.
 func notifyReadiness() error {
 	val, ok := os.LookupEnv("NOTIFY_SOCKET")
@@ -55,13 +55,25 @@ func notifyReadiness() error {
 	return nil
 }
 
-// notifyReadiness notifies systemd that caddy is reloading its config.
+// notifyReloading notifies systemd that caddy is reloading its config.
 func notifyReloading() error {
 	val, ok := os.LookupEnv("NOTIFY_SOCKET")
 	if !ok || val == "" {
 		return nil
 	}
 	if err := sdNotify(val, "RELOADING=1"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// notifyStopping notifies systemd that caddy is stopping.
+func notifyStopping() error {
+	val, ok := os.LookupEnv("NOTIFY_SOCKET")
+	if !ok || val == "" {
+		return nil
+	}
+	if err := sdNotify(val, "STOPPING=1"); err != nil {
 		return err
 	}
 	return nil

--- a/notify/notify_other.go
+++ b/notify/notify_other.go
@@ -12,14 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package caddycmd
+// +build !linux
 
-// NotifyReadiness notifies process manager of readiness.
-func NotifyReadiness() error {
-	return notifyReadiness()
+package notify
+
+func notifyReadiness() error {
+	return nil
 }
 
-// NotifyReloading notifies process manager of reloading.
-func NotifyReloading() error {
-	return notifyReloading()
+func notifyReloading() error {
+	return nil
+}
+
+func notifyStopping() error {
+	return nil
 }


### PR DESCRIPTION
Initial sd_notify support was added in #3963, but that sent signals from both cmdRun and cmdReload.  This approach has two drawbacks:

- Reloads initiated via the API do not send signals.
- The signals are sent from different processes, which requires the `NotifyAccess=exec` directive in the unit file.

This change moves the NotifyReloading and NotifyReadiness invocations to Load, which address both of those drawbacks.  It also adds a complimentary NotifyStopping method which is invoked from handleStop.  All the notify methods are defined in a notify package to avoid an import loop.