### PR TITLE
ci: use latest Go version on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,6 @@ jobs:
         - go: '1.18'
           GO_SEMVER: '~1.18.1'
 
-        # Go 1.18.1 isn't released yet for Mac as of Apr 13 2022
-        - go: '1.18'
-          os: 'macos-latest'
-          GO_SEMVER: '1.18.0'
-
         # Set some variables per OS, usable via ${{ matrix.VAR }}
         # CADDY_BIN_PATH: the path to the compiled Caddy binary, for artifact publishing
         # SUCCESS: the typical value for $? per OS (Windows/pwsh returns 'True')


### PR DESCRIPTION
An upstream issue prevented #4703 from using go1.18.1 on macOS. The issue was resolved.