### PR TITLE
caddyfile: Prevent invalid site addresses with comma

### DIFF
--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -229,6 +229,13 @@ func (p *parser) addresses() error {
 				expectingAnother = false // but we may still see another one on this line
 			}
 
+			// If there's a comma here, it's probably because they didn't use a space
+			// between their two domains, e.g. "foo.com,bar.com", which would not be
+			// parsed as two separate site addresses.
+			if strings.Contains(tkn, ",") {
+				return p.Errf("Site addresses cannot contain a comma ',': '%s' - put a space after the comma to separate site addresses", tkn)
+			}
+
 			p.block.Keys = append(p.block.Keys, tkn)
 		}
 


### PR DESCRIPTION
Some users forget to use a comma between their site addresses. This is invalid (commas aren't a valid character in domains) and later parts of the code like certificate automation will try to use this otherwise, which doesn't make sense. Best to error as early as possible.

Example thread on the forums where this happened: https://caddy.community/t/simplify-caddyfile/13281/9

```
foo.example.com,bar.example.com
respond "foo"
```

👇 

```
$ caddy adapt
2021/08/22 19:29:44.950 INFO    using adjacent Caddyfile
adapt: Caddyfile:1 - Error during parsing: Site addresses cannot contain a comma ',': 'foo.example.com,bar.example.com' - put a space after the comma to separate site addresses
```