### PR TITLE
encode: Drop `prefer` from Caddyfile

### DIFF
--- a/caddytest/integration/caddyfile_adapt/encode_options.txt
+++ b/caddytest/integration/caddyfile_adapt/encode_options.txt
@@ -3,7 +3,6 @@
 # All the options
 encode gzip zstd {
 	minimum_length 256
-	prefer zstd gzip
 	match {
 		status 2xx 4xx 500
 		header Content-Type text/*
@@ -16,18 +15,10 @@ encode gzip zstd {
 	}
 }
 
-# Prefer list is implied (short way)
-encode gzip zstd
-
-# Prefer list is implied (long way)
+# Long way with a block for each encoding
 encode {
-	gzip 5
 	zstd
-}
-
-# Prefer list is turned off
-encode gzip zstd {
-	prefer off
+	gzip 5
 }
 ----------
 {
@@ -67,17 +58,6 @@ encode gzip zstd {
 									},
 									"minimum_length": 256,
 									"prefer": [
-										"zstd",
-										"gzip"
-									]
-								},
-								{
-									"encodings": {
-										"gzip": {},
-										"zstd": {}
-									},
-									"handler": "encode",
-									"prefer": [
 										"gzip",
 										"zstd"
 									]
@@ -91,16 +71,9 @@ encode gzip zstd {
 									},
 									"handler": "encode",
 									"prefer": [
-										"gzip",
-										"zstd"
+										"zstd",
+										"gzip"
 									]
-								},
-								{
-									"encodings": {
-										"gzip": {},
-										"zstd": {}
-									},
-									"handler": "encode"
 								}
 							]
 						}


### PR DESCRIPTION
Followup to #4150, #4151 /cc @ueffel @polarathene

After a bit of discussion with @mholt, we decided to remove `prefer` as a subdirective and just go with using the order implicitly always. Simpler config, simpler docs, etc.