### PR TITLE
chore: promote creating 'caddy-build' to the release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+
+      - name: Create 'caddy-build'
+        run: mkdir -p caddy-build
+      
       - uses: goreleaser/goreleaser-action@v2
         with:
           version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go${{ matrix.go }}-release
 
+    - name: Create the 'caddy-build' dir for GoReleaser
+      run: |
+        mkdir -p caddy-build
+
     # GoReleaser will take care of publishing those artifacts into the release
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
The commit goreleaser/goreleaser@013bd69126459125694d7cb2c434dd9ba63e5a5b of GoReleaser is now checking the `go version` prior to executing any of the pre-hooks, which involves setting the current dir of the command to the `build.dir` of the build config. At the time of version check, the buil dir does not exist. It's created in the pre-hook. As a workaround, the build-dir is now created in the Github Action prior to executing goreleaser action.

Murphy's Law in action once again. Sigh...