### PR TITLE
cmd: Fix defaulting admin address if empty in config, fixes `reload`

### DIFF
--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -735,7 +735,7 @@ func DetermineAdminAPIAddress(address, configFile, configAdapter string) (string
 			return "", fmt.Errorf("no config file to load")
 		}
 
-		// get the address of the admin listener
+		// get the address of the admin listener if set
 		if len(config) > 0 {
 			var tmpStruct struct {
 				Admin caddy.AdminConfig `json:"admin"`
@@ -744,7 +744,9 @@ func DetermineAdminAPIAddress(address, configFile, configAdapter string) (string
 			if err != nil {
 				return "", fmt.Errorf("unmarshaling admin listener address from config: %v", err)
 			}
-			return tmpStruct.Admin.Listen, nil
+			if tmpStruct.Admin.Listen != "" {
+				return tmpStruct.Admin.Listen, nil
+			}
 		}
 	}
 


### PR DESCRIPTION
Just a silly oops. Followup to #4443

I broke `caddy reload` when the admin address is not explicitly set in the config 😬 it would take the empty admin address if a `--config` is specified at all, and never fall through to use the default.

https://caddy.community/t/caddy-reload-failing/15556