### PR TITLE
httpcaddyfile: Add `{vars.*}` placeholder shortcut, reverse `vars` sort order

### DIFF
--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -424,14 +424,29 @@ func sortRoutes(routes []ConfigValue) {
 			jPathLen = len(jPM[0])
 		}
 
-		// if both directives have no path matcher, use whichever one
-		// has any kind of matcher defined first.
-		if iPathLen == 0 && jPathLen == 0 {
-			return len(iRoute.MatcherSetsRaw) > 0 && len(jRoute.MatcherSetsRaw) == 0
-		}
+		// some directives involve setting values which can overwrite
+		// eachother, so it makes most sense to reverse the order so
+		// that the lease specific matcher is first; everything else
+		// has most-specific matcher first
+		if iDir == "vars" {
+			// if both directives have no path matcher, use whichever one
+			// has no matcher first.
+			if iPathLen == 0 && jPathLen == 0 {
+				return len(iRoute.MatcherSetsRaw) == 0 && len(jRoute.MatcherSetsRaw) > 0
+			}
 
-		// sort with the most-specific (longest) path first
-		return iPathLen > jPathLen
+			// sort with the least-specific (shortest) path first
+			return iPathLen < jPathLen
+		} else {
+			// if both directives have no path matcher, use whichever one
+			// has any kind of matcher defined first.
+			if iPathLen == 0 && jPathLen == 0 {
+				return len(iRoute.MatcherSetsRaw) > 0 && len(jRoute.MatcherSetsRaw) == 0
+			}
+
+			// sort with the most-specific (longest) path first
+			return iPathLen > jPathLen
+		}
 	})
 }
 

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -129,6 +129,7 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 		{regexp.MustCompile(`{header\.([\w-]*)}`), "{http.request.header.$1}"},
 		{regexp.MustCompile(`{path\.([\w-]*)}`), "{http.request.uri.path.$1}"},
 		{regexp.MustCompile(`{re\.([\w-]*)\.([\w-]*)}`), "{http.regexp.$1.$2}"},
+		{regexp.MustCompile(`{vars\.([\w-]*)}`), "{http.vars.$1}"},
 	}
 
 	for _, sb := range originalServerBlocks {

--- a/caddytest/integration/caddyfile_adapt/sort_vars_in_reverse.txt
+++ b/caddytest/integration/caddyfile_adapt/sort_vars_in_reverse.txt
@@ -1,0 +1,59 @@
+:80
+
+vars /foobar foo last
+vars /foo foo middle
+vars * foo first
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"foo": "first",
+									"handler": "vars"
+								}
+							]
+						},
+						{
+							"match": [
+								{
+									"path": [
+										"/foo"
+									]
+								}
+							],
+							"handle": [
+								{
+									"foo": "middle",
+									"handler": "vars"
+								}
+							]
+						},
+						{
+							"match": [
+								{
+									"path": [
+										"/foobar"
+									]
+								}
+							],
+							"handle": [
+								{
+									"foo": "last",
+									"handler": "vars"
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
I'm yoinking the placeholder from my https://github.com/caddyserver/caddy/pull/4657 PR because I think we should get this in ASAP for v2.5.0 along with the new `vars` directive.

Also, during testing while writing the docs, I realized we should reverse the `vars` directive sort order based on matchers; since this is a directive which overwrites existing values set by other previously run directives, we actually want the least-specific matcher to run first, and most-specific last, so that the most-specific is the last one to overwrites the value.

For example, with this config:

```
vars foo bar
vars /path* foo baz

respond {vars.foo}
```

Before this change, all requests would return `bar`, because the least specific matcher would run last, overwriting any more specific matcher. After the change, `/path*` requests will correctly return `baz`.