### PR TITLE
logging: Implement dial timeout for net writer (fix #4083)

### DIFF
--- a/modules/logging/netwriter.go
+++ b/modules/logging/netwriter.go
@@ -30,7 +30,9 @@ func init() {
 	caddy.RegisterModule(NetWriter{})
 }
 
-// NetWriter implements a log writer that outputs to a network socket.
+// NetWriter implements a log writer that outputs to a network socket. If
+// the socket goes down, it will dump logs to stderr while it attempts to
+// reconnect.
 type NetWriter struct {
 	// The address of the network socket to which to connect.
 	Address string `json:"address,omitempty"`


### PR DESCRIPTION
Replaces #4111, fixes #4083

My hypothesis is that if a dial timeout is configured, the server will still be able to respond to requests even if the log server is down, although there will probably still be a delay for up to the dial timeout.

I haven't had a chance to test this, if someone else could that would be great.

I did add simple redial memory, so it will only attempt to redial at most once every 10 seconds so that it doesn't block every single log emission for up to DialTimeout while the socket is offline. It just dumps the logs to stderr while the socket is down.