### PR TITLE
encode: ignore flushing until after first write

### DIFF
--- a/modules/caddyhttp/encode/encode.go
+++ b/modules/caddyhttp/encode/encode.go
@@ -200,10 +200,10 @@ func (enc *Encode) Match(rw *responseWriter) bool {
 // until headers were written.
 func (rw *responseWriter) Flush() {
 	if !rw.wroteHeader {
-		// flushing the underlying ResponseWriter will write header and status code
+		// flushing the underlying ResponseWriter will write header and status code,
 		// but we need to delay that until we can determine if we must encode and
-		// therefore add the Content-Encoding header
-		// this happens in the first call to rw.Write
+		// therefore add the Content-Encoding header; this happens in the first call
+		// to rw.Write (see bug in #4314)
 		return
 	}
 	rw.ResponseWriterWrapper.Flush()

--- a/modules/caddyhttp/encode/encode.go
+++ b/modules/caddyhttp/encode/encode.go
@@ -182,6 +182,7 @@ type responseWriter struct {
 	buf          *bytes.Buffer
 	config       *Encode
 	statusCode   int
+	wroteHeader  bool
 }
 
 // WriteHeader stores the status to write when the time comes
@@ -193,6 +194,19 @@ func (rw *responseWriter) WriteHeader(status int) {
 // Match determines, if encoding should be done based on the ResponseMatcher.
 func (enc *Encode) Match(rw *responseWriter) bool {
 	return enc.Matcher.Match(rw.statusCode, rw.Header())
+}
+
+// Flush implements http.Flusher. It delays the actual Flush of the underlying ResponseWriterWrapper
+// until headers were written.
+func (rw *responseWriter) Flush() {
+	if !rw.wroteHeader {
+		// flushing the underlying ResponseWriter will write header and status code
+		// but we need to delay that until we can determine if we must encode and
+		// therefore add the Content-Encoding header
+		// this happens in the first call to rw.Write
+		return
+	}
+	rw.ResponseWriterWrapper.Flush()
 }
 
 // Write writes to the response. If the response qualifies,
@@ -225,6 +239,7 @@ func (rw *responseWriter) Write(p []byte) (int, error) {
 	if rw.statusCode > 0 {
 		rw.ResponseWriter.WriteHeader(rw.statusCode)
 		rw.statusCode = 0
+		rw.wroteHeader = true
 	}
 
 	switch {
@@ -271,6 +286,7 @@ func (rw *responseWriter) Close() error {
 		// that rely on If-None-Match, for example
 		rw.ResponseWriter.WriteHeader(rw.statusCode)
 		rw.statusCode = 0
+		rw.wroteHeader = true
 	}
 	if rw.w != nil {
 		err2 := rw.w.Close()


### PR DESCRIPTION
The first write will determine if encoding has to be done and will add an Content-Encoding. Until then Flushing has to be delayed so the Content-Encoding header can be added before headers and status code is written. (A passthrough flush would write header and status code)

Fixes https://github.com/caddyserver/caddy/issues/4314

As of now, no integration test included