### PR TITLE
caddyhttp: Enhance vars matcher

### DIFF
--- a/caddytest/integration/caddyfile_adapt/matcher_syntax.txt
+++ b/caddytest/integration/caddyfile_adapt/matcher_syntax.txt
@@ -101,7 +101,9 @@
 							"match": [
 								{
 									"vars": {
-										"{http.request.uri}": "/vars-matcher"
+										"{http.request.uri}": [
+											"/vars-matcher"
+										]
 									}
 								}
 							],


### PR DESCRIPTION
Enable "or" logic for multiple values. Fall back to checking placeholders if not a var name.

Seemed useful, idk. :man_shrugging: 

This matcher is actually undocumented so far, since I wasn't sure if it'd have any purpose. But I think there might be value in matching on placeholders and variables for more advanced configurations.