### PR TITLE
fileserver: purple color for visited links in browse

### DIFF
--- a/modules/caddyhttp/fileserver/browsetpl.go
+++ b/modules/caddyhttp/fileserver/browsetpl.go
@@ -39,6 +39,10 @@ h1 a:hover {
 	color: #319cff;
 }
 
+a:visited {
+  color: #800080;
+}
+
 header,
 #summary {
 	padding-left: 5%;


### PR DESCRIPTION
Currently file browser template have all A link (visited and unvisited) in the same color (blue).

This PR make visited A links to be displayed in purpled color. 
Convenient to keep track of visited folders & opened files.