### PR TITLE
httpcaddyfile: Deprecate paths in site addresses; use zap everywhere

### DIFF
--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -18,13 +18,13 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/caddyserver/caddy/v2"
+	"go.uber.org/zap"
 )
 
 // Parse parses the input just enough to group tokens, in
@@ -393,7 +393,7 @@ func (p *parser) doImport() error {
 		}
 		if len(matches) == 0 {
 			if strings.ContainsAny(globPattern, "*?[]") {
-				log.Printf("[WARNING] No files matching import glob pattern: %s", importPattern)
+				caddy.Log().Warn("No files matching import glob pattern", zap.String("pattern", importPattern))
 			} else {
 				return p.Errf("File to import not found: %s", importPattern)
 			}

--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -496,7 +496,9 @@ func cmdAdaptConfig(fl Flags) (int, error) {
 		if warn.Directive != "" {
 			msg = fmt.Sprintf("%s: %s", warn.Directive, warn.Message)
 		}
-		fmt.Fprintf(os.Stderr, "[WARNING][%s] %s:%d: %s\n", adaptCmdAdapterFlag, warn.File, warn.Line, msg)
+		caddy.Log().Named(adaptCmdAdapterFlag).Warn(msg,
+			zap.String("file", warn.File),
+			zap.Int("line", warn.Line))
 	}
 
 	// validate output if requested

--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -129,7 +129,7 @@ func cmdFileServer(fs caddycmd.Flags) (int, error) {
 		return caddy.ExitCodeFailedStartup, err
 	}
 
-	log.Printf("Caddy 2 serving static files on %s", listen)
+	log.Printf("Caddy serving static files on %s", listen)
 
 	select {}
 }

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -15,7 +15,6 @@
 package reverseproxy
 
 import (
-	"log"
 	"net"
 	"net/http"
 	"reflect"
@@ -552,16 +551,16 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				case 2:
 					// some lint checks, I guess
 					if strings.EqualFold(args[0], "host") && (args[1] == "{hostport}" || args[1] == "{http.request.hostport}") {
-						log.Printf("[WARNING] Unnecessary header_up ('Host' field): the reverse proxy's default behavior is to pass headers to the upstream")
+						caddy.Log().Named("caddyfile").Warn("Unnecessary header_up Host: the reverse proxy's default behavior is to pass headers to the upstream")
 					}
 					if strings.EqualFold(args[0], "x-forwarded-for") && (args[1] == "{remote}" || args[1] == "{http.request.remote}" || args[1] == "{remote_host}" || args[1] == "{http.request.remote.host}") {
-						log.Printf("[WARNING] Unnecessary header_up ('X-Forwarded-For' field): the reverse proxy's default behavior is to pass headers to the upstream")
+						caddy.Log().Named("caddyfile").Warn("Unnecessary header_up X-Forwarded-For: the reverse proxy's default behavior is to pass headers to the upstream")
 					}
 					if strings.EqualFold(args[0], "x-forwarded-proto") && (args[1] == "{scheme}" || args[1] == "{http.request.scheme}") {
-						log.Printf("[WARNING] Unnecessary header_up ('X-Forwarded-Proto' field): the reverse proxy's default behavior is to pass headers to the upstream")
+						caddy.Log().Named("caddyfile").Warn("Unnecessary header_up X-Forwarded-Proto: the reverse proxy's default behavior is to pass headers to the upstream")
 					}
 					if strings.EqualFold(args[0], "x-forwarded-host") && (args[1] == "{host}" || args[1] == "{http.request.host}" || args[1] == "{hostport}" || args[1] == "{http.request.hostport}") {
-						log.Printf("[WARNING] Unnecessary header_up ('X-Forwarded-Host' field): the reverse proxy's default behavior is to pass headers to the upstream")
+						caddy.Log().Named("caddyfile").Warn("Unnecessary header_up X-Forwarded-Host: the reverse proxy's default behavior is to pass headers to the upstream")
 					}
 					err = headers.CaddyfileHeaderOp(h.Headers.Request, args[0], args[1], "")
 				case 3:


### PR DESCRIPTION
In the Caddyfile, [site addresses](https://caddyserver.com/docs/caddyfile/concepts#addresses) have historically supported paths. This was essentially a carry-over from Caddy v1. The idea is that you could write your sites with a path which would get turned into a subroute with that path as a matcher, and sites with the same domain would get grouped up together:

```
example.com/first* {
	respond "first"
}

example.com/second* {
	respond "second"
}

example.com {
	respond "anything else"
}
```

This is kinda fun, it can read nicely if your config is relatively simple. But, keeping this feature has many problems, both from a config UX standpoint and from a code complexity standpoint:

- Since the site address _looks_ like a proper URL, users may be tempted to write their site address like `https://example.com/` which is how the URL might look in the browser.

  The problem though, is that path matchers in Caddy v2 are exact, so this would only match requests to exactly `/` and nothing else; it would need to be configured as `https://example.com/*` to match all paths, but that's not _really_ a URL. In Caddy v1, this wasn't a problem because a matcher of `/` would match _all paths_ since it was always a prefix match (prefix matching has ambiguity though, so we changed to exact matching in v2).

  This has been a common mistake that has caused confusion for users, and we've gotten plenty of questions in the forums relating to this problem.

- Some directives such as `tls` and `log` are not HTTP handlers, but actually special directives that configure some settings for the server according to the _domain_ in the site.

  These directives don't make sense to be scoped by a URL path, because they can only operate on the domain; `tls` configures connection policies and cert automation policies for the domain(s) in the site address; `log` enables access logging based on domain (this technically could be extended to match on the path as well, but the effort isn't worth it, there's better ideas to extend this, such as #4689)

  If two site blocks are defined with the same domain and different paths, then which of the `tls` and `log` directives should we use? This causes ambiguity, and isn't obvious how it'll be have to users configuring it. Right now, we just sort the sites based on the length of their path matchers, and _I think_ the least specific matcher's config will win in that case (I haven't verified this, but either way, it's bad behaviour).

- The Caddyfile adapter has to include a bunch of extra code to deal with sorting site blocks based on their path matchers, creating new subroutes matching by the path, merging all of these together in one single set of routes, etc. Some of this code is shared with the logic for merging sites with different domains (reasonable), but it should be possible to significantly simplify certain loops to avoid this extra work, once we remove path support.

The preferred way to write your config if you need to have separate routes based on the request path, is to use `handle` blocks inside of a single site block. The above Caddyfile example would be better written like this:

```
example.com {
	handle /first* {
		respond "first"
	}

	handle /second* {
		respond "second"
	}

	handle {
		respond "anything else"
	}
}
```

This is slightly longer, and has an extra level of indentation, but the behaviour is _much_ clearer, and the domain doesn't need to be repeated for each site block.

---

Also in this branch, I adjusted a bunch of places where we used `fmt.Printf` or `log.Printf` to instead use our zap logger; looks nicer in the terminal, and improves logging consistency in the codebase.