### PR TITLE
.gitignore: add IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ vendor
 dist
 caddy-build
 caddy-dist
+
+# IDE files
+.idea/
+.vscode/


### PR DESCRIPTION
These tend to clutter up repositories.