### PR TITLE
admin: Synchronize server assignment/references to avoid data race

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -336,7 +336,6 @@ func replaceLocalAdminServer(cfg *Config) error {
 	}
 
 	serverMu.Lock()
-	defer serverMu.Unlock()
 	localAdminServer = &http.Server{
 		Addr:              addr.String(), // for logging purposes only
 		Handler:           handler,
@@ -345,6 +344,7 @@ func replaceLocalAdminServer(cfg *Config) error {
 		IdleTimeout:       60 * time.Second,
 		MaxHeaderBytes:    1024 * 64,
 	}
+	serverMu.Unlock()
 
 	adminLogger := Log().Named("admin")
 	go func() {
@@ -480,7 +480,6 @@ func replaceRemoteAdminServer(ctx Context, cfg *Config) error {
 	}
 
 	serverMu.Lock()
-	defer serverMu.Unlock()
 	// create secure HTTP server
 	remoteAdminServer = &http.Server{
 		Addr:              addr.String(), // for logging purposes only
@@ -492,6 +491,7 @@ func replaceRemoteAdminServer(ctx Context, cfg *Config) error {
 		MaxHeaderBytes:    1024 * 64,
 		ErrorLog:          serverLogger,
 	}
+	serverMu.Unlock()
 
 	// start listener
 	ln, err := Listen(addr.Network, addr.JoinHostPort(0))


### PR DESCRIPTION
Resolves #4260.

While stepping through the stack traces in the above issue, I initially thought the existing [config mutex](https://github.com/caddyserver/caddy/blob/master/caddy.go#L133-L134) should cover this situation, however, since we reference [`localAdminServer` (and `remoteAdminServer`)](https://github.com/caddyserver/caddy/blob/master/admin.go#L349) in a goroutine later on, it's still possible that the reads on those variables are concurrent with writes.

I added a test that when paired with the `-race` flag consistently fails against tag 2.4.3 (9d4ed3a3236df06e54c80c4f6633b66d68ad3673). With these changes, the test consistently passes with the `-race` flag (at least on my machine 😄).

The addition of a mutex here doesn't seem to appreciably impact performance and motivated my decision to go with a `sync.Mutex` over a `sync.RWMutex`:

```
goos: darwin
goarch: amd64
pkg: github.com/caddyserver/caddy/v2
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz

Without synchronization: BenchmarkLoad-4   	    6410	    208997 ns/op
                         BenchmarkLoad-4   	    5682	    205783 ns/op
                         BenchmarkLoad-4   	    6840	    201484 ns/op

With a plain ol mutex:   BenchmarkLoad-4   	    6616	    224705 ns/op
                         BenchmarkLoad-4   	    7945	    202252 ns/op
                         BenchmarkLoad-4   	    6192	    203228 ns/op

With a RWMutex:          BenchmarkLoad-4   	    6112	    205772 ns/op
                         BenchmarkLoad-4   	    6844	    221402 ns/op
                         BenchmarkLoad-4   	    6001	    188549 ns/op
```

IIUC, [CI runs test with `-race` enabled](https://github.com/caddyserver/caddy/blob/master/.github/workflows/ci.yml#L108), so this new test should also be useful there as well.