### PR TITLE
fastcgi: Fix a TODO, prevent zap using reflection for logging env

### DIFF
--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -354,7 +354,7 @@ func (t Transport) splitPos(path string) int {
 	return -1
 }
 
-// envVars is a simple type alias to allow for speeding up zap log encoding.
+// envVars is a simple type to allow for speeding up zap log encoding.
 type envVars map[string]string
 
 func (env envVars) MarshalLogObject(enc zapcore.ObjectEncoder) error {


### PR DESCRIPTION
Fixes a TODO in code, should be reasonably self-explanatory. Using `zap.Any()` would fallback to using reflection, which is slower and can allocate. I doubt this would have any kind of real-world performance impact, but 🤷‍♂️ easy fix.