### PR TITLE
ci: fuzz: add more fuzz targets

### DIFF
--- a/caddyconfig/caddyfile/formatter_fuzz.go
+++ b/caddyconfig/caddyfile/formatter_fuzz.go
@@ -1,0 +1,25 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build gofuzz
+
+package caddyfile
+
+func FuzzFormat(input []byte) int {
+	formatted := Format(input)
+	if formatted != Format(formatted) {
+		return 1
+	}
+	return 0
+}

--- a/caddyconfig/caddyfile/lexer_fuzz.go
+++ b/caddyconfig/caddyfile/lexer_fuzz.go
@@ -1,0 +1,28 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build gofuzz
+
+package caddyfile
+
+func FuzzTokenize(input []byte) int {
+	tokens, err := Tokenize(input, "Caddyfile")
+	if err != nil {
+		return 0
+	}
+	if len(tokens) == 0 {
+		return -1
+	}
+	return 1
+}

--- a/duration_fuzz.go
+++ b/duration_fuzz.go
@@ -1,0 +1,25 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build gofuzz
+
+package caddy
+
+func FuzzParseDuration(data []byte) int {
+	_, err := ParseDuration(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/modules/caddyhttp/templates/frontmatter_fuzz.go
+++ b/modules/caddyhttp/templates/frontmatter_fuzz.go
@@ -1,0 +1,25 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build gofuzz
+
+package templates
+
+func FuzzExtractFrontMatter(data []byte) int {
+	_, _, err := extractFrontMatter(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
I'm prepping to bring back the continuous fuzzing of Caddy on another platform after the departure of FuzzIt. In the process, I found more possible targets that can be included based on the criteria of:
- accept string|[]byte as input
- function body is more than mere `json.Unmarshal`

One dilemma for now is where to store the seed corpus to be retrieved by the new platform. Any thoughts? I think some projects store them in a branch, but not sure how much of a hassle will it be to keep that branch updated. I've considered hiding them behind a `refs/<something>/corpus`, but it feels too magical and needs insider knowledge.