### PR TITLE
fileserver: Add `pass_thru` Caddyfile option

### DIFF
--- a/caddytest/integration/caddyfile_adapt/file_server_pass_thru.txt
+++ b/caddytest/integration/caddyfile_adapt/file_server_pass_thru.txt
@@ -1,0 +1,32 @@
+:80
+
+file_server {
+	pass_thru
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "file_server",
+									"hide": [
+										"./Caddyfile"
+									],
+									"pass_thru": true
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -120,6 +120,12 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 				falseBool := false
 				fsrv.CanonicalURIs = &falseBool
 
+			case "pass_thru":
+				if h.NextArg() {
+					return nil, h.ArgErr()
+				}
+				fsrv.PassThru = true
+
 			default:
 				return nil, h.Errf("unknown subdirective '%s'", h.Val())
 			}


### PR DESCRIPTION
https://caddy.community/t/serve-available-static-content-and-proxy-otherwise/15289/4

I guess it was just forgotten 🤷‍♂️ 