### PR TITLE
caddyfile: Prevent bad block opening tokens

### DIFF
--- a/caddyconfig/caddyfile/dispenser.go
+++ b/caddyconfig/caddyfile/dispenser.go
@@ -461,3 +461,17 @@ func (d *Dispenser) isNewLine() bool {
 	return d.tokens[d.cursor-1].File != d.tokens[d.cursor].File ||
 		d.tokens[d.cursor-1].Line+d.numLineBreaks(d.cursor-1) < d.tokens[d.cursor].Line
 }
+
+// isNextOnNewLine determines whether the current token is on a different
+// line (higher line number) than the next token. It handles imported
+// tokens correctly. If there isn't a next token, it returns true.
+func (d *Dispenser) isNextOnNewLine() bool {
+	if d.cursor < 0 {
+		return false
+	}
+	if d.cursor >= len(d.tokens)-1 {
+		return true
+	}
+	return d.tokens[d.cursor].File != d.tokens[d.cursor+1].File ||
+		d.tokens[d.cursor].Line+d.numLineBreaks(d.cursor) < d.tokens[d.cursor+1].Line
+}

--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -494,6 +494,13 @@ func (p *parser) directive() error {
 	for p.Next() {
 		if p.Val() == "{" {
 			p.nesting++
+			if !p.isNextOnNewLine() && p.Token().wasQuoted == 0 {
+				return p.Err("Unexpected next token after '{' on same line")
+			}
+		} else if p.Val() == "{}" {
+			if p.isNextOnNewLine() && p.Token().wasQuoted == 0 {
+				return p.Err("Unexpected '{}' at end of line")
+			}
 		} else if p.isNewLine() && p.nesting == 0 {
 			p.cursor-- // read too far
 			break

--- a/caddyconfig/caddyfile/parse_test.go
+++ b/caddyconfig/caddyfile/parse_test.go
@@ -191,6 +191,20 @@ func TestParseOneAndImport(t *testing.T) {
 
 		{``, false, []string{}, []int{}},
 
+		// Unexpected next token after '{' on same line
+		{`localhost
+		  dir1 { a b }`, true, []string{"localhost"}, []int{}},
+		// Workaround with quotes
+		{`localhost
+		  dir1 "{" a b "}"`, false, []string{"localhost"}, []int{5}},
+
+		// Unexpected '{}' at end of line
+		{`localhost
+		  dir1 {}`, true, []string{"localhost"}, []int{}},
+		// Workaround with quotes
+		{`localhost
+		  dir1 "{}"`, false, []string{"localhost"}, []int{2}},
+
 		// import with args
 		{`import testdata/import_args0.txt a`, false, []string{"a"}, []int{}},
 		{`import testdata/import_args1.txt a b`, false, []string{"a", "b"}, []int{}},


### PR DESCRIPTION
Fix #4501

Basically, we want to prevent two cases where bad block openings can happen.

```
localhost
reverse_proxy { to abc:123 }
```

☝️ this one used to result in the upstreams list containing `}` (the last token on the line) because since no newline happens, `to` reads all the remaining tokens on the same line, consuming both `abc:123` and `}`, but never closing the block.

This bug is being fixed by checking if after we see a `{` token, whether the next token is on a new line; if not, err. This could break "legitimate" situations where some hypothetical `expression`-like directive wants to consume all the tokens on the line where `{` is some syntactical token of that "language", but I think this is unlikely, and can be worked around by quoting the tokens like `"{"` and `"}"` (or with backticks).

```
localhost
reverse_proxy abc:123 {}
```

☝️ this one ends up in an upstreams list with `abc:123` and `{}`; I don't think there's ever a case where there'd be a placeholder with no name, and having it at the end of line seems like almost always a mistake (where the user is trying to put an empty block in their config).

Same idea, we're checking if when we see `{}` whether the next token is on a new line, and if so, err. This can also be worked around by quoting with `"{}"` 

Worth noting that https://github.com/caddyserver/caddy/pull/4643 made the quote workaround possible in this implementation, because now we know whether a particular token was quoted. We would only know the token value previously, without context of quoting. 🎉 