### PR TITLE
improve fmt warning message

### DIFF
--- a/caddyconfig/caddyfile/adapter.go
+++ b/caddyconfig/caddyfile/adapter.go
@@ -88,7 +88,7 @@ func formattingDifference(filename string, body []byte) (caddyconfig.Warning, bo
 	return caddyconfig.Warning{
 		File:    filename,
 		Line:    line,
-		Message: "input is not formatted with 'caddy fmt'",
+		Message: "Caddyfile input is not formatted; run the 'caddy fmt' command to fix inconsistencies",
 	}, true
 }
 


### PR DESCRIPTION
Closes #4416 
This PR only modifies "caddy fmt" warning message. The former one may cause confusion, and this mod might save several hours for someone else.