### PR TITLE
pki: Implement `GET /pki/certificates/<id>` API, rework `caddy trust`

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -427,6 +427,13 @@ func run(newCfg *Config, start bool) error {
 		return nil
 	}
 
+	// Provision any admin routers which may need to access
+	// some of the other apps at runtime
+	err = newCfg.Admin.provisionAdminRouters(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Start
 	err = func() error {
 		var started []string
@@ -523,7 +530,6 @@ func finishSettingUp(ctx Context, cfg *Config) error {
 			// do this in a goroutine so current config can finish being loaded; otherwise deadlock
 			go runLoadedConfig(loadedConfig)
 		}
-
 	}
 
 	return nil

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -156,16 +156,19 @@ development environment.`,
 	RegisterCommand(Command{
 		Name:  "stop",
 		Func:  cmdStop,
+		Usage: "[--address <interface>] [--config <path> [--adapter <name>]]",
 		Short: "Gracefully stops a started Caddy process",
 		Long: `
 Stops the background Caddy process as gracefully as possible.
 
 It requires that the admin API is enabled and accessible, since it will
-use the API's /stop endpoint. The address of this request can be
-customized using the --address flag if it is not the default.`,
+use the API's /stop endpoint. The address of this request can be customized
+using the --address flag, or from the given --config, if not the default.`,
 		Flags: func() *flag.FlagSet {
 			fs := flag.NewFlagSet("stop", flag.ExitOnError)
 			fs.String("address", "", "The address to use to reach the admin API endpoint, if not the default")
+			fs.String("config", "", "Configuration file to use to parse the admin address, if --address is not used")
+			fs.String("adapter", "", "Name of config adapter to apply (when --config is used)")
 			return fs
 		}(),
 	})

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -103,7 +103,7 @@ func handlePingbackConn(conn net.Conn, expect []byte) error {
 	return nil
 }
 
-// loadConfig loads the config from configFile and adapts it
+// LoadConfig loads the config from configFile and adapts it
 // using adapterName. If adapterName is specified, configFile
 // must be also. If no configFile is specified, it tries
 // loading a default config file. The lack of a config file is
@@ -111,7 +111,7 @@ func handlePingbackConn(conn net.Conn, expect []byte) error {
 // there is no config available. It prints any warnings to stderr,
 // and returns the resulting JSON config bytes along with
 // whether a config file was loaded or not.
-func loadConfig(configFile, adapterName string) ([]byte, string, error) {
+func LoadConfig(configFile, adapterName string) ([]byte, string, error) {
 	// specifying an adapter without a config file is ambiguous
 	if adapterName != "" && configFile == "" {
 		return nil, "", fmt.Errorf("cannot adapt config without config file (use --config)")
@@ -262,7 +262,7 @@ func watchConfigFile(filename, adapterName string) {
 		lastModified = info.ModTime()
 
 		// load the contents of the file
-		config, _, err := loadConfig(filename, adapterName)
+		config, _, err := LoadConfig(filename, adapterName)
 		if err != nil {
 			logger().Error("unable to load latest config", zap.Error(err))
 			continue

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -110,7 +110,7 @@ func handlePingbackConn(conn net.Conn, expect []byte) error {
 // not treated as an error, but false will be returned if
 // there is no config available. It prints any warnings to stderr,
 // and returns the resulting JSON config bytes along with
-// whether a config file was loaded or not.
+// the name of the loaded config file (if any).
 func LoadConfig(configFile, adapterName string) ([]byte, string, error) {
 	// specifying an adapter without a config file is ambiguous
 	if adapterName != "" && configFile == "" {

--- a/context.go
+++ b/context.go
@@ -423,6 +423,17 @@ func (ctx Context) App(name string) (interface{}, error) {
 	return modVal, nil
 }
 
+// AppIsConfigured returns whether an app named name has been
+// configured. Can be called before calling App() to avoid
+// instantiating an empty app when that's not desirable.
+func (ctx Context) AppIsConfigured(name string) bool {
+	if _, ok := ctx.cfg.apps[name]; ok {
+		return true
+	}
+	appRaw := ctx.cfg.AppsRaw[name]
+	return appRaw != nil
+}
+
 // Storage returns the configured Caddy storage implementation.
 func (ctx Context) Storage() certmagic.Storage {
 	return ctx.cfg.storage

--- a/modules/caddypki/adminpki.go
+++ b/modules/caddypki/adminpki.go
@@ -72,7 +72,7 @@ func (a *adminPKI) Provision(ctx caddy.Context) error {
 func (a *adminPKI) Routes() []caddy.AdminRoute {
 	return []caddy.AdminRoute{
 		{
-			Pattern: amdinPKICertificatesEndpoint,
+			Pattern: adminPKICertificatesEndpoint,
 			Handler: caddy.AdminHandlerFunc(a.handleCertificates),
 		},
 	}
@@ -159,7 +159,7 @@ func (a *adminPKI) handleCertificates(w http.ResponseWriter, r *http.Request) er
 
 	// Build the response
 	response := CAInfo{
-		Id:           ca.ID,
+		ID:           ca.ID,
 		Name:         ca.Name,
 		Root:         rootPem,
 		Intermediate: interPem,
@@ -179,13 +179,13 @@ func (a *adminPKI) handleCertificates(w http.ResponseWriter, r *http.Request) er
 
 // CAInfo is the response from the certificates API endpoint
 type CAInfo struct {
-	Id           string `json:"id"`
+	ID           string `json:"id"`
 	Name         string `json:"name"`
 	Root         string `json:"root"`
 	Intermediate string `json:"intermediate"`
 }
 
-const amdinPKICertificatesEndpoint = "/pki/certificates/"
+const adminPKICertificatesEndpoint = "/pki/certificates/"
 
 // Interface guards
 var (

--- a/modules/caddypki/adminpki.go
+++ b/modules/caddypki/adminpki.go
@@ -1,0 +1,194 @@
+// Copyright 2020 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddypki
+
+import (
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/caddyserver/caddy/v2"
+	"go.uber.org/zap"
+)
+
+func init() {
+	caddy.RegisterModule(adminPKI{})
+}
+
+// adminPKI is a module that serves a PKI endpoint to retrieve
+// information about the CAs being managed by Caddy.
+type adminPKI struct {
+	ctx    caddy.Context
+	log    *zap.Logger
+	pkiApp *PKI
+}
+
+// CaddyModule returns the Caddy module information.
+func (adminPKI) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "admin.api.pki",
+		New: func() caddy.Module { return new(adminPKI) },
+	}
+}
+
+// Provision sets up the adminPKI module.
+func (a *adminPKI) Provision(ctx caddy.Context) error {
+	a.ctx = ctx
+	a.log = ctx.Logger(a)
+
+	// First check if the PKI app was configured, because
+	// a.ctx.App() has the side effect of instantiating
+	// and provisioning an app even if it wasn't configured.
+	pkiAppConfigured := a.ctx.AppIsConfigured("pki")
+	if !pkiAppConfigured {
+		return nil
+	}
+
+	// Load the PKI app, so we can query it for information.
+	appModule, err := a.ctx.App("pki")
+	if err != nil {
+		return err
+	}
+	a.pkiApp = appModule.(*PKI)
+
+	return nil
+}
+
+// Routes returns the admin routes for the PKI app.
+func (a *adminPKI) Routes() []caddy.AdminRoute {
+	return []caddy.AdminRoute{
+		{
+			Pattern: amdinPKICertificatesEndpoint,
+			Handler: caddy.AdminHandlerFunc(a.handleCertificates),
+		},
+	}
+}
+
+// handleCertificates returns certificate information about a particular
+// CA, by its ID. If the CA ID is the default, then the CA will be
+// provisioned if it has not already been. Other CA IDs will return an
+// error if they have not been previously provisioned.
+func (a *adminPKI) handleCertificates(w http.ResponseWriter, r *http.Request) error {
+	if r.Method != http.MethodGet {
+		return caddy.APIError{
+			HTTPStatus: http.StatusMethodNotAllowed,
+			Err:        fmt.Errorf("method not allowed"),
+		}
+	}
+
+	// Prep for a JSON response
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+
+	idPath := r.URL.Path
+
+	// Grab the CA ID from the request path, it should be the 4th segment
+	parts := strings.Split(idPath, "/")
+	if len(parts) < 4 || parts[3] == "" {
+		return caddy.APIError{
+			HTTPStatus: http.StatusBadRequest,
+			Err:        fmt.Errorf("request path is missing the CA ID"),
+		}
+	}
+	if parts[0] != "" || parts[1] != "pki" || parts[2] != "certificates" {
+		return caddy.APIError{
+			HTTPStatus: http.StatusBadRequest,
+			Err:        fmt.Errorf("malformed object path"),
+		}
+	}
+	id := parts[3]
+
+	// Find the CA by ID, if PKI is configured
+	var ca *CA
+	ok := false
+	if a.pkiApp != nil {
+		ca, ok = a.pkiApp.CAs[id]
+	}
+
+	// If we didn't find the CA, and PKI is not configured
+	// then we'll either error out if the CA ID is not the
+	// default. If the CA ID is the default, then we'll
+	// provision it, because the user probably aims to
+	// change their config to enable PKI immediately after
+	// if they actually requested the local CA ID.
+	if !ok {
+		if id != DefaultCAID {
+			return caddy.APIError{
+				HTTPStatus: http.StatusNotFound,
+				Err:        fmt.Errorf("no certificate authority configured with id: %s", id),
+			}
+		}
+
+		// Provision the default CA, which generates and stores a root
+		// certificate in storage, if one doesn't already exist.
+		ca = new(CA)
+		err := ca.Provision(a.ctx, id, a.log)
+		if err != nil {
+			return caddy.APIError{
+				HTTPStatus: http.StatusInternalServerError,
+				Err:        fmt.Errorf("failed to provision CA %s, %w", id, err),
+			}
+		}
+	}
+
+	// Convert the root certificate to PEM
+	rootPem := string(pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: ca.RootCertificate().Raw,
+	}))
+
+	// Convert the intermediate certificate to PEM
+	interPem := string(pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: ca.IntermediateCertificate().Raw,
+	}))
+
+	// Build the response
+	response := CAInfo{
+		Id:           ca.ID,
+		Name:         ca.Name,
+		Root:         rootPem,
+		Intermediate: interPem,
+	}
+
+	// Encode and write the JSON response
+	err := enc.Encode(response)
+	if err != nil {
+		return caddy.APIError{
+			HTTPStatus: http.StatusInternalServerError,
+			Err:        err,
+		}
+	}
+
+	return nil
+}
+
+// CAInfo is the response from the certificates API endpoint
+type CAInfo struct {
+	Id           string `json:"id"`
+	Name         string `json:"name"`
+	Root         string `json:"root"`
+	Intermediate string `json:"intermediate"`
+}
+
+const amdinPKICertificatesEndpoint = "/pki/certificates/"
+
+// Interface guards
+var (
+	_ caddy.AdminRouter = (*adminPKI)(nil)
+	_ caddy.Provisioner = (*adminPKI)(nil)
+)

--- a/modules/caddypki/pki.go
+++ b/modules/caddypki/pki.go
@@ -91,7 +91,7 @@ func (p *PKI) Start() error {
 	// install roots to trust store, if not disabled
 	for _, ca := range p.CAs {
 		if ca.InstallTrust != nil && !*ca.InstallTrust {
-			ca.log.Warn("root certificate trust store installation disabled; unconfigured clients may show warnings",
+			ca.log.Info("root certificate trust store installation disabled; unconfigured clients may show warnings",
 				zap.String("path", ca.rootCertPath))
 			continue
 		}


### PR DESCRIPTION
Fixes https://github.com/caddyserver/caddy/issues/4058, once this is completed. This is basically half-way to solving the linked issue.

This implements a new admin API, `GET /pki/certificates/<id>`, which returns information about the given PKI app's CA, by ID. 

For example, this is what a response might look like, for requesting info about the `local` CA (the default CA ID):

```bash
$ curl localhost:2019/pki/certificates/local
```
```json
{
  "id": "local",
  "name": "Caddy Local Authority",
  "root": "-----BEGIN CERTIFICATE-----\nMIIBpDCCAUmgAwIBAgIQTS5a+3LUKNxC6qN3ZDR8bDAKBggqhkjOPQQDAjAwMS4w\nLAYDVQQDEyVDYWRkeSBMb2NhbCBBdXRob3JpdHkgLSAyMDIxIEVDQyBSb290MB4X\nDTIxMTEyNTA1NDIxMloXDTMxMTAwNDA1NDIxMlowMDEuMCwGA1UEAxMlQ2FkZHkg\nTG9jYWwgQXV0aG9yaXR5IC0gMjAyMSBFQ0MgUm9vdDBZMBMGByqGSM49AgEGCCqG\nSM49AwEHA0IABIFW7LqyWf7ybSXh6FREAgGL+Bz9TktcmcmiKHAZXhWH8zCqun3k\nIg2mya+GgnA0k39OPrCaVUUMb+96UfldA9ujRTBDMA4GA1UdDwEB/wQEAwIBBjAS\nBgNVHRMBAf8ECDAGAQH/AgEBMB0GA1UdDgQWBBTrVHm2qnZLcRzky7u1NO2n8jUJ\n5DAKBggqhkjOPQQDAgNJADBGAiEA2JTbqaLhEbki73/Eb4k/KBVzSTwSKzqbssKQ\n9M9t0FwCIQCAlUr4ZlFzHE/3K6dARYKusR1ck4A3MtucSSyar6lgRw==\n-----END CERTIFICATE-----\n",
  "intermediate": "-----BEGIN CERTIFICATE-----\nMIIByDCCAW2gAwIBAgIQGRTBhcgdsiLXv0AA6r8GCTAKBggqhkjOPQQDAjAwMS4w\nLAYDVQQDEyVDYWRkeSBMb2NhbCBBdXRob3JpdHkgLSAyMDIxIEVDQyBSb290MB4X\nDTIxMTEyNTA1NDIxMloXDTIxMTIwMjA1NDIxMlowMzExMC8GA1UEAxMoQ2FkZHkg\nTG9jYWwgQXV0aG9yaXR5IC0gRUNDIEludGVybWVkaWF0ZTBZMBMGByqGSM49AgEG\nCCqGSM49AwEHA0IABNHTWLDx5jxS7x3WYEBIOXfuxQP2yvfitpEPiHJNJsf44XF8\ns31IBrDcd81Xzn63b8S2qn6elSTnZK1DdrCdtnSjZjBkMA4GA1UdDwEB/wQEAwIB\nBjASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBTvu/Kpad1XWLbaTHoqNS4U\nLBSfBTAfBgNVHSMEGDAWgBTrVHm2qnZLcRzky7u1NO2n8jUJ5DAKBggqhkjOPQQD\nAgNJADBGAiEAhUhwv6EQCgS+SGMnaze5FvHk0a9yfhDCdqmAdadhsjsCIQCTTNZF\njFM8CQL3vCfpCVzTiPR8EUbaCqxj8O9sg/70dQ==\n-----END CERTIFICATE-----\n"
}
```

To get there though, I had to refactor a bit of the `admin.go` and `caddy.go` internals. The tricky bit is that this is the first `AdminRouter` module that needs a `caddy.Context` to be able to fetch Caddy apps from the current config at runtime.

To solve it, I set up a temporary slice in `AdminConfig` to remember the routers that had their routes registered (previously, they were just forgotten immediately after), so that we can later call `Provision(ctx)` on them (if they need to be provisioned).

I also had to rework how `replaceLocalAdminServer` handles the default admin config, because I needed to make sure it would write the actual admin config in use back to the `caddy.Config` so that we could later do the provisioning stuff. Previously, it would just read from the config if it was non-nil, or use a default, and spin up the admin server. But that's not really consistent with how the rest of Caddy works, because all the other apps are actually kept as references in `caddy.Config`, I think. It also gets rid of a global var, which is nice I guess.

---

All that said, this isn't enough to call the issue done, we still need to implement the changes to the `caddy trust` so that it actually uses this new API, which would make the `caddy trust` process not need to care about its own storage as a side effect, instead it would always reach out to the API to get the correct root CA cert.