### PR TITLE
fileserver: Share template logic for both `templates` and `file_server browse`

### DIFF
--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -89,7 +89,7 @@ func (fsrv *FileServer) serveBrowse(root, dirPath string, w http.ResponseWriter,
 		TemplateContext: templates.TemplateContext{
 			Root:       fs,
 			Req:        r,
-			RespHeader: templates.TplWrappedHeader{w.Header()},
+			RespHeader: templates.TplWrappedHeader{Header: w.Header()},
 		},
 		browseListing: listing,
 	}

--- a/modules/caddyhttp/fileserver/browse_test.go
+++ b/modules/caddyhttp/fileserver/browse_test.go
@@ -7,10 +7,6 @@ import (
 
 func BenchmarkBrowseWriteJSON(b *testing.B) {
 	fsrv := new(FileServer)
-	fsrv.Browse = &Browse{
-		TemplateFile: "",
-		template:     template.New("test"),
-	}
 	listing := browseListing{
 		Name:     "test",
 		Path:     "test",

--- a/modules/caddyhttp/fileserver/browse_test.go
+++ b/modules/caddyhttp/fileserver/browse_test.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fileserver
 
 import (
@@ -7,7 +21,7 @@ import (
 
 func BenchmarkBrowseWriteJSON(b *testing.B) {
 	fsrv := new(FileServer)
-	listing := browseListing{
+	listing := browseTemplateContext{
 		Name:     "test",
 		Path:     "test",
 		CanGoUp:  false,
@@ -31,7 +45,7 @@ func BenchmarkBrowseWriteHTML(b *testing.B) {
 		TemplateFile: "",
 		template:     template.New("test"),
 	}
-	listing := browseListing{
+	listing := browseTemplateContext{
 		Name:     "test",
 		Path:     "test",
 		CanGoUp:  false,
@@ -43,7 +57,7 @@ func BenchmarkBrowseWriteHTML(b *testing.B) {
 		Limit:    42,
 	}
 	tplCtx := templateContext{
-		browseListing: listing,
+		browseTemplateContext: listing,
 	}
 	fsrv.browseParseTemplate(&tplCtx)
 	b.ResetTimer()

--- a/modules/caddyhttp/fileserver/browse_test.go
+++ b/modules/caddyhttp/fileserver/browse_test.go
@@ -56,13 +56,13 @@ func BenchmarkBrowseWriteHTML(b *testing.B) {
 		Order:    "",
 		Limit:    42,
 	}
-	tplCtx := templateContext{
+	tplCtx := &templateContext{
 		browseTemplateContext: listing,
 	}
-	fsrv.browseParseTemplate(&tplCtx)
+	fsrv.makeBrowseTemplate(tplCtx)
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		fsrv.browseWriteHTML(&tplCtx)
+		fsrv.browseWriteHTML(tplCtx)
 	}
 }

--- a/modules/caddyhttp/fileserver/browse_test.go
+++ b/modules/caddyhttp/fileserver/browse_test.go
@@ -1,36 +1,12 @@
 package fileserver
 
 import (
-	"html/template"
 	"testing"
-
-	"github.com/caddyserver/caddy/v2"
+	"text/template"
 )
 
 func BenchmarkBrowseWriteJSON(b *testing.B) {
 	fsrv := new(FileServer)
-	fsrv.Provision(caddy.Context{})
-	listing := browseListing{
-		Name:     "test",
-		Path:     "test",
-		CanGoUp:  false,
-		Items:    make([]fileInfo, 100),
-		NumDirs:  42,
-		NumFiles: 420,
-		Sort:     "",
-		Order:    "",
-		Limit:    42,
-	}
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
-		fsrv.browseWriteJSON(listing)
-	}
-}
-
-func BenchmarkBrowseWriteHTML(b *testing.B) {
-	fsrv := new(FileServer)
-	fsrv.Provision(caddy.Context{})
 	fsrv.Browse = &Browse{
 		TemplateFile: "",
 		template:     template.New("test"),
@@ -46,9 +22,41 @@ func BenchmarkBrowseWriteHTML(b *testing.B) {
 		Order:    "",
 		Limit:    42,
 	}
+	tplCtx := templateContext{
+		browseListing: listing,
+	}
+	fsrv.browseParseTemplate(&tplCtx)
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		fsrv.browseWriteHTML(listing)
+		fsrv.browseWriteJSON(&tplCtx)
+	}
+}
+
+func BenchmarkBrowseWriteHTML(b *testing.B) {
+	fsrv := new(FileServer)
+	fsrv.Browse = &Browse{
+		TemplateFile: "",
+		template:     template.New("test"),
+	}
+	listing := browseListing{
+		Name:     "test",
+		Path:     "test",
+		CanGoUp:  false,
+		Items:    make([]fileInfo, 100),
+		NumDirs:  42,
+		NumFiles: 420,
+		Sort:     "",
+		Order:    "",
+		Limit:    42,
+	}
+	tplCtx := templateContext{
+		browseListing: listing,
+	}
+	fsrv.browseParseTemplate(&tplCtx)
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		fsrv.browseWriteHTML(&tplCtx)
 	}
 }

--- a/modules/caddyhttp/fileserver/browse_test.go
+++ b/modules/caddyhttp/fileserver/browse_test.go
@@ -22,14 +22,10 @@ func BenchmarkBrowseWriteJSON(b *testing.B) {
 		Order:    "",
 		Limit:    42,
 	}
-	tplCtx := templateContext{
-		browseListing: listing,
-	}
-	fsrv.browseParseTemplate(&tplCtx)
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		fsrv.browseWriteJSON(&tplCtx)
+		fsrv.browseWriteJSON(listing)
 	}
 }
 

--- a/modules/caddyhttp/fileserver/browsetplcontext.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext.go
@@ -27,7 +27,7 @@ import (
 	"github.com/dustin/go-humanize"
 )
 
-func (fsrv *FileServer) directoryListing(files []os.FileInfo, canGoUp bool, root, urlPath string, repl *caddy.Replacer) browseListing {
+func (fsrv *FileServer) directoryListing(files []os.FileInfo, canGoUp bool, root, urlPath string, repl *caddy.Replacer) browseTemplateContext {
 	filesToHide := fsrv.transformHidePaths(repl)
 
 	var dirCount, fileCount int
@@ -62,7 +62,7 @@ func (fsrv *FileServer) directoryListing(files []os.FileInfo, canGoUp bool, root
 		})
 	}
 
-	return browseListing{
+	return browseTemplateContext{
 		Name:     path.Base(urlPath),
 		Path:     urlPath,
 		CanGoUp:  canGoUp,
@@ -72,7 +72,8 @@ func (fsrv *FileServer) directoryListing(files []os.FileInfo, canGoUp bool, root
 	}
 }
 
-type browseListing struct {
+// browseTemplateContext provides the template context for directory listings.
+type browseTemplateContext struct {
 	// The name of the directory (the last element of the path).
 	Name string `json:"name"`
 
@@ -106,7 +107,7 @@ type browseListing struct {
 
 // Breadcrumbs returns l.Path where every element maps
 // the link to the text to display.
-func (l browseListing) Breadcrumbs() []crumb {
+func (l browseTemplateContext) Breadcrumbs() []crumb {
 	if len(l.Path) == 0 {
 		return []crumb{}
 	}
@@ -130,7 +131,7 @@ func (l browseListing) Breadcrumbs() []crumb {
 	return result
 }
 
-func (l *browseListing) applySortAndLimit(sortParam, orderParam, limitParam string, offsetParam string) {
+func (l *browseTemplateContext) applySortAndLimit(sortParam, orderParam, limitParam string, offsetParam string) {
 	l.Sort = sortParam
 	l.Order = orderParam
 
@@ -207,10 +208,12 @@ func (fi fileInfo) HumanModTime(format string) string {
 	return fi.ModTime.Format(format)
 }
 
-type byName browseListing
-type byNameDirFirst browseListing
-type bySize browseListing
-type byTime browseListing
+type (
+	byName         browseTemplateContext
+	byNameDirFirst browseTemplateContext
+	bySize         browseTemplateContext
+	byTime         browseTemplateContext
+)
 
 func (l byName) Len() int      { return len(l.Items) }
 func (l byName) Swap(i, j int) { l.Items[i], l.Items[j] = l.Items[j], l.Items[i] }

--- a/modules/caddyhttp/fileserver/browsetplcontext_test.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext_test.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fileserver
 
 import (
@@ -25,7 +39,7 @@ func TestBreadcrumbs(t *testing.T) {
 	}
 
 	for _, d := range testdata {
-		l := browseListing{Path: d.path}
+		l := browseTemplateContext{Path: d.path}
 		actual := l.Breadcrumbs()
 		if len(actual) != len(d.expected) {
 			t.Errorf("wrong size output, got %d elements but expected %d", len(actual), len(d.expected))

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -16,8 +16,6 @@ package fileserver
 
 import (
 	"bytes"
-	"fmt"
-	"html/template"
 	"io"
 	weakrand "math/rand"
 	"mime"
@@ -100,23 +98,6 @@ func (fsrv *FileServer) Provision(ctx caddy.Context) error {
 
 	if fsrv.IndexNames == nil {
 		fsrv.IndexNames = defaultIndexNames
-	}
-
-	if fsrv.Browse != nil {
-		var tpl *template.Template
-		var err error
-		if fsrv.Browse.TemplateFile != "" {
-			tpl, err = template.ParseFiles(fsrv.Browse.TemplateFile)
-			if err != nil {
-				return fmt.Errorf("parsing browse template file: %v", err)
-			}
-		} else {
-			tpl, err = template.New("default_listing").Parse(defaultBrowseTemplate)
-			if err != nil {
-				return fmt.Errorf("parsing default browse template: %v", err)
-			}
-		}
-		fsrv.Browse.template = tpl
 	}
 
 	// for hide paths that are static (i.e. no placeholders), we can transform them into

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -16,6 +16,7 @@ package fileserver
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	weakrand "math/rand"
 	"mime"

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -17,7 +17,6 @@ package fileserver
 import (
 	"bytes"
 	"fmt"
-	"io"
 	weakrand "math/rand"
 	"mime"
 	"net/http"

--- a/modules/caddyhttp/templates/templates.go
+++ b/modules/caddyhttp/templates/templates.go
@@ -37,7 +37,7 @@ func init() {
 //
 // [All Sprig functions](https://masterminds.github.io/sprig/) are supported.
 //
-// In addition to the standard functions and Sprig functions, Caddy adds
+// In addition to the standard functions and the Sprig library, Caddy adds
 // extra functions and data that are available to a template:
 //
 // ##### `.Args`
@@ -306,7 +306,7 @@ func (t *Templates) executeTemplate(rr caddyhttp.ResponseRecorder, r *http.Reque
 	ctx := &TemplateContext{
 		Root:       fs,
 		Req:        r,
-		RespHeader: TplWrappedHeader{rr.Header()},
+		RespHeader: WrappedHeader{rr.Header()},
 		config:     t,
 	}
 

--- a/modules/caddyhttp/templates/templates.go
+++ b/modules/caddyhttp/templates/templates.go
@@ -303,10 +303,10 @@ func (t *Templates) executeTemplate(rr caddyhttp.ResponseRecorder, r *http.Reque
 		fs = http.Dir(repl.ReplaceAll(t.FileRoot, "."))
 	}
 
-	ctx := &templateContext{
+	ctx := &TemplateContext{
 		Root:       fs,
 		Req:        r,
-		RespHeader: tplWrappedHeader{rr.Header()},
+		RespHeader: TplWrappedHeader{rr.Header()},
 		config:     t,
 	}
 

--- a/modules/caddyhttp/templates/tplcontext.go
+++ b/modules/caddyhttp/templates/tplcontext.go
@@ -43,7 +43,7 @@ type TemplateContext struct {
 	Root       http.FileSystem
 	Req        *http.Request
 	Args       []interface{} // defined by arguments to funcInclude
-	RespHeader TplWrappedHeader
+	RespHeader WrappedHeader
 
 	config *Templates
 }
@@ -344,21 +344,21 @@ func (c TemplateContext) funcFileExists(filename string) (bool, error) {
 }
 
 // funcHTTPError returns a structured HTTP handler error. EXPERIMENTAL.
-// TODO: Requires https://github.com/golang/go/issues/34201 to be fixed.
+// TODO: Requires https://github.com/golang/go/issues/34201 to be fixed (Go 1.17).
 // Example usage might be: `{{if not (fileExists $includeFile)}}{{httpError 404}}{{end}}`
 func (c TemplateContext) funcHTTPError(statusCode int) (bool, error) {
 	return false, caddyhttp.Error(statusCode, nil)
 }
 
-// tplWrappedHeader wraps niladic functions so that they
+// WrappedHeader wraps niladic functions so that they
 // can be used in templates. (Template functions must
 // return a value.)
-type TplWrappedHeader struct{ http.Header }
+type WrappedHeader struct{ http.Header }
 
 // Add adds a header field value, appending val to
 // existing values for that field. It returns an
 // empty string.
-func (h TplWrappedHeader) Add(field, val string) string {
+func (h WrappedHeader) Add(field, val string) string {
 	h.Header.Add(field, val)
 	return ""
 }
@@ -366,13 +366,13 @@ func (h TplWrappedHeader) Add(field, val string) string {
 // Set sets a header field value, overwriting any
 // other values for that field. It returns an
 // empty string.
-func (h TplWrappedHeader) Set(field, val string) string {
+func (h WrappedHeader) Set(field, val string) string {
 	h.Header.Set(field, val)
 	return ""
 }
 
 // Del deletes a header field. It returns an empty string.
-func (h TplWrappedHeader) Del(field string) string {
+func (h WrappedHeader) Del(field string) string {
 	h.Header.Del(field)
 	return ""
 }

--- a/modules/caddyhttp/templates/tplcontext.go
+++ b/modules/caddyhttp/templates/tplcontext.go
@@ -38,19 +38,19 @@ import (
 	gmhtml "github.com/yuin/goldmark/renderer/html"
 )
 
-// templateContext is the templateContext with which HTTP templates are executed.
-type templateContext struct {
+// TemplateContext is the TemplateContext with which HTTP templates are executed.
+type TemplateContext struct {
 	Root       http.FileSystem
 	Req        *http.Request
 	Args       []interface{} // defined by arguments to funcInclude
-	RespHeader tplWrappedHeader
+	RespHeader TplWrappedHeader
 
 	config *Templates
 }
 
 // OriginalReq returns the original, unmodified, un-rewritten request as
 // it originally came in over the wire.
-func (c templateContext) OriginalReq() http.Request {
+func (c TemplateContext) OriginalReq() http.Request {
 	or, _ := c.Req.Context().Value(caddyhttp.OriginalRequestCtxKey).(http.Request)
 	return or
 }
@@ -59,7 +59,7 @@ func (c templateContext) OriginalReq() http.Request {
 // Note that included files are NOT escaped, so you should only include
 // trusted files. If it is not trusted, be sure to use escaping functions
 // in your template.
-func (c templateContext) funcInclude(filename string, args ...interface{}) (string, error) {
+func (c TemplateContext) funcInclude(filename string, args ...interface{}) (string, error) {
 	if c.Root == nil {
 		return "", fmt.Errorf("root file system not specified")
 	}
@@ -93,7 +93,7 @@ func (c templateContext) funcInclude(filename string, args ...interface{}) (stri
 // to the given URI on the same server. Note that included bodies
 // are NOT escaped, so you should only include trusted resources.
 // If it is not trusted, be sure to use escaping functions yourself.
-func (c templateContext) funcHTTPInclude(uri string) (string, error) {
+func (c TemplateContext) funcHTTPInclude(uri string) (string, error) {
 	// prevent virtual request loops by counting how many levels
 	// deep we are; and if we get too deep, return an error
 	recursionCount := 1
@@ -137,15 +137,9 @@ func (c templateContext) funcHTTPInclude(uri string) (string, error) {
 	return buf.String(), nil
 }
 
-func (c templateContext) executeTemplateInBuffer(tplName string, buf *bytes.Buffer) error {
-	tpl := template.New(tplName)
-	if len(c.config.Delimiters) == 2 {
-		tpl.Delims(c.config.Delimiters[0], c.config.Delimiters[1])
-	}
-
-	tpl.Funcs(sprigFuncMap)
-
-	tpl.Funcs(template.FuncMap{
+func (c TemplateContext) AddFuns(tpl *template.Template) *template.Template {
+	tpl = tpl.Funcs(sprigFuncMap)
+	tpl = tpl.Funcs(template.FuncMap{
 		"include":          c.funcInclude,
 		"httpInclude":      c.funcHTTPInclude,
 		"stripHTML":        c.funcStripHTML,
@@ -158,6 +152,17 @@ func (c templateContext) executeTemplateInBuffer(tplName string, buf *bytes.Buff
 		"httpError":        c.funcHTTPError,
 	})
 
+	return tpl
+}
+
+func (c TemplateContext) executeTemplateInBuffer(tplName string, buf *bytes.Buffer) error {
+	tpl := template.New(tplName)
+	if c.config != nil && len(c.config.Delimiters) == 2 {
+		tpl.Delims(c.config.Delimiters[0], c.config.Delimiters[1])
+	}
+
+	tpl = c.AddFuns(tpl)
+
 	parsedTpl, err := tpl.Parse(buf.String())
 	if err != nil {
 		return err
@@ -168,18 +173,18 @@ func (c templateContext) executeTemplateInBuffer(tplName string, buf *bytes.Buff
 	return parsedTpl.Execute(buf, c)
 }
 
-func (c templateContext) funcPlaceholder(name string) string {
+func (c TemplateContext) funcPlaceholder(name string) string {
 	repl := c.Req.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 	value, _ := repl.GetString(name)
 	return value
 }
 
-func (templateContext) funcEnv(varName string) string {
+func (TemplateContext) funcEnv(varName string) string {
 	return os.Getenv(varName)
 }
 
 // Cookie gets the value of a cookie with name name.
-func (c templateContext) Cookie(name string) string {
+func (c TemplateContext) Cookie(name string) string {
 	cookies := c.Req.Cookies()
 	for _, cookie := range cookies {
 		if cookie.Name == name {
@@ -190,7 +195,7 @@ func (c templateContext) Cookie(name string) string {
 }
 
 // RemoteIP gets the IP address of the client making the request.
-func (c templateContext) RemoteIP() string {
+func (c TemplateContext) RemoteIP() string {
 	ip, _, err := net.SplitHostPort(c.Req.RemoteAddr)
 	if err != nil {
 		return c.Req.RemoteAddr
@@ -200,7 +205,7 @@ func (c templateContext) RemoteIP() string {
 
 // Host returns the hostname portion of the Host header
 // from the HTTP request.
-func (c templateContext) Host() (string, error) {
+func (c TemplateContext) Host() (string, error) {
 	host, _, err := net.SplitHostPort(c.Req.Host)
 	if err != nil {
 		if !strings.Contains(c.Req.Host, ":") {
@@ -214,7 +219,7 @@ func (c templateContext) Host() (string, error) {
 
 // funcStripHTML returns s without HTML tags. It is fairly naive
 // but works with most valid HTML inputs.
-func (templateContext) funcStripHTML(s string) string {
+func (TemplateContext) funcStripHTML(s string) string {
 	var buf bytes.Buffer
 	var inTag, inQuotes bool
 	var tagStart int
@@ -247,7 +252,7 @@ func (templateContext) funcStripHTML(s string) string {
 
 // funcMarkdown renders the markdown body as HTML. The resulting
 // HTML is NOT escaped so that it can be rendered as HTML.
-func (templateContext) funcMarkdown(input interface{}) (string, error) {
+func (TemplateContext) funcMarkdown(input interface{}) (string, error) {
 	inputStr := toString(input)
 
 	md := goldmark.New(
@@ -283,7 +288,7 @@ func (templateContext) funcMarkdown(input interface{}) (string, error) {
 // splitFrontMatter parses front matter out from the beginning of input,
 // and returns the separated key-value pairs and the body/content. input
 // must be a "stringy" value.
-func (templateContext) funcSplitFrontMatter(input interface{}) (parsedMarkdownDoc, error) {
+func (TemplateContext) funcSplitFrontMatter(input interface{}) (parsedMarkdownDoc, error) {
 	meta, body, err := extractFrontMatter(toString(input))
 	if err != nil {
 		return parsedMarkdownDoc{}, err
@@ -293,7 +298,7 @@ func (templateContext) funcSplitFrontMatter(input interface{}) (parsedMarkdownDo
 
 // funcListFiles reads and returns a slice of names from the given
 // directory relative to the root of c.
-func (c templateContext) funcListFiles(name string) ([]string, error) {
+func (c TemplateContext) funcListFiles(name string) ([]string, error) {
 	if c.Root == nil {
 		return nil, fmt.Errorf("root file system not specified")
 	}
@@ -326,7 +331,7 @@ func (c templateContext) funcListFiles(name string) ([]string, error) {
 }
 
 // funcFileExists returns true if filename can be opened successfully.
-func (c templateContext) funcFileExists(filename string) (bool, error) {
+func (c TemplateContext) funcFileExists(filename string) (bool, error) {
 	if c.Root == nil {
 		return false, fmt.Errorf("root file system not specified")
 	}
@@ -341,19 +346,19 @@ func (c templateContext) funcFileExists(filename string) (bool, error) {
 // funcHTTPError returns a structured HTTP handler error. EXPERIMENTAL.
 // TODO: Requires https://github.com/golang/go/issues/34201 to be fixed.
 // Example usage might be: `{{if not (fileExists $includeFile)}}{{httpError 404}}{{end}}`
-func (c templateContext) funcHTTPError(statusCode int) (bool, error) {
+func (c TemplateContext) funcHTTPError(statusCode int) (bool, error) {
 	return false, caddyhttp.Error(statusCode, nil)
 }
 
 // tplWrappedHeader wraps niladic functions so that they
 // can be used in templates. (Template functions must
 // return a value.)
-type tplWrappedHeader struct{ http.Header }
+type TplWrappedHeader struct{ http.Header }
 
 // Add adds a header field value, appending val to
 // existing values for that field. It returns an
 // empty string.
-func (h tplWrappedHeader) Add(field, val string) string {
+func (h TplWrappedHeader) Add(field, val string) string {
 	h.Header.Add(field, val)
 	return ""
 }
@@ -361,13 +366,13 @@ func (h tplWrappedHeader) Add(field, val string) string {
 // Set sets a header field value, overwriting any
 // other values for that field. It returns an
 // empty string.
-func (h tplWrappedHeader) Set(field, val string) string {
+func (h TplWrappedHeader) Set(field, val string) string {
 	h.Header.Set(field, val)
 	return ""
 }
 
 // Del deletes a header field. It returns an empty string.
-func (h tplWrappedHeader) Del(field string) string {
+func (h TplWrappedHeader) Del(field string) string {
 	h.Header.Del(field)
 	return ""
 }

--- a/modules/caddyhttp/templates/tplcontext_test.go
+++ b/modules/caddyhttp/templates/tplcontext_test.go
@@ -12,20 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright 2015 Light Code Labs, LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package templates
 
 import (
@@ -374,6 +360,6 @@ func initTestContext() (TemplateContext, error) {
 	return TemplateContext{
 		Root:       http.Dir(os.TempDir()),
 		Req:        request,
-		RespHeader: TplWrappedHeader{make(http.Header)},
+		RespHeader: WrappedHeader{make(http.Header)},
 	}, nil
 }

--- a/modules/caddyhttp/templates/tplcontext_test.go
+++ b/modules/caddyhttp/templates/tplcontext_test.go
@@ -357,7 +357,7 @@ title = "Welcome"
 
 }
 
-func getContextOrFail(t *testing.T) templateContext {
+func getContextOrFail(t *testing.T) TemplateContext {
 	context, err := initTestContext()
 	if err != nil {
 		t.Fatalf("failed to prepare test context: %v", err)
@@ -365,15 +365,15 @@ func getContextOrFail(t *testing.T) templateContext {
 	return context
 }
 
-func initTestContext() (templateContext, error) {
+func initTestContext() (TemplateContext, error) {
 	body := bytes.NewBufferString("request body")
 	request, err := http.NewRequest("GET", "https://example.com/foo/bar", body)
 	if err != nil {
-		return templateContext{}, err
+		return TemplateContext{}, err
 	}
-	return templateContext{
+	return TemplateContext{
 		Root:       http.Dir(os.TempDir()),
 		Req:        request,
-		RespHeader: tplWrappedHeader{make(http.Header)},
+		RespHeader: TplWrappedHeader{make(http.Header)},
 	}, nil
 }


### PR DESCRIPTION
Fixes #3637