### PR TITLE
ci: revert workaround implemented in #4306

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-
-      - name: Create 'caddy-build'
-        run: mkdir -p caddy-build
       
       - uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,10 +88,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go${{ matrix.go }}-release
 
-    - name: Create the 'caddy-build' dir for GoReleaser
-      run: |
-        mkdir -p caddy-build
-
     # GoReleaser will take care of publishing those artifacts into the release
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
GoReleaser v0.177.0 fixes the issue, so the workaround is no longer needed.