### PR TITLE
/modules/caddyhttp/reverseproxy/reverseproxy.go : fix If reverse_prox…

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -819,6 +819,7 @@ func (h Handler) directRequest(req *http.Request, di DialInfo) {
 	}
 
 	req.URL.Host = reqHost
+	req.Host = reqHost
 }
 
 // bufferedBody reads originalBody into a buffer, then returns a reader for the buffer.


### PR DESCRIPTION
/modules/caddyhttp/reverseproxy/reverseproxy.go : fix If reverse_proxy upstream dial target is HTTP,when directRequest just add HOST to http.Request.URL.Host but no http.Request.Host,it makes when u have a proxy,but dial a DNS IP address.