### PR TITLE
feat(time): bring back time.now unix formats

### DIFF
--- a/replacer.go
+++ b/replacer.go
@@ -301,6 +301,10 @@ func globalDefaultReplacements(key string) (interface{}, bool) {
 		return nowFunc().Format("02/Jan/2006:15:04:05 -0700"), true
 	case "time.now.year":
 		return strconv.Itoa(nowFunc().Year()), true
+	case "time.now.unix":
+		return strconv.FormatInt(nowFunc().Unix(), 10), true
+	case "time.now.unix_ms":
+		return strconv.FormatInt(nanoToMilliseconds(nowFunc().UnixNano()), 10), true
 	}
 
 	return nil, false
@@ -322,3 +326,7 @@ var nowFunc = time.Now
 const ReplacerCtxKey CtxKey = "replacer"
 
 const phOpen, phClose, phEscape = '{', '}', '\\'
+
+func nanoToMilliseconds(d int64) int64 {
+	return d / 1e6
+}


### PR DESCRIPTION
This PR is necessary to support a header called `X-Request-Start` that is a UNIX timestamp of when the request was first received. Monitoring tools like AppSignal and NewRelic uses this header to track request queue time. If you need more information, you can read more about it:

- [Is it normal for requests to spend a long time in "Request Queuing" as reported by NewRelic?](https://help.heroku.com/QB0BKTNJ/is-it-normal-for-requests-to-spend-a-long-time-in-request-queuing-as-reported-by-newrelic)
- [Track request queue time](https://docs.appsignal.com/ruby/instrumentation/request-queue-time.html)