### PR TITLE
httpcaddyfile: Empty tls policy for internal http localhost

### DIFF
--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -485,7 +485,7 @@ func (sb serverBlock) hostsFromKeysNotHTTP(httpPort string) []string {
 		if addr.Host == "" {
 			continue
 		}
-		if addr.Scheme != "http" && addr.Port != httpPort {
+		if addr.Scheme != "http" || addr.Port != httpPort {
 			hostMap[addr.Host] = struct{}{}
 		}
 	}

--- a/caddytest/integration/caddyfile_adapt/tls_automation_policies_8.txt
+++ b/caddytest/integration/caddyfile_adapt/tls_automation_policies_8.txt
@@ -90,8 +90,7 @@ http://localhost:8081 {
 								"module": "zerossl"
 							}
 						]
-					},
-					{}
+					}
 				]
 			}
 		}


### PR DESCRIPTION
The commit https://github.com/caddyserver/caddy/commit/05656a60b3b089ce1735a1ebb02539cca9f68fb4 has introduced a bug where any http://localhost hosts running with on a port which isn't the HTTP port or HTTPS port (internal hosts that are only available to the local machine), generate an empty `tls.automation.policy` object.

Which in turn generates the following error message:
```
run: loading initial config: loading new config: loading http app module: provision http: getting tls app: loading tls app module: tls: invalid configuration: automation policy X is the second policy that acts as default/catch-all, but will never be used
```
  
I believe I have tracked down the issue to the `hostsFromKeysNotHTTP` method that was added in https://github.com/caddyserver/caddy/commit/05656a60b3b089ce1735a1ebb02539cca9f68fb4 

I added a test fixture first to demonstrate the error (red test, green test approach), however I understand it that you like to squash down commits, so if this is problem please let me know.