### PR TITLE
logging: Actually use `level_key`

### DIFF
--- a/modules/logging/encoders.go
+++ b/modules/logging/encoders.go
@@ -264,6 +264,9 @@ func (lec *LogEncoderConfig) ZapcoreEncoderConfig() zapcore.EncoderConfig {
 	if lec.MessageKey != nil {
 		cfg.MessageKey = *lec.MessageKey
 	}
+	if lec.LevelKey != nil {
+		cfg.LevelKey = *lec.LevelKey
+	}
 	if lec.TimeKey != nil {
 		cfg.TimeKey = *lec.TimeKey
 	}


### PR DESCRIPTION
Whoops! 😅 

https://caddy.community/t/google-cloud-structured-logging-format/12678