### PR TITLE
fileserver: Implement `show` list

### DIFF
--- a/modules/caddyhttp/fileserver/browsetplcontext.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext.go
@@ -29,7 +29,7 @@ import (
 )
 
 func (fsrv *FileServer) directoryListing(files []os.FileInfo, canGoUp bool, root, urlPath string, repl *caddy.Replacer) browseTemplateContext {
-	filesToHide := fsrv.transformHidePaths(repl)
+	filesToShow, filesToHide := fsrv.transformShowHidePaths(repl)
 
 	var dirCount, fileCount int
 	fileInfos := []fileInfo{}
@@ -37,7 +37,7 @@ func (fsrv *FileServer) directoryListing(files []os.FileInfo, canGoUp bool, root
 	for _, f := range files {
 		name := f.Name()
 
-		if fileHidden(name, filesToHide) {
+		if fileHidden(name, filesToShow, filesToHide) {
 			continue
 		}
 

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -36,6 +36,7 @@ func init() {
 //
 //    file_server [<matcher>] [browse] {
 //        root          <path>
+//        show          <files...>
 //        hide          <files...>
 //        index         <files...>
 //        browse        [<template_file>]
@@ -62,6 +63,12 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 
 		for h.NextBlock(0) {
 			switch h.Val() {
+			case "show":
+				fsrv.Show = h.RemainingArgs()
+				if len(fsrv.Show) == 0 {
+					return nil, h.ArgErr()
+				}
+
 			case "hide":
 				fsrv.Hide = h.RemainingArgs()
 				if len(fsrv.Hide) == 0 {
@@ -136,7 +143,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 	if configFiles := h.Caddyfiles(); len(configFiles) > 0 {
 		for _, file := range configFiles {
 			file = filepath.Clean(file)
-			if !fileHidden(file, fsrv.Hide) {
+			if !fileHidden(file, fsrv.Show, fsrv.Hide) {
 				// if there's no path separator, the file server module will hide all
 				// files by that name, rather than a specific one; but we want to hide
 				// only this specific file, so ensure there's always a path separator

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -519,6 +519,13 @@ func fileHidden(filename string, show []string, hide []string) bool {
 	// cache the components of the input filename
 	var components []string
 
+	// if the filename is the root of the fileserver, then
+	// it should always be shown, because otherwise the
+	// index would always be hidden
+	if filename == separator {
+		goto shown
+	}
+
 	for _, s := range show {
 		if !strings.Contains(s, separator) {
 			// if there is no separator in s, then we assume the user

--- a/modules/caddyhttp/fileserver/staticfiles_test.go
+++ b/modules/caddyhttp/fileserver/staticfiles_test.go
@@ -23,89 +23,148 @@ import (
 
 func TestFileHidden(t *testing.T) {
 	for i, tc := range []struct {
+		inputShow []string
 		inputHide []string
 		inputPath string
 		expect    bool
 	}{
 		{
+			inputShow: nil,
 			inputHide: nil,
 			inputPath: "",
 			expect:    false,
 		},
 		{
+			inputShow: nil,
 			inputHide: []string{".gitignore"},
 			inputPath: "/.gitignore",
 			expect:    true,
 		},
 		{
+			inputShow: nil,
 			inputHide: []string{".git"},
 			inputPath: "/.gitignore",
 			expect:    false,
 		},
 		{
+			inputShow: nil,
 			inputHide: []string{"/.git"},
 			inputPath: "/.gitignore",
 			expect:    false,
 		},
 		{
+			inputShow: nil,
 			inputHide: []string{".git"},
 			inputPath: "/.git",
 			expect:    true,
 		},
 		{
+			inputShow: nil,
 			inputHide: []string{".git"},
 			inputPath: "/.git/foo",
 			expect:    true,
 		},
 		{
+			inputShow: nil,
 			inputHide: []string{".git"},
 			inputPath: "/foo/.git/bar",
 			expect:    true,
 		},
 		{
+			inputShow: nil,
 			inputHide: []string{"/prefix"},
 			inputPath: "/prefix/foo",
 			expect:    true,
 		},
 		{
+			inputShow: nil,
 			inputHide: []string{"/foo/*/bar"},
 			inputPath: "/foo/asdf/bar",
 			expect:    true,
 		},
 		{
+			inputShow: nil,
 			inputHide: []string{"*.txt"},
 			inputPath: "/foo/bar.txt",
 			expect:    true,
 		},
 		{
+			inputShow: nil,
 			inputHide: []string{"/foo/bar/*.txt"},
 			inputPath: "/foo/bar/baz.txt",
 			expect:    true,
 		},
 		{
+			inputShow: nil,
 			inputHide: []string{"/foo/bar/*.txt"},
 			inputPath: "/foo/bar.txt",
 			expect:    false,
 		},
 		{
+			inputShow: nil,
 			inputHide: []string{"/foo/bar/*.txt"},
 			inputPath: "/foo/bar/index.html",
 			expect:    false,
 		},
 		{
+			inputShow: nil,
 			inputHide: []string{"/foo"},
 			inputPath: "/foo",
 			expect:    true,
 		},
 		{
+			inputShow: nil,
 			inputHide: []string{"/foo"},
 			inputPath: "/foobar",
 			expect:    false,
 		},
 		{
+			inputShow: nil,
 			inputHide: []string{"first", "second"},
 			inputPath: "/second",
 			expect:    true,
+		},
+		{
+			inputShow: []string{"/foo"},
+			inputHide: nil,
+			inputPath: "/foobar",
+			expect:    true,
+		},
+		{
+			inputShow: []string{"/foo"},
+			inputHide: nil,
+			inputPath: "/foo/bar",
+			expect:    false,
+		},
+		{
+			inputShow: []string{"first", "second"},
+			inputHide: nil,
+			inputPath: "/third",
+			expect:    true,
+		},
+		{
+			inputShow: []string{"*.txt"},
+			inputHide: nil,
+			inputPath: "/foo/bar.txt",
+			expect:    false,
+		},
+		{
+			inputShow: []string{"*.txt"},
+			inputHide: nil,
+			inputPath: "/foo/bar.nope",
+			expect:    true,
+		},
+		{
+			inputShow: []string{"*.txt"},
+			inputHide: []string{"/foo"},
+			inputPath: "/foo/bar.txt",
+			expect:    true,
+		},
+		{
+			inputShow: []string{"*.txt"},
+			inputHide: []string{"/foo"},
+			inputPath: "/bar/baz.txt",
+			expect:    false,
 		},
 	} {
 		if runtime.GOOS == "windows" {
@@ -113,6 +172,12 @@ func TestFileHidden(t *testing.T) {
 				tc.inputPath, _ = filepath.Abs(tc.inputPath)
 			}
 			tc.inputPath = filepath.FromSlash(tc.inputPath)
+			for i := range tc.inputShow {
+				if strings.HasPrefix(tc.inputShow[i], "/") {
+					tc.inputShow[i], _ = filepath.Abs(tc.inputShow[i])
+				}
+				tc.inputShow[i] = filepath.FromSlash(tc.inputShow[i])
+			}
 			for i := range tc.inputHide {
 				if strings.HasPrefix(tc.inputHide[i], "/") {
 					tc.inputHide[i], _ = filepath.Abs(tc.inputHide[i])
@@ -121,10 +186,10 @@ func TestFileHidden(t *testing.T) {
 			}
 		}
 
-		actual := fileHidden(tc.inputPath, tc.inputHide)
+		actual := fileHidden(tc.inputPath, tc.inputShow, tc.inputHide)
 		if actual != tc.expect {
-			t.Errorf("Test %d: Does %v hide %s? Got %t but expected %t",
-				i, tc.inputHide, tc.inputPath, actual, tc.expect)
+			t.Errorf("Test %d: Is %s hidden by show(%v) hide(%v)? Got %t but expected %t",
+				i, tc.inputPath, tc.inputShow, tc.inputHide, actual, tc.expect)
 		}
 	}
 }

--- a/modules/caddyhttp/fileserver/staticfiles_test.go
+++ b/modules/caddyhttp/fileserver/staticfiles_test.go
@@ -155,6 +155,12 @@ func TestFileHidden(t *testing.T) {
 			expect:    true,
 		},
 		{
+			inputShow: []string{"/foo"},
+			inputHide: nil,
+			inputPath: "/",
+			expect:    false,
+		},
+		{
 			inputShow: []string{"*.txt"},
 			inputHide: []string{"/foo"},
 			inputPath: "/foo/bar.txt",


### PR DESCRIPTION
Closes #4683

I found a legitimate use for `goto`! 😅 

Pretty self explanatory, I think. `show` list is checked first, if non-empty. `hide` now further restricts on top of that, if `show` didn't cause it to be hidden.