### PR TITLE
reverseproxy: Fix incorrect `health_headers` Caddyfile parsing

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_health_headers.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_health_headers.txt
@@ -7,6 +7,7 @@ reverse_proxy 127.0.0.1:65535 {
 		X-Header-Keys VbG4NZwWnipo 335Q9/MhqcNU3s2TO
 		X-Empty-Value
 	}
+	health_uri /health
 }
 ----------
 {
@@ -38,7 +39,8 @@ reverse_proxy 127.0.0.1:65535 {
 													"VbG4NZwWnipo",
 													"335Q9/MhqcNU3s2TO"
 												]
-											}
+											},
+											"uri": "/health"
 										}
 									},
 									"upstreams": [

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -361,15 +361,13 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 
 			case "health_headers":
 				healthHeaders := make(http.Header)
-				for d.Next() {
-					for d.NextBlock(0) {
-						key := d.Val()
-						values := d.RemainingArgs()
-						if len(values) == 0 {
-							values = append(values, "")
-						}
-						healthHeaders[key] = values
+				for nesting := d.Nesting(); d.NextBlock(nesting); {
+					key := d.Val()
+					values := d.RemainingArgs()
+					if len(values) == 0 {
+						values = append(values, "")
 					}
+					healthHeaders[key] = values
 				}
 				if h.HealthChecks == nil {
 					h.HealthChecks = new(HealthChecks)


### PR DESCRIPTION
Fixes #4481

Basically `health_headers` would eat any config items that came after it because the nesting wasn't properly set up.

I just did a bare-minimum change to the tests (fails before).