### PR TITLE
caddyauth: Speed up basicauth provision, deprecate `scrypt`

### DIFF
--- a/modules/caddyhttp/caddyauth/basicauth.go
+++ b/modules/caddyhttp/caddyauth/basicauth.go
@@ -118,6 +118,7 @@ func (hba *HTTPBasicAuth) Provision(ctx caddy.Context) error {
 			return fmt.Errorf("account %d: username and password are required", i)
 		}
 
+		// TODO: Remove support for redundantly-encoded b64-encoded hashes
 		// Passwords starting with '$' are likely in Modular Crypt Format,
 		// so we don't need to base64 decode them. But historically, we
 		// required redundant base64, so we try to decode it otherwise.

--- a/modules/caddyhttp/caddyauth/basicauth.go
+++ b/modules/caddyhttp/caddyauth/basicauth.go
@@ -94,7 +94,7 @@ func (hba *HTTPBasicAuth) Provision(ctx caddy.Context) error {
 
 	// if supported, generate a fake password we can compare against if needed
 	if hasher, ok := hba.Hash.(Hasher); ok {
-		hba.fakePassword, err = hasher.Hash([]byte("antitiming"), []byte("fakesalt"))
+		hba.fakePassword = hasher.FakeHash()
 		if err != nil {
 			return fmt.Errorf("generating anti-timing password hash: %v", err)
 		}
@@ -271,9 +271,11 @@ type Comparer interface {
 // that require a salt). Hashing modules which implement
 // this interface can be used with the hash-password
 // subcommand as well as benefitting from anti-timing
-// features.
+// features. A hasher also returns a fake hash which
+// can be used for timing side-channel mitigation.
 type Hasher interface {
 	Hash(plaintext, salt []byte) ([]byte, error)
+	FakeHash() []byte
 }
 
 // Account contains a username, password, and salt (if applicable).

--- a/modules/caddyhttp/caddyauth/hashes.go
+++ b/modules/caddyhttp/caddyauth/hashes.go
@@ -16,6 +16,7 @@ package caddyauth
 
 import (
 	"crypto/subtle"
+	"encoding/base64"
 
 	"github.com/caddyserver/caddy/v2"
 	"golang.org/x/crypto/bcrypt"
@@ -53,6 +54,13 @@ func (BcryptHash) Compare(hashed, plaintext, _ []byte) (bool, error) {
 // Hash hashes plaintext using a random salt.
 func (BcryptHash) Hash(plaintext, _ []byte) ([]byte, error) {
 	return bcrypt.GenerateFromPassword(plaintext, 14)
+}
+
+// FakeHash returns a fake hash.
+func (BcryptHash) FakeHash() []byte {
+	// hashed with the following command:
+	// caddy hash-password --plaintext "antitiming" --algorithm "bcrypt"
+	return []byte("$2a$14$X3ulqf/iGxnf1k6oMZ.RZeJUoqI9PX2PM4rS5lkIKJXduLGXGPrt6")
 }
 
 // ScryptHash implements the scrypt KDF as a hash.
@@ -121,6 +129,14 @@ func (s ScryptHash) Compare(hashed, plaintext, salt []byte) (bool, error) {
 // Hash hashes plaintext using the given salt.
 func (s ScryptHash) Hash(plaintext, salt []byte) ([]byte, error) {
 	return scrypt.Key(plaintext, salt, s.N, s.R, s.P, s.KeyLength)
+}
+
+// FakeHash returns a fake hash.
+func (ScryptHash) FakeHash() []byte {
+	// hashed with the following command:
+	// caddy hash-password --plaintext "antitiming" --salt "fakesalt" --algorithm "scrypt"
+	bytes, _ := base64.StdEncoding.DecodeString("kFbjiVemlwK/ZS0tS6/UQqEDeaNMigyCs48KEsGUse8=")
+	return bytes
 }
 
 func hashesMatch(pwdHash1, pwdHash2 []byte) bool {

--- a/modules/caddyhttp/caddyauth/hashes.go
+++ b/modules/caddyhttp/caddyauth/hashes.go
@@ -64,6 +64,8 @@ func (BcryptHash) FakeHash() []byte {
 }
 
 // ScryptHash implements the scrypt KDF as a hash.
+//
+// DEPRECATED, please use 'bcrypt' instead.
 type ScryptHash struct {
 	// scrypt's N parameter. If unset or 0, a safe default is used.
 	N int `json:"N,omitempty"`
@@ -88,8 +90,9 @@ func (ScryptHash) CaddyModule() caddy.ModuleInfo {
 }
 
 // Provision sets up s.
-func (s *ScryptHash) Provision(_ caddy.Context) error {
+func (s *ScryptHash) Provision(ctx caddy.Context) error {
 	s.SetDefaults()
+	ctx.Logger(s).Warn("use of 'scrypt' is deprecated, please use 'bcrypt' instead")
 	return nil
 }
 


### PR DESCRIPTION
When provisioning `basicauth`, there's a big performance hit on loading/reloading configs because it calculates a fake password; we don't need to do this on-the-fly, it's totally fine to hash the password once offline and just hardcode it.

I did change the `Hasher` interface unfortunately because it's really the cleanest way to implement this, but I'm not aware of any plugins that implement another hashing algorithm anyways, so the breaking change should probably be fine.

---

FWIW I still think we should drop `scrypt` altogether, and stop using base64-encoded strings.

I don't see any compelling reason to keep `scrypt`, it has way too many knobs, and having the salt not being built-in makes it very error prone to use correctly. See https://passlib.readthedocs.io/en/stable/lib/passlib.hash.scrypt.html for example, which discourages its use.

And no need for base64 because `bcrypt` already uses a safe string format (called Modular Crypt Format), so we're just base64 encoding an already-ASCII string which just obfuscates the configured work factor (which is plainly visible in the bcrypt header). For example, the `bcrypt` I hard-coded in here, base64 decoded, is `$2a$14$X3ulqf/iGxnf1k6oMZ.RZeJUoqI9PX2PM4rS5lkIKJXduLGXGPrt6` which you can clearly see at the start `$14` which means the work factor is `14`. That's its only config knob, and can tell you if it's time to re-hash the passwords if that work factor is now too weak (14 is still ridiculously strong, arguably way too high for a webserver, see https://twitter.com/TychoTithonus/status/1546270126730723329 and above).