### PR TITLE
caddyhttp: Fix incorrect determination of gRPC protocol

### DIFF
--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -667,7 +667,7 @@ func (MatchProtocol) CaddyModule() caddy.ModuleInfo {
 func (m MatchProtocol) Match(r *http.Request) bool {
 	switch string(m) {
 	case "grpc":
-		return r.Header.Get("content-type") == "application/grpc"
+		return strings.HasPrefix(r.Header.Get("content-type"), "application/grpc")
 	case "https":
 		return r.TLS != nil
 	case "http":


### PR DESCRIPTION
Use `strings.HasPrefix` to identify gRPC protocol. Fix https://github.com/caddyserver/caddy/issues/4234.