### PR TITLE
httpcaddyfile: Fix sorting edgecase for nested `handle_path`

### DIFF
--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -340,6 +340,9 @@ func parseSegmentAsConfig(h Helper) ([]ConfigValue, error) {
 			if err != nil {
 				return nil, h.Errf("parsing caddyfile tokens for '%s': %v", dir, err)
 			}
+
+			dir = normalizeDirectiveName(dir)
+
 			for _, result := range results {
 				result.directive = dir
 				allResults = append(allResults, result)

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -193,13 +193,7 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 				return nil, warnings, fmt.Errorf("parsing caddyfile tokens for '%s': %v", dir, err)
 			}
 
-			// As a special case, we want "handle_path" to be sorted
-			// at the same level as "handle", so we force them to use
-			// the same directive name after their parsing is complete.
-			// See https://github.com/caddyserver/caddy/issues/3675#issuecomment-678042377
-			if dir == "handle_path" {
-				dir = "handle"
-			}
+			dir = normalizeDirectiveName(dir)
 
 			for _, result := range results {
 				result.directive = dir
@@ -1059,6 +1053,19 @@ func buildSubroute(routes []ConfigValue, groupCounter counter) (*caddyhttp.Subro
 	subroute.Routes = consolidateRoutes(subroute.Routes)
 
 	return subroute, nil
+}
+
+// normalizeDirectiveName ensures directives that should be sorted
+// at the same level are named the same before sorting happens.
+func normalizeDirectiveName(directive string) string {
+	// As a special case, we want "handle_path" to be sorted
+	// at the same level as "handle", so we force them to use
+	// the same directive name after their parsing is complete.
+	// See https://github.com/caddyserver/caddy/issues/3675#issuecomment-678042377
+	if directive == "handle_path" {
+		directive = "handle"
+	}
+	return directive
 }
 
 // consolidateRoutes combines routes with the same properties

--- a/caddytest/integration/caddyfile_adapt/sort_directives_within_handle.txt
+++ b/caddytest/integration/caddyfile_adapt/sort_directives_within_handle.txt
@@ -1,0 +1,133 @@
+*.example.com {
+	@foo host foo.example.com
+	handle @foo {
+		handle_path /strip* {
+			respond "this should be first"
+		}
+		handle {
+			respond "this should be second"
+		}
+	}
+    handle {
+        respond "this should be last"
+    }
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"*.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"group": "group5",
+											"handle": [
+												{
+													"handler": "subroute",
+													"routes": [
+														{
+															"group": "group2",
+															"handle": [
+																{
+																	"handler": "subroute",
+																	"routes": [
+																		{
+																			"handle": [
+																				{
+																					"handler": "rewrite",
+																					"strip_path_prefix": "/strip"
+																				}
+																			]
+																		},
+																		{
+																			"handle": [
+																				{
+																					"body": "this should be first",
+																					"handler": "static_response"
+																				}
+																			]
+																		}
+																	]
+																}
+															],
+															"match": [
+																{
+																	"path": [
+																		"/strip*"
+																	]
+																}
+															]
+														},
+														{
+															"group": "group2",
+															"handle": [
+																{
+																	"handler": "subroute",
+																	"routes": [
+																		{
+																			"handle": [
+																				{
+																					"body": "this should be second",
+																					"handler": "static_response"
+																				}
+																			]
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											],
+											"match": [
+												{
+													"host": [
+														"foo.example.com"
+													]
+												}
+											]
+										},
+										{
+											"group": "group5",
+											"handle": [
+												{
+													"handler": "subroute",
+													"routes": [
+														{
+															"handle": [
+																{
+																	"body": "this should be last",
+																	"handler": "static_response"
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes a bug reported in https://caddy.community/t/handle-path-being-ignored-when-paired-with-handle-in-same-block/14393

We had some code in `ServerType.Setup()` that would ensure `handle_path` has the same sort level as `handle`, but we were missing the same check in `parseSegmentAsConfig` to make sure that works properly inside of any nested subroute (`handle`, `route`, `handle_errors`, `handle_response`).

To be clear, the fix is copy-paste from another spot where we do the same thing:

https://github.com/caddyserver/caddy/blob/78b5356f2b1945a90de1ef7f2c7669d82098edbd/caddyconfig/httpcaddyfile/httptype.go#L196-L202

The new test fails before the change (the `handle_path` ends up after the `handle` in the same level, and they're missing a `group` name because the group is omitted if there's no two handlers with the same level) and passes after.