### PR TITLE
logging: Support turning off roll compression via Caddyfile

### DIFF
--- a/caddytest/integration/caddyfile_adapt/log_roll_days.txt
+++ b/caddytest/integration/caddyfile_adapt/log_roll_days.txt
@@ -3,6 +3,7 @@
 log {
 	output file /var/log/access.log {
 		roll_size 1gb
+		roll_uncompressed
 		roll_keep 5
 		roll_keep_for 90d
 	}
@@ -20,6 +21,7 @@ log {
 				"writer": {
 					"filename": "/var/log/access.log",
 					"output": "file",
+					"roll_gzip": false,
 					"roll_keep": 5,
 					"roll_keep_days": 90,
 					"roll_size_mb": 954

--- a/modules/logging/filewriter.go
+++ b/modules/logging/filewriter.go
@@ -134,12 +134,16 @@ func (fw FileWriter) OpenWriter() (io.WriteCloser, error) {
 //     file <filename> {
 //         roll_disabled
 //         roll_size     <size>
+//         roll_uncompressed
 //         roll_keep     <num>
 //         roll_keep_for <days>
 //     }
 //
 // The roll_size value has megabyte resolution.
 // Fractional values are rounded up to the next whole megabyte (MiB).
+//
+// By default, compression is enabled, but can be turned off by setting
+// the roll_uncompressed option.
 //
 // The roll_keep_for duration has day resolution.
 // Fractional values are rounded up to the next whole number of days.
@@ -176,6 +180,13 @@ func (fw *FileWriter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.Errf("parsing size: %v", err)
 				}
 				fw.RollSizeMB = int(math.Ceil(float64(size) / humanize.MiByte))
+
+			case "roll_uncompressed":
+				var f bool
+				fw.RollCompress = &f
+				if d.NextArg() {
+					return d.ArgErr()
+				}
 
 			case "roll_keep":
 				var keepStr string


### PR DESCRIPTION
As requested in https://caddy.community/t/caddyfile-vs-json-config-roll-gzip/14564