### PR TITLE
caddyhttp: Make logging of sensitive headers opt-in

### DIFF
--- a/caddytest/integration/caddyfile_adapt/global_server_options_single.txt
+++ b/caddytest/integration/caddyfile_adapt/global_server_options_single.txt
@@ -10,6 +10,7 @@
 			idle 30s
 		}
 		max_header_size 100MB
+		log_credentials
 		protocol {
 			allow_h2c
 			experimental_http3
@@ -53,6 +54,9 @@ foo.com {
 						}
 					],
 					"strict_sni_host": true,
+					"logs": {
+						"should_log_credentials": true
+					},
 					"experimental_http3": true,
 					"allow_h2c": true
 				}

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -574,6 +574,9 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, repl *
 	// point the request to this upstream
 	h.directRequest(req, di)
 
+	server := req.Context().Value(caddyhttp.ServerCtxKey).(*caddyhttp.Server)
+	shouldLogCredentials := server.Logs != nil && server.Logs.ShouldLogCredentials
+
 	// do the round-trip; emit debug log with values we know are
 	// safe, or if there is no error, emit fuller log entry
 	start := time.Now()
@@ -582,14 +585,20 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, repl *
 	logger := h.logger.With(
 		zap.String("upstream", di.Upstream.String()),
 		zap.Duration("duration", duration),
-		zap.Object("request", caddyhttp.LoggableHTTPRequest{Request: req}),
+		zap.Object("request", caddyhttp.LoggableHTTPRequest{
+			Request:              req,
+			ShouldLogCredentials: shouldLogCredentials,
+		}),
 	)
 	if err != nil {
 		logger.Debug("upstream roundtrip", zap.Error(err))
 		return err
 	}
 	logger.Debug("upstream roundtrip",
-		zap.Object("headers", caddyhttp.LoggableHTTPHeader(res.Header)),
+		zap.Object("headers", caddyhttp.LoggableHTTPHeader{
+			Header:               res.Header,
+			ShouldLogCredentials: shouldLogCredentials,
+		}),
 		zap.Int("status", res.StatusCode))
 
 	// duration until upstream wrote response headers (roundtrip duration)

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -157,7 +157,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// it enters any handler chain; this is necessary
 	// to capture the original request in case it gets
 	// modified during handling
-	loggableReq := zap.Object("request", LoggableHTTPRequest{r})
+	shouldLogCredentials := s.Logs != nil && s.Logs.ShouldLogCredentials
+	loggableReq := zap.Object("request", LoggableHTTPRequest{
+		Request:              r,
+		ShouldLogCredentials: shouldLogCredentials,
+	})
 	errLog := s.errorLogger.With(loggableReq)
 
 	var duration time.Duration
@@ -191,7 +195,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				zap.Duration("duration", duration),
 				zap.Int("size", wrec.Size()),
 				zap.Int("status", wrec.Status()),
-				zap.Object("resp_headers", LoggableHTTPHeader(wrec.Header())),
+				zap.Object("resp_headers", LoggableHTTPHeader{
+					Header:               wrec.Header(),
+					ShouldLogCredentials: shouldLogCredentials,
+				}),
 			)
 		}()
 	}
@@ -508,6 +515,12 @@ type ServerLogConfig struct {
 	// If true, requests to any host not appearing in the
 	// LoggerNames (logger_names) map will not be logged.
 	SkipUnmappedHosts bool `json:"skip_unmapped_hosts,omitempty"`
+
+	// If true, credentials that are otherwise omitted, will be logged.
+	// The definition of credentials is defined by https://fetch.spec.whatwg.org/#credentials,
+	// and this includes some request and response headers, i.e `Cookie`,
+	// `Set-Cookie`, `Authorization`, and `Proxy-Authorization`.
+	ShouldLogCredentials bool `json:"should_log_credentials,omitempty"`
 }
 
 // wrapLogger wraps logger in a logger named according to user preferences for the given host.


### PR DESCRIPTION
Followup to https://github.com/caddyserver/caddy/commit/7d5047c1f190421528695e1cc3a4ad71c97eb022, as discussed off-Github.

Adds an opt-in flag to `http.servers.logs` which informs the Loggables about whether they should log sensitive headers (default omitted).

Also puts the flag in the request context so that it can bubble down into request handlers which may also log headers (`reverseproxy` and `push` both log their headers).

I'm finding the name of the option kiiinda verbose, but it's a balancing act. 

/cc @dunglas