### PR TITLE
caddyhttp: Redirect HTTP requests on the HTTPS port to https://

### DIFF
--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -346,7 +346,7 @@ func (app *App) Start() error {
 					// create HTTP redirect wrapper, which detects if
 					// the request had HTTP bytes on the HTTPS port, and
 					// triggers a redirect if so.
-					ln = NewHttpRedirectListener(ln)
+					ln = &httpRedirectListener{Listener: ln}
 
 					// create TLS listener
 					tlsCfg := srv.TLSConnPolicies.TLSConfig(app.ctx)

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -343,6 +343,11 @@ func (app *App) Start() error {
 				// enable TLS if there is a policy and if this is not the HTTP port
 				useTLS := len(srv.TLSConnPolicies) > 0 && int(listenAddr.StartPort+portOffset) != app.httpPort()
 				if useTLS {
+					// create HTTP redirect wrapper, which detects if
+					// the request had HTTP bytes on the HTTPS port, and
+					// triggers a redirect if so.
+					ln = NewHttpRedirectListener(ln)
+
 					// create TLS listener
 					tlsCfg := srv.TLSConnPolicies.TLSConfig(app.ctx)
 					ln = tls.NewListener(ln, tlsCfg)

--- a/modules/caddyhttp/httpredirectlistener.go
+++ b/modules/caddyhttp/httpredirectlistener.go
@@ -1,0 +1,120 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddyhttp
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+)
+
+// httpRedirectListener is listener that checks the first few bytes
+// of the request when the server is intended to accept HTTPS requests,
+// to respond to an HTTP request with a redirect.
+type httpRedirectListener struct {
+	net.Listener
+}
+
+// NewHttpRedirectListener wraps inner, handling
+func NewHttpRedirectListener(inner net.Listener) net.Listener {
+	l := &httpRedirectListener{Listener: inner}
+	return l
+}
+
+// Accept waits for and returns the next connection to the listener,
+// wrapping it with a httpRedirectConn.
+func (l *httpRedirectListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	return &httpRedirectConn{
+		Conn: c,
+		r:    bufio.NewReader(c),
+	}, nil
+}
+
+type httpRedirectConn struct {
+	net.Conn
+	once sync.Once
+	r    *bufio.Reader
+}
+
+// Read tries to peek at the first few bytes of the request, and if we get
+// an error reading the headers, and that error was due to the bytes looking
+// like an HTTP request, then we perform a HTTP->HTTPS redirect on the same
+// port as the original connection.
+func (c *httpRedirectConn) Read(p []byte) (int, error) {
+	var errReturn error
+	c.once.Do(func() {
+		firstBytes, err := c.r.Peek(5)
+		if err != nil {
+			return
+		}
+
+		// If the request doesn't look like HTTP, then it's probably
+		// TLS bytes and we don't need to do anything.
+		if !firstBytesLookLikeHTTP(firstBytes) {
+			return
+		}
+
+		// Parse the HTTP request, so we can get the Host and URL to redirect to.
+		req, err := http.ReadRequest(c.r)
+		if err != nil {
+			return
+		}
+
+		// Build the redirect response, using the same Host and URL,
+		// but replacing the scheme with https.
+		headers := make(http.Header)
+		headers.Add("Location", "https://"+req.Host+req.URL.String())
+		resp := &http.Response{
+			Proto:      "HTTP/1.0",
+			Status:     "308 Permanent Redirect",
+			StatusCode: 308,
+			ProtoMajor: 1,
+			ProtoMinor: 0,
+			Header:     headers,
+		}
+
+		err = resp.Write(c.Conn)
+		if err != nil {
+			errReturn = fmt.Errorf("couldn't write HTTP->HTTPS redirect")
+			return
+		}
+
+		errReturn = fmt.Errorf("redirected HTTP request on HTTPS port")
+		c.Conn.Close()
+	})
+
+	if errReturn != nil {
+		return 0, errReturn
+	}
+
+	return c.r.Read(p)
+}
+
+// firstBytesLookLikeHTTP reports whether a TLS record header
+// looks like it might've been a misdirected plaintext HTTP request.
+func firstBytesLookLikeHTTP(hdr []byte) bool {
+	switch string(hdr[:5]) {
+	case "GET /", "HEAD ", "POST ", "PUT /", "OPTIO":
+		return true
+	}
+	return false
+}

--- a/modules/caddyhttp/httpredirectlistener.go
+++ b/modules/caddyhttp/httpredirectlistener.go
@@ -29,12 +29,6 @@ type httpRedirectListener struct {
 	net.Listener
 }
 
-// NewHttpRedirectListener wraps inner, handling
-func NewHttpRedirectListener(inner net.Listener) net.Listener {
-	l := &httpRedirectListener{Listener: inner}
-	return l
-}
-
 // Accept waits for and returns the next connection to the listener,
 // wrapping it with a httpRedirectConn.
 func (l *httpRedirectListener) Accept() (net.Conn, error) {


### PR DESCRIPTION
This is very much not done yet, but I just wanted to show the proof of concept.

---

Background: in certain cases, users would like HTTP->HTTPS redirects in situations where they only actually serve HTTPS on one port; if an HTTP request is made to that port, Caddy currently responds with `Client sent an HTTP request to an HTTPS server.` This response comes directly from Go's stdlib (added in https://go-review.googlesource.com/c/go/+/143177/, see https://github.com/golang/go/issues/23689#issuecomment-362936254 for context):

https://github.com/golang/go/blob/56c3856d529d72e280ad6b185f7927657de86c37/src/net/http/server.go#L1817-1825

While it could be argued that HTTP responses should never be sent on the HTTPS port... Go already does it.

This is alright, but Caddy _could_ go a step further and do an HTTP->HTTPS redirect, which would make HTTP clients happier, skipping the error and instead going straight to HTTPS. This can help avoid confusion for users making mistakes, etc.

---

So after hacking on this a bit, the idea I came up with is to make `tlsPlaceholderWrapper` a bit more useful by peeking the first bytes of the connection. Turns out that if we just call `Peek()` on the wrapped request, then the stdlib TLS listener will return an error `tls.RecordHeaderError` that we can watch for, which is the same one that gets handled for writing the `Client sent an HTTP request to an HTTPS server.` message. We can do the same check on the first 5 bytes to see if it looks like HTTP, and write our own response instead.

Note that `tlsPlaceholderWrapper` is now _always_ registered, and is no longer skipped when performing the wrapping. If I didn't make this change, then the logic in the wrapper would never get called.

We'll probably want to rename `tlsPlaceholderWrapper` to something more meaningful now that it has a secondary purpose 🤷‍♂️

Still `TODO`, I need to figure out how to get the wrapper to read a bit more of the request in the error case to grab the `Host` header to help us perform the redirect. I have a hunch that might not be possible with this current approach, because any attempts to read would trigger the same error since the stdlib TLS listener is still under ours. I'll have to dig into this more another day.