### PR TITLE
caddyhttp: Move HTTP redirect listener to an optional module

### DIFF
--- a/caddytest/integration/caddyfile_adapt/global_server_options_single.txt
+++ b/caddytest/integration/caddyfile_adapt/global_server_options_single.txt
@@ -1,6 +1,7 @@
 {
 	servers {
 		listener_wrappers {
+			http_redirect
 			tls
 		}
 		timeouts {
@@ -32,6 +33,9 @@ foo.com {
 						":443"
 					],
 					"listener_wrappers": [
+						{
+							"wrapper": "http_redirect"
+						},
 						{
 							"wrapper": "tls"
 						}

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -343,11 +343,6 @@ func (app *App) Start() error {
 				// enable TLS if there is a policy and if this is not the HTTP port
 				useTLS := len(srv.TLSConnPolicies) > 0 && int(listenAddr.StartPort+portOffset) != app.httpPort()
 				if useTLS {
-					// create HTTP redirect wrapper, which detects if
-					// the request had HTTP bytes on the HTTPS port, and
-					// triggers a redirect if so.
-					ln = &httpRedirectListener{Listener: ln}
-
 					// create TLS listener
 					tlsCfg := srv.TLSConnPolicies.TLSConfig(app.ctx)
 					ln = tls.NewListener(ln, tlsCfg)


### PR DESCRIPTION
Followup to https://github.com/caddyserver/caddy/pull/4313

Turns out we have some issues with this being turned on by default, so we'll have to provide it as an optional module for now.

To turn it on, this needs to be added in global options:

```
{
	servers {
		listener_wrappers {
			http_redirect
			tls
		}
	}
}
```