### PR TITLE
caddyfile: Fix `import` replacing unrelated placeholders

### DIFF
--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -321,7 +321,7 @@ func (p *parser) doImport() error {
 	args := p.RemainingArgs()
 
 	// add args to the replacer
-	repl := caddy.NewReplacer()
+	repl := caddy.NewEmptyReplacer()
 	for index, arg := range args {
 		repl.Set("args."+strconv.Itoa(index), arg)
 	}

--- a/caddytest/integration/caddyfile_adapt/import_args_snippet_env_placeholder.txt
+++ b/caddytest/integration/caddyfile_adapt/import_args_snippet_env_placeholder.txt
@@ -1,0 +1,31 @@
+(foo) {
+	respond {env.FOO}
+}
+
+:80 {
+	import foo
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"body": "{env.FOO}",
+									"handler": "static_response"
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/replacer.go
+++ b/replacer.go
@@ -36,6 +36,18 @@ func NewReplacer() *Replacer {
 	return rep
 }
 
+// NewEmptyReplacer returns a new Replacer,
+// without the global default replacements.
+func NewEmptyReplacer() *Replacer {
+	rep := &Replacer{
+		static: make(map[string]interface{}),
+	}
+	rep.providers = []ReplacerFunc{
+		rep.fromStatic,
+	}
+	return rep
+}
+
 // Replacer can replace values in strings.
 // A default/empty Replacer is not valid;
 // use NewReplacer to make one.


### PR DESCRIPTION
See https://caddy.community/t/snippet-issue-works-outside-snippet/12231

So it turns out that `NewReplacer()` gives a replacer with some global defaults (like `{env.*}` and some system and time placeholders), which is not ideal when running `import` because we just want to replace `{args.*}` only, and nothing else.