### PR TITLE
metrics: Enforce smaller set of method labels

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,39 @@
+package metrics
+
+import (
+	"net/http"
+	"strconv"
+)
+
+func SanitizeCode(s int) string {
+	switch s {
+	case 0, 200:
+		return "200"
+	default:
+		return strconv.Itoa(s)
+	}
+}
+
+// Only support the list of "regular" HTTP methods, see
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+var methodMap = map[string]string{
+	"GET": http.MethodGet, "get": http.MethodGet,
+	"HEAD": http.MethodHead, "head": http.MethodHead,
+	"PUT": http.MethodPut, "put": http.MethodPut,
+	"POST": http.MethodPost, "post": http.MethodPost,
+	"DELETE": http.MethodDelete, "delete": http.MethodDelete,
+	"CONNECT": http.MethodConnect, "connect": http.MethodConnect,
+	"OPTIONS": http.MethodOptions, "options": http.MethodOptions,
+	"TRACE": http.MethodTrace, "trace": http.MethodTrace,
+	"PATCH": http.MethodPatch, "patch": http.MethodPatch,
+}
+
+// SanitizeMethod sanitizes the method for use as a metric label. This helps
+// prevent high cardinality on the method label. The name is always upper case.
+func SanitizeMethod(m string) string {
+	if m, ok := methodMap[m]; ok {
+		return m
+	}
+
+	return "OTHER"
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,28 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeMethod(t *testing.T) {
+	tests := []struct {
+		method   string
+		expected string
+	}{
+		{method: "get", expected: "GET"},
+		{method: "POST", expected: "POST"},
+		{method: "OPTIONS", expected: "OPTIONS"},
+		{method: "connect", expected: "CONNECT"},
+		{method: "trace", expected: "TRACE"},
+		{method: "UNKNOWN", expected: "OTHER"},
+		{method: strings.Repeat("ohno", 9999), expected: "OTHER"},
+	}
+
+	for _, d := range tests {
+		actual := SanitizeMethod(d.method)
+		if actual != d.expected {
+			t.Errorf("Not same: expected %#v, but got %#v", d.expected, actual)
+		}
+	}
+}

--- a/metrics.go
+++ b/metrics.go
@@ -97,5 +97,5 @@ func sanitizeMethod(m string) string {
 		return m
 	}
 
-	return "other"
+	return "OTHER"
 }

--- a/metrics.go
+++ b/metrics.go
@@ -3,7 +3,6 @@ package caddy
 import (
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -47,7 +46,7 @@ func instrumentHandlerCounter(counter *prometheus.CounterVec, next http.Handler)
 		next.ServeHTTP(d, r)
 		counter.With(prometheus.Labels{
 			"code":   sanitizeCode(d.status),
-			"method": strings.ToUpper(r.Method),
+			"method": sanitizeMethod(r.Method),
 		}).Inc()
 	})
 }
@@ -75,4 +74,28 @@ func sanitizeCode(s int) string {
 	default:
 		return strconv.Itoa(s)
 	}
+}
+
+// Only support the list of "regular" HTTP methods, see
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+var methodMap = map[string]string{
+	"GET": http.MethodGet, "get": http.MethodGet,
+	"HEAD": http.MethodHead, "head": http.MethodHead,
+	"PUT": http.MethodPut, "put": http.MethodPut,
+	"POST": http.MethodPost, "post": http.MethodPost,
+	"DELETE": http.MethodDelete, "delete": http.MethodDelete,
+	"CONNECT": http.MethodConnect, "connect": http.MethodConnect,
+	"OPTIONS": http.MethodOptions, "options": http.MethodOptions,
+	"TRACE": http.MethodTrace, "trace": http.MethodTrace,
+	"PATCH": http.MethodPatch, "patch": http.MethodPatch,
+}
+
+// sanitizeMethod sanitizes the method for use as a metric label. This helps
+// prevent high cardinality on the method label. The name is always upper case.
+func sanitizeMethod(m string) string {
+	if m, ok := methodMap[m]; ok {
+		return m
+	}
+
+	return "other"
 }

--- a/modules/caddyhttp/metrics.go
+++ b/modules/caddyhttp/metrics.go
@@ -180,7 +180,7 @@ func sanitizeMethod(m string) string {
 		return m
 	}
 
-	return "other"
+	return "OTHER"
 }
 
 // taken from https://github.com/prometheus/client_golang/blob/6007b2b5cae01203111de55f753e76d8dac1f529/prometheus/promhttp/instrument_server.go#L298

--- a/modules/caddyhttp/metrics_test.go
+++ b/modules/caddyhttp/metrics_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -82,26 +81,4 @@ type middlewareHandlerFunc func(http.ResponseWriter, *http.Request, Handler) err
 
 func (f middlewareHandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request, h Handler) error {
 	return f(w, r, h)
-}
-
-func TestSanitizeMethod(t *testing.T) {
-	tests := []struct {
-		method   string
-		expected string
-	}{
-		{method: "get", expected: "GET"},
-		{method: "POST", expected: "POST"},
-		{method: "OPTIONS", expected: "OPTIONS"},
-		{method: "connect", expected: "CONNECT"},
-		{method: "trace", expected: "TRACE"},
-		{method: "UNKNOWN", expected: "OTHER"},
-		{method: strings.Repeat("ohno", 9999), expected: "OTHER"},
-	}
-
-	for _, d := range tests {
-		actual := sanitizeMethod(d.method)
-		if actual != d.expected {
-			t.Errorf("Not same: expected %#v, but got %#v", d.expected, actual)
-		}
-	}
 }

--- a/modules/caddyhttp/metrics_test.go
+++ b/modules/caddyhttp/metrics_test.go
@@ -94,8 +94,8 @@ func TestSanitizeMethod(t *testing.T) {
 		{method: "OPTIONS", expected: "OPTIONS"},
 		{method: "connect", expected: "CONNECT"},
 		{method: "trace", expected: "TRACE"},
-		{method: "UNKNOWN", expected: "other"},
-		{method: strings.Repeat("ohno", 9999), expected: "other"},
+		{method: "UNKNOWN", expected: "OTHER"},
+		{method: strings.Repeat("ohno", 9999), expected: "OTHER"},
 	}
 
 	for _, d := range tests {

--- a/modules/caddyhttp/metrics_test.go
+++ b/modules/caddyhttp/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -81,4 +82,26 @@ type middlewareHandlerFunc func(http.ResponseWriter, *http.Request, Handler) err
 
 func (f middlewareHandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request, h Handler) error {
 	return f(w, r, h)
+}
+
+func TestSanitizeMethod(t *testing.T) {
+	tests := []struct {
+		method   string
+		expected string
+	}{
+		{method: "get", expected: "GET"},
+		{method: "POST", expected: "POST"},
+		{method: "OPTIONS", expected: "OPTIONS"},
+		{method: "connect", expected: "CONNECT"},
+		{method: "trace", expected: "TRACE"},
+		{method: "UNKNOWN", expected: "other"},
+		{method: strings.Repeat("ohno", 9999), expected: "other"},
+	}
+
+	for _, d := range tests {
+		actual := sanitizeMethod(d.method)
+		if actual != d.expected {
+			t.Errorf("Not same: expected %#v, but got %#v", d.expected, actual)
+		}
+	}
 }


### PR DESCRIPTION
Protects against unbounded cardinality on the method label.

Note: I'm finding myself copying code again between the two metrics endpoints - how do we feel about `internal/`? I ask because there's no use of it yet... Otherwise I think I'd rather throw the common code in an `internal/metrics` package or something like that...

Signed-off-by: Dave Henderson <dhenderson@gmail.com>