### PR TITLE
logging: Add missing interface guards for replace filter

### DIFF
--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -188,9 +188,11 @@ func (m IPMaskFilter) Filter(in zapcore.Field) zapcore.Field {
 // Interface guards
 var (
 	_ LogFieldFilter = (*DeleteFilter)(nil)
+	_ LogFieldFilter = (*ReplaceFilter)(nil)
 	_ LogFieldFilter = (*IPMaskFilter)(nil)
 
 	_ caddyfile.Unmarshaler = (*DeleteFilter)(nil)
+	_ caddyfile.Unmarshaler = (*ReplaceFilter)(nil)
 	_ caddyfile.Unmarshaler = (*IPMaskFilter)(nil)
 
 	_ caddy.Provisioner = (*IPMaskFilter)(nil)


### PR DESCRIPTION
While looking at the code base I noticed that probably interface guards for `ReplaceFilter` were missing.