### PR TITLE
logging: add a filter for query parameters

### DIFF
--- a/caddytest/integration/caddyfile_adapt/log_filters.txt
+++ b/caddytest/integration/caddyfile_adapt/log_filters.txt
@@ -5,6 +5,10 @@ log {
 	format filter {
 		wrap console
 		fields {
+			uri query {
+				replace foo REDACTED
+				delete bar
+			}
 			request>headers>Authorization replace REDACTED
 			request>headers>Server delete
 			request>remote_addr ip_mask {
@@ -40,6 +44,20 @@ log {
 							"filter": "ip_mask",
 							"ipv4_cidr": 24,
 							"ipv6_cidr": 32
+						},
+						"uri": {
+							"actions": [
+								{
+									"parameter": "foo",
+									"type": "replace",
+									"value": "REDACTED"
+								},
+								{
+									"parameter": "bar",
+									"type": "delete"
+								}
+							],
+							"filter": "query"
 						}
 					},
 					"format": "filter",

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -262,8 +262,8 @@ func (m QueryFilter) Filter(in zapcore.Field) zapcore.Field {
 	for _, a := range m.Actions {
 		switch a.Type {
 		case ReplaceType:
-			if _, ok := q[a.Parameter]; ok {
-				q.Set(a.Parameter, a.Value)
+			for i := range q[a.Parameter] {
+				q[a.Parameter][i] = a.Value
 			}
 
 		case DeleteType:

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -188,7 +188,7 @@ func (m IPMaskFilter) Filter(in zapcore.Field) zapcore.Field {
 	return in
 }
 
-type ActionType string
+type FilterAction string
 
 const (
 	// Replace value(s) of query parameter(s).

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -188,18 +188,18 @@ func (m IPMaskFilter) Filter(in zapcore.Field) zapcore.Field {
 	return in
 }
 
-type FilterAction string
+type filterAction string
 
 const (
 	// Replace value(s) of query parameter(s).
-	ReplaceAction FilterAction = "replace"
+	replaceAction filterAction = "replace"
 	// Delete query parameter(s).
-	DeleteAction FilterAction = "delete"
+	deleteAction filterAction = "delete"
 )
 
-func (a FilterAction) IsValid() error {
+func (a filterAction) IsValid() error {
 	switch a {
-	case ReplaceAction, DeleteAction:
+	case replaceAction, deleteAction:
 		return nil
 	}
 
@@ -208,7 +208,7 @@ func (a FilterAction) IsValid() error {
 
 type queryFilterAction struct {
 	// `replace` to replace the value(s) associated with the parameter(s) or `delete` to remove them entirely.
-	Type FilterAction `json:"type"`
+	Type filterAction `json:"type"`
 
 	// The name of the query parameter.
 	Parameter string `json:"parameter"`
@@ -259,7 +259,7 @@ func (m *QueryFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.ArgErr()
 				}
 
-				qfa.Type = ReplaceAction
+				qfa.Type = replaceAction
 				qfa.Parameter = d.Val()
 
 				if !d.NextArg() {
@@ -272,7 +272,7 @@ func (m *QueryFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.ArgErr()
 				}
 
-				qfa.Type = DeleteAction
+				qfa.Type = deleteAction
 				qfa.Parameter = d.Val()
 
 			default:
@@ -295,12 +295,12 @@ func (m QueryFilter) Filter(in zapcore.Field) zapcore.Field {
 	q := u.Query()
 	for _, a := range m.Actions {
 		switch a.Type {
-		case ReplaceAction:
+		case replaceAction:
 			for i := range q[a.Parameter] {
 				q[a.Parameter][i] = a.Value
 			}
 
-		case DeleteAction:
+		case deleteAction:
 			q.Del(a.Parameter)
 		}
 	}

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -15,6 +15,7 @@
 package logging
 
 import (
+	"errors"
 	"net"
 	"net/url"
 	"strconv"
@@ -196,6 +197,15 @@ const (
 	DeleteType ActionType = "delete"
 )
 
+func (a ActionType) IsValid() error {
+	switch a {
+	case ReplaceType, DeleteType:
+		return nil
+	}
+
+	return errors.New("invalid action type")
+}
+
 type queryFilterAction struct {
 	// `replace` to replace the value(s) associated with the parameter(s) or `delete` to remove them entirely.
 	Type ActionType `json:"type"`
@@ -214,6 +224,17 @@ type queryFilterAction struct {
 type QueryFilter struct {
 	// A list of actions to apply to the query parameters of the URL.
 	Actions []queryFilterAction `json:"actions"`
+}
+
+// Validate checks that action types are correct.
+func (f *QueryFilter) Validate() error {
+	for _, a := range f.Actions {
+		if err := a.Type.IsValid(); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // CaddyModule returns the Caddy module information.
@@ -300,4 +321,6 @@ var (
 	_ caddyfile.Unmarshaler = (*QueryFilter)(nil)
 
 	_ caddy.Provisioner = (*IPMaskFilter)(nil)
+
+	_ caddy.Validator = (*QueryFilter)(nil)
 )

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -192,9 +192,9 @@ type ActionType string
 
 const (
 	// Replace value(s) of query parameter(s).
-	ReplaceType ActionType = "replace"
+	ReplaceAction ActionType = "replace"
 	// Delete query parameter(s).
-	DeleteType ActionType = "delete"
+	DeleteAction ActionType = "delete"
 )
 
 func (a ActionType) IsValid() error {

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -209,18 +209,21 @@ func (a ActionType) IsValid() error {
 type queryFilterAction struct {
 	// `replace` to replace the value(s) associated with the parameter(s) or `delete` to remove them entirely.
 	Type ActionType `json:"type"`
+
 	// The name of the query parameter.
 	Parameter string `json:"parameter"`
+
 	// The value to use as replacement if the action is `replace`.
 	Value string `json:"value,omitempty"`
 }
 
-// QueryFilter is a Caddy log field filter that
-// filters query parameters from an URL.
-// It updates the filtered URL to remove or replace query parameters containing sensitive data.
-// For instance, it can be used to redact OAuth access tokens, session IDs, magic links tokens
-// or JWT when passed as query parameters (which is generally considered a bad practice, but cannot
-// always be avoided).
+// QueryFilter is a Caddy log field filter that filters
+// query parameters from a URL.
+//
+// This filter updates the logged URL string to remove or replace query
+// parameters containing sensitive data. For instance, it can be used
+// to redact any kind of secrets which were passed as query parameters,
+// such as OAuth access tokens, session IDs, magic link tokens, etc.
 type QueryFilter struct {
 	// A list of actions to apply to the query parameters of the URL.
 	Actions []queryFilterAction `json:"actions"`

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -190,19 +190,29 @@ func (m IPMaskFilter) Filter(in zapcore.Field) zapcore.Field {
 type ActionType string
 
 const (
+	// Replace value(s) of query parameter(s).
 	ReplaceType ActionType = "replace"
-	DeleteType  ActionType = "delete"
+	// Delete query parameter(s).
+	DeleteType ActionType = "delete"
 )
 
 type queryFilterAction struct {
-	Type      ActionType `json:"type"`
-	Parameter string     `json:"parameter"`
-	Value     string     `json:"value,omitempty"`
+	// `replace` to replace the value(s) associated with the parameter(s) or `delete` to remove them entirely.
+	Type ActionType `json:"type"`
+	// The name of the query parameter.
+	Parameter string `json:"parameter"`
+	// The value to use as replacement if the action is `replace`.
+	Value string `json:"value,omitempty"`
 }
 
 // QueryFilter is a Caddy log field filter that
-// filters query parameters.
+// filters query parameters from an URL.
+// It updates the filtered URL to remove or replace query parameters containing sensitive data.
+// For instance, it can be used to redact OAuth access tokens, session IDs, magic links tokens
+// or JWT when passed as query parameters (which is generally considered a bad practice, but cannot
+// always be avoided).
 type QueryFilter struct {
+	// A list of actions to apply to the query parameters of the URL.
 	Actions []queryFilterAction `json:"actions"`
 }
 

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -262,7 +262,7 @@ func (m QueryFilter) Filter(in zapcore.Field) zapcore.Field {
 	for _, a := range m.Actions {
 		switch a.Type {
 		case ReplaceType:
-			if q.Has(a.Parameter) {
+			if _, ok := q[a.Parameter]; ok {
 				q.Set(a.Parameter, a.Value)
 			}
 

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -192,14 +192,14 @@ type FilterAction string
 
 const (
 	// Replace value(s) of query parameter(s).
-	ReplaceAction ActionType = "replace"
+	ReplaceAction FilterAction = "replace"
 	// Delete query parameter(s).
-	DeleteAction ActionType = "delete"
+	DeleteAction FilterAction = "delete"
 )
 
-func (a ActionType) IsValid() error {
+func (a FilterAction) IsValid() error {
 	switch a {
-	case ReplaceType, DeleteType:
+	case ReplaceAction, DeleteAction:
 		return nil
 	}
 
@@ -208,7 +208,7 @@ func (a ActionType) IsValid() error {
 
 type queryFilterAction struct {
 	// `replace` to replace the value(s) associated with the parameter(s) or `delete` to remove them entirely.
-	Type ActionType `json:"type"`
+	Type FilterAction `json:"type"`
 
 	// The name of the query parameter.
 	Parameter string `json:"parameter"`
@@ -259,7 +259,7 @@ func (m *QueryFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.ArgErr()
 				}
 
-				qfa.Type = ReplaceType
+				qfa.Type = ReplaceAction
 				qfa.Parameter = d.Val()
 
 				if !d.NextArg() {
@@ -272,7 +272,7 @@ func (m *QueryFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.ArgErr()
 				}
 
-				qfa.Type = DeleteType
+				qfa.Type = DeleteAction
 				qfa.Parameter = d.Val()
 
 			default:
@@ -295,12 +295,12 @@ func (m QueryFilter) Filter(in zapcore.Field) zapcore.Field {
 	q := u.Query()
 	for _, a := range m.Actions {
 		switch a.Type {
-		case ReplaceType:
+		case ReplaceAction:
 			for i := range q[a.Parameter] {
 				q[a.Parameter][i] = a.Value
 			}
 
-		case DeleteType:
+		case DeleteAction:
 			q.Del(a.Parameter)
 		}
 	}

--- a/modules/logging/filters_test.go
+++ b/modules/logging/filters_test.go
@@ -14,8 +14,28 @@ func TestQueryFilter(t *testing.T) {
 		{DeleteType, "notexist", ""},
 	}}
 
+	if f.Validate() != nil {
+		t.Fatalf("the filter must be valid")
+	}
+
 	out := f.Filter(zapcore.Field{String: "/path?foo=a&foo=b&bar=c&bar=d&baz=e"})
 	if out.String != "/path?baz=e&foo=REDACTED&foo=REDACTED" {
 		t.Fatalf("query parameters have not been filtered: %s", out.String)
+	}
+}
+
+func TestValidateQueryFilter(t *testing.T) {
+	f := QueryFilter{[]queryFilterAction{
+		{},
+	}}
+	if f.Validate() == nil {
+		t.Fatalf("empty action type must be invalid")
+	}
+
+	f = QueryFilter{[]queryFilterAction{
+		{Type: "foo"},
+	}}
+	if f.Validate() == nil {
+		t.Fatalf("unknown action type must be invalid")
 	}
 }

--- a/modules/logging/filters_test.go
+++ b/modules/logging/filters_test.go
@@ -9,11 +9,13 @@ import (
 func TestQueryFilter(t *testing.T) {
 	f := QueryFilter{[]queryFilterAction{
 		{ReplaceType, "foo", "REDACTED"},
+		{ReplaceType, "notexist", "REDACTED"},
 		{DeleteType, "bar", ""},
+		{DeleteType, "notexist", ""},
 	}}
 
 	out := f.Filter(zapcore.Field{String: "/path?foo=a&foo=b&bar=c&bar=d&baz=e"})
-	if out.String != "/path?baz=e&foo=REDACTED" {
+	if out.String != "/path?baz=e&foo=REDACTED&foo=REDACTED" {
 		t.Fatalf("query parameters have not been filtered: %s", out.String)
 	}
 }

--- a/modules/logging/filters_test.go
+++ b/modules/logging/filters_test.go
@@ -8,10 +8,10 @@ import (
 
 func TestQueryFilter(t *testing.T) {
 	f := QueryFilter{[]queryFilterAction{
-		{ReplaceAction, "foo", "REDACTED"},
-		{ReplaceAction, "notexist", "REDACTED"},
-		{DeleteAction, "bar", ""},
-		{DeleteAction, "notexist", ""},
+		{replaceAction, "foo", "REDACTED"},
+		{replaceAction, "notexist", "REDACTED"},
+		{deleteAction, "bar", ""},
+		{deleteAction, "notexist", ""},
 	}}
 
 	if f.Validate() != nil {

--- a/modules/logging/filters_test.go
+++ b/modules/logging/filters_test.go
@@ -8,10 +8,10 @@ import (
 
 func TestQueryFilter(t *testing.T) {
 	f := QueryFilter{[]queryFilterAction{
-		{ReplaceType, "foo", "REDACTED"},
-		{ReplaceType, "notexist", "REDACTED"},
-		{DeleteType, "bar", ""},
-		{DeleteType, "notexist", ""},
+		{ReplaceAction, "foo", "REDACTED"},
+		{ReplaceAction, "notexist", "REDACTED"},
+		{DeleteAction, "bar", ""},
+		{DeleteAction, "notexist", ""},
 	}}
 
 	if f.Validate() != nil {

--- a/modules/logging/filters_test.go
+++ b/modules/logging/filters_test.go
@@ -1,0 +1,19 @@
+package logging
+
+import (
+	"testing"
+
+	"go.uber.org/zap/zapcore"
+)
+
+func TestQueryFilter(t *testing.T) {
+	f := QueryFilter{[]queryFilterAction{
+		{ReplaceType, "foo", "REDACTED"},
+		{DeleteType, "bar", ""},
+	}}
+
+	out := f.Filter(zapcore.Field{String: "/path?foo=a&foo=b&bar=c&bar=d&baz=e"})
+	if out.String != "/path?baz=e&foo=REDACTED" {
+		t.Fatalf("query parameters have not been filtered: %s", out.String)
+	}
+}


### PR DESCRIPTION
Even if it's considered a bad security practice, it's common that query parameters contain sensitive information. Some examples:

* [OAuth access token](https://datatracker.ietf.org/doc/html/rfc6750#section-2.3)
* "magic links" and other temporary URLs
* [PHP session IDs](https://www.php.net/manual/en/session.idpassing.php)
* [Mercure JWT](https://github.com/dunglas/mercure/pull/562) (the reason why I started working on this patch in the first time)

This PR adds the possibility to redact such sensitive information from the logs.