### PR TITLE
Reverse proxy fix: copy headers as-is, don't canonicalize implicitly

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -1079,7 +1079,7 @@ func cloneRequest(origReq *http.Request) *http.Request {
 func copyHeader(dst, src http.Header) {
 	for k, vv := range src {
 		for _, v := range vv {
-			dst.Add(k, v)
+			dst[k] = append(dst[k], v)
 		}
 	}
 }


### PR DESCRIPTION
Just simple fix to avoid implicit canonicalization of headers. In my case, it was breaking services, which were using non-canonically named headers