### PR TITLE
fix: retain and restore terminal mode on Windows

### DIFF
--- a/cmd/cleanup_other.go
+++ b/cmd/cleanup_other.go
@@ -1,0 +1,6 @@
+//go:build !windows
+// +build !windows
+
+package caddycmd
+
+func cleanup() error { return nil }

--- a/cmd/cleanup_windows.go
+++ b/cmd/cleanup_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+// +build windows
+
+package caddycmd
+
+import "golang.org/x/sys/windows"
+
+// Retain the original mode of the console to restore later.
+// See: https://github.com/caddyserver/caddy/issues/4251
+// The evaluation of this takes place before calling init()
+// ref: https://golang.org/ref/spec#Order_of_evaluation
+var inMode, outMode uint32
+var _ = windows.GetConsoleMode(windows.Stdin, &inMode)
+var _ = windows.GetConsoleMode(windows.Stdout, &outMode)
+
+func cleanup() error {
+	if err := windows.SetConsoleMode(windows.Stdin, inMode); err != nil {
+		return err
+	}
+	if err := windows.SetConsoleMode(windows.Stdout, outMode); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,7 +85,9 @@ func Main() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %v\n", subcommand.Name, err)
 	}
-
+	if err := cleanup(); err != nil {
+		fmt.Fprintf(os.Stderr, "error restoring console to functional state: %v\n", err)
+	}
 	os.Exit(exitCode)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	go.uber.org/zap v1.19.0
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
 	golang.org/x/term v0.0.0-20210503060354-a79de5458b56
 	google.golang.org/genproto v0.0.0-20210604141403-392c879c8b08
 	google.golang.org/protobuf v1.27.1


### PR DESCRIPTION
Given this is caused by a dependency, not possible to remove the dependency, and not easy to excise the code from the dependency due to their needs, I'm attempting to retain the original terminal mode bits and to be set before exit. Bitwise OR operations aren't reversible, so retaining the original state is the other option.

Fixes #4251