### PR TITLE
caddyhttp: Add support for triggering errors from `try_files`

### DIFF
--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -211,7 +211,7 @@ func (m MatchFile) selectFile(r *http.Request) (matched bool) {
 	case "", tryPolicyFirstExist:
 		for _, f := range m.TryFiles {
 			if err := parseErrorCode(f); err != nil {
-				repl.Set(caddyhttp.MatcherErrorPlaceholder, err)
+				caddyhttp.SetVar(r.Context(), caddyhttp.MatcherErrorVarKey, err)
 				return
 			}
 			suffix, fullpath, remainder := prepareFilePath(f)

--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -60,7 +61,11 @@ type MatchFile struct {
 	// directories are treated distinctly, so to match
 	// a directory, the filepath MUST end in a forward
 	// slash `/`. To match a regular file, there must
-	// be no trailing slash. Accepts placeholders.
+	// be no trailing slash. Accepts placeholders. If
+	// the policy is "first_exist", then an error may
+	// be triggered as a fallback by configuring "="
+	// followed by a status code number,
+	// for example "=404".
 	TryFiles []string `json:"try_files,omitempty"`
 
 	// How to choose a file in TryFiles. Can be:
@@ -205,6 +210,10 @@ func (m MatchFile) selectFile(r *http.Request) (matched bool) {
 	switch m.TryPolicy {
 	case "", tryPolicyFirstExist:
 		for _, f := range m.TryFiles {
+			if err := parseErrorCode(f); err != nil {
+				repl.Set(caddyhttp.MatcherErrorPlaceholder, err)
+				return
+			}
 			suffix, fullpath, remainder := prepareFilePath(f)
 			if info, exists := strictFileExists(fullpath); exists {
 				setPlaceholders(info, suffix, fullpath, remainder)
@@ -272,6 +281,20 @@ func (m MatchFile) selectFile(r *http.Request) (matched bool) {
 	}
 
 	return
+}
+
+// parseErrorCode checks if the input is a status
+// code number, prefixed by "=", and returns an
+// error if so.
+func parseErrorCode(input string) error {
+	if len(input) > 1 && input[0] == '=' {
+		code, err := strconv.Atoi(input[1:])
+		if err != nil || code < 100 || code > 999 {
+			return nil
+		}
+		return caddyhttp.Error(code, fmt.Errorf("%s", input[1:]))
+	}
+	return nil
 }
 
 // strictFileExists returns true if file exists

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -986,6 +986,11 @@ func (mre *MatchRegexp) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 var wordRE = regexp.MustCompile(`\w+`)
 
 const regexpPlaceholderPrefix = "http.regexp"
+
+// MatcherErrorVarKey is the key used for the variable that
+// holds an optional error emitted from a request matcher,
+// to short-circuit the handler chain, since matchers cannot
+// return errors via the RequestMatcher interface.
 const MatcherErrorVarKey = "matchers.error"
 
 // Interface guards

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -986,7 +986,7 @@ func (mre *MatchRegexp) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 var wordRE = regexp.MustCompile(`\w+`)
 
 const regexpPlaceholderPrefix = "http.regexp"
-const MatcherErrorPlaceholder = "http.matchers.error"
+const MatcherErrorVarKey = "matchers.error"
 
 // Interface guards
 var (

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -986,6 +986,7 @@ func (mre *MatchRegexp) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 var wordRE = regexp.MustCompile(`\w+`)
 
 const regexpPlaceholderPrefix = "http.regexp"
+const MatcherErrorPlaceholder = "http.matchers.error"
 
 // Interface guards
 var (

--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -202,12 +202,9 @@ func wrapRoute(route Route) Middleware {
 			if !route.MatcherSets.AnyMatch(req) {
 				// allow matchers the opportunity to short circuit
 				// the request and trigger the error handling chain
-				repl := req.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
-				val, ok := repl.Get(MatcherErrorPlaceholder)
+				err, ok := GetVar(req.Context(), MatcherErrorVarKey).(error)
 				if ok {
-					if err, ok := val.(error); ok {
-						return err
-					}
+					return err
 				}
 
 				// call the next handler, and skip this one,


### PR DESCRIPTION
See #4344, this is a first step towards completing that issue.

Nginx supports a couple pieces of functionality in its implementation of `try_files` that allow handling the request either as an HTTP error, or by routing to a named location block. http://nginx.org/en/docs/http/ngx_http_core_module.html#try_files

For Caddy, I think it would be quite beneficial to add support to `try_files` for triggering an error as a fallback case, to short-circuit the request handling early. In many cases, it's not simply the case of "try_files matches, or doesn't".

The one potentially contentious bit here, implementation-wise, is the usage of a placeholder `http.matchers.error` as a way to carry the error from the matcher logic up to the HTTP handler chain logic. I'm hoping that this would have a minimal performance impact, but I'm not totally certain, haven't benchmarked. It's also I guess kinda cross-cutting concerns. But I don't really see a cleaner way to do this. We can't use `r.Context()` directly, because that's immutable at this point, so the replacer, being mutable, is the mechanism that would let us do it.

Anyways, an example of how this would look:

```
:8080 {
	root * /srv
	try_files {path} {path}/index.php =404
	php_fastcgi localhost:9000
	file_server

	handle_errors {
		respond "Error!"
	}
}
```

Given the files: `/srv/foo.js`, `/srv/index.php`, `/srv/bar.php`

```
$ curl localhost:8080/foo.js
foo.js contents

$ curl localhost:8080/
index.php executed

$ curl localhost:8080/index.php
index.php executed

$ curl localhost:8080/bar.php
bar.php executed

$ curl localhost:8080/foo.php
Error!
```

Whereas without this, `curl localhost:8080/foo.php` would be sent through fastcgi when the file is already known not to exist.