### PR TITLE
rewrite: Fix a double-encode issue when using the `{uri}` placeholder

### DIFF
--- a/modules/caddyhttp/rewrite/rewrite_test.go
+++ b/modules/caddyhttp/rewrite/rewrite_test.go
@@ -189,6 +189,21 @@ func TestRewrite(t *testing.T) {
 			input:  newRequest(t, "GET", "/foo/?a=b"),
 			expect: newRequest(t, "GET", "/foo/bar?c=d"),
 		},
+		{
+			rule:   Rewrite{URI: "/i{http.request.uri}"},
+			input:  newRequest(t, "GET", "/%C2%B7%E2%88%B5.png"),
+			expect: newRequest(t, "GET", "/i/%C2%B7%E2%88%B5.png"),
+		},
+		{
+			rule:   Rewrite{URI: "/i{http.request.uri}"},
+			input:  newRequest(t, "GET", "/·∵.png?a=b"),
+			expect: newRequest(t, "GET", "/i/%C2%B7%E2%88%B5.png?a=b"),
+		},
+		{
+			rule:   Rewrite{URI: "/i{http.request.uri}"},
+			input:  newRequest(t, "GET", "/%C2%B7%E2%88%B5.png?a=b"),
+			expect: newRequest(t, "GET", "/i/%C2%B7%E2%88%B5.png?a=b"),
+		},
 
 		{
 			rule:   Rewrite{StripPathPrefix: "/prefix"},


### PR DESCRIPTION
Fix https://github.com/caddyserver/caddy/issues/4515