### PR TITLE
caddytls: Add internal Caddyfile `lifetime`, `sign_with_root` opts

### DIFF
--- a/caddytest/integration/caddyfile_adapt/tls_internal_options.txt
+++ b/caddytest/integration/caddyfile_adapt/tls_internal_options.txt
@@ -1,0 +1,54 @@
+a.example.com {
+	tls {
+		issuer internal {
+			ca foo
+			lifetime 24h
+			sign_with_root
+		}
+	}
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"a.example.com"
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		},
+		"tls": {
+			"automation": {
+				"policies": [
+					{
+						"subjects": [
+							"a.example.com"
+						],
+						"issuers": [
+							{
+								"ca": "foo",
+								"lifetime": 86400000000000,
+								"module": "internal",
+								"sign_with_root": true
+							}
+						]
+					}
+				]
+			}
+		}
+	}
+}

--- a/modules/caddytls/internalissuer.go
+++ b/modules/caddytls/internalissuer.go
@@ -149,7 +149,9 @@ func (iss InternalIssuer) Issue(ctx context.Context, csr *x509.CertificateReques
 // UnmarshalCaddyfile deserializes Caddyfile tokens into iss.
 //
 //     ... internal {
-//         ca <name>
+//         ca       <name>
+//         lifetime <duration>
+//         sign_with_root
 //     }
 //
 func (iss *InternalIssuer) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
@@ -160,6 +162,23 @@ func (iss *InternalIssuer) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if !d.AllArgs(&iss.CA) {
 					return d.ArgErr()
 				}
+
+			case "lifetime":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				dur, err := caddy.ParseDuration(d.Val())
+				if err != nil {
+					return err
+				}
+				iss.Lifetime = caddy.Duration(dur)
+
+			case "sign_with_root":
+				if d.NextArg() {
+					return d.ArgErr()
+				}
+				iss.SignWithRoot = true
+
 			}
 		}
 	}


### PR DESCRIPTION
Options missing from Caddyfile which are configurable in JSON.

While these options are strongly recommended to not change, better to have the Caddyfile have them then not.