### PR TITLE
cmd: Fix paths when using an env file

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -363,7 +363,8 @@ func loadEnvFromFile(envFile string) error {
 
 	// Update the storage paths to ensure they have the proper
 	// value after loading a specified env file.
-	caddy.UpdateStoragePaths()
+	caddy.ConfigAutosavePath = filepath.Join(caddy.AppConfigDir(), "autosave.json")
+	caddy.DefaultStorage = &certmagic.FileStorage{Path: caddy.AppDataDir()}
 
 	return nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -361,6 +361,10 @@ func loadEnvFromFile(envFile string) error {
 		}
 	}
 
+	// Update the storage paths to ensure they have the proper
+	// value after loading a specified env file.
+	caddy.UpdateStoragePaths()
+
 	return nil
 }
 

--- a/storage.go
+++ b/storage.go
@@ -153,16 +153,6 @@ func AppDataDir() string {
 	return "./caddy"
 }
 
-// UpdateStoragePaths sets the config auto save and default storage path
-// again. This ensures that env files that overwrite the paths
-// have the expected effect.
-// If used, this function must be called before ConfigAutosavePath and
-// DefaultStorage are being used.
-func UpdateStoragePaths() {
-	ConfigAutosavePath = filepath.Join(AppConfigDir(), "autosave.json")
-	DefaultStorage = &certmagic.FileStorage{Path: AppDataDir()}
-}
-
 // ConfigAutosavePath is the default path to which the last config will be persisted.
 var ConfigAutosavePath = filepath.Join(AppConfigDir(), "autosave.json")
 

--- a/storage.go
+++ b/storage.go
@@ -153,6 +153,16 @@ func AppDataDir() string {
 	return "./caddy"
 }
 
+// UpdateStoragePaths sets the config auto save and default storage path
+// again. This ensures that env files that overwrite the paths
+// have the expected effect.
+// If used, this function must be called before ConfigAutosavePath and
+// DefaultStorage are being used.
+func UpdateStoragePaths() {
+	ConfigAutosavePath = filepath.Join(AppConfigDir(), "autosave.json")
+	DefaultStorage = &certmagic.FileStorage{Path: AppDataDir()}
+}
+
 // ConfigAutosavePath is the default path to which the last config will be persisted.
 var ConfigAutosavePath = filepath.Join(AppConfigDir(), "autosave.json")
 


### PR DESCRIPTION
### Description
Fix the behaviour of the environment variables `XDG_DATA_HOME` and `XDG_CONFIG_HOME` when supplied through an env file to match the expected one.

For further information, check #4273 

### Related Issues
Resolves #4273 

### Testing
 - Caddy should create its data and config directories and files at the common location as always when no env file is specified using `--envfile`.
   - For example: `/home/user/.local/share/caddy/<files and/or folders>`
 - When an env file is specified using `--envfile`, Caddy should use the environment variables `XDG_DATA_HOME` and `XDG_CONFIG_HOME` from the env file instead (instead) of the system ones. This should cause Caddy to create its files/directories at the location specified in the env file. 
   - Example: Instead of `/home/user/.local/share/caddy/autosave.json` Caddy now uses `/home/user/caddydata/caddy/autosave.json`, when `XDG_CONFIG_HOME` was set to `/home/user/caddydata` in the env file.