### PR TITLE
fastcgi: ensure `SERVER_PORT` is always set

### DIFF
--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -296,10 +296,15 @@ func (t Transport) buildEnv(r *http.Request) (envVars, error) {
 	}
 
 	// compliance with the CGI specification requires that
-	// SERVER_PORT should only exist if it's a valid numeric value.
-	// Info: https://www.ietf.org/rfc/rfc3875 Page 18
+	// the SERVER_PORT variable MUST be set to the TCP/IP port number on which this request is received from the client
+	// even if the port is the default port for the scheme and could otherwise be omitted from a URI.
+	// https://tools.ietf.org/html/rfc3875#section-4.1.15
 	if reqPort != "" {
 		env["SERVER_PORT"] = reqPort
+	} else if requestScheme == "http" {
+		env["SERVER_PORT"] = "80"
+	} else if requestScheme == "https" {
+		env["SERVER_PORT"] = "443"
 	}
 
 	// Some web apps rely on knowing HTTPS or not


### PR DESCRIPTION

as [tools.ietf.org/html/rfc3875#section-4.1.15](https://tools.ietf.org/html/rfc3875#section-4.1.15)

```
4.1.15.  SERVER_PORT

   The SERVER_PORT variable MUST be set to the TCP/IP port number on
   which this request is received from the client.  This value is used
   in the port part of the Script-URI.

      SERVER_PORT = server-port
      server-port = 1*digit

   Note that this variable MUST be set, even if the port is the default
   port for the scheme and could otherwise be omitted from a URI.
```

related problem caused by this:  when works with xdebug , "Cannot accept external Xdebug connection: Cannot evaluate expression '$_SERVER['SERVER_PORT']'"

