### PR TITLE
reverseproxy: Move status replacement intercept to `replace_status`

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_handle_response.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_handle_response.txt
@@ -1,6 +1,9 @@
 :8884
 
 reverse_proxy 127.0.0.1:65535 {
+	@changeStatus status 500
+	replace_status @changeStatus 400
+
 	@accel header X-Accel-Redirect *
 	handle_response @accel {
 		respond "Header X-Accel-Redirect!"
@@ -38,9 +41,6 @@ reverse_proxy 127.0.0.1:65535 {
 	handle_response @multi {
 		respond "Headers Foo, Bar AND statuses 401, 403 and 404!"
 	}
-
-	@changeStatus status 500
-	handle_response @changeStatus 400
 }
 ----------
 {
@@ -56,6 +56,14 @@ reverse_proxy 127.0.0.1:65535 {
 							"handle": [
 								{
 									"handle_response": [
+										{
+											"match": {
+												"status_code": [
+													500
+												]
+											},
+											"status_code": 400
+										},
 										{
 											"match": {
 												"headers": {
@@ -154,14 +162,6 @@ reverse_proxy 127.0.0.1:65535 {
 													]
 												}
 											]
-										},
-										{
-											"match": {
-												"status_code": [
-													500
-												]
-											},
-											"status_code": 400
 										},
 										{
 											"routes": [


### PR DESCRIPTION
I was doing some thinking in https://github.com/caddyserver/caddy/issues/4298#issuecomment-903219435 and I think the UX of `handle_response` is super awkward in that it was doing two different things in one subdirective.

Semantically, it's expected that the `handle` family of options imply that subroutes will be defined (as per `handle` and `handle_path` directives).

Separating the status code replacement usecase into its own Caddyfile subdirective (even if it doesn't match the JSON 1:1) is easier to understand.

This is a breaking change, so we could defer this to v2.5.0, but I don't think many people use this yet so the impact should be very low. I haven't seen anyone on the forums asking questions using this feature yet since we released it in v2.4.0.