### PR TITLE
reverseproxy: Set cookie path to `/` when using cookie lb_policy

### DIFF
--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -445,7 +445,7 @@ func selectNewHostWithCookieHashSelection(pool []*Upstream, w http.ResponseWrite
 		sha, err := hashCookie(cookieSecret, randomHost.Dial)
 		if err == nil {
 			// write the cookie.
-			http.SetCookie(w, &http.Cookie{Name: cookieName, Value: sha, Secure: false})
+			http.SetCookie(w, &http.Cookie{Name: cookieName, Value: sha, Path: "/", Secure: false})
 		}
 	}
 	return randomHost


### PR DESCRIPTION
When using cookie lb_policy, the cookie sent doesn't contain a path. So the path of the cookie stored by the browser is the url path

For exemple with this Caddyfile:

```
{
 debug
 admin localhost:2010
 auto_https disable_redirects
}
http://localhost:8443 {
    respond "B"
}
http://localhost:8444 {
    respond "C"
}
http://localhost:8442 {
    reverse_proxy /* {
        to http://localhost:8443 http://localhost:8444
        lb_policy cookie 
    }
}
```  

1) When using url http://localhost:8442/A/B/C, caddy send a cookie without path and this cookie is stored in the browser with the path `/A/B`
2) When the same brower try to reach url http://localhost:8442/A/E/D, the browser doesn't send the first cookie (as the path doesn't match), so the server is sending a new cookie without path, the stickyness is no more guarantee and the browser store the same cookie a second time with a different path (`/A/E`)

=> We should always send the path `/` in the cookie
