### PR TITLE
headers: use ReplaceKnown instead of ReplaceAll to avoid ignoring JSON values

### DIFF
--- a/modules/caddyhttp/headers/headers.go
+++ b/modules/caddyhttp/headers/headers.go
@@ -188,38 +188,38 @@ type RespHeaderOps struct {
 func (ops HeaderOps) ApplyTo(hdr http.Header, repl *caddy.Replacer) {
 	// add
 	for fieldName, vals := range ops.Add {
-		fieldName = repl.ReplaceAll(fieldName, "")
+		fieldName = repl.ReplaceKnown(fieldName, "")
 		for _, v := range vals {
-			hdr.Add(fieldName, repl.ReplaceAll(v, ""))
+			hdr.Add(fieldName, repl.ReplaceKnown(v, ""))
 		}
 	}
 
 	// set
 	for fieldName, vals := range ops.Set {
-		fieldName = repl.ReplaceAll(fieldName, "")
+		fieldName = repl.ReplaceKnown(fieldName, "")
 		var newVals []string
 		for i := range vals {
 			// append to new slice so we don't overwrite
 			// the original values in ops.Set
-			newVals = append(newVals, repl.ReplaceAll(vals[i], ""))
+			newVals = append(newVals, repl.ReplaceKnown(vals[i], ""))
 		}
 		hdr.Set(fieldName, strings.Join(newVals, ","))
 	}
 
 	// delete
 	for _, fieldName := range ops.Delete {
-		hdr.Del(repl.ReplaceAll(fieldName, ""))
+		hdr.Del(repl.ReplaceKnown(fieldName, ""))
 	}
 
 	// replace
 	for fieldName, replacements := range ops.Replace {
-		fieldName = http.CanonicalHeaderKey(repl.ReplaceAll(fieldName, ""))
+		fieldName = http.CanonicalHeaderKey(repl.ReplaceKnown(fieldName, ""))
 
 		// all fields...
 		if fieldName == "*" {
 			for _, r := range replacements {
-				search := repl.ReplaceAll(r.Search, "")
-				replace := repl.ReplaceAll(r.Replace, "")
+				search := repl.ReplaceKnown(r.Search, "")
+				replace := repl.ReplaceKnown(r.Replace, "")
 				for fieldName, vals := range hdr {
 					for i := range vals {
 						if r.re != nil {
@@ -235,8 +235,8 @@ func (ops HeaderOps) ApplyTo(hdr http.Header, repl *caddy.Replacer) {
 
 		// ...or only with the named field
 		for _, r := range replacements {
-			search := repl.ReplaceAll(r.Search, "")
-			replace := repl.ReplaceAll(r.Replace, "")
+			search := repl.ReplaceKnown(r.Search, "")
+			replace := repl.ReplaceKnown(r.Replace, "")
 			for hdrFieldName, vals := range hdr {
 				// see issue #4330 for why we don't simply use hdr[fieldName]
 				if http.CanonicalHeaderKey(hdrFieldName) != fieldName {

--- a/modules/caddyhttp/headers/headers_test.go
+++ b/modules/caddyhttp/headers/headers_test.go
@@ -182,11 +182,31 @@ func TestHandler(t *testing.T) {
 				"Other-Header":     []string{"issue4330"},
 			},
 		},
+		{
+			handler: Handler{
+				Response: &RespHeaderOps{
+					HeaderOps: &HeaderOps{
+						Set: http.Header{
+							"WithReplace":   []string{"an actual {repl}"},
+							"Straight-JSON": []string{`{"foo": "bar"}`},
+							"Escaped":       []string{`\{"foo": "bar"}`},
+						},
+					},
+				},
+			},
+			respHeader: http.Header{},
+			expectedRespHeader: http.Header{
+				"Withreplace":   []string{"an actual replacement"},
+				"Straight-Json": []string{`{"foo": "bar"}`},
+				"Escaped":       []string{`{"foo": "bar"}`},
+			},
+		},
 	} {
 		rr := httptest.NewRecorder()
 
 		req := &http.Request{Header: tc.reqHeader}
 		repl := caddy.NewReplacer()
+		repl.Set("repl", "replacement")
 		ctx := context.WithValue(req.Context(), caddy.ReplacerCtxKey, repl)
 		req = req.WithContext(ctx)
 


### PR DESCRIPTION
Fixes #4418

`repl.ReplaceAll` silently ignores anything between unescaped `{}`s, which is somewhat unexpected behaviour.

Replacing this usage with `repl.ReplaceKnown` fixes this, however I wonder if perhaps it would be better to use `ReplaceOrErr`, since that way we can encourage properly escaping values that aren't actually placeholders... The challenge is that `ApplyTo` doesn't return an `error` so the best we could do (without changing the signature) is log the error and allow the header to either be ignored, or the value to be set to an empty string - neither of these are desirable IMO...

Signed-off-by: Dave Henderson <dhenderson@gmail.com>