### PR TITLE
docs: use backticks to not italicise glob path

### DIFF
--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -46,7 +46,7 @@ type FileServer struct {
 	Root string `json:"root,omitempty"`
 
 	// A list of files or folders to hide; the file server will pretend as if
-	// they don't exist. Accepts globular patterns like "*.ext" or "/foo/*/bar"
+	// they don't exist. Accepts globular patterns like `*.ext` or `/foo/*/bar`
 	// as well as placeholders. Because site roots can be dynamic, this list
 	// uses file system paths, not request paths. To clarify, the base of
 	// relative paths is the current working directory, NOT the site root.


### PR DESCRIPTION
https://caddyserver.com/docs/json/apps/http/servers/errors/routes/handle/file_server/#hide interprets the markdown and it's a tad hard to read

I did a quick grep and I couldn't see any other places where this happens (in this repo at least).