### PR TITLE
fileserver: Fix browse not redirecting query parameters

### DIFF
--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -50,7 +50,8 @@ func (fsrv *FileServer) serveBrowse(root, dirPath string, w http.ResponseWriter,
 	oldReq := r.Context().Value(caddyhttp.OriginalRequestCtxKey).(http.Request)
 	if !strings.HasSuffix(oldReq.URL.Path, "/") {
 		fsrv.logger.Debug("redirecting to trailing slash to preserve hrefs", zap.String("request_path", oldReq.URL.Path))
-		http.Redirect(w, r, oldReq.URL.Path+"/", http.StatusMovedPermanently)
+		oldReq.URL.Path += "/"
+		http.Redirect(w, r, oldReq.URL.String(), http.StatusMovedPermanently)
 		return nil
 	}
 


### PR DESCRIPTION
This commit is a follow up to PR #4179 that introduced a bug where browse redirections to the right URL would not preserve query parameters.

Below is the copy-pasted comment that describes the issue:

---

I think you're right after all. With the path redirection, I'm not getting the query parameters back.

```
―❤―▶ cat main.go
...
http.Redirect(w, r, r.URL.Path+"/", 200)
...

―❤―▶ curl -v localhost:8080/path?a=b
...
< HTTP/1.1 200 OK
< Location: /path/
< 
<a href="/path/">OK</a>.
```

With the `String()` redirection, I'm getting the query parameters as expected in the `Location` header.

```
―❤―▶ cat main.go
...
r.URL.Path += "/"
http.Redirect(w, r, r.URL.String(), 200)
...

―❤―▶ curl -v localhost:8080/path?a=b
< HTTP/1.1 200 OK
< Location: /path/?a=b
< 
<a href="/path/?a=b">OK</a>.
```