### PR TITLE
admin: support ETags

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -865,6 +865,7 @@ func handleConfig(w http.ResponseWriter, r *http.Request) error {
 	switch r.Method {
 	case http.MethodGet:
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("ETag", configHash())
 
 		err := readConfig(r.URL.Path, w)
 		if err != nil {
@@ -904,7 +905,7 @@ func handleConfig(w http.ResponseWriter, r *http.Request) error {
 
 		forceReload := r.Header.Get("Cache-Control") == "must-revalidate"
 
-		err := changeConfig(r.Method, r.URL.Path, body, forceReload)
+		err := changeConfig(r.Method, r.URL.Path, body, r.Header.Get("If-Match"), forceReload)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
For #4578.

Computes a MD5 hash of the full config when it is updated. This is added to the response headers of all GET requests.

Adds an additional argument to the `changeConfig` function which if not empty, will return an error if it doesn't match the current config hash.

This PR doesn't yet include tests. I can add tests for just the `changeConfig` function later but I'm not sure if there is an easy way to test the `adminHandler`?

