### PR TITLE
caddyhttp: Always log handled errors at debug level

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -259,11 +259,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if err2 == nil {
 			// user's error route handled the error response
 			// successfully, so now just log the error
-			if errStatus >= 500 {
-				logger.Error(errMsg, errFields...)
-			} else {
-				logger.Debug(errMsg, errFields...)
-			}
+			logger.Debug(errMsg, errFields...)
 		} else {
 			// well... this is awkward
 			errFields = append([]zapcore.Field{


### PR DESCRIPTION
Context: https://caddy.community/t/optional-reverse-proxy-with-file-system-fallback/15105

There are some situations where error handling is used to intercept 5xx errors emitted by Caddy, like from `reverse_proxy`, and those errors would still be logged at the ERROR level.

This could get noisy when this is being done "on-purpose". For example, a proxy being turned off half the time and only used as an optimization during development (for hot-module reload or something).

So instead, it probably makes more sense to always log _handled_ errors at DEBUG level, since it was actually handled. If the error falls through unhandled, or a new error is triggered, then it'll still log at ERROR level.