### PR TITLE
fix struct field alignment

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -48,24 +48,10 @@ import (
 // AdminConfig configures Caddy's API endpoint, which is used
 // to manage Caddy while it is running.
 type AdminConfig struct {
-	// If true, the admin endpoint will be completely disabled.
-	// Note that this makes any runtime changes to the config
-	// impossible, since the interface to do so is through the
-	// admin endpoint.
-	Disabled bool `json:"disabled,omitempty"`
-
 	// The address to which the admin endpoint's listener should
 	// bind itself. Can be any single network address that can be
 	// parsed by Caddy. Default: localhost:2019
 	Listen string `json:"listen,omitempty"`
-
-	// If true, CORS headers will be emitted, and requests to the
-	// API will be rejected if their `Host` and `Origin` headers
-	// do not match the expected value(s). Use `origins` to
-	// customize which origins/hosts are allowed. If `origins` is
-	// not set, the listen address is the only value allowed by
-	// default. Enforced only on local (plaintext) endpoint.
-	EnforceOrigin bool `json:"enforce_origin,omitempty"`
 
 	// The list of allowed origins/hosts for API requests. Only needed
 	// if accessing the admin endpoint from a host different from the
@@ -92,6 +78,20 @@ type AdminConfig struct {
 	//
 	// EXPERIMENTAL: This feature is subject to change.
 	Remote *RemoteAdmin `json:"remote,omitempty"`
+
+	// If true, the admin endpoint will be completely disabled.
+	// Note that this makes any runtime changes to the config
+	// impossible, since the interface to do so is through the
+	// admin endpoint.
+	Disabled bool `json:"disabled,omitempty"`
+
+	// If true, CORS headers will be emitted, and requests to the
+	// API will be rejected if their `Host` and `Origin` headers
+	// do not match the expected value(s). Use `origins` to
+	// customize which origins/hosts are allowed. If `origins` is
+	// not set, the listen address is the only value allowed by
+	// default. Enforced only on local (plaintext) endpoint.
+	EnforceOrigin bool `json:"enforce_origin,omitempty"`
 }
 
 // ConfigSettings configures the management of configuration.

--- a/modules/caddyhttp/autohttps.go
+++ b/modules/caddyhttp/autohttps.go
@@ -31,13 +31,6 @@ import (
 // HTTPS is enabled automatically and by default when
 // qualifying hostnames are available from the config.
 type AutoHTTPSConfig struct {
-	// If true, automatic HTTPS will be entirely disabled.
-	Disabled bool `json:"disable,omitempty"`
-
-	// If true, only automatic HTTP->HTTPS redirects will
-	// be disabled.
-	DisableRedir bool `json:"disable_redirects,omitempty"`
-
 	// Hosts/domain names listed here will not be included
 	// in automatic HTTPS (they will not have certificates
 	// loaded nor redirects applied).
@@ -48,6 +41,13 @@ type AutoHTTPSConfig struct {
 	// that certificates will not be provisioned and managed
 	// for these names.
 	SkipCerts []string `json:"skip_certificates,omitempty"`
+
+	// If true, automatic HTTPS will be entirely disabled.
+	Disabled bool `json:"disable,omitempty"`
+
+	// If true, only automatic HTTP->HTTPS redirects will
+	// be disabled.
+	DisableRedir bool `json:"disable_redirects,omitempty"`
 
 	// By default, automatic HTTPS will obtain and renew
 	// certificates for qualifying hostnames. However, if

--- a/modules/caddytls/automation.go
+++ b/modules/caddytls/automation.go
@@ -93,11 +93,6 @@ type AutomationPolicy struct {
 	// be removed in the future.
 	IssuerRaw json.RawMessage `json:"issuer,omitempty" caddy:"namespace=tls.issuance inline_key=module"`
 
-	// If true, certificates will be requested with MustStaple. Not all
-	// CAs support this, and there are potentially serious consequences
-	// of enabling this feature without proper threat modeling.
-	MustStaple bool `json:"must_staple,omitempty"`
-
 	// How long before a certificate's expiration to try renewing it,
 	// as a function of its total lifetime. As a general and conservative
 	// rule, it is a good idea to renew a certificate when it has about
@@ -115,18 +110,6 @@ type AutomationPolicy struct {
 	// manager, instead of using Caddy's global/default-configured storage.
 	StorageRaw json.RawMessage `json:"storage,omitempty" caddy:"namespace=caddy.storage inline_key=module"`
 
-	// If true, certificates will be managed "on demand"; that is, during
-	// TLS handshakes or when needed, as opposed to at startup or config
-	// load.
-	OnDemand bool `json:"on_demand,omitempty"`
-
-	// Disables OCSP stapling. Disabling OCSP stapling puts clients at
-	// greater risk, reduces their privacy, and usually lowers client
-	// performance. It is NOT recommended to disable this unless you
-	// are able to justify the costs.
-	// EXPERIMENTAL. Subject to change.
-	DisableOCSPStapling bool `json:"disable_ocsp_stapling,omitempty"`
-
 	// Overrides the URLs of OCSP responders embedded in certificates.
 	// Each key is a OCSP server URL to override, and its value is the
 	// replacement. An empty value will disable querying of that server.
@@ -140,6 +123,23 @@ type AutomationPolicy struct {
 
 	magic   *certmagic.Config
 	storage certmagic.Storage
+
+	// If true, certificates will be requested with MustStaple. Not all
+	// CAs support this, and there are potentially serious consequences
+	// of enabling this feature without proper threat modeling.
+	MustStaple bool `json:"must_staple,omitempty"`
+
+	// If true, certificates will be managed "on demand"; that is, during
+	// TLS handshakes or when needed, as opposed to at startup or config
+	// load.
+	OnDemand bool `json:"on_demand,omitempty"`
+
+	// Disables OCSP stapling. Disabling OCSP stapling puts clients at
+	// greater risk, reduces their privacy, and usually lowers client
+	// performance. It is NOT recommended to disable this unless you
+	// are able to justify the costs.
+	// EXPERIMENTAL. Subject to change.
+	DisableOCSPStapling bool `json:"disable_ocsp_stapling,omitempty"`
 }
 
 // Provision sets up ap and builds its underlying CertMagic config.


### PR DESCRIPTION
`maligned` analysis shows below info:

```
modules/caddytls/automation.go:83:23: struct of size 192 bytes could be of size 184 bytes
admin.go:50:18: struct of size 80 bytes could be of size 72 bytes
modules/caddyhttp/autohttps.go:33:22: struct of size 64 bytes could be of size 56 bytes
```