### PR TITLE
caddyfile: make renew_interval option configurable

### DIFF
--- a/caddyconfig/httpcaddyfile/options.go
+++ b/caddyconfig/httpcaddyfile/options.go
@@ -34,6 +34,7 @@ func init() {
 	RegisterGlobalOption("order", parseOptOrder)
 	RegisterGlobalOption("storage", parseOptStorage)
 	RegisterGlobalOption("storage_clean_interval", parseOptDuration)
+	RegisterGlobalOption("renew_interval", parseOptDuration)
 	RegisterGlobalOption("acme_ca", parseOptSingleString)
 	RegisterGlobalOption("acme_ca_root", parseOptSingleString)
 	RegisterGlobalOption("acme_dns", parseOptACMEDNS)

--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -286,6 +286,14 @@ func (st ServerType) buildTLSApp(
 		tlsApp.Automation.StorageCleanInterval = storageCleanInterval
 	}
 
+	// set the expired certificates renew interval if configured
+	if renewCheckInterval, ok := options["renew_interval"].(caddy.Duration); ok {
+		if tlsApp.Automation == nil {
+			tlsApp.Automation = new(caddytls.AutomationConfig)
+		}
+		tlsApp.Automation.RenewCheckInterval = renewCheckInterval
+	}
+
 	// if any hostnames appear on the same server block as a key with
 	// no host, they will not be used with route matchers because the
 	// hostless key matches all hosts, therefore, it wouldn't be

--- a/caddytest/integration/caddyfile_adapt/global_options_acme.txt
+++ b/caddytest/integration/caddyfile_adapt/global_options_acme.txt
@@ -21,6 +21,7 @@
 		burst 20
 	}
 	storage_clean_interval 7d
+	renew_interval 1d
 
 	key_type ed25519
 }
@@ -82,6 +83,7 @@
 					},
 					"ask": "https://example.com"
 				},
+				"renew_interval": 86400000000000,
 				"storage_clean_interval": 604800000000000
 			}
 		}


### PR DESCRIPTION
This option is pretty useful for setups with more than 30k+ certificates. To understand more about the motivation, please see:

- [Caddy + dynamodb: background maintenance taking too long and creating read spikes on dynamodb](https://caddy.community/t/caddy-dynamodb-background-maintenance-taking-too-long-and-creating-read-spikes-on-dynamodb/14153)
- [Caddy server huge drop of requests](https://caddy.community/t/caddy-server-huge-drop-of-requests/14180)