### PR TITLE
logging: Use `RedirectStdLog`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 _gitignore/
 *.log
 Caddyfile
+Caddyfile.*
 !caddyfile/
 
 # artifacts from pprof tooling

--- a/logging.go
+++ b/logging.go
@@ -661,9 +661,15 @@ func newDefaultProductionLog() (*defaultCustomLog, error) {
 
 	cl.buildCore()
 
+	logger := zap.New(cl.core)
+
+	// capture logs from other libraries which
+	// may not be using zap logging directly
+	_ = zap.RedirectStdLog(logger)
+
 	return &defaultCustomLog{
 		CustomLog: cl,
-		logger:    zap.New(cl.core),
+		logger:    logger,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes #4688

Before:

```
$ caddy trust --address localhost:2021 --ca local
2022/04/27 02:21:33.454 WARN    installing root certificate (you might be prompted for password)        {"path": "localhost:2021/pki/ca/local"}
2022/04/26 22:21:33 Note: NSS support is not available on your platform
2022/04/26 22:21:33 define JAVA_HOME environment variable to use the Java trust
2022/04/26 22:21:34 certificate installed properly in windows trusts
```

After:

```
$ caddy trust --address localhost:2021 --ca local
2022/04/27 02:39:49.365 WARN    installing root certificate (you might be prompted for password)        {"path": "localhost:2021/pki/ca/local"}
2022/04/27 02:39:49.367 INFO    Note: NSS support is not available on your platform
2022/04/27 02:39:49.367 INFO    define JAVA_HOME environment variable to use the Java trust
2022/04/27 02:39:50.939 INFO    certificate installed properly in windows trusts
```