### PR TITLE
caddyhttp: Fix edgecase with HTTP->HTTPS logic

### DIFF
--- a/caddytest/integration/autohttps_test.go
+++ b/caddytest/integration/autohttps_test.go
@@ -103,3 +103,23 @@ func TestAutoHTTPRedirectsInsertedBeforeUserDefinedCatchAll(t *testing.T) {
 	tester.AssertGetResponse("http://foo.localhost:9080/", 200, "Foo")
 	tester.AssertGetResponse("http://baz.localhost:9080/", 200, "Baz")
 }
+
+func TestAutoHTTPRedirectsInsertedBeforeUserDefinedCatchAllWithNoExplicitHTTPSite(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		http_port     9080
+		https_port    9443
+		local_certs
+	}
+	http://:9080 {
+		respond "Foo"
+	}
+	bar.localhost {
+		respond "Bar"
+	}
+  `, "caddyfile")
+	tester.AssertRedirect("http://bar.localhost:9080/", "https://bar.localhost/", http.StatusPermanentRedirect)
+	tester.AssertGetResponse("http://foo.localhost:9080/", 200, "Foo")
+	tester.AssertGetResponse("http://baz.localhost:9080/", 200, "Foo")
+}

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -379,7 +379,9 @@ func (s *Server) hasTLSClientAuth() bool {
 // that it is after any other host matcher but before any "catch-all"
 // route without a host matcher.
 func (s *Server) findLastRouteWithHostMatcher() int {
+	foundHostMatcher := false
 	lastIndex := len(s.Routes)
+
 	for i, route := range s.Routes {
 		// since we want to break out of an inner loop, use a closure
 		// to allow us to use 'return' when we found a host matcher
@@ -388,6 +390,7 @@ func (s *Server) findLastRouteWithHostMatcher() int {
 				for _, matcher := range sets {
 					switch matcher.(type) {
 					case *MatchHost:
+						foundHostMatcher = true
 						return true
 					}
 				}
@@ -401,6 +404,14 @@ func (s *Server) findLastRouteWithHostMatcher() int {
 			lastIndex = i + 1
 		}
 	}
+
+	// If we didn't actually find a host matcher, return 0
+	// because that means every defined route was a "catch-all".
+	// See https://caddy.community/t/how-to-set-priority-in-caddyfile/13002/8
+	if !foundHostMatcher {
+		return 0
+	}
+
 	return lastIndex
 }
 


### PR DESCRIPTION
Followup to https://github.com/caddyserver/caddy/pull/4033, see https://caddy.community/t/how-to-set-priority-in-caddyfile/13002/8 for context

As it turns out, my earlier change for HTTP->HTTPS redirect was not enough, because it left one edgecase.

If none of the routes in the HTTP server had host matchers, then it would return the index of the last route, even if the only route was a catch-all (which is defined as having no host matcher).

This means that a config like this would not work correctly, and `Foo` would be returned on requests to `http://bar.localhost/`

```
http:// {
	respond "Foo"
}
bar.localhost {
	respond "Bar"
}
```

What we want is for `http://bar.localhost/` to return a redirect to `https://bar.localhost/` instead (and this can be overridden by using `auto_https disable_redirects` if you want it otherwise).

So the fix I went with is to keep track of whether we actually found a host matcher during the loop, and if we didn't, then return `0` as the index to insert the redirect routes, i.e. before any user-defined catch-all.

P.S. Integration tests don't actually run in CI because they're flaky and slow, but I ran them all again with my change and the new test to cover this case, and it passes.