### PR TITLE
headers: Fix `+` in Caddyfile to properly append rather than set

### DIFF
--- a/caddytest/integration/caddyfile_adapt/header.txt
+++ b/caddytest/integration/caddyfile_adapt/header.txt
@@ -13,6 +13,10 @@
 	header @images {
 		Cache-Control "public, max-age=3600, stale-while-revalidate=86400"
 	}
+	header {
+		+Link "Foo"
+		+Link "Bar"
+	}
 }
 ----------
 {
@@ -118,6 +122,17 @@
 										"set": {
 											"Tim": [
 												"Berners-Lee"
+											]
+										}
+									}
+								},
+								{
+									"handler": "headers",
+									"response": {
+										"add": {
+											"Link": [
+												"Foo",
+												"Bar"
 											]
 										}
 									}

--- a/modules/caddyhttp/headers/caddyfile.go
+++ b/modules/caddyhttp/headers/caddyfile.go
@@ -222,7 +222,7 @@ func applyHeaderOp(ops *HeaderOps, respHeaderOps *RespHeaderOps, field, value, r
 		if ops.Add == nil {
 			ops.Add = make(http.Header)
 		}
-		ops.Add.Set(field[1:], value)
+		ops.Add.Add(field[1:], value)
 
 	case strings.HasPrefix(field, "-"): // delete
 		ops.Delete = append(ops.Delete, field[1:])


### PR DESCRIPTION
See https://caddy.community/t/only-one-header-link-applied/14571

In a single `header` handler, using `+` with the same field name multiple times would only use the last value, instead of adding each value.

Super simple fix, just need to use `.Add()` instead of `.Set()` if we're using the `+` operator.