### PR TITLE
fileserver: browse: do not encode the paths in breadcrumbs and page title

### DIFF
--- a/modules/caddyhttp/fileserver/browsetplcontext.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext.go
@@ -72,9 +72,9 @@ func (fsrv *FileServer) directoryListing(files []os.FileInfo, canGoUp bool, root
 			Mode:      f.Mode(),
 		})
 	}
-
+	name, _ := url.PathUnescape(urlPath)
 	return browseTemplateContext{
-		Name:     path.Base(urlPath),
+		Name:     path.Base(name),
 		Path:     urlPath,
 		CanGoUp:  canGoUp,
 		Items:    fileInfos,
@@ -128,13 +128,16 @@ func (l browseTemplateContext) Breadcrumbs() []crumb {
 	if lpath[len(lpath)-1] == '/' {
 		lpath = lpath[:len(lpath)-1]
 	}
-
 	parts := strings.Split(lpath, "/")
 	result := make([]crumb, len(parts))
 	for i, p := range parts {
 		if i == 0 && p == "" {
 			p = "/"
 		}
+		// the directory name could include an encoded slash in its path,
+		// so the item name should be unescaped in the loop rather than unescaping the
+		// entire path outside the loop.
+		p, _ = url.PathUnescape(p)
 		lnk := strings.Repeat("../", len(parts)-i-1)
 		result[i] = crumb{Link: lnk, Text: p}
 	}

--- a/modules/caddyhttp/fileserver/browsetplcontext_test.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext_test.go
@@ -36,6 +36,19 @@ func TestBreadcrumbs(t *testing.T) {
 			{Link: "../", Text: "quux"},
 			{Link: "", Text: "corge"},
 		}},
+		{"/مجلد/", []crumb{
+			{Link: "../", Text: "/"},
+			{Link: "", Text: "مجلد"},
+		}},
+		{"/مجلد-1/مجلد-2", []crumb{
+			{Link: "../../", Text: "/"},
+			{Link: "../", Text: "مجلد-1"},
+			{Link: "", Text: "مجلد-2"},
+		}},
+		{"/مجلد%2F1", []crumb{
+			{Link: "../", Text: "/"},
+			{Link: "", Text: "مجلد/1"},
+		}},
 	}
 
 	for _, d := range testdata {


### PR DESCRIPTION
Breadcrumbs use the `.Name` field as the visual item while `.Path` is the data-oriented item. Earlier implementation used the URL path as-is, which could have been in escaped format. This PR un-escapes the URL path to use as for the `.Name`.

Fixes #4409