### PR TITLE
pki: Avoid provisioning the `local` CA when not necessary

### DIFF
--- a/modules/caddypki/acmeserver/acmeserver.go
+++ b/modules/caddypki/acmeserver/acmeserver.go
@@ -102,19 +102,9 @@ func (ash *Handler) Provision(ctx caddy.Context) error {
 		return err
 	}
 	pkiApp := appModule.(*caddypki.PKI)
-	ca, ok := pkiApp.CAs[ash.CA]
-	if !ok {
-		// for anything other than the default CA ID, error out if it wasn't configured
-		if ash.CA != caddypki.DefaultCAID {
-			return fmt.Errorf("no certificate authority configured with id: %s", ash.CA)
-		}
-
-		// for the default CA ID, provision it, because we want it to "just work"
-		err = pkiApp.ProvisionDefaultCA(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to provision default CA: %s", err)
-		}
-		ca = pkiApp.CAs[ash.CA]
+	ca, err := pkiApp.GetCA(ash.CA, &ctx)
+	if err != nil {
+		return err
 	}
 
 	database, err := ash.openDatabase()

--- a/modules/caddytls/internalissuer.go
+++ b/modules/caddytls/internalissuer.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
-	"fmt"
 	"time"
 
 	"github.com/caddyserver/caddy/v2"
@@ -79,19 +78,9 @@ func (iss *InternalIssuer) Provision(ctx caddy.Context) error {
 		return err
 	}
 	pkiApp := appModule.(*caddypki.PKI)
-	ca, ok := pkiApp.CAs[iss.CA]
-	if !ok {
-		// for anything other than the default CA ID, error out if it wasn't configured
-		if iss.CA != caddypki.DefaultCAID {
-			return fmt.Errorf("no certificate authority configured with id: %s", iss.CA)
-		}
-
-		// for the default CA ID, provision it, because we want it to "just work"
-		err = pkiApp.ProvisionDefaultCA(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to provision default CA: %s", err)
-		}
-		ca = pkiApp.CAs[iss.CA]
+	ca, err := pkiApp.GetCA(iss.CA, &ctx)
+	if err != nil {
+		return err
 	}
 	iss.ca = ca
 


### PR DESCRIPTION
Fixes #4461

Previously, we would provision the `local` CA no matter what, if the PKI app has a config. That doesn't really make sense in all cases.

Instead, we should provision it only if there's no other CA, and if either `tls internal` is configured (implicitly or otherwise), or the `acme_server` is configured with the default CA.

I think this should have slightly less surprising behaviour for users who want to configure their own CA with an ID that isn't `local`.