### PR TITLE
encode: Tweak compression settings

### DIFF
--- a/modules/caddyhttp/encode/gzip/gzip.go
+++ b/modules/caddyhttp/encode/gzip/gzip.go
@@ -15,7 +15,6 @@
 package caddygzip
 
 import (
-	"compress/flate"
 	"fmt"
 	"strconv"
 
@@ -68,11 +67,11 @@ func (g *Gzip) Provision(ctx caddy.Context) error {
 
 // Validate validates g's configuration.
 func (g Gzip) Validate() error {
-	if g.Level < flate.NoCompression {
-		return fmt.Errorf("quality too low; must be >= %d", flate.NoCompression)
+	if g.Level < gzip.StatelessCompression {
+		return fmt.Errorf("quality too low; must be >= %d", gzip.StatelessCompression)
 	}
-	if g.Level > flate.BestCompression {
-		return fmt.Errorf("quality too high; must be <= %d", flate.BestCompression)
+	if g.Level > gzip.BestCompression {
+		return fmt.Errorf("quality too high; must be <= %d", gzip.BestCompression)
 	}
 	return nil
 }

--- a/modules/caddyhttp/encode/zstd/zstd.go
+++ b/modules/caddyhttp/encode/zstd/zstd.go
@@ -47,7 +47,8 @@ func (Zstd) AcceptEncoding() string { return "zstd" }
 
 // NewEncoder returns a new gzip writer.
 func (z Zstd) NewEncoder() encode.Encoder {
-	writer, _ := zstd.NewWriter(nil)
+	// Limit the window to 128K.
+	writer, _ := zstd.NewWriter(nil, zstd.WithWindowSize(128<<10), zstd.WithEncoderConcurrency(1), zstd.WithZeroFrames(true))
 	return writer
 }
 

--- a/modules/caddyhttp/encode/zstd/zstd.go
+++ b/modules/caddyhttp/encode/zstd/zstd.go
@@ -47,7 +47,9 @@ func (Zstd) AcceptEncoding() string { return "zstd" }
 
 // NewEncoder returns a new gzip writer.
 func (z Zstd) NewEncoder() encode.Encoder {
-	// Limit the window to 128K.
+	// The default of 8MB for the window is
+	// too large for many clients, so we limit
+	// it to 128K to lighten their load.
 	writer, _ := zstd.NewWriter(nil, zstd.WithWindowSize(128<<10), zstd.WithEncoderConcurrency(1), zstd.WithZeroFrames(true))
 	return writer
 }


### PR DESCRIPTION
zstd: Limit window sizes to 128K to keep memory in control both server and client size.
zstd: Write 0 length frames. This may be needed for compatibility.
zstd: Create fewer encoders. Small memory improvement.
gzip: Allow -2 (Huffman only) and -3 (stateless) compression modes.