### PR TITLE
caddyhttp: Placeholder for client cert in DER + base64 format

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -113,7 +113,7 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 		"{tls_client_serial}", "{http.request.tls.client.serial}",
 		"{tls_client_subject}", "{http.request.tls.client.subject}",
 		"{tls_client_certificate_pem}", "{http.request.tls.client.certificate_pem}",
-		"{tls_client_certificate_pem_encoded}", "{http.request.tls.client.certificate_pem_encoded}",
+		"{tls_client_certificate_pem_base64}", "{http.request.tls.client.certificate_pem_base64}",
 		"{upstream_hostport}", "{http.reverse_proxy.upstream.hostport}",
 	)
 

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -113,6 +113,7 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 		"{tls_client_serial}", "{http.request.tls.client.serial}",
 		"{tls_client_subject}", "{http.request.tls.client.subject}",
 		"{tls_client_certificate_pem}", "{http.request.tls.client.certificate_pem}",
+		"{tls_client_certificate_pem_encoded}", "{http.request.tls.client.certificate_pem_encoded}",
 		"{upstream_hostport}", "{http.reverse_proxy.upstream.hostport}",
 	)
 

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -113,7 +113,7 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 		"{tls_client_serial}", "{http.request.tls.client.serial}",
 		"{tls_client_subject}", "{http.request.tls.client.subject}",
 		"{tls_client_certificate_pem}", "{http.request.tls.client.certificate_pem}",
-		"{tls_client_certificate_pem_base64}", "{http.request.tls.client.certificate_pem_base64}",
+		"{tls_client_certificate_der_base64}", "{http.request.tls.client.certificate_der_base64}",
 		"{upstream_hostport}", "{http.reverse_proxy.upstream.hostport}",
 	)
 

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -77,7 +77,7 @@ func init() {
 // `{http.request.tls.client.public_key}` | The public key of the client certificate.
 // `{http.request.tls.client.public_key_sha256}` | The SHA256 checksum of the client's public key.
 // `{http.request.tls.client.certificate_pem}` | The PEM-encoded value of the certificate.
-// `{http.request.tls.client.certificate_pem_base64}` | The base64-encoded value of the certificate.
+// `{http.request.tls.client.certificate_der_base64}` | The base64-encoded value of the certificate.
 // `{http.request.tls.client.issuer}` | The issuer DN of the client certificate
 // `{http.request.tls.client.serial}` | The serial number of the client certificate
 // `{http.request.tls.client.subject}` | The subject DN of the client certificate

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -77,6 +77,7 @@ func init() {
 // `{http.request.tls.client.public_key}` | The public key of the client certificate.
 // `{http.request.tls.client.public_key_sha256}` | The SHA256 checksum of the client's public key.
 // `{http.request.tls.client.certificate_pem}` | The PEM-encoded value of the certificate.
+// `{http.request.tls.client.certificate_pem_encoded}` | The PEM-encoded Base64 value of the certificate.
 // `{http.request.tls.client.issuer}` | The issuer DN of the client certificate
 // `{http.request.tls.client.serial}` | The serial number of the client certificate
 // `{http.request.tls.client.subject}` | The subject DN of the client certificate

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -77,7 +77,7 @@ func init() {
 // `{http.request.tls.client.public_key}` | The public key of the client certificate.
 // `{http.request.tls.client.public_key_sha256}` | The SHA256 checksum of the client's public key.
 // `{http.request.tls.client.certificate_pem}` | The PEM-encoded value of the certificate.
-// `{http.request.tls.client.certificate_pem_encoded}` | The PEM-encoded Base64 value of the certificate.
+// `{http.request.tls.client.certificate_pem_base64}` | The base64-encoded value of the certificate.
 // `{http.request.tls.client.issuer}` | The issuer DN of the client certificate
 // `{http.request.tls.client.serial}` | The serial number of the client certificate
 // `{http.request.tls.client.subject}` | The subject DN of the client certificate

--- a/modules/caddyhttp/replacer.go
+++ b/modules/caddyhttp/replacer.go
@@ -353,9 +353,8 @@ func getReqTLSReplacement(req *http.Request, key string) (interface{}, bool) {
 		case "client.certificate_pem":
 			block := pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}
 			return pem.EncodeToMemory(&block), true
-		case "client.certificate_pem_base64":
-			block := pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}
-			return base64.StdEncoding.EncodeToString(block.Bytes), true
+		case "client.certificate_der_base64":
+			return base64.StdEncoding.EncodeToString(cert.Raw), true
 		default:
 			return nil, false
 		}

--- a/modules/caddyhttp/replacer.go
+++ b/modules/caddyhttp/replacer.go
@@ -25,6 +25,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/asn1"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -352,6 +353,9 @@ func getReqTLSReplacement(req *http.Request, key string) (interface{}, bool) {
 		case "client.certificate_pem":
 			block := pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}
 			return pem.EncodeToMemory(&block), true
+		case "client.certificate_pem_encoded":
+			block := pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}
+			return base64.StdEncoding.EncodeToString(pem.EncodeToMemory(&block)), true
 		default:
 			return nil, false
 		}

--- a/modules/caddyhttp/replacer.go
+++ b/modules/caddyhttp/replacer.go
@@ -353,9 +353,9 @@ func getReqTLSReplacement(req *http.Request, key string) (interface{}, bool) {
 		case "client.certificate_pem":
 			block := pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}
 			return pem.EncodeToMemory(&block), true
-		case "client.certificate_pem_encoded":
+		case "client.certificate_pem_base64":
 			block := pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}
-			return base64.StdEncoding.EncodeToString(pem.EncodeToMemory(&block)), true
+			return base64.StdEncoding.EncodeToString(block.Bytes), true
 		default:
 			return nil, false
 		}


### PR DESCRIPTION
Fixes https://github.com/caddyserver/caddy/issues/3767