### PR TITLE
reverseproxy: Improve hashing LB policies with HRW

### DIFF
--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -524,7 +524,7 @@ func hostByHashing(pool []*Upstream, s string) *Upstream {
 	var highestHash uint32
 	var upstream *Upstream
 	for _, up := range pool {
-		if !upstream.Available() {
+		if !up.Available() {
 			continue
 		}
 		h := hash(s + up.String()) // important to hash key and server together


### PR DESCRIPTION
Previously, if a list of upstreams changed, hash-based LB policies
would be greatly affected because the hash relied on the position of
upstreams in the pool. Highest Random Weight or "rendezvous" hashing
is apparently robust to pool changes. It runs in O(n) instead of
O(log n), but n is very small usually.

- https://en.wikipedia.org/wiki/Rendezvous_hashing
- https://randorithms.com/2020/12/26/rendezvous-hashing.html
- https://medium.com/i0exception/rendezvous-hashing-8c00e2fb58b0 (:arrow_backward: what I used as a starting point)

This algorithm is very simple and makes sense to me. Hopefully I implemented this correctly! :)

/cc @jjiang-stripe and @cds2-stripe