### PR TITLE
fileserver: Fix browse name_dir_first sorting

### DIFF
--- a/modules/caddyhttp/fileserver/browsetplcontext.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext.go
@@ -264,7 +264,7 @@ func (l byTime) Less(i, j int) bool { return l.Items[i].ModTime.Before(l.Items[j
 
 const (
 	sortByName         = "name"
-	sortByNameDirFirst = "name_dir_first"
+	sortByNameDirFirst = "namedirfirst"
 	sortBySize         = "size"
 	sortByTime         = "time"
 )


### PR DESCRIPTION
This pull request fixes browse's default template to make `name_dir_first` sorting work.

The fix is basically a minor typo fix, changing `namedirfirst` in the template to `name_dir_first` to reflect `sortByNameDirFirst = "name_dir_first"`.