### PR TITLE
caddyhttp: Log non-500 handler errors at debug level

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -244,6 +244,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// successfully, so now just log the error
 			if errStatus >= 500 {
 				logger.Error(errMsg, errFields...)
+			} else {
+				logger.Debug(errMsg, errFields...)
 			}
 		} else {
 			// well... this is awkward
@@ -262,6 +264,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if errStatus >= 500 {
 			logger.Error(errMsg, errFields...)
+		} else {
+			logger.Debug(errMsg, errFields...)
 		}
 		w.WriteHeader(errStatus)
 	}


### PR DESCRIPTION
Fixes #4428

It's best to still log handler errors at debug level so that they're hidden by default, but still accessible if additional details are necessary.