### PR TITLE
httpcaddyfile: Add `auto_https ignore_loaded_certs`

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -126,10 +126,10 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 			// must load each cert only once; otherwise, they each get a
 			// different tag... since a cert loaded twice has the same
 			// bytes, it will overwrite the first one in the cache, and
-			// only the last cert (and its tag) will survive, so a any conn
-			// policy that is looking for any tag but the last one to be
-			// loaded won't find it, and TLS handshakes will fail (see end)
-			// of issue #3004)
+			// only the last cert (and its tag) will survive, so any conn
+			// policy that is looking for any tag other than the last one
+			// to be loaded won't find it, and TLS handshakes will fail
+			// (see end of issue #3004)
 			//
 			// tlsCertTags maps certificate filenames to their tag.
 			// This is used to remember which tag is used for each

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -451,6 +451,9 @@ func (st *ServerType) serversFromPairings(
 			if autoHTTPS == "disable_redirects" {
 				srv.AutoHTTPS.DisableRedir = true
 			}
+			if autoHTTPS == "ignore_loaded_certs" {
+				srv.AutoHTTPS.IgnoreLoadedCerts = true
+			}
 		}
 
 		// sort server blocks by their keys; this is important because

--- a/caddyconfig/httpcaddyfile/options.go
+++ b/caddyconfig/httpcaddyfile/options.go
@@ -364,8 +364,8 @@ func parseOptAutoHTTPS(d *caddyfile.Dispenser, _ interface{}) (interface{}, erro
 	if d.Next() {
 		return "", d.ArgErr()
 	}
-	if val != "off" && val != "disable_redirects" {
-		return "", d.Errf("auto_https must be either 'off' or 'disable_redirects'")
+	if val != "off" && val != "disable_redirects" && val != "ignore_loaded_certs" {
+		return "", d.Errf("auto_https must be one of 'off', 'disable_redirects' or 'ignore_loaded_certs'")
 	}
 	return val, nil
 }

--- a/caddytest/integration/caddyfile_adapt/auto_https_ignore_loaded_certs.txt
+++ b/caddytest/integration/caddyfile_adapt/auto_https_ignore_loaded_certs.txt
@@ -1,0 +1,34 @@
+{
+	auto_https ignore_loaded_certs
+}
+
+localhost
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"localhost"
+									]
+								}
+							],
+							"terminal": true
+						}
+					],
+					"automatic_https": {
+						"ignore_loaded_certificates": true
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #4048

Adds `ignore_loaded_certs` as an option for the `auto_https` global option, which turns on `ignore_loaded_certificates`, i.e. making the automation policy still run for domains in the server even if they're covered by otherwise loaded certificates (such as a wildcard cert that covers that specific domain).

~~I went with the name `always` as suggested by a user in #4048 because I think it somewhat better describes what happens in a more user-friendly way, even if it's somewhat ambiguous.~~

And obviously it's not possible to set `ignore_loaded_certs` and `disable_redirects` at the same time, but I think the likelyhood of that being a valid usecase is quite low.

Example:

```
{
	auto_https ignore_loaded_certs
}

*.example.com {
	tls {
		dns <provider>
	}
	respond "Wildcard"
}

# Without `ignore_loaded_certs`, this site would not have its own
# certificate, but instead inherit the wildcard cert from `*.example.com`
foo.example.com {
	respond "Foo"
}
```