### PR TITLE
metrics: use buildinfo collector from new collectors pkg

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -6,12 +6,13 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 // define and register the metrics used in this package.
 func init() {
-	prometheus.MustRegister(prometheus.NewBuildInfoCollector())
+	prometheus.MustRegister(collectors.NewBuildInfoCollector())
 
 	const ns, sub = "caddy", "admin"
 


### PR DESCRIPTION
This oughtta shut the linter up:

```console
$ golangci-lint run .        
metrics.go:14:26: SA1019: prometheus.NewBuildInfoCollector is deprecated: Use collectors.NewBuildInfoCollector instead. (staticcheck)
        prometheus.MustRegister(prometheus.NewBuildInfoCollector())
                                ^
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>