### PR TITLE
caddyfile: Support for raw token values, improve `map`, `expression`

### DIFF
--- a/caddyconfig/caddyfile/dispenser.go
+++ b/caddyconfig/caddyfile/dispenser.go
@@ -210,13 +210,13 @@ func (d *Dispenser) RawVal() string {
 	}
 	quote := d.tokens[d.cursor].wasQuoted
 	if quote > 0 {
-		return string(quote) + d.tokens[d.cursor].Text + string(quote)
+		return string(quote) + d.tokens[d.cursor].Text + string(quote) // string literal
 	}
 	return d.tokens[d.cursor].Text
 }
 
-// ScalarVal gets value of the current token, converted to the
-// appropriate scalar type. If there is no token loaded, it returns nil.
+// ScalarVal gets value of the current token, converted to the closest
+// scalar type. If there is no token loaded, it returns nil.
 func (d *Dispenser) ScalarVal() interface{} {
 	if d.cursor < 0 || d.cursor >= len(d.tokens) {
 		return nil
@@ -225,7 +225,7 @@ func (d *Dispenser) ScalarVal() interface{} {
 	text := d.tokens[d.cursor].Text
 
 	if quote > 0 {
-		return text
+		return text // string literal
 	}
 	if num, err := strconv.Atoi(text); err == nil {
 		return num
@@ -312,11 +312,11 @@ func (d *Dispenser) RemainingArgs() []string {
 	return args
 }
 
-// RawRemainingArgs loads any more arguments (tokens on the same line,
+// RemainingArgsRaw loads any more arguments (tokens on the same line,
 // retaining quotes) into a slice and returns them. Open curly brace
 // tokens also indicate the end of arguments, and the curly brace is
 // not included in the return value nor is it loaded.
-func (d *Dispenser) RawRemainingArgs() []string {
+func (d *Dispenser) RemainingArgsRaw() []string {
 	var args []string
 	for d.NextArg() {
 		args = append(args, d.RawVal())

--- a/caddyconfig/caddyfile/dispenser.go
+++ b/caddyconfig/caddyfile/dispenser.go
@@ -202,9 +202,9 @@ func (d *Dispenser) Val() string {
 	return d.tokens[d.cursor].Text
 }
 
-// RawVal gets the raw text of the current token (including quotes).
+// ValRaw gets the raw text of the current token (including quotes).
 // If there is no token loaded, it returns empty string.
-func (d *Dispenser) RawVal() string {
+func (d *Dispenser) ValRaw() string {
 	if d.cursor < 0 || d.cursor >= len(d.tokens) {
 		return ""
 	}
@@ -319,7 +319,7 @@ func (d *Dispenser) RemainingArgs() []string {
 func (d *Dispenser) RemainingArgsRaw() []string {
 	var args []string
 	for d.NextArg() {
-		args = append(args, d.RawVal())
+		args = append(args, d.ValRaw())
 	}
 	return args
 }

--- a/caddyconfig/caddyfile/lexer.go
+++ b/caddyconfig/caddyfile/lexer.go
@@ -38,7 +38,7 @@ type (
 		File        string
 		Line        int
 		Text        string
-		wasQuoted   rune
+		wasQuoted   rune // enclosing quote character, if any
 		inSnippet   bool
 		snippetName string
 	}
@@ -89,7 +89,7 @@ func (l *lexer) next() bool {
 		ch, _, err := l.reader.ReadRune()
 		if err != nil {
 			if len(val) > 0 {
-				return makeToken(-1)
+				return makeToken(0)
 			}
 			if err == io.EOF {
 				return false
@@ -141,7 +141,7 @@ func (l *lexer) next() bool {
 				comment = false
 			}
 			if len(val) > 0 {
-				return makeToken(-1)
+				return makeToken(0)
 			}
 			continue
 		}

--- a/caddyconfig/caddyfile/lexer.go
+++ b/caddyconfig/caddyfile/lexer.go
@@ -38,6 +38,7 @@ type (
 		File        string
 		Line        int
 		Text        string
+		wasQuoted   rune
 		inSnippet   bool
 		snippetName string
 	}
@@ -78,8 +79,9 @@ func (l *lexer) next() bool {
 	var val []rune
 	var comment, quoted, btQuoted, escaped bool
 
-	makeToken := func() bool {
+	makeToken := func(quoted rune) bool {
 		l.token.Text = string(val)
+		l.token.wasQuoted = quoted
 		return true
 	}
 
@@ -87,7 +89,7 @@ func (l *lexer) next() bool {
 		ch, _, err := l.reader.ReadRune()
 		if err != nil {
 			if len(val) > 0 {
-				return makeToken()
+				return makeToken(-1)
 			}
 			if err == io.EOF {
 				return false
@@ -110,10 +112,10 @@ func (l *lexer) next() bool {
 				escaped = false
 			} else {
 				if quoted && ch == '"' {
-					return makeToken()
+					return makeToken('"')
 				}
 				if btQuoted && ch == '`' {
-					return makeToken()
+					return makeToken('`')
 				}
 			}
 			if ch == '\n' {
@@ -139,7 +141,7 @@ func (l *lexer) next() bool {
 				comment = false
 			}
 			if len(val) > 0 {
-				return makeToken()
+				return makeToken(-1)
 			}
 			continue
 		}

--- a/caddytest/integration/caddyfile_adapt/expression_quotes.txt
+++ b/caddytest/integration/caddyfile_adapt/expression_quotes.txt
@@ -1,0 +1,114 @@
+example.com
+
+@a expression {http.error.status_code} == 400
+abort @a
+
+@b expression {http.error.status_code} == "401"
+abort @b
+
+@c expression {http.error.status_code} == `402`
+abort @c
+
+@d expression "{http.error.status_code} == 403"
+abort @d
+
+@e expression `{http.error.status_code} == 404`
+abort @e
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"abort": true,
+													"handler": "static_response"
+												}
+											],
+											"match": [
+												{
+													"expression": "{http.error.status_code} == 400"
+												}
+											]
+										},
+										{
+											"handle": [
+												{
+													"abort": true,
+													"handler": "static_response"
+												}
+											],
+											"match": [
+												{
+													"expression": "{http.error.status_code} == \"401\""
+												}
+											]
+										},
+										{
+											"handle": [
+												{
+													"abort": true,
+													"handler": "static_response"
+												}
+											],
+											"match": [
+												{
+													"expression": "{http.error.status_code} == `402`"
+												}
+											]
+										},
+										{
+											"handle": [
+												{
+													"abort": true,
+													"handler": "static_response"
+												}
+											],
+											"match": [
+												{
+													"expression": "{http.error.status_code} == 403"
+												}
+											]
+										},
+										{
+											"handle": [
+												{
+													"abort": true,
+													"handler": "static_response"
+												}
+											],
+											"match": [
+												{
+													"expression": "{http.error.status_code} == 404"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/caddytest/integration/caddyfile_adapt/map_with_raw_types.txt
+++ b/caddytest/integration/caddyfile_adapt/map_with_raw_types.txt
@@ -1,0 +1,107 @@
+example.com
+
+map {host}             {my_placeholder}  {magic_number} {
+	# Should output boolean "true" and an integer
+	example.com        true              3
+
+	# Should output a string and null
+	foo.example.com    "string value"
+
+	# Should output two strings (quoted int)
+	(.*)\.example.com  "${1} subdomain"  "5"
+
+	# Should output null and a string (quoted int)
+	~.*\.net$          -                 `7`
+
+	# Should output a float and the string "false"
+	~.*\.xyz$          123.456           "false"
+
+	# Should output two strings, second being escaped quote
+	default            "unknown domain"  \"""
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"defaults": [
+														"unknown domain",
+														"\""
+													],
+													"destinations": [
+														"{my_placeholder}",
+														"{magic_number}"
+													],
+													"handler": "map",
+													"mappings": [
+														{
+															"input": "example.com",
+															"outputs": [
+																true,
+																3
+															]
+														},
+														{
+															"input": "foo.example.com",
+															"outputs": [
+																"string value",
+																null
+															]
+														},
+														{
+															"input": "(.*)\\.example.com",
+															"outputs": [
+																"${1} subdomain",
+																"5"
+															]
+														},
+														{
+															"input_regexp": ".*\\.net$",
+															"outputs": [
+																null,
+																"7"
+															]
+														},
+														{
+															"input_regexp": ".*\\.xyz$",
+															"outputs": [
+																123.456,
+																"false"
+															]
+														}
+													],
+													"source": "{http.request.host}"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -150,7 +150,11 @@ func (m MatchExpression) Match(r *http.Request) bool {
 // UnmarshalCaddyfile implements caddyfile.Unmarshaler.
 func (m *MatchExpression) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
-		m.Expr = strings.Join(d.RemainingArgs(), " ")
+		if d.CountRemainingArgs() > 1 {
+			m.Expr = strings.Join(d.RawRemainingArgs(), " ")
+		} else {
+			m.Expr = d.Val()
+		}
 	}
 	return nil
 }

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -151,7 +151,7 @@ func (m MatchExpression) Match(r *http.Request) bool {
 func (m *MatchExpression) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		if d.CountRemainingArgs() > 1 {
-			m.Expr = strings.Join(d.RawRemainingArgs(), " ")
+			m.Expr = strings.Join(d.RemainingArgsRaw(), " ")
 		} else {
 			m.Expr = d.Val()
 		}

--- a/modules/caddyhttp/map/caddyfile.go
+++ b/modules/caddyhttp/map/caddyfile.go
@@ -15,7 +15,6 @@
 package maphandler
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
@@ -75,11 +74,12 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 			// every other line maps one input to one or more outputs
 			in := h.Val()
 			var outs []interface{}
-			for _, out := range h.RemainingArgs() {
-				if out == "-" {
+			for h.NextArg() {
+				val := h.ScalarVal()
+				if val == "-" {
 					outs = append(outs, nil)
 				} else {
-					outs = append(outs, specificType(out))
+					outs = append(outs, val)
 				}
 			}
 
@@ -107,17 +107,4 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 	}
 
 	return handler, nil
-}
-
-func specificType(v string) interface{} {
-	if num, err := strconv.Atoi(v); err == nil {
-		return num
-	}
-	if num, err := strconv.ParseFloat(v, 64); err == nil {
-		return num
-	}
-	if bool, err := strconv.ParseBool(v); err == nil {
-		return bool
-	}
-	return v
 }


### PR DESCRIPTION
Followup to https://github.com/caddyserver/caddy/commit/93c99f67342504efe9f6b58a734aaec3929fe785 as pointed out in https://github.com/caddyserver/website/issues/221, and fixing the issue mentioned in https://github.com/caddyserver/website/issues/220

See the adapt tests, which cover how it behaves.

Note: This _is_ a breaking change, because people using `map` with numbers used to get strings, and will now get numbers.