### PR TITLE
fileserver: Fix displayed file size if it is symlink

### DIFF
--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -137,7 +137,12 @@ func (fsrv *FileServer) loadDirectoryContents(dir *os.File, root, urlPath string
 	// user can presumably browse "up" to parent folder if path is longer than "/"
 	canGoUp := len(urlPath) > 1
 
-	return fsrv.directoryListing(files, canGoUp, root, urlPath, repl), nil
+	l, err := fsrv.directoryListing(files, canGoUp, root, urlPath, repl)
+	if err != nil {
+		return browseTemplateContext{}, err
+	}
+
+	return l, nil
 }
 
 // browseApplyQueryParams applies query parameters to the listing.

--- a/modules/caddyhttp/fileserver/browsetplcontext.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext.go
@@ -52,9 +52,9 @@ func (fsrv *FileServer) directoryListing(files []os.FileInfo, canGoUp bool, root
 			fileCount++
 		}
 
-		isSymlink := isSymlink(f)
+		fileIsSymlink := isSymlink(f)
 		size := f.Size()
-		if isSymlink {
+		if fileIsSymlink {
 			info, err := os.Stat(name)
 			if err != nil {
 				return browseTemplateContext{}, err
@@ -64,7 +64,7 @@ func (fsrv *FileServer) directoryListing(files []os.FileInfo, canGoUp bool, root
 
 		fileInfos = append(fileInfos, fileInfo{
 			IsDir:     isDir,
-			IsSymlink: isSymlink,
+			IsSymlink: fileIsSymlink,
 			Name:      name,
 			Size:      size,
 			URL:       u.String(),


### PR DESCRIPTION
Fix: [#4353](https://github.com/caddyserver/caddy/issues/4353)