### PR TITLE
fileserver: Redirect within the original URL

### DIFF
--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -47,10 +47,10 @@ func (fsrv *FileServer) serveBrowse(root, dirPath string, w http.ResponseWriter,
 	// URL doesn't end in a trailing slash because hrefs like
 	// "/b/c" on a path like "/a" end up going to "/b/c" instead
 	// of "/a/b/c" - so we have to redirect in this case
-	if !strings.HasSuffix(r.URL.Path, "/") {
-		fsrv.logger.Debug("redirecting to trailing slash to preserve hrefs", zap.String("request_path", r.URL.Path))
-		r.URL.Path += "/"
-		http.Redirect(w, r, r.URL.String(), http.StatusMovedPermanently)
+	oldReq := r.Context().Value(caddyhttp.OriginalRequestCtxKey).(http.Request)
+	if !strings.HasSuffix(oldReq.URL.Path, "/") {
+		fsrv.logger.Debug("redirecting to trailing slash to preserve hrefs", zap.String("request_path", oldReq.URL.Path))
+		http.Redirect(w, r, oldReq.URL.Path+"/", http.StatusMovedPermanently)
 		return nil
 	}
 

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -243,12 +243,14 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 	// trailing slash - not enforcing this can break relative hrefs
 	// in HTML (see https://github.com/caddyserver/caddy/issues/2741)
 	if fsrv.CanonicalURIs == nil || *fsrv.CanonicalURIs {
-		if implicitIndexFile && !strings.HasSuffix(r.URL.Path, "/") {
-			fsrv.logger.Debug("redirecting to canonical URI (adding trailing slash for directory)", zap.String("path", r.URL.Path))
-			return redirect(w, r, r.URL.Path+"/")
-		} else if !implicitIndexFile && strings.HasSuffix(r.URL.Path, "/") {
-			fsrv.logger.Debug("redirecting to canonical URI (removing trailing slash for file)", zap.String("path", r.URL.Path))
-			return redirect(w, r, r.URL.Path[:len(r.URL.Path)-1])
+		oldReq := r.Context().Value(caddyhttp.OriginalRequestCtxKey).(http.Request)
+
+		if implicitIndexFile && !strings.HasSuffix(oldReq.URL.Path, "/") {
+			fsrv.logger.Debug("redirecting to canonical URI (adding trailing slash for directory)", zap.String("path", oldReq.URL.Path))
+			return redirect(w, r, oldReq.URL.Path+"/")
+		} else if !implicitIndexFile && strings.HasSuffix(oldReq.URL.Path, "/") {
+			fsrv.logger.Debug("redirecting to canonical URI (removing trailing slash for file)", zap.String("path", oldReq.URL.Path))
+			return redirect(w, r, oldReq.URL.Path[:len(oldReq.URL.Path)-1])
 		}
 	}
 


### PR DESCRIPTION
This commit changes the file_server directive to redirect using the original request's URL instead of the possibly trimmed URL. This should make file_server work with handle_path.

This fix is taken from mholt's comment in https://caddy.community/t/file-servers-on-different-paths-not-working/11698/11.

---

For testing purposes, below Caddyfile should reproduce the before and afters:

```
{
	debug
	admin off
}

http://127.0.0.1:28475 {
	root * /home/diamond

	handle_path /browse* {
		file_server browse
	}

	respond "Hi"
}
```

When accessing `http://127.0.0.1:28475/browse`, the redirection would lead to `/`; after the changes, it would lead to `/browse/`.