### PR TITLE
httpcaddyfile: Support configuring `pki` app names via global options

### DIFF
--- a/caddyconfig/httpcaddyfile/pkiapp.go
+++ b/caddyconfig/httpcaddyfile/pkiapp.go
@@ -16,8 +16,77 @@ package httpcaddyfile
 
 import (
 	"github.com/caddyserver/caddy/v2/caddyconfig"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddypki"
 )
+
+func init() {
+	RegisterGlobalOption("pki", parsePKIApp)
+}
+
+// parsePKIApp parses the global log option. Syntax:
+//
+//     pki [id] {
+//         name                     <name>
+//         root_common_name         <name>
+//         intermediate_common_name <name>
+//     }
+//
+// When the CA ID is unspecified, 'local' is assumed.
+//
+func parsePKIApp(d *caddyfile.Dispenser, existingVal interface{}) (interface{}, error) {
+	var pki *caddypki.PKI
+	if existingVal != nil {
+		unwrappedPki, ok := existingVal.(*caddypki.PKI)
+		if !ok {
+			return nil, d.Errf("failed to unwrap existing PKI value")
+		}
+		pki = unwrappedPki
+	} else {
+		pki = &caddypki.PKI{CAs: make(map[string]*caddypki.CA)}
+	}
+
+	pkiCa := new(caddypki.CA)
+	for d.Next() {
+		if d.NextArg() {
+			pkiCa.ID = d.Val()
+			if d.NextArg() {
+				return nil, d.ArgErr()
+			}
+		}
+		for nesting := d.Nesting(); d.NextBlock(nesting); {
+			switch d.Val() {
+			case "name":
+				if !d.NextArg() {
+					return nil, d.ArgErr()
+				}
+				pkiCa.Name = d.Val()
+
+			case "root_common_name":
+				if !d.NextArg() {
+					return nil, d.ArgErr()
+				}
+				pkiCa.Name = d.Val()
+
+			case "intermediate_common_name":
+				if !d.NextArg() {
+					return nil, d.ArgErr()
+				}
+				pkiCa.Name = d.Val()
+
+			default:
+				return nil, d.Errf("unrecognized pki option '%s'", d.Val())
+			}
+		}
+	}
+	if pkiCa.ID == "" {
+		pkiCa.ID = caddypki.DefaultCAID
+	}
+
+	pki.CAs[pkiCa.ID] = pkiCa
+
+	return pki, nil
+}
 
 func (st ServerType) buildPKIApp(
 	pairings []sbAddrAssociation,
@@ -25,14 +94,28 @@ func (st ServerType) buildPKIApp(
 	warnings []caddyconfig.Warning,
 ) (*caddypki.PKI, []caddyconfig.Warning, error) {
 
-	pkiApp := &caddypki.PKI{CAs: make(map[string]*caddypki.CA)}
-
 	skipInstallTrust := false
 	if _, ok := options["skip_install_trust"]; ok {
 		skipInstallTrust = true
 	}
 	falseBool := false
 
+	// Load the PKI app configured via global options
+	var pkiApp *caddypki.PKI
+	unwrappedPki, ok := options["pki"].(*caddypki.PKI)
+	if ok {
+		pkiApp = unwrappedPki
+	} else {
+		pkiApp = &caddypki.PKI{CAs: make(map[string]*caddypki.CA)}
+	}
+	for _, ca := range pkiApp.CAs {
+		if skipInstallTrust {
+			ca.InstallTrust = &falseBool
+		}
+		pkiApp.CAs[ca.ID] = ca
+	}
+
+	// Add in the CAs configured via directives
 	for _, p := range pairings {
 		for _, sblock := range p.serverBlocks {
 			// find all the CAs that were defined and add them to the app config
@@ -42,7 +125,12 @@ func (st ServerType) buildPKIApp(
 				if skipInstallTrust {
 					ca.InstallTrust = &falseBool
 				}
-				pkiApp.CAs[ca.ID] = ca
+
+				// the CA might already exist from global options, so
+				// don't overwrite it in that case
+				if _, ok := pkiApp.CAs[ca.ID]; !ok {
+					pkiApp.CAs[ca.ID] = ca
+				}
 			}
 		}
 	}

--- a/caddyconfig/httpcaddyfile/pkiapp.go
+++ b/caddyconfig/httpcaddyfile/pkiapp.go
@@ -28,9 +28,9 @@ func init() {
 //
 //     pki {
 //         ca [<id>] {
-//             name                     <name>
-//             root_common_name         <name>
-//             intermediate_common_name <name>
+//             name            <name>
+//             root_cn         <name>
+//             intermediate_cn <name>
 //         }
 //     }
 //
@@ -62,17 +62,17 @@ func parsePKIApp(d *caddyfile.Dispenser, existingVal interface{}) (interface{}, 
 						}
 						pkiCa.Name = d.Val()
 
-					case "root_common_name":
+					case "root_cn":
 						if !d.NextArg() {
 							return nil, d.ArgErr()
 						}
-						pkiCa.Name = d.Val()
+						pkiCa.RootCommonName = d.Val()
 
-					case "intermediate_common_name":
+					case "intermediate_cn":
 						if !d.NextArg() {
 							return nil, d.ArgErr()
 						}
-						pkiCa.Name = d.Val()
+						pkiCa.IntermediateCommonName = d.Val()
 
 					default:
 						return nil, d.Errf("unrecognized pki ca option '%s'", d.Val())

--- a/caddytest/integration/caddyfile_adapt/global_options_skip_install_trust.txt
+++ b/caddytest/integration/caddyfile_adapt/global_options_skip_install_trust.txt
@@ -1,14 +1,16 @@
 {
 	skip_install_trust
 	pki {
-		name "Local"
-		root_common_name "Custom Local Root Name"
-		intermediate_common_name "Custom Local Intermediate Name"
-	}
-	pki foo {
-		name "Foo"
-		root_common_name "Custom Foo Root Name"
-		intermediate_common_name "Custom Foo Intermediate Name"
+		ca {
+			name "Local"
+			root_common_name "Custom Local Root Name"
+			intermediate_common_name "Custom Local Intermediate Name"
+		}
+		ca foo {
+			name "Foo"
+			root_common_name "Custom Foo Root Name"
+			intermediate_common_name "Custom Foo Intermediate Name"
+		}
 	}
 }
 

--- a/caddytest/integration/caddyfile_adapt/global_options_skip_install_trust.txt
+++ b/caddytest/integration/caddyfile_adapt/global_options_skip_install_trust.txt
@@ -1,9 +1,31 @@
 {
 	skip_install_trust
+	pki {
+		name "Local"
+		root_common_name "Custom Local Root Name"
+		intermediate_common_name "Custom Local Intermediate Name"
+	}
+	pki foo {
+		name "Foo"
+		root_common_name "Custom Foo Root Name"
+		intermediate_common_name "Custom Foo Intermediate Name"
+	}
 }
 
 a.example.com {
 	tls internal
+}
+
+acme.example.com {
+	acme_server {
+		ca foo
+	}
+}
+
+acme-bar.example.com {
+	acme_server {
+		ca bar
+	}
 }
 ----------
 {
@@ -15,6 +37,56 @@ a.example.com {
 						":443"
 					],
 					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"acme-bar.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"ca": "bar",
+													"handler": "acme_server"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						},
+						{
+							"match": [
+								{
+									"host": [
+										"acme.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"ca": "foo",
+													"handler": "acme_server"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						},
 						{
 							"match": [
 								{
@@ -31,7 +103,15 @@ a.example.com {
 		},
 		"pki": {
 			"certificate_authorities": {
+				"bar": {
+					"install_trust": false
+				},
+				"foo": {
+					"name": "Custom Foo Intermediate Name",
+					"install_trust": false
+				},
 				"local": {
+					"name": "Custom Local Intermediate Name",
 					"install_trust": false
 				}
 			}
@@ -39,6 +119,12 @@ a.example.com {
 		"tls": {
 			"automation": {
 				"policies": [
+					{
+						"subjects": [
+							"acme-bar.example.com",
+							"acme.example.com"
+						]
+					},
 					{
 						"subjects": [
 							"a.example.com"

--- a/caddytest/integration/caddyfile_adapt/global_options_skip_install_trust.txt
+++ b/caddytest/integration/caddyfile_adapt/global_options_skip_install_trust.txt
@@ -3,13 +3,13 @@
 	pki {
 		ca {
 			name "Local"
-			root_common_name "Custom Local Root Name"
-			intermediate_common_name "Custom Local Intermediate Name"
+			root_cn "Custom Local Root Name"
+			intermediate_cn "Custom Local Intermediate Name"
 		}
 		ca foo {
 			name "Foo"
-			root_common_name "Custom Foo Root Name"
-			intermediate_common_name "Custom Foo Intermediate Name"
+			root_cn "Custom Foo Root Name"
+			intermediate_cn "Custom Foo Intermediate Name"
 		}
 	}
 }
@@ -109,11 +109,15 @@ acme-bar.example.com {
 					"install_trust": false
 				},
 				"foo": {
-					"name": "Custom Foo Intermediate Name",
+					"name": "Foo",
+					"root_common_name": "Custom Foo Root Name",
+					"intermediate_common_name": "Custom Foo Intermediate Name",
 					"install_trust": false
 				},
 				"local": {
-					"name": "Custom Local Intermediate Name",
+					"name": "Local",
+					"root_common_name": "Custom Local Root Name",
+					"intermediate_common_name": "Custom Local Intermediate Name",
 					"install_trust": false
 				}
 			}


### PR DESCRIPTION
Fixes #4435

Pretty self explanatory, allows configuring the PKI app name and root/intermediate common names. Works alongside the existing `acme_server` directive and `skip_install_trust` options. We could deprecate the top-level `skip_install_trust` in favor of configuring it via the default `pki` app, but 🤷‍♂️ I need no reason to do that right now. This works fine.