### PR TITLE
core: Allow LoadConfig to return ErrConfigUnchanged

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -938,7 +938,7 @@ func handleConfig(w http.ResponseWriter, r *http.Request) error {
 		forceReload := r.Header.Get("Cache-Control") == "must-revalidate"
 
 		err := changeConfig(r.Method, r.URL.Path, body, forceReload)
-		if err != nil && !errors.Is(err, errSameConfig) {
+		if err != nil && !errors.Is(err, ErrConfigUnchanged) {
 			return err
 		}
 

--- a/caddy.go
+++ b/caddy.go
@@ -112,7 +112,7 @@ func Load(cfgJSON []byte, forceReload bool) error {
 	}()
 
 	err := changeConfig(http.MethodPost, "/"+rawConfigKey, cfgJSON, forceReload)
-	if errors.Is(err, errSameConfig) {
+	if errors.Is(err, ErrConfigUnchanged) {
 		err = nil // not really an error
 	}
 	return err
@@ -123,7 +123,7 @@ func Load(cfgJSON []byte, forceReload bool) error {
 // the new value (if applicable; i.e. "DELETE" doesn't have an input).
 // If the resulting config is the same as the previous, no reload will
 // occur unless forceReload is true. If the config is unchanged and not
-// forcefully reloaded, then errConfigUnchanged This function is safe for
+// forcefully reloaded, then ErrConfigUnchanged. This function is safe for
 // concurrent use.
 func changeConfig(method, path string, input []byte, forceReload bool) error {
 	switch method {
@@ -155,7 +155,7 @@ func changeConfig(method, path string, input []byte, forceReload bool) error {
 	// if nothing changed, no need to do a whole reload unless the client forces it
 	if !forceReload && bytes.Equal(rawCfgJSON, newCfg) {
 		Log().Info("config is unchanged")
-		return errSameConfig
+		return ErrConfigUnchanged
 	}
 
 	// find any IDs in this config and index them
@@ -500,12 +500,10 @@ func finishSettingUp(ctx Context, cfg *Config) error {
 
 		runLoadedConfig := func(config []byte) error {
 			logger.Info("applying dynamically-loaded config")
-			err := changeConfig(http.MethodPost, "/"+rawConfigKey, config, false)
-			if errors.Is(err, errSameConfig) {
-				return err
-			}
-			if err != nil {
-				logger.Error("failed to run dynamically-loaded config", zap.Error(err))
+			if err := changeConfig(http.MethodPost, "/"+rawConfigKey, config, false); err != nil {
+				if !errors.Is(err, ErrConfigUnchanged) {
+					logger.Error("failed to run dynamically-loaded config", zap.Error(err))
+				}
 				return err
 			}
 			logger.Info("successfully applied dynamically-loaded config")
@@ -522,15 +520,18 @@ func finishSettingUp(ctx Context, cfg *Config) error {
 					case <-timer.C:
 						loadedConfig, err := val.(ConfigLoader).LoadConfig(ctx)
 						if err != nil {
-							logger.Error("failed loading dynamic config; will retry", zap.Error(err))
+							if errors.Is(err, ErrConfigUnchanged) {
+								logger.Info("dynamically-loaded config was unchanged; will retry")
+							} else {
+								logger.Error("failed loading dynamic config; will retry", zap.Error(err))
+							}
 							continue
 						}
 						if loadedConfig == nil {
 							logger.Info("dynamically-loaded config was nil; will retry")
 							continue
 						}
-						err = runLoadedConfig(loadedConfig)
-						if errors.Is(err, errSameConfig) {
+						if err = runLoadedConfig(loadedConfig); errors.Is(err, ErrConfigUnchanged) {
 							logger.Info("dynamically-loaded config was unchanged; will retry")
 							continue
 						}
@@ -560,7 +561,8 @@ func finishSettingUp(ctx Context, cfg *Config) error {
 // ConfigLoader is a type that can load a Caddy config. If
 // the return value is non-nil, it must be valid Caddy JSON;
 // if nil or with non-nil error, it is considered to be a
-// no-op load and may be retried later.
+// no-op load and may be retried later. In particular, the error
+// ErrConfigUnchanged will be returned if there is no change.
 type ConfigLoader interface {
 	LoadConfig(Context) ([]byte, error)
 }
@@ -812,10 +814,9 @@ var (
 	rawCfgIndex map[string]string
 )
 
-// errSameConfig is returned if the new config is the same
-// as the old one. This isn't usually an actual, actionable
-// error; it's mostly a sentinel value.
-var errSameConfig = errors.New("config is unchanged")
+// ErrConfigUnchanged the error returned by LoadConfig or changeConfig if
+// there is no change in the config.
+var ErrConfigUnchanged = errors.New("config is unchanged")
 
 // ImportPath is the package import path for Caddy core.
 const ImportPath = "github.com/caddyserver/caddy/v2"


### PR DESCRIPTION
Other changes:

- Always enable force-reload for dynamic config load
- Rename errSameConfig to ErrConfigUnchanged

See previous discussions in #4615. 

Some more thoughts behind this PR:

1. `forceReload` is always set to true for dynamic config load, since I think the responsibility is more clear and the logic can be simpler if `ErrConfigUnchanged` will be returned by `LoadConfig()` only.
    - (**EDIT**: Sorry, I realized that this change will break #4603 if used with the built-in HTTP loader, which will never return `ErrConfigUnchanged`. Therefore, I reverted this change.)
3. `changeConfig()` can still return `ErrConfigUnchanged`, which I think is helpful for callers to differentiate "config unchanged" from "config successfully changed" when `forceReload` is false.