### PR TITLE
admin: Implement a simple timer to pull config

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -109,6 +109,12 @@ type ConfigSettings struct {
 	//
 	// EXPERIMENTAL: Subject to change.
 	LoadRaw json.RawMessage `json:"load,omitempty" caddy:"namespace=caddy.config_loaders inline_key=module"`
+
+	// The interval to pull config. With a non-zero value, will pull config
+	// from config loader (eg. a http loader) with given interval.
+	//
+	// EXPERIMENTAL: Subject to change.
+	PullInterval time.Duration `json:"pull_interval,omitempty"`
 }
 
 // IdentityConfig configures management of this server's identity. An identity

--- a/admin.go
+++ b/admin.go
@@ -114,7 +114,7 @@ type ConfigSettings struct {
 	// from config loader (eg. a http loader) with given interval.
 	//
 	// EXPERIMENTAL: Subject to change.
-	PullInterval Duration `json:"pull_interval,omitempty"`
+	LoadInterval Duration `json:"pull_interval,omitempty"`
 }
 
 // IdentityConfig configures management of this server's identity. An identity

--- a/admin.go
+++ b/admin.go
@@ -114,7 +114,7 @@ type ConfigSettings struct {
 	// from config loader (eg. a http loader) with given interval.
 	//
 	// EXPERIMENTAL: Subject to change.
-	PullInterval caddy.Duration `json:"pull_interval,omitempty"`
+	PullInterval Duration `json:"pull_interval,omitempty"`
 }
 
 // IdentityConfig configures management of this server's identity. An identity

--- a/admin.go
+++ b/admin.go
@@ -114,7 +114,7 @@ type ConfigSettings struct {
 	// from config loader (eg. a http loader) with given interval.
 	//
 	// EXPERIMENTAL: Subject to change.
-	PullInterval time.Duration `json:"pull_interval,omitempty"`
+	PullInterval caddy.Duration `json:"pull_interval,omitempty"`
 }
 
 // IdentityConfig configures management of this server's identity. An identity

--- a/admin.go
+++ b/admin.go
@@ -114,7 +114,7 @@ type ConfigSettings struct {
 	// from config loader (eg. a http loader) with given interval.
 	//
 	// EXPERIMENTAL: Subject to change.
-	LoadInterval Duration `json:"pull_interval,omitempty"`
+	LoadInterval Duration `json:"load_interval,omitempty"`
 }
 
 // IdentityConfig configures management of this server's identity. An identity

--- a/caddy.go
+++ b/caddy.go
@@ -269,7 +269,7 @@ func unsyncedDecodeAndRun(cfgJSON []byte, allowPersist bool) error {
 		newCfg.Admin != nil &&
 		newCfg.Admin.Config != nil &&
 		newCfg.Admin.Config.LoadRaw != nil &&
-		!(newCfg.Admin.Config.PullInterval > 0) {
+		newCfg.Admin.Config.PullInterval <= 0 {
 		return fmt.Errorf("recursive config loading detected: pulled configs cannot pull other configs")
 	}
 

--- a/caddy.go
+++ b/caddy.go
@@ -270,7 +270,7 @@ func unsyncedDecodeAndRun(cfgJSON []byte, allowPersist bool) error {
 		newCfg.Admin.Config != nil &&
 		newCfg.Admin.Config.LoadRaw != nil &&
 		newCfg.Admin.Config.LoadInterval <= 0 {
-		return fmt.Errorf("recursive config loading detected: pulled configs cannot pull other configs")
+		return fmt.Errorf("recursive config loading detected: pulled configs cannot pull other configs without positive load_interval")
 	}
 
 	// run the new config and start all its apps


### PR DESCRIPTION
Implemented mostly referenced to the #4106

- add a `PullInterval` filed in config
- setup a timer in a goroutine
- `select` with context and timer

A trick point is that

https://github.com/colinaaa/caddy/blob/169bb265104d0ade5f8bab05d82e53eef30c0129/caddy.go#L485-L494

here I did not use if-else to check whether `PullInterval` is non-zero, but I directly use `time.After(PullInterval)` so that with 0 intervals. 
This will return immediately which is the same as executing without `time.After`

re #4106