### PR TITLE
reverseproxy: Fix Security flaw on Windows Pro OS' + PHP setup

### DIFF
--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -203,7 +203,8 @@ func (t Transport) buildEnv(r *http.Request) (envVars, error) {
 		}
 	}
 
-	fpath := r.URL.Path
+	// No NULL character allowed here, fix a Windows Pro OS'+PHP security flaw
+	fpath := strings.ReplaceAll(r.URL.Path, "\x00", "")
 	scriptName := fpath
 
 	docURI := fpath


### PR DESCRIPTION
Step to reproduce sent at Matt + Francis
This character is not RFC compliant and should be avoid in all paths