### PR TITLE
reverseproxy: Add ID field for upstreams

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_ids.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_ids.txt
@@ -1,0 +1,46 @@
+:8884
+
+reverse_proxy one|http://localhost two|http://localhost {
+	to three|srv+http://localhost four|srv+http://localhost
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8884"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "reverse_proxy",
+									"upstreams": [
+										{
+											"dial": "localhost:80",
+											"id": "one"
+										},
+										{
+											"dial": "localhost:80",
+											"id": "two"
+										},
+										{
+											"id": "three",
+											"lookup_srv": "localhost"
+										},
+										{
+											"id": "four",
+											"lookup_srv": "localhost"
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/reverseproxy/admin.go
+++ b/modules/caddyhttp/reverseproxy/admin.go
@@ -34,7 +34,8 @@ type adminUpstreams struct{}
 
 // upstreamResults holds the status of a particular upstream
 type upstreamStatus struct {
-	Address     string `json:"address"`
+	ID          string `json:"id"`
+	Address     string `json:"address"` // Address is deprecated, should be removed in a future release.
 	Healthy     bool   `json:"healthy"`
 	NumRequests int    `json:"num_requests"`
 	Fails       int    `json:"fails"`
@@ -78,7 +79,7 @@ func (adminUpstreams) handleUpstreams(w http.ResponseWriter, r *http.Request) er
 	// Iterate over the upstream pool (needs to be fast)
 	var rangeErr error
 	hosts.Range(func(key, val interface{}) bool {
-		address, ok := key.(string)
+		id, ok := key.(string)
 		if !ok {
 			rangeErr = caddy.APIError{
 				HTTPStatus: http.StatusInternalServerError,
@@ -97,7 +98,8 @@ func (adminUpstreams) handleUpstreams(w http.ResponseWriter, r *http.Request) er
 		}
 
 		results = append(results, upstreamStatus{
-			Address:     address,
+			ID:          id,
+			Address:     id,
 			Healthy:     !upstream.Unhealthy(),
 			NumRequests: upstream.NumRequests(),
 			Fails:       upstream.Fails(),

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -219,6 +219,12 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	// treated as a SRV-based upstream, and any port will be
 	// dropped.
 	appendUpstream := func(address string) error {
+		var id string
+		if strings.Contains(address, "|") {
+			parts := strings.SplitN(address, "|", 2)
+			id = parts[0]
+			address = parts[1]
+		}
 		isSRV := strings.HasPrefix(address, "srv+")
 		if isSRV {
 			address = strings.TrimPrefix(address, "srv+")
@@ -231,9 +237,9 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			if host, _, err := net.SplitHostPort(dialAddr); err == nil {
 				dialAddr = host
 			}
-			h.Upstreams = append(h.Upstreams, &Upstream{LookupSRV: dialAddr})
+			h.Upstreams = append(h.Upstreams, &Upstream{ID: id, LookupSRV: dialAddr})
 		} else {
-			h.Upstreams = append(h.Upstreams, &Upstream{Dial: dialAddr})
+			h.Upstreams = append(h.Upstreams, &Upstream{ID: id, Dial: dialAddr})
 		}
 		return nil
 	}

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -65,6 +65,12 @@ type UpstreamPool []*Upstream
 type Upstream struct {
 	Host `json:"-"`
 
+	// The unique ID for this upstream, to disambiguate multiple
+	// upstreams with the same Dial address. This is optional,
+	// and only necessary if the upstream states need to be
+	// separate, such as having different health checking policies.
+	ID string `json:"id,omitempty"`
+
 	// The [network address](/docs/conventions#network-addresses)
 	// to dial to connect to the upstream. Must represent precisely
 	// one socket (i.e. no port ranges). A valid network address
@@ -98,6 +104,9 @@ type Upstream struct {
 }
 
 func (u Upstream) String() string {
+	if u.ID != "" {
+		return u.ID
+	}
 	if u.LookupSRV != "" {
 		return u.LookupSRV
 	}


### PR DESCRIPTION
First step for #4341, Caddyfile support would be needed to complete it. /cc @ulrichSchreiner

This makes it possible to specify upstreams in JSON with an `"id"` field, to disambiguate upstreams with the same dial address:

```json
"upstreams": [
    {
        "id": "second",
        "dial": "httpbin.org:443"
    }
],
```

Given the JSON config from https://caddy.community/t/healthcheck-not-working-with-multiple-servers/13563, with just `"id"` fields added, we see that it works, the internal state has separate upstreams:

```json
$ curl -s localhost:2019/reverse_proxy/upstreams | jq
[
  {
    "id": "second",
    "address": "second",
    "healthy": true,
    "num_requests": 0,
    "fails": 0
  },
  {
    "id": "first",
    "address": "first",
    "healthy": false,
    "num_requests": 0,
    "fails": 0
  }
]
```

To avoid it being a breaking change, I left in the `"address"` field in the admin API, deprecated for now, to be removed at a later date. It's more accurate to call it "ID" even though it could be an ID, a dial address, or a SRV address, depending on how it was configured (i.e. whatever the upstream's `String()` function returns).