### PR TITLE
logging: Add `roll_local_time` Caddyfile option

### DIFF
--- a/caddytest/integration/caddyfile_adapt/log_roll_days.txt
+++ b/caddytest/integration/caddyfile_adapt/log_roll_days.txt
@@ -4,6 +4,7 @@ log {
 	output file /var/log/access.log {
 		roll_size 1gb
 		roll_uncompressed
+		roll_local_time
 		roll_keep 5
 		roll_keep_for 90d
 	}
@@ -24,6 +25,7 @@ log {
 					"roll_gzip": false,
 					"roll_keep": 5,
 					"roll_keep_days": 90,
+					"roll_local_time": true,
 					"roll_size_mb": 954
 				},
 				"include": [

--- a/modules/logging/filewriter.go
+++ b/modules/logging/filewriter.go
@@ -135,6 +135,7 @@ func (fw FileWriter) OpenWriter() (io.WriteCloser, error) {
 //         roll_disabled
 //         roll_size     <size>
 //         roll_uncompressed
+//         roll_local_time
 //         roll_keep     <num>
 //         roll_keep_for <days>
 //     }
@@ -184,6 +185,12 @@ func (fw *FileWriter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			case "roll_uncompressed":
 				var f bool
 				fw.RollCompress = &f
+				if d.NextArg() {
+					return d.ArgErr()
+				}
+
+			case "roll_local_time":
+				fw.RollLocalTime = true
 				if d.NextArg() {
 					return d.ArgErr()
 				}


### PR DESCRIPTION
Tiny fix, something that was forgotten