### PR TITLE
caddyfile: keep error chain info in Dispenser.Errf

### DIFF
--- a/caddyconfig/caddyfile/dispenser.go
+++ b/caddyconfig/caddyfile/dispenser.go
@@ -343,28 +343,15 @@ func (d *Dispenser) EOFErr() error {
 	return d.Errf("Unexpected EOF")
 }
 
-type parseError struct {
-	file       string
-	line       int
-	innerError error
-}
-
-func (e parseError) Error() string {
-	return fmt.Sprintf("%s:%d - Error during parsing: %s", e.file, e.line, e.innerError.Error())
-}
-
-func (e parseError) Unwrap() error {
-	return e.innerError
-}
-
 // Err generates a custom parse-time error with a message of msg.
 func (d *Dispenser) Err(msg string) error {
-	return parseError{d.File(), d.Line(), errors.New(msg)}
+	return d.Errf(msg)
 }
 
 // Errf is like Err, but for formatted error messages
 func (d *Dispenser) Errf(format string, args ...interface{}) error {
-	return parseError{d.File(), d.Line(), fmt.Errorf(format, args...)}
+	err := fmt.Errorf(format, args...)
+	return fmt.Errorf("%s:%d - Error during parsing: %w", d.File(), d.Line(), err)
 }
 
 // Delete deletes the current token and returns the updated slice

--- a/caddyconfig/caddyfile/dispenser_test.go
+++ b/caddyconfig/caddyfile/dispenser_test.go
@@ -15,6 +15,7 @@
 package caddyfile
 
 import (
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -302,5 +303,11 @@ func TestDispenser_ArgErr_Err(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "foobar") {
 		t.Errorf("Expected error message with custom message in it ('foobar'); got '%v'", err)
+	}
+
+	var ErrBarIsFull = errors.New("bar is full")
+	bookingError := d.Errf("unable to reserve: %w", ErrBarIsFull)
+	if !errors.Is(bookingError, ErrBarIsFull) {
+		t.Errorf("Errf(): should be able to unwrap the error chain")
 	}
 }


### PR DESCRIPTION
Use `fmt.Errorf` instead of `fmt.Sprintf` in `Dispenser.Errf` method to reserve the error chain information. Make the underlying error unwrapable by using `errors.Is` or `errors.As` helpers.