### PR TITLE
caddyfile(formatter): fix nesting not decrementing

### DIFF
--- a/caddyconfig/caddyfile/formatter.go
+++ b/caddyconfig/caddyfile/formatter.go
@@ -43,6 +43,7 @@ func Format(input []byte) []byte {
 
 		newLines int // count of newlines consumed
 
+		wasComment bool // whether the last line was a comment
 		comment bool // whether we're in a comment
 		quoted  bool // whether we're in a quoted segment
 		escaped bool // whether current char is escaped
@@ -64,6 +65,7 @@ func Format(input []byte) []byte {
 	nextLine := func() {
 		write('\n')
 		beginningOfLine = true
+		wasComment = false
 	}
 
 	for {
@@ -79,6 +81,7 @@ func Format(input []byte) []byte {
 			if ch == '\n' {
 				comment = false
 				nextLine()
+				wasComment = true
 				continue
 			} else {
 				write(ch)
@@ -164,6 +167,9 @@ func Format(input []byte) []byte {
 				write(' ')
 			}
 			continue
+
+		case nesting == 1 && wasComment && ch == '}':
+			nesting--
 
 		case ch == '}' && (spacePrior || !openBrace):
 			if last != '\n' {

--- a/caddyconfig/caddyfile/formatter_test.go
+++ b/caddyconfig/caddyfile/formatter_test.go
@@ -321,6 +321,44 @@ baz`,
 	foo
 }`,
 		},
+		{
+			description: "matthewpi/vscode-caddyfile-support#13",
+			input: `{
+	email {$ACMEEMAIL}
+	#debug
+}
+
+block {
+}
+`,
+			expect: `{
+	email {$ACMEEMAIL}
+	#debug
+}
+
+block {
+}
+`,
+		},
+		{
+			description: "matthewpi/vscode-caddyfile-support#13 - bad formatting",
+			input: `{
+	email {$ACMEEMAIL}
+	#debug
+	}
+
+	block {
+	}
+`,
+			expect: `{
+	email {$ACMEEMAIL}
+	#debug
+}
+
+block {
+}
+`,
+		},
 	} {
 		// the formatter should output a trailing newline,
 		// even if the tests aren't written to expect that


### PR DESCRIPTION
This is an extremely weird edge-case where if you had a environment variable {}
on one line, a comment on the next line, and the closing of the block on the
following line; the rest of the Caddyfile would be indented further than it
should've been.

ref; https://github.com/matthewpi/vscode-caddyfile-support/issues/13

---

A preview of what happens without this fix can be seen at https://streamable.com/ouziak

Formatting the file shown in the video worked fine before https://github.com/caddyserver/caddy/commit/635f075f187ac73c65e6939b8402494469a4d627

Additional testing (or even a better way to handle this edge-case) would be appreciated.