### PR TITLE
caddyfile: Add parse error on site address with trailing `{`

### DIFF
--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -216,7 +216,7 @@ func (p *parser) addresses() error {
 
 		// Users commonly forget to place a space between the address and the '{'
 		if strings.HasSuffix(tkn, "{") {
-			return p.Errf("Addresses cannot end in '{', got '%s' - did you mean to put a space between the address and '{'?", tkn)
+			return p.Errf("Site addresses cannot end with a curly brace: '%s' - put a space between the token and the brace", tkn)
 		}
 
 		if tkn != "" { // empty token possible if user typed ""

--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -214,6 +214,11 @@ func (p *parser) addresses() error {
 			break
 		}
 
+		// Users commonly forget to place a space between the address and the '{'
+		if strings.HasSuffix(tkn, "{") {
+			return p.Errf("Addresses cannot end in '{', got '%s' - did you mean to put a space between the address and '{'?", tkn)
+		}
+
 		if tkn != "" { // empty token possible if user typed ""
 			// Trailing comma indicates another address will follow, which
 			// may possibly be on the next line

--- a/caddyconfig/caddyfile/parse_test.go
+++ b/caddyconfig/caddyfile/parse_test.go
@@ -160,6 +160,10 @@ func TestParseOneAndImport(t *testing.T) {
 			"localhost",
 		}, []int{}},
 
+		{`localhost{
+		    dir1
+		  }`, true, []string{}, []int{}},
+
 		{`localhost
 		  dir1 {
 		    nested {


### PR DESCRIPTION
Honestly, we should've done this a long time ago, but better late than never.

This is an incredibly common mistake made by users, so we should catch it earlier in the parser and give a more friendly message. Often it ends up adapting but with mistakes, or erroring out later due to other site addresses being read as directives.

There's not really ever a situation where a lone `{` is valid at the end of a site address, so this should be fine. But I suppose there are edgecases where the user wants to use a path matcher where it ends specifically in `{`, but... why?