### PR TITLE
httpcaddyfile: Add pki app `root` and `intermediate` cert/key config

### DIFF
--- a/caddyconfig/httpcaddyfile/pkiapp.go
+++ b/caddyconfig/httpcaddyfile/pkiapp.go
@@ -31,6 +31,16 @@ func init() {
 //             name            <name>
 //             root_cn         <name>
 //             intermediate_cn <name>
+//             root {
+//                 cert   <path>
+//                 key    <path>
+//                 format <format>
+//             }
+//             intermediate {
+//                 cert   <path>
+//                 key    <path>
+//                 format <format>
+//             }
 //         }
 //     }
 //
@@ -73,6 +83,64 @@ func parsePKIApp(d *caddyfile.Dispenser, existingVal interface{}) (interface{}, 
 							return nil, d.ArgErr()
 						}
 						pkiCa.IntermediateCommonName = d.Val()
+
+					case "root":
+						if pkiCa.Root == nil {
+							pkiCa.Root = new(caddypki.KeyPair)
+						}
+						for nesting := d.Nesting(); d.NextBlock(nesting); {
+							switch d.Val() {
+							case "cert":
+								if !d.NextArg() {
+									return nil, d.ArgErr()
+								}
+								pkiCa.Root.Certificate = d.Val()
+
+							case "key":
+								if !d.NextArg() {
+									return nil, d.ArgErr()
+								}
+								pkiCa.Root.PrivateKey = d.Val()
+
+							case "format":
+								if !d.NextArg() {
+									return nil, d.ArgErr()
+								}
+								pkiCa.Root.Format = d.Val()
+
+							default:
+								return nil, d.Errf("unrecognized pki ca root option '%s'", d.Val())
+							}
+						}
+
+					case "intermediate":
+						if pkiCa.Intermediate == nil {
+							pkiCa.Intermediate = new(caddypki.KeyPair)
+						}
+						for nesting := d.Nesting(); d.NextBlock(nesting); {
+							switch d.Val() {
+							case "cert":
+								if !d.NextArg() {
+									return nil, d.ArgErr()
+								}
+								pkiCa.Intermediate.Certificate = d.Val()
+
+							case "key":
+								if !d.NextArg() {
+									return nil, d.ArgErr()
+								}
+								pkiCa.Intermediate.PrivateKey = d.Val()
+
+							case "format":
+								if !d.NextArg() {
+									return nil, d.ArgErr()
+								}
+								pkiCa.Intermediate.Format = d.Val()
+
+							default:
+								return nil, d.Errf("unrecognized pki ca intermediate option '%s'", d.Val())
+							}
+						}
 
 					default:
 						return nil, d.Errf("unrecognized pki ca option '%s'", d.Val())

--- a/caddytest/integration/caddyfile_adapt/global_options_skip_install_trust.txt
+++ b/caddytest/integration/caddyfile_adapt/global_options_skip_install_trust.txt
@@ -5,6 +5,16 @@
 			name "Local"
 			root_cn "Custom Local Root Name"
 			intermediate_cn "Custom Local Intermediate Name"
+			root {
+				cert /path/to/cert.pem
+				key /path/to/key.pem
+				format pem_file
+			}
+			intermediate {
+				cert /path/to/cert.pem
+				key /path/to/key.pem
+				format pem_file
+			}
 		}
 		ca foo {
 			name "Foo"
@@ -118,7 +128,17 @@ acme-bar.example.com {
 					"name": "Local",
 					"root_common_name": "Custom Local Root Name",
 					"intermediate_common_name": "Custom Local Intermediate Name",
-					"install_trust": false
+					"install_trust": false,
+					"root": {
+						"certificate": "/path/to/cert.pem",
+						"private_key": "/path/to/key.pem",
+						"format": "pem_file"
+					},
+					"intermediate": {
+						"certificate": "/path/to/cert.pem",
+						"private_key": "/path/to/key.pem",
+						"format": "pem_file"
+					}
 				}
 			}
 		},


### PR DESCRIPTION
Followup to #4450, I was being lazy. Adds the cert/key config.