### PR TITLE
httpcaddyfile: Support explicitly turning off `strict_sni_host`

### DIFF
--- a/caddyconfig/httpcaddyfile/serveroptions.go
+++ b/caddyconfig/httpcaddyfile/serveroptions.go
@@ -157,11 +157,14 @@ func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (interface{}, error
 						serverOpts.ExperimentalHTTP3 = true
 
 					case "strict_sni_host":
-						if d.NextArg() {
-							return nil, d.ArgErr()
+						if d.NextArg() && d.Val() != "off" && d.Val() != "on" {
+							return nil, d.Errf("strict_sni_host only supports 'on' or 'off', got '%s'", d.Val())
 						}
-						trueBool := true
-						serverOpts.StrictSNIHost = &trueBool
+						boolVal := true
+						if d.Val() == "off" {
+							boolVal = false
+						}
+						serverOpts.StrictSNIHost = &boolVal
 
 					default:
 						return nil, d.Errf("unrecognized protocol option '%s'", d.Val())

--- a/caddyconfig/httpcaddyfile/serveroptions.go
+++ b/caddyconfig/httpcaddyfile/serveroptions.go
@@ -157,11 +157,11 @@ func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (interface{}, error
 						serverOpts.ExperimentalHTTP3 = true
 
 					case "strict_sni_host":
-						if d.NextArg() && d.Val() != "off" && d.Val() != "on" {
-							return nil, d.Errf("strict_sni_host only supports 'on' or 'off', got '%s'", d.Val())
+						if d.NextArg() && d.Val() != "insecure_off" && d.Val() != "on" {
+							return nil, d.Errf("strict_sni_host only supports 'on' or 'insecure_off', got '%s'", d.Val())
 						}
 						boolVal := true
-						if d.Val() == "off" {
+						if d.Val() == "insecure_off" {
 							boolVal = false
 						}
 						serverOpts.StrictSNIHost = &boolVal

--- a/caddytest/integration/caddyfile_adapt/global_server_options_multi.txt
+++ b/caddytest/integration/caddyfile_adapt/global_server_options_multi.txt
@@ -3,6 +3,9 @@
 		timeouts {
 			idle 90s
 		}
+		protocol {
+			strict_sni_host off
+		}
 	}
 	servers :80 {
 		timeouts {
@@ -12,6 +15,9 @@
 	servers :443 {
 		timeouts {
 			idle 30s
+		}
+		protocol {
+			strict_sni_host
 		}
 	}
 }
@@ -46,7 +52,8 @@ http://bar.com {
 							],
 							"terminal": true
 						}
-					]
+					],
+					"strict_sni_host": true
 				},
 				"srv1": {
 					"listen": [
@@ -70,7 +77,8 @@ http://bar.com {
 					"listen": [
 						":8080"
 					],
-					"idle_timeout": 90000000000
+					"idle_timeout": 90000000000,
+					"strict_sni_host": false
 				}
 			}
 		}

--- a/caddytest/integration/caddyfile_adapt/global_server_options_multi.txt
+++ b/caddytest/integration/caddyfile_adapt/global_server_options_multi.txt
@@ -4,7 +4,7 @@
 			idle 90s
 		}
 		protocol {
-			strict_sni_host off
+			strict_sni_host insecure_off
 		}
 	}
 	servers :80 {


### PR DESCRIPTION
In the Caddyfile, we were only allowing turning on `strict_sni_host` explicitly, but provided no way to explicitly turn it off, which may be necessary for situations where it gets turned on implicitly like when TLS client_auth is turned on.

This adds support for a first arg to be `on` (for symmetry, least surprise) or `insecure_off` (what's actually new in terms of behaviour). If the arg is omitted, then it's the same behaviour as before, i.e. turning it on.

```
{
	servers {
		protocol {
			strict_sni_host [on|insecure_off]
		}
	}
}
```