### PR TITLE
map: Prevent output destinations overlap with Caddyfile shorthands

### DIFF
--- a/modules/caddyhttp/map/caddyfile.go
+++ b/modules/caddyhttp/map/caddyfile.go
@@ -56,6 +56,11 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 		if len(handler.Destinations) == 0 {
 			return nil, h.Err("missing destination argument(s)")
 		}
+		for _, dest := range handler.Destinations {
+			if shorthand := httpcaddyfile.WasReplacedPlaceholderShorthand(dest); shorthand != "" {
+				return nil, h.Errf("destination %s conflicts with a Caddyfile placeholder shorthand", shorthand)
+			}
+		}
 
 		// mappings
 		for h.NextBlock(0) {


### PR DESCRIPTION
Essentially, this tries to prevent configs like this:

```
example.com {
    map {host} {path} {
        example.com /example
    }
}
```

Where the output `{path}` is no good, because it's one of the [placeholder shorthands](https://caddyserver.com/docs/caddyfile/concepts#placeholders). This means that the map destination would actually clobber an existing replacer output, and produce unexpected behaviour.

The implementation is kiiinda tricky though.

Since shorthand replacement happens _before_ directive parsing (this surprised me when I was working on this, but "duh" I should've realized sooner), the `map`'s Caddyfile parser _actually_ sees `{http.request.uri.path}` instead of `{path}`; this means that we need to actually look for the _replacements_ and map them back to the shorthand (for the error message).

With this change, the above Caddyfile will now spit out:

```
adapt: parsing caddyfile tokens for 'map': Caddyfile:2 - Error during parsing: destination {path} conflicts with a Caddyfile placeholder shorthand
```

Also, this adds `{vars.*}` shorthand. Nice to have now that we have a `vars` directive.