### PR TITLE
Unix socket cleanup

### DIFF
--- a/listeners.go
+++ b/listeners.go
@@ -16,7 +16,6 @@ package caddy
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"strconv"
@@ -41,13 +40,10 @@ func Listen(network, addr string) (net.Listener, error) {
 	sharedLn, _, err := listenerPool.LoadOrNew(lnKey, func() (Destructor, error) {
 
 		if isUnixNetwork(network) {
-			_, err := os.Stat(addr)
-			if err == nil {
-				log.Printf("unix socket file '%s' already exists, attempting to unlink it before calling net.Listen...\n", addr)
-				err := syscall.Unlink(addr)
-				if err != nil {
-					log.Printf("attempting to unlink '%s' returned '%s'\n", addr, err)
-				}
+			fileInfo, err := os.Stat(addr)
+			fileIsUnixSocket := (fileInfo.Mode() & os.ModeSocket) != 0
+			if err == nil && fileIsUnixSocket {
+				syscall.Unlink(addr)
 			}
 		}
 
@@ -74,13 +70,10 @@ func ListenPacket(network, addr string) (net.PacketConn, error) {
 	sharedPc, _, err := listenerPool.LoadOrNew(lnKey, func() (Destructor, error) {
 
 		if isUnixNetwork(network) {
-			_, err := os.Stat(addr)
-			if err == nil {
-				log.Printf("unix socket file '%s' already exists, attempting to unlink it before calling net.ListenPacket...\n", addr)
-				err := syscall.Unlink(addr)
-				if err != nil {
-					log.Printf("attempting to unlink '%s' returned '%s'\n", addr, err)
-				}
+			fileInfo, err := os.Stat(addr)
+			fileIsUnixSocket := (fileInfo.Mode() & os.ModeSocket) != 0
+			if err == nil && fileIsUnixSocket {
+				syscall.Unlink(addr)
 			}
 		}
 

--- a/listeners.go
+++ b/listeners.go
@@ -253,11 +253,7 @@ func (sl *sharedListener) setDeadline() error {
 // Destruct is called by the UsagePool when the listener is
 // finally not being used anymore. It closes the socket.
 func (sl *sharedListener) Destruct() error {
-	err := sl.Listener.Close()
-	if err != nil {
-		return err
-	}
-	return nil
+	return sl.Listener.Close()
 }
 
 // sharedPacketConn is like sharedListener, but for net.PacketConns.
@@ -268,11 +264,7 @@ type sharedPacketConn struct {
 
 // Destruct closes the underlying socket.
 func (spc *sharedPacketConn) Destruct() error {
-	err := spc.PacketConn.Close()
-	if err != nil {
-		return err
-	}
-	return nil
+	return spc.PacketConn.Close()
 }
 
 // NetworkAddress contains the individual components


### PR DESCRIPTION

I am using Caddy to serve Unix domain sockets on the internet.  When I restart Caddy, I see this error: 

```
{"error":"loading new config: http app module: start: unix: listening on //var/run/caddy-serve-http.sock: listen unix //var/run/caddy-serve-http.sock: bind: address already in use"} 
```

Unix Socket listeners in golang [are supposed to unlink the socket file when closed](https://stackoverflow.com/questions/16681944/how-to-reliably-unlink-a-unix-domain-socket-in-go-programming-language). 

However they will not be unlinked in the case that the caddy process is killed instead of terminated (`SIGKILL` vs `SIGTERM`) because `.Close()` is never called on the unix domain socket listener.  That's why I was seeing this error: my setup was not cleanly exiting caddy, it was `.Kill()`ing it.

In this case, the next time we try to listen, we'll get an "address already in use error" because the file already exists.

I propose this change to fix this issue:

  * If there already is a file when we are about to try to listen, check if it is a unix domain socket file, and if it is, then unlink it before attempting to listen



As an alternative, it may be possible to somehow begin listening on the already created file without unlinking and creating a new one?  I know some client applications can have issues with this "socket file flickers in and out of existence" behavior.

I saw this: [stackoverflow.com -- golang-accept-on-already-opened-fd](https://stackoverflow.com/questions/44806115/golang-accept-on-already-opened-fd)  but I'm not sure if that would work, as it's just a file on disk not a currently open file descriptor, and I haven't tried it yet. 


Another possible alternative:  simply log a better error message explaining that the reason this error is happening is probably because the caddy process was not exited cleanly.
