### PR TITLE
Add missing backticks

### DIFF
--- a/modules/caddyhttp/templates/templates.go
+++ b/modules/caddyhttp/templates/templates.go
@@ -100,6 +100,7 @@ func init() {
 // {{ define "main" }}
 // content
 // {{ end }}
+// ```
 //
 // **index.html**
 // ```


### PR DESCRIPTION
As stated in #4736, the documentation is missing backticks that causes it to render incorrectly.