### PR TITLE
cmd: Use `caddy.Log()` instead of `fmt.Printf` for config adapter warnings

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -185,7 +185,7 @@ func loadConfig(configFile, adapterName string) ([]byte, string, error) {
 			if warn.Directive != "" {
 				msg = fmt.Sprintf("%s: %s", warn.Directive, warn.Message)
 			}
-			fmt.Printf("[WARNING][%s] %s:%d: %s\n", adapterName, warn.File, warn.Line, msg)
+			caddy.Log().Warn(msg, zap.String("adapter", adapterName), zap.String("file", warn.File), zap.Int("line", warn.Line))
 		}
 		config = adaptedConfig
 	}


### PR DESCRIPTION
Lines in the logs like this:

```
2021/03/22 06:11:28.733 INFO    using adjacent Caddyfile
[WARNING][caddyfile] Caddyfile:2: input is not formatted with 'caddy fmt'
```

Now become:

```
2021/03/22 06:16:08.734 INFO    using adjacent Caddyfile
2021/03/22 06:16:08.735 WARN    input is not formatted with 'caddy fmt' {"adapter": "caddyfile", "file": "Caddyfile", "line": 2}
```

Just a bit nicer.