### PR TITLE
ci: Build and test on Go 1.17, bump minimum to 1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go: [ '1.15', '1.16' ]
+        go: [ '1.16', '1.17' ]
 
         # Set some variables per OS, usable via ${{ matrix.VAR }}
         # CADDY_BIN_PATH: the path to the compiled Caddy binary, for artifact publishing

--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         goos: ['android', 'linux', 'solaris', 'illumos', 'dragonfly', 'freebsd', 'openbsd', 'plan9', 'windows', 'darwin', 'netbsd']
-        go: [ '1.15', '1.16' ]
+        go: [ '1.16', '1.17' ]
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        go: [ '1.16' ]
+        go: [ '1.17' ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For other install options, see https://caddyserver.com/docs/install.
 
 Requirements:
 
-- [Go 1.15 or newer](https://golang.org/dl/)
+- [Go 1.16 or newer](https://golang.org/dl/)
 
 ### For development
  

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/caddyserver/caddy/v2
 
-go 1.15
+go 1.16
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2


### PR DESCRIPTION
Used https://github.com/caddyserver/caddy/pull/4024 as a template. Pretty much the same change, different versions.