### PR TITLE
reverseproxy: Keep path to unix socket as dial address

### DIFF
--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -189,13 +189,14 @@ func (h *Handler) doActiveHealthCheckForAllHosts() {
 				return
 			}
 			hostAddr := addr.JoinHostPort(0)
+			dialAddr := hostAddr
 			if addr.IsUnixNetwork() {
 				// this will be used as the Host portion of a http.Request URL, and
 				// paths to socket files would produce an error when creating URL,
 				// so use a fake Host value instead; unix sockets are usually local
 				hostAddr = "localhost"
 			}
-			err = h.doActiveHealthCheck(DialInfo{Network: addr.Network, Address: hostAddr}, hostAddr, upstream.Host)
+			err = h.doActiveHealthCheck(DialInfo{Network: addr.Network, Address: dialAddr}, hostAddr, upstream.Host)
 			if err != nil {
 				h.HealthChecks.Active.logger.Error("active health check failed",
 					zap.String("address", hostAddr),


### PR DESCRIPTION
Hello, 

This is a fix for https://github.com/caddyserver/caddy/issues/4231. I tried changing the Path variable in different ways but it did not help. 

It seems http transport relies on the address in the dial info context var which caused the issue (https://github.com/caddyserver/caddy/blob/master/modules/caddyhttp/reverseproxy/httptransport.go#L181). 

I have also added a test for healthchecks to reproduce the bug described in the issue. 


