### PR TITLE
sigtrap_posix: add missing comma to SIGTERM info

### DIFF
--- a/sigtrap_posix.go
+++ b/sigtrap_posix.go
@@ -39,7 +39,7 @@ func trapSignalsPosix() {
 				os.Exit(ExitCodeForceQuit)
 
 			case syscall.SIGTERM:
-				Log().Info("shutting down apps then terminating", zap.String("signal", "SIGTERM"))
+				Log().Info("shutting down apps, then terminating", zap.String("signal", "SIGTERM"))
 				exitProcessFromSignal("SIGTERM")
 
 			case syscall.SIGUSR1:


### PR DESCRIPTION
Was missing a comma, so added it