### PR TITLE
caddyhttp: Sanitize scheme and host on incoming requests

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -541,6 +541,14 @@ func (slc ServerLogConfig) getLoggerName(host string) string {
 // PrepareRequest fills the request r for use in a Caddy HTTP handler chain. w and s can
 // be nil, but the handlers will lose response placeholders and access to the server.
 func PrepareRequest(r *http.Request, repl *caddy.Replacer, w http.ResponseWriter, s *Server) *http.Request {
+	// sanitize the request URL; we expect it to not contain the scheme and host
+	// since those should be determined by r.TLS and r.Host respectively, but
+	// some clients may include it in the request-line, which is technically
+	// valid in HTTP, but breaks various expectations, for example when copying
+	// the URL to be used by the reverseproxy module.
+	r.URL.Scheme = ""
+	r.URL.Host = ""
+
 	// set up the context for the request
 	ctx := context.WithValue(r.Context(), caddy.ReplacerCtxKey, repl)
 	ctx = context.WithValue(ctx, ServerCtxKey, s)


### PR DESCRIPTION
See https://caddy.community/t/caddy-attempts-to-connect-downstream-server-via-https-although-not-configured-to-do-so/12765 for context.

Basically some wacky HTTP clients may sometimes make HTTP requests with request-line like this:

```
GET https://example.com/some/path
Host example.com
```

_Most_ well behaved clients make requests like this:

```
GET /some/path
Host example.com
```

Technically, both are valid as per HTTP RFCs, but the former ends up breaking some assumptions that the code makes, like that the scheme is empty before being passed onto the `reverse_proxy` module.

The effect was that these requests would tell `http.Client` to use a different scheme than configured. For example, configured `reverse_proxy` to proxy over HTTP, but the scheme in the original request's request-line had `https://` so it would try to proxy over HTTPS :scream:

The docs for `[Request.URL`](https://golang.org/pkg/net/http/#Request.URL) do say:

    // For server requests, the URL is parsed from the URI
    // supplied on the Request-Line as stored in RequestURI.  For
    // most requests, fields other than Path and RawQuery will be
    // empty. (See RFC 7230, Section 5.3)

So it's definitely pretty unexpected to receive the scheme and host in the URL.

This change should just wipe out the scheme and host in the URL, which are otherwise covered by `Request.Host` and `Request.TLS` (and that's how all of the code in Caddy access the host and whether the request was secured).

I realize this is a risky change because it affects _every request_ handled by Caddy. I haven't tested this yet. We should definitely tread lightly here. But I think this is the most logical and simplest way to solve this.