### PR TITLE
caddyhttp: Implement `http.request.uuid` placeholder

### DIFF
--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -50,6 +50,7 @@ func init() {
 // `{http.request.body}` | The request body (⚠️ inefficient; use only for debugging)
 // `{http.request.cookie.*}` | HTTP request cookie
 // `{http.request.duration}` | Time up to now spent handling the request (after decoding headers from client)
+// `{http.request.uuid}` | The request unique identifier
 // `{http.request.header.*}` | Specific request header field
 // `{http.request.host.labels.*}` | Request host labels (0-based from right); e.g. for foo.example.com: 0=com, 1=example, 2=foo
 // `{http.request.host}` | The host part of the request's Host header

--- a/modules/caddyhttp/replacer.go
+++ b/modules/caddyhttp/replacer.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
+	"github.com/google/uuid"
 )
 
 // NewTestReplacer creates a replacer for an http.Request
@@ -54,6 +55,7 @@ func NewTestReplacer(req *http.Request) *caddy.Replacer {
 
 func addHTTPVarsToReplacer(repl *caddy.Replacer, req *http.Request, w http.ResponseWriter) {
 	SetVar(req.Context(), "start_time", time.Now())
+	SetVar(req.Context(), "uuid", new(requestID))
 
 	httpVars := func(key string) (interface{}, bool) {
 		if req != nil {
@@ -146,6 +148,9 @@ func addHTTPVarsToReplacer(repl *caddy.Replacer, req *http.Request, w http.Respo
 			case "http.request.duration":
 				start := GetVar(req.Context(), "start_time").(time.Time)
 				return time.Since(start), true
+			case "http.request.uuid":
+				id := GetVar(req.Context(), "uuid").(*requestID)
+				return id.String(), true
 			case "http.request.body":
 				if req.Body == nil {
 					return "", true
@@ -396,6 +401,20 @@ func getTLSPeerCert(cs *tls.ConnectionState) *x509.Certificate {
 		return nil
 	}
 	return cs.PeerCertificates[0]
+}
+
+type requestID struct {
+	value string
+}
+
+// Lazy generates UUID string or return cached value if present
+func (rid *requestID) String() string {
+	if rid.value == "" {
+		if id, err := uuid.NewRandom(); err == nil {
+			rid.value = id.String()
+		}
+	}
+	return rid.value
 }
 
 const (


### PR DESCRIPTION
`http.request.uuid` placeholder enables you to trace and troubleshoot requests end‑to‑end. 
```caddyfile
reverse_proxy web:3000 {
  header_up X-Request-Id {http.request.uuid}
}
```