### PR TITLE
reverseproxy: Avoid returning a `nil` error during GetClientCertificate

### DIFF
--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -364,6 +364,9 @@ func (t TLSConfig) MakeTLSClientConfig(ctx caddy.Context) (*tls.Config, error) {
 					return &cert.Certificate, nil
 				}
 			}
+			if err == nil {
+				err = fmt.Errorf("no client certificate found for automate name: %s", t.ClientCertificateAutomate)
+			}
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Fix https://github.com/caddyserver/caddy/issues/4509