### PR TITLE
headers: Fix Caddyfile parsing for `request_header` with matchers

### DIFF
--- a/caddytest/integration/caddyfile_adapt/request_header.txt
+++ b/caddytest/integration/caddyfile_adapt/request_header.txt
@@ -1,0 +1,90 @@
+:80
+
+@matcher path /something*
+request_header @matcher Denis "Ritchie"
+
+request_header +Edsger "Dijkstra"
+request_header -Wolfram
+
+@images path /images/*
+request_header @images Cache-Control "public, max-age=3600, stale-while-revalidate=86400"
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"path": [
+										"/something*"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "headers",
+									"request": {
+										"set": {
+											"Denis": [
+												"Ritchie"
+											]
+										}
+									}
+								}
+							]
+						},
+						{
+							"match": [
+								{
+									"path": [
+										"/images/*"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "headers",
+									"request": {
+										"set": {
+											"Cache-Control": [
+												"public, max-age=3600, stale-while-revalidate=86400"
+											]
+										}
+									}
+								}
+							]
+						},
+						{
+							"handle": [
+								{
+									"handler": "headers",
+									"request": {
+										"add": {
+											"Edsger": [
+												"Dijkstra"
+											]
+										}
+									}
+								},
+								{
+									"handler": "headers",
+									"request": {
+										"delete": [
+											"Wolfram"
+										]
+									}
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/headers/caddyfile.go
+++ b/modules/caddyhttp/headers/caddyfile.go
@@ -151,6 +151,10 @@ func parseCaddyfile(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error)
 //     request_header [<matcher>] [[+|-]<field> [<value|regexp>] [<replacement>]]
 //
 func parseReqHdrCaddyfile(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error) {
+	if !h.Next() {
+		return nil, h.ArgErr()
+	}
+
 	matcherSet, err := h.ExtractMatcherSet()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #4084

The first token needs to be skipped with `h.Next()`, otherwise the matcher token is read as the header field.