### PR TITLE
caddyhttp: Sanitize the path before evaluating path matchers

### DIFF
--- a/modules/caddyhttp/matchers_test.go
+++ b/modules/caddyhttp/matchers_test.go
@@ -258,6 +258,21 @@ func TestPathMatcher(t *testing.T) {
 			expect: true,
 		},
 		{
+			match:  MatchPath{"/foo*"},
+			input:  "//foo/bar",
+			expect: true,
+		},
+		{
+			match:  MatchPath{"/foo*"},
+			input:  "//foo",
+			expect: true,
+		},
+		{
+			match:  MatchPath{"/foo*"},
+			input:  "/%2F/foo",
+			expect: true,
+		},
+		{
 			match:  MatchPath{"*"},
 			input:  "/",
 			expect: true,
@@ -326,13 +341,28 @@ func TestPathREMatcher(t *testing.T) {
 			expect: true,
 		},
 		{
-			match:  MatchPathRE{MatchRegexp{Pattern: "/foo"}},
+			match:  MatchPathRE{MatchRegexp{Pattern: "^/foo"}},
 			input:  "/foo",
 			expect: true,
 		},
 		{
-			match:  MatchPathRE{MatchRegexp{Pattern: "/foo"}},
+			match:  MatchPathRE{MatchRegexp{Pattern: "^/foo"}},
 			input:  "/foo/",
+			expect: true,
+		},
+		{
+			match:  MatchPathRE{MatchRegexp{Pattern: "^/foo"}},
+			input:  "//foo",
+			expect: true,
+		},
+		{
+			match:  MatchPathRE{MatchRegexp{Pattern: "^/foo"}},
+			input:  "//foo/",
+			expect: true,
+		},
+		{
+			match:  MatchPathRE{MatchRegexp{Pattern: "^/foo"}},
+			input:  "/%2F/foo/",
 			expect: true,
 		},
 		{


### PR DESCRIPTION
I found an issue where it's possible to bypass path matchers by crafting a request with a path that doubles up slashes, or uses URL-encoded characters to smuggle the request past the path matcher.

This becomes a security issue, because auth gates using [`basicauth`](https://caddyserver.com/docs/caddyfile/directives/basicauth) can be bypassed 😬

The solution is to unescape (convert URL-encoded characters) then clean the path, before matching.

This could be a breaking change if exact behaviour of the matcher is required (without cleaning the path). In that case, then it's possible to use the [`expression`](https://caddyserver.com/docs/caddyfile/matchers#expression) matcher to do a direct string comparison or regexp on the `{http.request.uri.path}` placeholder (or simply `{path}` [in the Caddyfile](https://caddyserver.com/docs/caddyfile/concepts#placeholders)). For example:

```
# Simple prefix match
expression `{path}.startsWith("/foo")`

# Complex regexp match
expression `{path}.matches("^/foo.*$")`
```