### PR TITLE
add placeholder like nginx $upstream_addr

### DIFF
--- a/modules/caddyhttp/reverseproxy/dialer.go
+++ b/modules/caddyhttp/reverseproxy/dialer.go
@@ -1,0 +1,32 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reverseproxy
+
+import (
+	"context"
+	"net"
+)
+
+// DialContext connects to the address on the named network using the provided context.
+// See net.Dialer for more details.
+type DialContext func(ctx context.Context, network, address string) (net.Conn, error)
+
+// ListenerWrapper is a type that wraps a dialer.DialContext method
+// so it can modify the input dialer's DialContext method.
+// Modules that implement this interface are found
+// in the caddy.dial_context_wrappers namespace.
+type DialContextWrapper interface {
+	WrapDialContext(DialContext) DialContext
+}

--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -191,6 +191,13 @@ func (h *HTTPTransport) NewTransport(ctx caddy.Context) (*http.Transport, error)
 				// decide whether to retry a request
 				return nil, DialError{err}
 			}
+			repl := ctx.Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+			upstreamAddr, ok := repl.GetString("http.reverse_proxy.upstream.addr")
+			if ok {
+				repl.Set("http.reverse_proxy.upstream.addr", fmt.Sprintf("%s, %s", upstreamAddr, conn.RemoteAddr()))
+			} else {
+				repl.Set("http.reverse_proxy.upstream.addr", conn.RemoteAddr())
+			}
 			return conn, nil
 		},
 		MaxConnsPerHost:        h.MaxConnsPerHost,


### PR DESCRIPTION
nginx ngx_http_upstream_module module has a embed var $upstream_addr, see [details](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#variables) . 

Caddy has a placeholder {http.reverse_proxy.upstream.address}, but when specify an upstream dial with a domain name(without lookup_srv), then the placeholder value will be the domain name while not a IP address, which is more useful for debug.