### PR TITLE
ci: Run CI on PRs targeting minor version branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,11 @@ on:
   push:
     branches:
       - master
+      - 2.*
   pull_request:
     branches:
       - master
+      - 2.*
 
 jobs:
   test:

--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - 2.*
   pull_request:
     branches:
       - master
+      - 2.*
 
 jobs:
   cross-build-test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - 2.*
   pull_request:
     branches:
       - master
+      - 2.*
 
 jobs:
   # From https://github.com/golangci/golangci-lint-action


### PR DESCRIPTION
We decided that we'll use branches like `2.4` as the target for any changes that we might want to release in a `2.4.x` version like `2.4.1`, so that we can continue to merge changes targeting the next minor release (e.g. `2.5.0`) on master.

Our CI config wasn't set up for this to work properly though, since it was only running checks on PRs targeting master. See https://github.com/caddyserver/caddy/pull/4163 for example. This should fix it (then I'll rebase that PR so CI runs).

I couldn't find a way to do a pattern to only match digits for the branch names from Github's docs, it just looks like a pretty generic glob syntax. But this should do until we get to 3.0