### PR TITLE
fileserver: Add `disable_canonical_uris` Caddyfile subdirective

### DIFF
--- a/caddytest/integration/caddyfile_adapt/file_server_disable_canonical_uris.txt
+++ b/caddytest/integration/caddyfile_adapt/file_server_disable_canonical_uris.txt
@@ -1,0 +1,32 @@
+:80
+
+file_server {
+	disable_canonical_uris
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"canonical_uris": false,
+									"handler": "file_server",
+									"hide": [
+										"./Caddyfile"
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -41,7 +41,7 @@ func init() {
 //        browse        [<template_file>]
 //        precompressed <formats...>
 //        status        <status>
-//        canonical_uris <false>
+//        disable_canonical_uris
 //    }
 //
 func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
@@ -112,8 +112,9 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 					return nil, h.ArgErr()
 				}
 				fsrv.StatusCode = caddyhttp.WeakString(h.Val())
-			case "canonical_uris":
-				if !h.NextArg() || h.Val() != "false" {
+
+			case "disable_canonical_uris":
+				if h.NextArg() {
 					return nil, h.ArgErr()
 				}
 				falseBool := false

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -41,6 +41,7 @@ func init() {
 //        browse        [<template_file>]
 //        precompressed <formats...>
 //        status        <status>
+//        canonical_uris <false>
 //    }
 //
 func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
@@ -111,6 +112,12 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 					return nil, h.ArgErr()
 				}
 				fsrv.StatusCode = caddyhttp.WeakString(h.Val())
+			case "canonical_uris":
+				if !h.NextArg() || h.Val() != "false" {
+					return nil, h.ArgErr()
+				}
+				falseBool := false
+				fsrv.CanonicalURIs = &falseBool
 
 			default:
 				return nil, h.Errf("unknown subdirective '%s'", h.Val())


### PR DESCRIPTION
add 'canonical_uris' parameter to caddyfile

reference #2741

Signed-off-by: mritd <mritd@linux.com>