### PR TITLE
reverseproxy: Sync up `handleUpgradeResponse` with stdlib

### DIFF
--- a/modules/caddyhttp/reverseproxy/ascii.go
+++ b/modules/caddyhttp/reverseproxy/ascii.go
@@ -1,0 +1,57 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Most of the code in this file was initially borrowed from the Go
+// standard library and modified; It had this copyright notice:
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Original source, copied because the package was marked internal:
+// https://github.com/golang/go/blob/5c489514bc5e61ad9b5b07bd7d8ec65d66a0512a/src/net/http/internal/ascii/print.go
+
+package reverseproxy
+
+// EqualFold is strings.EqualFold, ASCII only. It reports whether s and t
+// are equal, ASCII-case-insensitively.
+func asciiEqualFold(s, t string) bool {
+	if len(s) != len(t) {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if asciiLower(s[i]) != asciiLower(t[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// lower returns the ASCII lowercase version of b.
+func asciiLower(b byte) byte {
+	if 'A' <= b && b <= 'Z' {
+		return b + ('a' - 'A')
+	}
+	return b
+}
+
+// IsPrint returns whether s is ASCII and printable according to
+// https://tools.ietf.org/html/rfc20#section-4.2.
+func asciiIsPrint(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < ' ' || s[i] > '~' {
+			return false
+		}
+	}
+	return true
+}

--- a/modules/caddyhttp/reverseproxy/ascii.go
+++ b/modules/caddyhttp/reverseproxy/ascii.go
@@ -23,7 +23,7 @@
 
 package reverseproxy
 
-// EqualFold is strings.EqualFold, ASCII only. It reports whether s and t
+// asciiEqualFold is strings.EqualFold, ASCII only. It reports whether s and t
 // are equal, ASCII-case-insensitively.
 func asciiEqualFold(s, t string) bool {
 	if len(s) != len(t) {
@@ -37,7 +37,7 @@ func asciiEqualFold(s, t string) bool {
 	return true
 }
 
-// lower returns the ASCII lowercase version of b.
+// asciiLower returns the ASCII lowercase version of b.
 func asciiLower(b byte) byte {
 	if 'A' <= b && b <= 'Z' {
 		return b + ('a' - 'A')
@@ -45,7 +45,7 @@ func asciiLower(b byte) byte {
 	return b
 }
 
-// IsPrint returns whether s is ASCII and printable according to
+// asciiIsPrint returns whether s is ASCII and printable according to
 // https://tools.ietf.org/html/rfc20#section-4.2.
 func asciiIsPrint(s string) bool {
 	for i := 0; i < len(s); i++ {

--- a/modules/caddyhttp/reverseproxy/ascii_test.go
+++ b/modules/caddyhttp/reverseproxy/ascii_test.go
@@ -1,0 +1,114 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Most of the code in this file was initially borrowed from the Go
+// standard library and modified; It had this copyright notice:
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Original source, copied because the package was marked internal:
+// https://github.com/golang/go/blob/5c489514bc5e61ad9b5b07bd7d8ec65d66a0512a/src/net/http/internal/ascii/print_test.go
+
+package reverseproxy
+
+import "testing"
+
+func TestEqualFold(t *testing.T) {
+	var tests = []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{
+			name: "empty",
+			want: true,
+		},
+		{
+			name: "simple match",
+			a:    "CHUNKED",
+			b:    "chunked",
+			want: true,
+		},
+		{
+			name: "same string",
+			a:    "chunked",
+			b:    "chunked",
+			want: true,
+		},
+		{
+			name: "Unicode Kelvin symbol",
+			a:    "chunKed", // This "K" is 'KELVIN SIGN' (\u212A)
+			b:    "chunked",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := asciiEqualFold(tt.a, tt.b); got != tt.want {
+				t.Errorf("AsciiEqualFold(%q,%q): got %v want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsPrint(t *testing.T) {
+	var tests = []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{
+			name: "empty",
+			want: true,
+		},
+		{
+			name: "ASCII low",
+			in:   "This is a space: ' '",
+			want: true,
+		},
+		{
+			name: "ASCII high",
+			in:   "This is a tilde: '~'",
+			want: true,
+		},
+		{
+			name: "ASCII low non-print",
+			in:   "This is a unit separator: \x1F",
+			want: false,
+		},
+		{
+			name: "Ascii high non-print",
+			in:   "This is a Delete: \x7F",
+			want: false,
+		},
+		{
+			name: "Unicode letter",
+			in:   "Today it's 280K outside: it's freezing!", // This "K" is 'KELVIN SIGN' (\u212A)
+			want: false,
+		},
+		{
+			name: "Unicode emoji",
+			in:   "Gophers like 🧀",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := asciiIsPrint(tt.in); got != tt.want {
+				t.Errorf("IsASCIIPrint(%q): got %v want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I had left this as a TODO for when we bump to minimum 1.17, but I should've realized it was under `internal` so it couldn't be used directly.

Copied the functions we needed for parity. Hopefully this is ok!