### PR TITLE
ci: Only test cross-build on latest Go version

### DIFF
--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         goos: ['android', 'linux', 'solaris', 'illumos', 'dragonfly', 'freebsd', 'openbsd', 'plan9', 'windows', 'darwin', 'netbsd']
-        go: [ '1.16', '1.17' ]
+        go: [ '1.17' ]
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:


### PR DESCRIPTION
This generated way too many test jobs, which weren't really that useful. Cross-build is just to keep us posted on which architectures are building okay, so it's not necessary to do it twice. Only plan9 is not working at this point (see https://github.com/caddyserver/caddy/issues/3615)