### PR TITLE
caddyhttp: Fix HTTP->HTTPS redir not preferring HTTPS port if ambiguous

### DIFF
--- a/modules/caddyhttp/autohttps.go
+++ b/modules/caddyhttp/autohttps.go
@@ -232,7 +232,7 @@ func (app *App) automaticHTTPSPhase1(ctx caddy.Context, repl *caddy.Replacer) er
 				// port, we'll have to choose one, so prefer the HTTPS port
 				if _, ok := redirDomains[d]; !ok ||
 					addr.StartPort == uint(app.httpsPort()) {
-					redirDomains[d] = append(redirDomains[d], addr)
+					redirDomains[d] = []caddy.NetworkAddress{addr}
 				}
 			}
 		}


### PR DESCRIPTION
Fix #4529 

I think it doesn't make sense to append to this slice if we actually want to prefer one port over the other. We don't need to keep a redirect for more than one port at all, I think, because we have no way to distinguish which port is the right target otherwise, when requests come in on the HTTP port.

I think the comment here was correct, but the behaviour was wrong.

This should fix it, by always preferring the HTTPS port -- if `443` is seen first then it will set it (because no value is set), then it will ignore any subsequent cause they aren't the HTTPS port. If something else comes first, and `443` follows, then it will overwrite it.

 