### PR TITLE
reverseproxy: Dynamic upstreams (with support for SRV and A/AAAA lookups)

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_dynamic_upstreams.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_dynamic_upstreams.txt
@@ -17,13 +17,13 @@
 
 :8885 {
 	reverse_proxy {
-		dynamic srv _api._http.example.com
+		dynamic srv _api._tcp.example.com
 	}
 
 	reverse_proxy {
 		dynamic srv {
 			service api
-			proto http
+			proto tcp
 			name example.com
 			refresh 5m
 			resolvers 8.8.8.8 8.8.4.4
@@ -83,9 +83,7 @@
 							"handle": [
 								{
 									"dynamic_upstreams": {
-										"name": "example.com",
-										"proto": "http",
-										"service": "api",
+										"name": "_api._tcp.example.com",
 										"source": "srv"
 									},
 									"handler": "reverse_proxy"
@@ -95,7 +93,7 @@
 										"dial_fallback_delay": -1000000000,
 										"dial_timeout": 1000000000,
 										"name": "example.com",
-										"proto": "http",
+										"proto": "tcp",
 										"refresh": 300000000000,
 										"resolver": {
 											"addresses": [

--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_dynamic_upstreams.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_dynamic_upstreams.txt
@@ -8,6 +8,9 @@
 			name foo
 			port 9000
 			refresh 5m
+			resolvers 8.8.8.8 8.8.4.4
+			dial_timeout 2s
+			dial_fallback_delay 300ms
 		}
 	}
 }
@@ -23,6 +26,9 @@
 			proto http
 			name example.com
 			refresh 5m
+			resolvers 8.8.8.8 8.8.4.4
+			dial_timeout 1s
+			dial_fallback_delay -1s
 		}
 	}
 }
@@ -49,9 +55,17 @@
 								},
 								{
 									"dynamic_upstreams": {
+										"dial_fallback_delay": 300000000,
+										"dial_timeout": 2000000000,
 										"name": "foo",
 										"port": "9000",
 										"refresh": 300000000000,
+										"resolver": {
+											"addresses": [
+												"8.8.8.8",
+												"8.8.4.4"
+											]
+										},
 										"source": "a"
 									},
 									"handler": "reverse_proxy"
@@ -78,9 +92,17 @@
 								},
 								{
 									"dynamic_upstreams": {
+										"dial_fallback_delay": -1000000000,
+										"dial_timeout": 1000000000,
 										"name": "example.com",
 										"proto": "http",
 										"refresh": 300000000000,
+										"resolver": {
+											"addresses": [
+												"8.8.8.8",
+												"8.8.4.4"
+											]
+										},
 										"service": "api",
 										"source": "srv"
 									},

--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_dynamic_upstreams.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_dynamic_upstreams.txt
@@ -1,0 +1,96 @@
+:8884 {
+	reverse_proxy {
+		dynamic a foo 9000
+	}
+
+	reverse_proxy {
+		dynamic a {
+			name foo
+			port 9000
+			refresh 5m
+		}
+	}
+}
+
+:8885 {
+	reverse_proxy {
+		dynamic srv _api._http.example.com
+	}
+
+	reverse_proxy {
+		dynamic srv {
+			service api
+			proto http
+			name example.com
+			refresh 5m
+		}
+	}
+}
+
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8884"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"dynamic_upstreams": {
+										"name": "foo",
+										"port": "9000",
+										"source": "a"
+									},
+									"handler": "reverse_proxy"
+								},
+								{
+									"dynamic_upstreams": {
+										"name": "foo",
+										"port": "9000",
+										"refresh": 300000000000,
+										"source": "a"
+									},
+									"handler": "reverse_proxy"
+								}
+							]
+						}
+					]
+				},
+				"srv1": {
+					"listen": [
+						":8885"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"dynamic_upstreams": {
+										"name": "example.com",
+										"proto": "http",
+										"service": "api",
+										"source": "srv"
+									},
+									"handler": "reverse_proxy"
+								},
+								{
+									"dynamic_upstreams": {
+										"name": "example.com",
+										"proto": "http",
+										"refresh": 300000000000,
+										"service": "api",
+										"source": "srv"
+									},
+									"handler": "reverse_proxy"
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_options.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_options.txt
@@ -17,6 +17,7 @@ https://example.com {
 			dial_fallback_delay 5s
 			response_header_timeout 8s
 			expect_continue_timeout 9s
+			resolvers 8.8.8.8 8.8.4.4
 
 			versions h2c 2
 			compression off
@@ -88,6 +89,12 @@ https://example.com {
 														"max_response_header_size": 30000000,
 														"protocol": "http",
 														"read_buffer_size": 10000000,
+														"resolver": {
+															"addresses": [
+																"8.8.8.8",
+																"8.8.4.4"
+															]
+														},
 														"response_header_timeout": 8000000000,
 														"versions": [
 															"h2c",

--- a/modules/caddyhttp/reverseproxy/admin.go
+++ b/modules/caddyhttp/reverseproxy/admin.go
@@ -87,7 +87,7 @@ func (adminUpstreams) handleUpstreams(w http.ResponseWriter, r *http.Request) er
 			return false
 		}
 
-		upstream, ok := val.(*upstreamHost)
+		upstream, ok := val.(*Host)
 		if !ok {
 			rangeErr = caddy.APIError{
 				HTTPStatus: http.StatusInternalServerError,

--- a/modules/caddyhttp/reverseproxy/admin.go
+++ b/modules/caddyhttp/reverseproxy/admin.go
@@ -98,7 +98,6 @@ func (adminUpstreams) handleUpstreams(w http.ResponseWriter, r *http.Request) er
 
 		results = append(results, upstreamStatus{
 			Address:     address,
-			Healthy:     !upstream.Unhealthy(),
 			NumRequests: upstream.NumRequests(),
 			Fails:       upstream.Fails(),
 		})

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -1194,4 +1194,6 @@ const matcherPrefix = "@"
 var (
 	_ caddyfile.Unmarshaler = (*Handler)(nil)
 	_ caddyfile.Unmarshaler = (*HTTPTransport)(nil)
+	_ caddyfile.Unmarshaler = (*SRVUpstreams)(nil)
+	_ caddyfile.Unmarshaler = (*AUpstreams)(nil)
 )

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -1069,7 +1069,7 @@ func (h *HTTPTransport) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 
 // UnmarshalCaddyfile deserializes Caddyfile tokens into h.
 //
-//     dynamic srv [<address>] {
+//     dynamic srv [<name>] {
 //         service             <service>
 //         proto               <proto>
 //         name                <name>
@@ -1086,13 +1086,7 @@ func (u *SRVUpstreams) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			return d.ArgErr()
 		}
 		if len(args) > 0 {
-			service, proto, name, err := u.ParseAddress(args[0])
-			if err != nil {
-				return err
-			}
-			u.Service = service
-			u.Proto = proto
-			u.Name = name
+			u.Name = args[0]
 		}
 
 		for d.NextBlock(0) {

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -69,8 +69,7 @@ type HealthChecks struct {
 // health checks (that is, health checks which occur in a
 // background goroutine independently).
 type ActiveHealthChecks struct {
-	// The path to use for health checks.
-	// DEPRECATED: Use 'uri' instead.
+	// DEPRECATED: Use 'uri' instead. This field will be removed. TODO: remove this field
 	Path string `json:"path,omitempty"`
 
 	// The URI (path and query) to use for health checks

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -213,7 +213,7 @@ func (h *Handler) doActiveHealthCheckForAllHosts() {
 // according to whether it passes the health check. An error is
 // returned only if the health check fails to occur or if marking
 // the host's health status fails.
-func (h *Handler) doActiveHealthCheck(dialInfo DialInfo, hostAddr string, host Host) error {
+func (h *Handler) doActiveHealthCheck(dialInfo DialInfo, hostAddr string, host *Host) error {
 	// create the URL for the request that acts as a health check
 	scheme := "http"
 	if ht, ok := h.Transport.(TLSTransport); ok && ht.TLSEnabled() {
@@ -375,7 +375,7 @@ func (h *Handler) countFailure(upstream *Upstream) {
 	}
 
 	// forget it later
-	go func(host Host, failDuration time.Duration) {
+	go func(host *Host, failDuration time.Duration) {
 		defer func() {
 			if err := recover(); err != nil {
 				log.Printf("[PANIC] health check failure forgetter: %v\n%s", err, debug.Stack())

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -143,7 +143,7 @@ func (u *Upstream) fillDialInfo(r *http.Request) (DialInfo, error) {
 	}, nil
 }
 
-func (u *Upstream) setHost() {
+func (u *Upstream) fillHost() {
 	host := new(Host)
 	existingHost, loaded := hosts.LoadOrStore(u.String(), host)
 	if loaded {

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -143,6 +143,15 @@ func (u *Upstream) fillDialInfo(r *http.Request) (DialInfo, error) {
 	}, nil
 }
 
+func (u *Upstream) setHost() {
+	host := new(Host)
+	existingHost, loaded := hosts.LoadOrStore(u.String(), host)
+	if loaded {
+		host = existingHost.(*Host)
+	}
+	u.Host = host
+}
+
 // Host is the basic, in-memory representation
 // of the state of a remote host.
 type Host struct {

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -46,6 +46,10 @@ type Upstream struct {
 	// backends is down. Also be aware of open proxy vulnerabilities.
 	Dial string `json:"dial,omitempty"`
 
+	// DEPRECATED: Use the SRVUpstreams module instead
+	// (http.reverse_proxy.upstreams.srv). This field will be
+	// removed in a future version of Caddy.
+	//
 	// If DNS SRV records are used for service discovery with this
 	// upstream, specify the DNS name for which to look up SRV
 	// records here, instead of specifying a dial address.

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -161,7 +161,7 @@ func (u *Upstream) fillHost() {
 type Host struct {
 	numRequests int64 // must be 64-bit aligned on 32-bit systems (see https://golang.org/pkg/sync/atomic/#pkg-note-BUG)
 	fails       int64
-	unhealthy   int32
+	unhealthy   int32 // TODO: this should be removed from Host; this decision should be made by the health checker
 }
 
 // NumRequests returns the number of active requests to the upstream.

--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -168,15 +168,9 @@ func (h *HTTPTransport) NewTransport(ctx caddy.Context) (*http.Transport, error)
 	}
 
 	if h.Resolver != nil {
-		for _, v := range h.Resolver.Addresses {
-			addr, err := caddy.ParseNetworkAddress(v)
-			if err != nil {
-				return nil, err
-			}
-			if addr.PortRangeSize() != 1 {
-				return nil, fmt.Errorf("resolver address must have exactly one address; cannot call %v", addr)
-			}
-			h.Resolver.netAddrs = append(h.Resolver.netAddrs, addr)
+		err := h.Resolver.ParseAddresses()
+		if err != nil {
+			return nil, err
 		}
 		d := &net.Dialer{
 			Timeout:       time.Duration(h.DialTimeout),
@@ -404,18 +398,6 @@ func (t TLSConfig) MakeTLSClientConfig(ctx caddy.Context) (*tls.Config, error) {
 	}
 
 	return cfg, nil
-}
-
-// UpstreamResolver holds the set of addresses of DNS resolvers of
-// upstream addresses
-type UpstreamResolver struct {
-	// The addresses of DNS resolvers to use when looking up the addresses of proxy upstreams.
-	// It accepts [network addresses](/docs/conventions#network-addresses)
-	// with port range of only 1. If the host is an IP address, it will be dialed directly to resolve the upstream server.
-	// If the host is not an IP address, the addresses are resolved using the [name resolution convention](https://golang.org/pkg/net/#hdr-Name_Resolution) of the Go standard library.
-	// If the array contains more than 1 resolver address, one is chosen at random.
-	Addresses []string `json:"addresses,omitempty"`
-	netAddrs  []caddy.NetworkAddress
 }
 
 // KeepAlive holds configuration pertaining to HTTP Keep-Alive.

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -160,7 +160,7 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 	h.ctx = ctx
 	h.logger = ctx.Logger(h)
 
-	// verify SRV compatibility
+	// verify SRV compatibility - TODO: LookupSRV deprecated; will be removed
 	for i, v := range h.Upstreams {
 		if v.LookupSRV == "" {
 			continue

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -438,6 +438,7 @@ func (h *Handler) proxyLoopIteration(r *http.Request, w http.ResponseWriter, pro
 			for _, dUp := range dUpstreams {
 				h.provisionUpstream(dUp)
 			}
+			h.logger.Debug("provisioned dynamic upstreams", zap.Int("count", len(dUpstreams)))
 			defer func() {
 				// these upstreams are dynamic, so they are only used for this iteration
 				// of the proxy loop; be sure to let them go away when we're done with them
@@ -467,6 +468,10 @@ func (h *Handler) proxyLoopIteration(r *http.Request, w http.ResponseWriter, pro
 	if err != nil {
 		return true, fmt.Errorf("making dial info: %v", err)
 	}
+
+	h.logger.Debug("selected upstream",
+		zap.String("dial", dialInfo.Address),
+		zap.Int("total_upstreams", len(upstreams)))
 
 	// attach to the request information about how to dial the upstream;
 	// this is necessary because the information cannot be sufficiently

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -249,7 +249,7 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 	// set up upstreams
 	for _, upstream := range h.Upstreams {
 		// create or get the host representation for this upstream
-		upstream.setHost()
+		upstream.fillHost()
 
 		// give it the circuit breaker, if any
 		upstream.cb = h.CB

--- a/modules/caddyhttp/reverseproxy/selectionpolicies_test.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies_test.go
@@ -22,9 +22,9 @@ import (
 
 func testPool() UpstreamPool {
 	return UpstreamPool{
-		{Host: new(upstreamHost)},
-		{Host: new(upstreamHost)},
-		{Host: new(upstreamHost)},
+		{Host: new(Host)},
+		{Host: new(Host)},
+		{Host: new(Host)},
 	}
 }
 
@@ -167,8 +167,8 @@ func TestIPHashPolicy(t *testing.T) {
 	// We should be able to resize the host pool and still be able to predict
 	// where a req will be routed with the same IP's used above
 	pool = UpstreamPool{
-		{Host: new(upstreamHost)},
-		{Host: new(upstreamHost)},
+		{Host: new(Host)},
+		{Host: new(Host)},
 	}
 	req.RemoteAddr = "172.0.0.1:80"
 	h = ipHash.Select(pool, req, nil)
@@ -201,15 +201,15 @@ func TestIPHashPolicy(t *testing.T) {
 
 	// Reproduce #4135
 	pool = UpstreamPool{
-		{Host: new(upstreamHost)},
-		{Host: new(upstreamHost)},
-		{Host: new(upstreamHost)},
-		{Host: new(upstreamHost)},
-		{Host: new(upstreamHost)},
-		{Host: new(upstreamHost)},
-		{Host: new(upstreamHost)},
-		{Host: new(upstreamHost)},
-		{Host: new(upstreamHost)},
+		{Host: new(Host)},
+		{Host: new(Host)},
+		{Host: new(Host)},
+		{Host: new(Host)},
+		{Host: new(Host)},
+		{Host: new(Host)},
+		{Host: new(Host)},
+		{Host: new(Host)},
+		{Host: new(Host)},
 	}
 	pool[0].SetHealthy(false)
 	pool[1].SetHealthy(false)
@@ -271,8 +271,8 @@ func TestURIHashPolicy(t *testing.T) {
 	// We should be able to resize the host pool and still be able to predict
 	// where a request will be routed with the same URI's used above
 	pool = UpstreamPool{
-		{Host: new(upstreamHost)},
-		{Host: new(upstreamHost)},
+		{Host: new(Host)},
+		{Host: new(Host)},
 	}
 
 	request = httptest.NewRequest(http.MethodGet, "/test", nil)

--- a/modules/caddyhttp/reverseproxy/selectionpolicies_test.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies_test.go
@@ -48,20 +48,20 @@ func TestRoundRobinPolicy(t *testing.T) {
 		t.Error("Expected third round robin host to be first host in the pool.")
 	}
 	// mark host as down
-	pool[1].SetHealthy(false)
+	pool[1].setHealthy(false)
 	h = rrPolicy.Select(pool, req, nil)
 	if h != pool[2] {
 		t.Error("Expected to skip down host.")
 	}
 	// mark host as up
-	pool[1].SetHealthy(true)
+	pool[1].setHealthy(true)
 
 	h = rrPolicy.Select(pool, req, nil)
 	if h == pool[2] {
 		t.Error("Expected to balance evenly among healthy hosts")
 	}
 	// mark host as full
-	pool[1].CountRequest(1)
+	pool[1].countRequest(1)
 	pool[1].MaxRequests = 1
 	h = rrPolicy.Select(pool, req, nil)
 	if h != pool[2] {
@@ -74,13 +74,13 @@ func TestLeastConnPolicy(t *testing.T) {
 	lcPolicy := new(LeastConnSelection)
 	req, _ := http.NewRequest("GET", "/", nil)
 
-	pool[0].CountRequest(10)
-	pool[1].CountRequest(10)
+	pool[0].countRequest(10)
+	pool[1].countRequest(10)
 	h := lcPolicy.Select(pool, req, nil)
 	if h != pool[2] {
 		t.Error("Expected least connection host to be third host.")
 	}
-	pool[2].CountRequest(100)
+	pool[2].countRequest(100)
 	h = lcPolicy.Select(pool, req, nil)
 	if h != pool[0] && h != pool[1] {
 		t.Error("Expected least connection host to be first or second host.")
@@ -139,7 +139,7 @@ func TestIPHashPolicy(t *testing.T) {
 	// we should get a healthy host if the original host is unhealthy and a
 	// healthy host is available
 	req.RemoteAddr = "172.0.0.1"
-	pool[1].SetHealthy(false)
+	pool[1].setHealthy(false)
 	h = ipHash.Select(pool, req, nil)
 	if h != pool[2] {
 		t.Error("Expected ip hash policy host to be the third host.")
@@ -150,10 +150,10 @@ func TestIPHashPolicy(t *testing.T) {
 	if h != pool[2] {
 		t.Error("Expected ip hash policy host to be the third host.")
 	}
-	pool[1].SetHealthy(true)
+	pool[1].setHealthy(true)
 
 	req.RemoteAddr = "172.0.0.3"
-	pool[2].SetHealthy(false)
+	pool[2].setHealthy(false)
 	h = ipHash.Select(pool, req, nil)
 	if h != pool[0] {
 		t.Error("Expected ip hash policy host to be the first host.")
@@ -192,8 +192,8 @@ func TestIPHashPolicy(t *testing.T) {
 	}
 
 	// We should get nil when there are no healthy hosts
-	pool[0].SetHealthy(false)
-	pool[1].SetHealthy(false)
+	pool[0].setHealthy(false)
+	pool[1].setHealthy(false)
 	h = ipHash.Select(pool, req, nil)
 	if h != nil {
 		t.Error("Expected ip hash policy host to be nil.")
@@ -211,15 +211,15 @@ func TestIPHashPolicy(t *testing.T) {
 		{Host: new(Host)},
 		{Host: new(Host)},
 	}
-	pool[0].SetHealthy(false)
-	pool[1].SetHealthy(false)
-	pool[2].SetHealthy(false)
-	pool[3].SetHealthy(false)
-	pool[4].SetHealthy(false)
-	pool[5].SetHealthy(false)
-	pool[6].SetHealthy(false)
-	pool[7].SetHealthy(false)
-	pool[8].SetHealthy(true)
+	pool[0].setHealthy(false)
+	pool[1].setHealthy(false)
+	pool[2].setHealthy(false)
+	pool[3].setHealthy(false)
+	pool[4].setHealthy(false)
+	pool[5].setHealthy(false)
+	pool[6].setHealthy(false)
+	pool[7].setHealthy(false)
+	pool[8].setHealthy(true)
 
 	// We should get a result back when there is one healthy host left.
 	h = ipHash.Select(pool, req, nil)
@@ -239,7 +239,7 @@ func TestFirstPolicy(t *testing.T) {
 		t.Error("Expected first policy host to be the first host.")
 	}
 
-	pool[0].SetHealthy(false)
+	pool[0].setHealthy(false)
 	h = firstPolicy.Select(pool, req, nil)
 	if h != pool[1] {
 		t.Error("Expected first policy host to be the second host.")
@@ -256,7 +256,7 @@ func TestURIHashPolicy(t *testing.T) {
 		t.Error("Expected uri policy host to be the first host.")
 	}
 
-	pool[0].SetHealthy(false)
+	pool[0].setHealthy(false)
 	h = uriPolicy.Select(pool, request, nil)
 	if h != pool[1] {
 		t.Error("Expected uri policy host to be the first host.")
@@ -281,7 +281,7 @@ func TestURIHashPolicy(t *testing.T) {
 		t.Error("Expected uri policy host to be the first host.")
 	}
 
-	pool[0].SetHealthy(false)
+	pool[0].setHealthy(false)
 	h = uriPolicy.Select(pool, request, nil)
 	if h != pool[1] {
 		t.Error("Expected uri policy host to be the first host.")
@@ -293,8 +293,8 @@ func TestURIHashPolicy(t *testing.T) {
 		t.Error("Expected uri policy host to be the second host.")
 	}
 
-	pool[0].SetHealthy(false)
-	pool[1].SetHealthy(false)
+	pool[0].setHealthy(false)
+	pool[1].setHealthy(false)
 	h = uriPolicy.Select(pool, request, nil)
 	if h != nil {
 		t.Error("Expected uri policy policy host to be nil.")
@@ -306,12 +306,12 @@ func TestLeastRequests(t *testing.T) {
 	pool[0].Dial = "localhost:8080"
 	pool[1].Dial = "localhost:8081"
 	pool[2].Dial = "localhost:8082"
-	pool[0].SetHealthy(true)
-	pool[1].SetHealthy(true)
-	pool[2].SetHealthy(true)
-	pool[0].CountRequest(10)
-	pool[1].CountRequest(20)
-	pool[2].CountRequest(30)
+	pool[0].setHealthy(true)
+	pool[1].setHealthy(true)
+	pool[2].setHealthy(true)
+	pool[0].countRequest(10)
+	pool[1].countRequest(20)
+	pool[2].countRequest(30)
 
 	result := leastRequests(pool)
 
@@ -329,12 +329,12 @@ func TestRandomChoicePolicy(t *testing.T) {
 	pool[0].Dial = "localhost:8080"
 	pool[1].Dial = "localhost:8081"
 	pool[2].Dial = "localhost:8082"
-	pool[0].SetHealthy(false)
-	pool[1].SetHealthy(true)
-	pool[2].SetHealthy(true)
-	pool[0].CountRequest(10)
-	pool[1].CountRequest(20)
-	pool[2].CountRequest(30)
+	pool[0].setHealthy(false)
+	pool[1].setHealthy(true)
+	pool[2].setHealthy(true)
+	pool[0].countRequest(10)
+	pool[1].countRequest(20)
+	pool[2].countRequest(30)
 
 	request := httptest.NewRequest(http.MethodGet, "/test", nil)
 	randomChoicePolicy := new(RandomChoiceSelection)
@@ -357,9 +357,9 @@ func TestCookieHashPolicy(t *testing.T) {
 	pool[0].Dial = "localhost:8080"
 	pool[1].Dial = "localhost:8081"
 	pool[2].Dial = "localhost:8082"
-	pool[0].SetHealthy(true)
-	pool[1].SetHealthy(false)
-	pool[2].SetHealthy(false)
+	pool[0].setHealthy(true)
+	pool[1].setHealthy(false)
+	pool[2].setHealthy(false)
 	request := httptest.NewRequest(http.MethodGet, "/test", nil)
 	w := httptest.NewRecorder()
 	cookieHashPolicy := new(CookieHashSelection)
@@ -374,8 +374,8 @@ func TestCookieHashPolicy(t *testing.T) {
 	if h != pool[0] {
 		t.Error("Expected cookieHashPolicy host to be the first only available host.")
 	}
-	pool[1].SetHealthy(true)
-	pool[2].SetHealthy(true)
+	pool[1].setHealthy(true)
+	pool[2].setHealthy(true)
 	request = httptest.NewRequest(http.MethodGet, "/test", nil)
 	w = httptest.NewRecorder()
 	request.AddCookie(cookieServer1)
@@ -387,7 +387,7 @@ func TestCookieHashPolicy(t *testing.T) {
 	if len(s) != 0 {
 		t.Error("Expected cookieHashPolicy to not set a new cookie.")
 	}
-	pool[0].SetHealthy(false)
+	pool[0].setHealthy(false)
 	request = httptest.NewRequest(http.MethodGet, "/test", nil)
 	w = httptest.NewRecorder()
 	request.AddCookie(cookieServer1)

--- a/modules/caddyhttp/reverseproxy/upstreams.go
+++ b/modules/caddyhttp/reverseproxy/upstreams.go
@@ -116,11 +116,10 @@ func (su SRVUpstreams) GetUpstreams(r *http.Request) ([]*Upstream, error) {
 		upstreams[i] = &Upstream{
 			Dial: net.JoinHostPort(rec.Target, strconv.Itoa(int(rec.Port))),
 		}
-		upstreams[i].fillHost()
 	}
 
 	// before adding a new one to the cache (as opposed to replacing stale one), make room if cache is full
-	if cached.freshness.IsZero() && len(srvs) >= 1000 {
+	if cached.freshness.IsZero() && len(srvs) >= 100 {
 		for randomKey := range srvs {
 			delete(srvs, randomKey)
 			break
@@ -223,11 +222,10 @@ func (au AUpstreams) GetUpstreams(r *http.Request) ([]*Upstream, error) {
 		upstreams[i] = &Upstream{
 			Dial: net.JoinHostPort(ip.String(), port),
 		}
-		upstreams[i].fillHost()
 	}
 
 	// before adding a new one to the cache (as opposed to replacing stale one), make room if cache is full
-	if cached.freshness.IsZero() && len(srvs) >= 1000 {
+	if cached.freshness.IsZero() && len(srvs) >= 100 {
 		for randomKey := range aAaaa {
 			delete(aAaaa, randomKey)
 			break

--- a/modules/caddyhttp/reverseproxy/upstreams.go
+++ b/modules/caddyhttp/reverseproxy/upstreams.go
@@ -1,0 +1,243 @@
+package reverseproxy
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
+)
+
+func init() {
+	caddy.RegisterModule(SRVUpstreams{})
+	caddy.RegisterModule(AUpstreams{})
+}
+
+// SRVUpstreams provides upstreams from SRV lookups.
+// The lookup DNS name can be configured either by
+// its individual parts (that is, specifying the
+// service, protocol, and name separately) to form
+// the standard "_service._proto.name" domain, or
+// the domain can be specified directly in name by
+// leaving service and proto empty. See RFC 2782.
+//
+// Lookups are cached and refreshed at the configured
+// refresh interval.
+//
+// Returned upstreams are sorted by priority and weight.
+type SRVUpstreams struct {
+	// The interval at which to refresh the SRV lookup.
+	// Results are cached between lookups. Default: 1m
+	Refresh time.Duration `json:"refresh,omitempty"`
+
+	// The service label.
+	Service string `json:"service,omitempty"`
+
+	// The protocol label; either tcp or udp.
+	Proto string `json:"proto,omitempty"`
+
+	// The name label; or, if service and proto are
+	// empty, the entire domain name to look up.
+	Name string `json:"name,omitempty"`
+}
+
+// CaddyModule returns the Caddy module information.
+func (SRVUpstreams) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "http.reverse_proxy.upstreams.srv",
+		New: func() caddy.Module { return new(SRVUpstreams) },
+	}
+}
+
+// String returns the RFC 2782 representation of the SRV domain.
+func (su SRVUpstreams) String() string {
+	return fmt.Sprintf("_%s._%s.%s", su.Service, su.Proto, su.Name)
+}
+
+func (su *SRVUpstreams) Provision(_ caddy.Context) error {
+	if su.Proto != "tcp" && su.Proto != "udp" {
+		return fmt.Errorf("invalid proto '%s'", su.Proto)
+	}
+	if su.Refresh == 0 {
+		su.Refresh = time.Minute
+	}
+	return nil
+}
+
+func (su SRVUpstreams) GetUpstreams(r *http.Request) ([]*Upstream, error) {
+	suStr := su.String()
+
+	// first, use a cheap read-lock to return a cached result quickly
+	srvsMu.RLock()
+	cached := srvs[suStr]
+	srvsMu.RUnlock()
+	if cached.fresh() {
+		return cached.upstreams, nil
+	}
+
+	// otherwise, obtain a write-lock to update the cached value
+	srvsMu.Lock()
+	defer srvsMu.Unlock()
+
+	// check to see if it's still stale, since we're now in a different
+	// lock from when we first checked freshness; another goroutine might
+	// have refreshed it in the meantime before we re-obtained our lock
+	cached = srvs[suStr]
+	if cached.fresh() {
+		return cached.upstreams, nil
+	}
+
+	// prepare parameters and perform the SRV lookup
+	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+	service := repl.ReplaceAll(su.Service, "")
+	proto := repl.ReplaceAll(su.Proto, "")
+	name := repl.ReplaceAll(su.Name, "")
+
+	_, records, err := net.DefaultResolver.LookupSRV(r.Context(), service, proto, name)
+	if err != nil {
+		return nil, err
+	}
+
+	upstreams := make([]*Upstream, len(records))
+	for i, rec := range records {
+		upstreams[i] = &Upstream{
+			Dial: net.JoinHostPort(rec.Target, strconv.Itoa(int(rec.Port))),
+		}
+		upstreams[i].setHost()
+	}
+
+	// TODO: expire these somehow
+	srvs[suStr] = srvLookup{
+		srvUpstreams: su,
+		freshness:    time.Now(),
+		upstreams:    upstreams,
+	}
+
+	return upstreams, nil
+}
+
+type srvLookup struct {
+	srvUpstreams SRVUpstreams
+	freshness    time.Time
+	upstreams    []*Upstream
+}
+
+func (sl srvLookup) fresh() bool {
+	return time.Since(sl.freshness) < sl.srvUpstreams.Refresh
+}
+
+var (
+	srvs   = make(map[string]srvLookup)
+	srvsMu sync.RWMutex
+)
+
+// AUpstreams provides upstreams from A/AAAA lookups.
+// Results are cached and refreshed at the configured
+// refresh interval.
+type AUpstreams struct {
+	// The domain name to look up.
+	Name string `json:"name,omitempty"`
+
+	// The port to use with the upstreams. Default: 80
+	Port string `json:"port,omitempty"`
+
+	// The interval at which to refresh the SRV lookup.
+	// Results are cached between lookups. Default: 1m
+	Refresh time.Duration `json:"refresh,omitempty"`
+}
+
+// CaddyModule returns the Caddy module information.
+func (AUpstreams) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "http.reverse_proxy.upstreams.a",
+		New: func() caddy.Module { return new(AUpstreams) },
+	}
+}
+
+func (au AUpstreams) String() string { return au.Name }
+
+func (au *AUpstreams) Provision(_ caddy.Context) error {
+	if au.Refresh == 0 {
+		au.Refresh = time.Minute
+	}
+	if au.Port == "" {
+		au.Port = "80"
+	}
+	return nil
+}
+
+func (au AUpstreams) GetUpstreams(r *http.Request) ([]*Upstream, error) {
+	auStr := au.String()
+
+	// first, use a cheap read-lock to return a cached result quickly
+	aAaaaMu.RLock()
+	cached := aAaaa[auStr]
+	aAaaaMu.RUnlock()
+	if cached.fresh() {
+		return cached.upstreams, nil
+	}
+
+	// otherwise, obtain a write-lock to update the cached value
+	aAaaaMu.Lock()
+	defer aAaaaMu.Unlock()
+
+	// check to see if it's still stale, since we're now in a different
+	// lock from when we first checked freshness; another goroutine might
+	// have refreshed it in the meantime before we re-obtained our lock
+	cached = aAaaa[auStr]
+	if cached.fresh() {
+		return cached.upstreams, nil
+	}
+
+	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+	name := repl.ReplaceAll(au.Name, "")
+	port := repl.ReplaceAll(au.Port, "")
+
+	ips, err := net.DefaultResolver.LookupIPAddr(r.Context(), name)
+	if err != nil {
+		return nil, err
+	}
+
+	upstreams := make([]*Upstream, len(ips))
+	for i, ip := range ips {
+		upstreams[i] = &Upstream{
+			Dial: net.JoinHostPort(ip.String(), port),
+		}
+		upstreams[i].setHost()
+	}
+
+	// TODO: expire these somehow
+	aAaaa[auStr] = aLookup{
+		aUpstreams: au,
+		freshness:  time.Now(),
+		upstreams:  upstreams,
+	}
+
+	return upstreams, nil
+}
+
+type aLookup struct {
+	aUpstreams AUpstreams
+	freshness  time.Time
+	upstreams  []*Upstream
+}
+
+func (al aLookup) fresh() bool {
+	return time.Since(al.freshness) < al.aUpstreams.Refresh
+}
+
+var (
+	aAaaa   = make(map[string]aLookup)
+	aAaaaMu sync.RWMutex
+)
+
+// Interface guards
+var (
+	_ caddy.Provisioner = (*SRVUpstreams)(nil)
+	_ UpstreamSource    = (*SRVUpstreams)(nil)
+	_ caddy.Provisioner = (*AUpstreams)(nil)
+	_ UpstreamSource    = (*AUpstreams)(nil)
+)

--- a/modules/caddyhttp/reverseproxy/upstreams.go
+++ b/modules/caddyhttp/reverseproxy/upstreams.go
@@ -119,7 +119,14 @@ func (su SRVUpstreams) GetUpstreams(r *http.Request) ([]*Upstream, error) {
 		upstreams[i].fillHost()
 	}
 
-	// TODO: expire these somehow
+	// before adding a new one to the cache (as opposed to replacing stale one), make room if cache is full
+	if cached.freshness.IsZero() && len(srvs) >= 1000 {
+		for randomKey := range srvs {
+			delete(srvs, randomKey)
+			break
+		}
+	}
+
 	srvs[suStr] = srvLookup{
 		srvUpstreams: su,
 		freshness:    time.Now(),
@@ -219,7 +226,14 @@ func (au AUpstreams) GetUpstreams(r *http.Request) ([]*Upstream, error) {
 		upstreams[i].fillHost()
 	}
 
-	// TODO: expire these somehow
+	// before adding a new one to the cache (as opposed to replacing stale one), make room if cache is full
+	if cached.freshness.IsZero() && len(srvs) >= 1000 {
+		for randomKey := range aAaaa {
+			delete(aAaaa, randomKey)
+			break
+		}
+	}
+
 	aAaaa[auStr] = aLookup{
 		aUpstreams: au,
 		freshness:  time.Now(),

--- a/modules/caddyhttp/reverseproxy/upstreams.go
+++ b/modules/caddyhttp/reverseproxy/upstreams.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -80,9 +79,6 @@ func (su SRVUpstreams) String() string {
 
 func (su *SRVUpstreams) Provision(ctx caddy.Context) error {
 	su.logger = ctx.Logger(su)
-	if su.Proto != "tcp" && su.Proto != "udp" {
-		return fmt.Errorf("invalid proto '%s'", su.Proto)
-	}
 	if su.Refresh == 0 {
 		su.Refresh = caddy.Duration(time.Minute)
 	}
@@ -174,19 +170,6 @@ func (su SRVUpstreams) GetUpstreams(r *http.Request) ([]*Upstream, error) {
 	}
 
 	return upstreams, nil
-}
-
-// ParseAddress takes a full SRV address and parses it into
-// its three constituent parts. Used for parsing configuration
-// so that users may specify the address with dots instead of
-// specifying each part separately.
-func (SRVUpstreams) ParseAddress(address string) (string, string, string, error) {
-	parts := strings.SplitN(address, ".", 3)
-	if len(parts) != 3 {
-		return "", "", "", fmt.Errorf("expected 3 parts (service, proto, name), got %d parts", len(parts))
-	}
-
-	return strings.TrimLeft(parts[0], "_"), strings.TrimLeft(parts[1], "_"), strings.TrimLeft(parts[2], "_"), nil
 }
 
 type srvLookup struct {

--- a/modules/caddyhttp/reverseproxy/upstreams.go
+++ b/modules/caddyhttp/reverseproxy/upstreams.go
@@ -340,7 +340,7 @@ type UpstreamResolver struct {
 
 // ParseAddresses parses all the configured network addresses
 // and ensures they're ready to be used.
-func (u UpstreamResolver) ParseAddresses() error {
+func (u *UpstreamResolver) ParseAddresses() error {
 	for _, v := range u.Addresses {
 		addr, err := caddy.ParseNetworkAddress(v)
 		if err != nil {


### PR DESCRIPTION
Right now, proxy upstreams have to be hard-coded into the config (with the only dyanamism coming from placeholders, which all act as a single upstream anyway). This change adds supports for truly dynamic upstreams, with the potential for every request to have different upstreams -- not only every request, but every _retry_ within a single request, too.

Instead of (or in addition to) specifying `upstreams` in your config, you could specify `dynamic_upstreams` and then define your upstream source module. Currently I'm implementing SRV and A/AAAA lookups as sources.

Fixes or related to:

- #1545 (currently the oldest open issue)
- #4174
- A currently-private sponsor's request. Hope to reveal this later!

When we're done, it will hopefully close or supercede #4350, #3801, #4446, and #4245. Closes #4341 too.

For dynamic SRV lookups:

```json
{
    "handler": "reverse_proxy",
    "dynamic_upstreams": {
        "source": "srv",
        "name": "_service._proto.name"
     }
}
```

For dynamic A/AAAA DNS lookups:

```json
{
    "handler": "reverse_proxy",
    "dynamic_upstreams": {
        "source": "a",
        "name": "backends.example.com",
        "port": "8080"
     }
}
```

The default refresh interval for lookups is 1 minute, but can be configured with the `refresh` property. SRV lookups can also optionally be configured by their individual service, proto, and name components, or the entire domain as the name by itself.

Still need to integrate health checks, add docs and tests, and cache eviction.

May be of interest to @danlsgiga, @dazoot, @sorenisanerd, and @furkanmustafa.

CC: @jjiang-stripe and @cds2-stripe 