### PR TITLE
logging: Prep for `common_log` removal

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -184,8 +184,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				log = logger.Error
 			}
 
+			userID, _ := repl.GetString("http.auth.user.id")
+
 			log("handled request",
 				zap.String("common_log", repl.ReplaceAll(commonLogFormat, commonLogEmptyValue)),
+				zap.String("user_id", userID),
 				zap.Duration("duration", duration),
 				zap.Int("size", wrec.Size()),
 				zap.Int("status", wrec.Status()),

--- a/modules/logging/encoders.go
+++ b/modules/logging/encoders.go
@@ -304,6 +304,8 @@ func (lec *LogEncoderConfig) ZapcoreEncoderConfig() zapcore.EncoderConfig {
 			timeFormat = "2006/01/02 15:04:05.000"
 		case "wall_nano":
 			timeFormat = "2006/01/02 15:04:05.000000000"
+		case "common_log":
+			timeFormat = "02/Jan/2006:15:04:05 -0700"
 		}
 		timeFormatter = func(ts time.Time, encoder zapcore.PrimitiveArrayEncoder) {
 			encoder.AppendString(ts.UTC().Format(timeFormat))


### PR DESCRIPTION
See https://github.com/caddyserver/caddy/issues/4148#issuecomment-833207811

With the upcoming removal of `common_log` from access logs, there's a few things we should do to smooth things out to offer a path for backwards compatibility.

- Add a `common_log` time format, which matches the format from the `{time.now.common_log}` placeholder which is currently used for the `common_log` field. This will make it easier for users of https://github.com/caddyserver/format-encoder to get the same time format by doing something like this:

      log {
	    format formatted <insert common log template here> {
          time_format common_log
        }
      }

- Add the `http.auth.user.id` placeholder's value to the logs. This currently isn't in the access logs, so if we drop `common_log`, that wouldn't be visible anywhere in the access logs, and therefore not be possible to recover using https://github.com/caddyserver/format-encoder. I went with `user_id` for the field name but it could just as easily be `auth_user_id`. 🤷‍♂️ 