### PR TITLE
caddyhttp: Fix test when /tmp/etc already exists

### DIFF
--- a/modules/caddyhttp/templates/tplcontext_test.go
+++ b/modules/caddyhttp/templates/tplcontext_test.go
@@ -608,6 +608,9 @@ title = "Welcome"
 
 func getContextOrFail(t *testing.T) TemplateContext {
 	tplContext, err := initTestContext()
+	t.Cleanup(func() {
+		os.RemoveAll(string(tplContext.Root.(http.Dir)))
+	})
 	if err != nil {
 		t.Fatalf("failed to prepare test context: %v", err)
 	}
@@ -620,8 +623,12 @@ func initTestContext() (TemplateContext, error) {
 	if err != nil {
 		return TemplateContext{}, err
 	}
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "caddy")
+	if err != nil {
+		return TemplateContext{}, err
+	}
 	return TemplateContext{
-		Root:       http.Dir(os.TempDir()),
+		Root:       http.Dir(tmpDir),
 		Req:        request,
 		RespHeader: WrappedHeader{make(http.Header)},
 	}, nil


### PR DESCRIPTION
The TestFileListing test in tplcontext_test has one test that verifies
if directory traversal is not happening. The context root is set to
'/tmp' and then it tries to open '../../../../../etc', which gets
normalized to '/tmp/etc'.

The test then expects an error to be returned, assuming that '/tmp/etc'
does not exist on the system. When it does exist, it results in a test
failure:

```
--- FAIL: TestFileListing (0.00s)
    tplcontext_test.go:422: Test 4: Expected error but had none
    FAIL
    FAIL
    github.com/caddyserver/caddy/v2/modules/caddyhttp/templates	0.042s
```

Instead of using '/tmp' as root, use a dedicated directory created with
`os.MkdirTemp()` instead. That way, we know that the directory is empty.