### PR TITLE
logging: add support for hashing data

### DIFF
--- a/caddytest/integration/caddyfile_adapt/log_filters.txt
+++ b/caddytest/integration/caddyfile_adapt/log_filters.txt
@@ -8,18 +8,21 @@ log {
 			uri query {
 				replace foo REDACTED
 				delete bar
+				hash baz
 			}
 			request>headers>Authorization replace REDACTED
 			request>headers>Server delete
 			request>headers>Cookie cookie {
 				replace foo REDACTED
 				delete bar
+				hash baz
 			}
 			request>remote_addr ip_mask {
 				ipv4 24
 				ipv6 32
 			}
 			request>headers>Regexp regexp secret REDACTED
+			request>headers>Hash hash
 		}
 	}
 }
@@ -52,9 +55,16 @@ log {
 								{
 									"name": "bar",
 									"type": "delete"
+								},
+								{
+									"name": "baz",
+									"type": "hash"
 								}
 							],
 							"filter": "cookie"
+						},
+						"request\u003eheaders\u003eHash": {
+							"filter": "hash"
 						},
 						"request\u003eheaders\u003eRegexp": {
 							"filter": "regexp",
@@ -79,6 +89,10 @@ log {
 								{
 									"parameter": "bar",
 									"type": "delete"
+								},
+								{
+									"parameter": "baz",
+									"type": "hash"
 								}
 							],
 							"filter": "query"

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -247,7 +247,7 @@ func (a filterAction) IsValid() error {
 }
 
 type queryFilterAction struct {
-	// `replace` to replace the value(s) associated with the parameter(s), `hash` to replace them with the 4 initial bytes of the SHA-156 of their content or `delete` to remove them entirely.
+	// `replace` to replace the value(s) associated with the parameter(s), `hash` to replace them with the 4 initial bytes of the SHA-256 of their content or `delete` to remove them entirely.
 	Type filterAction `json:"type"`
 
 	// The name of the query parameter.

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -365,7 +365,7 @@ func (m QueryFilter) Filter(in zapcore.Field) zapcore.Field {
 }
 
 type cookieFilterAction struct {
-	// `replace` to replace the value of the cookie, `hash` to replace it with the 4 initial bytes of the SHA-156 of its content or `delete` to remove it entirely.
+	// `replace` to replace the value of the cookie, `hash` to replace it with the 4 initial bytes of the SHA-256 of its content or `delete` to remove it entirely.
 	Type filterAction `json:"type"`
 
 	// The name of the cookie.


### PR DESCRIPTION
Follows #4424, #4425 and #4426. Implements a hash filter and hash actions for the query and cookie filters ask suggested by @wiese in https://github.com/caddyserver/caddy/pull/4424#issuecomment-972650688.