### PR TITLE
ci: Ensure we always check for latest version of Go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go: [ '1.17', '1.18' ]
+        go: [ '^1.17.9', '^1.18.1' ]
 
         # Set some variables per OS, usable via ${{ matrix.VAR }}
         # CADDY_BIN_PATH: the path to the compiled Caddy binary, for artifact publishing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
         - go: '1.18'
           GO_SEMVER: '~1.18.1'
 
+        # Go 1.18.1 isn't released yet for Mac as of Apr 13 2022
+        - go: '1.18'
+          os: 'macos-latest'
+          GO_SEMVER: '1.18.0'
+
         # Set some variables per OS, usable via ${{ matrix.VAR }}
         # CADDY_BIN_PATH: the path to the compiled Caddy binary, for artifact publishing
         # SUCCESS: the typical value for $? per OS (Windows/pwsh returns 'True')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,20 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go: [ '^1.17.9', '^1.18.1' ]
+        go: [ '1.17', '1.18' ]
+
+        include:
+        # Set the minimum Go patch version for the given Go minor
+        # Usable via ${{ matrix.GO_SEMVER }}
+        - go: '1.17'
+          GO_SEMVER: '^1.17.9'
+
+        - go: '1.18'
+          GO_SEMVER: '^1.18.1'
 
         # Set some variables per OS, usable via ${{ matrix.VAR }}
         # CADDY_BIN_PATH: the path to the compiled Caddy binary, for artifact publishing
         # SUCCESS: the typical value for $? per OS (Windows/pwsh returns 'True')
-        include:
         - os: ubuntu-latest
           CADDY_BIN_PATH: ./cmd/caddy/caddy
           SUCCESS: 0
@@ -43,7 +51,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ matrix.go }}
+        go-version: ${{ matrix.GO_SEMVER }}
         check-latest: true
 
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
         # Set the minimum Go patch version for the given Go minor
         # Usable via ${{ matrix.GO_SEMVER }}
         - go: '1.17'
-          GO_SEMVER: '^1.17.9'
+          GO_SEMVER: '~1.17.9'
 
         - go: '1.18'
-          GO_SEMVER: '^1.18.1'
+          GO_SEMVER: '~1.18.1'
 
         # Set some variables per OS, usable via ${{ matrix.VAR }}
         # CADDY_BIN_PATH: the path to the compiled Caddy binary, for artifact publishing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
+        check-latest: true
 
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -22,7 +22,7 @@ jobs:
         # Set the minimum Go patch version for the given Go minor
         # Usable via ${{ matrix.GO_SEMVER }}
         - go: '1.18'
-          GO_SEMVER: '^1.18.1'
+          GO_SEMVER: '~1.18.1'
 
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
+          check-latest: true
 
       - name: Print Go version and environment
         id: vars

--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -16,14 +16,21 @@ jobs:
       fail-fast: false
       matrix:
         goos: ['android', 'linux', 'solaris', 'illumos', 'dragonfly', 'freebsd', 'openbsd', 'plan9', 'windows', 'darwin', 'netbsd']
-        go: [ '^1.18.1' ]
+        go: [ '1.18' ]
+
+        include:
+        # Set the minimum Go patch version for the given Go minor
+        # Usable via ${{ matrix.GO_SEMVER }}
+        - go: '1.18'
+          GO_SEMVER: '^1.18.1'
+
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.go }}
+          go-version: ${{ matrix.GO_SEMVER }}
           check-latest: true
 
       - name: Print Go version and environment

--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         goos: ['android', 'linux', 'solaris', 'illumos', 'dragonfly', 'freebsd', 'openbsd', 'plan9', 'windows', 'darwin', 'netbsd']
-        go: [ '1.18' ]
+        go: [ '^1.18.1' ]
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: '^1.17.9'
           check-latest: true
 
       - name: golangci-lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.17
+          check-latest: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.17.9'
+          go-version: '~1.17.9'
           check-latest: true
 
       - name: golangci-lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,21 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        go: [ '>=1.18.1' ]
+        go: [ '1.18' ]
+
+        include:
+        # Set the minimum Go patch version for the given Go minor
+        # Usable via ${{ matrix.GO_SEMVER }}
+        - go: '1.17'
+          GO_SEMVER: '^1.18.1'
+
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ matrix.go }}
+        go-version: ${{ matrix.GO_SEMVER }}
         check-latest: true
 
     - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         # Set the minimum Go patch version for the given Go minor
         # Usable via ${{ matrix.GO_SEMVER }}
         - go: '1.17'
-          GO_SEMVER: '^1.18.1'
+          GO_SEMVER: '~1.18.1'
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        go: [ '1.18' ]
+        go: [ '>=1.18.1' ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
+        check-latest: true
 
     - name: Checkout code
       uses: actions/checkout@v3


### PR DESCRIPTION
- Go `1.18.1` isn't being pulled by https://github.com/actions/setup-go right now because the versions are pulled from https://github.com/actions/go-versions and it hasn't been updated with it yet

- We were incidentally using `1.17` and `1.18` as our semver strings previously; if we change the matrix to use an actual semver like `~1.18.1` then it actually renames the job itself, which breaks the "required job" thing in github

- Mac 1.18.1 isn't out yet because of "an issue" https://github.com/golang/go/issues/52317 so I need to implement a hack for that too

- So to keep the same labels, but customize the semver string, I'm using an `include` to write to a `GO_SEMVER` variable for it, and using that as the `setup-go` version; the rest uses the short version name from the matrix.