### PR TITLE
reverseproxy: Support performing pre-check requests

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -596,8 +596,8 @@ func parseRedir(h Helper) (caddyhttp.MiddlewareHandler, error) {
 		// Location header and do a window.location redirect manually.
 		// see https://stackoverflow.com/a/2573589/846934
 		// see https://github.com/oauth2-proxy/oauth2-proxy/issues/1522
-		if codeInt < 300 || codeInt > 499 {
-			return nil, h.Errf("Redir code not in the 3xx or 4xx range: '%v'", codeInt)
+		if codeInt < 300 || (codeInt > 399 && codeInt != 401) {
+			return nil, h.Errf("Redir code not in the 3xx range or 401: '%v'", codeInt)
 		}
 	}
 

--- a/caddyconfig/httpcaddyfile/builtins_test.go
+++ b/caddyconfig/httpcaddyfile/builtins_test.go
@@ -149,6 +149,21 @@ func TestRedirDirectiveSyntax(t *testing.T) {
 			expectError: false,
 		},
 		{
+			// this is now allowed so a Location header
+			// can be written and consumed by JS
+			// in the case of XHR requests
+			input: `:8080 {
+				redir * :8081 401
+			}`,
+			expectError: false,
+		},
+		{
+			input: `:8080 {
+				redir * :8081 {http.reverse_proxy.status_code}
+			}`,
+			expectError: false,
+		},
+		{
 			input: `:8080 {
 				redir /old.html /new.html htlm
 			}`,
@@ -157,12 +172,6 @@ func TestRedirDirectiveSyntax(t *testing.T) {
 		{
 			input: `:8080 {
 				redir * :8081 200
-			}`,
-			expectError: true,
-		},
-		{
-			input: `:8080 {
-				redir * :8081 400
 			}`,
 			expectError: true,
 		},

--- a/caddyconfig/httpcaddyfile/builtins_test.go
+++ b/caddyconfig/httpcaddyfile/builtins_test.go
@@ -159,6 +159,12 @@ func TestRedirDirectiveSyntax(t *testing.T) {
 		},
 		{
 			input: `:8080 {
+				redir * :8081 402
+			}`,
+			expectError: true,
+		},
+		{
+			input: `:8080 {
 				redir * :8081 {http.reverse_proxy.status_code}
 			}`,
 			expectError: false,

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -57,6 +57,7 @@ var directiveOrder = []string{
 
 	// middleware handlers; some wrap responses
 	"basicauth",
+	"forward_auth",
 	"request_header",
 	"encode",
 	"push",

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -130,6 +130,7 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 		{regexp.MustCompile(`{path\.([\w-]*)}`), "{http.request.uri.path.$1}"},
 		{regexp.MustCompile(`{re\.([\w-]*)\.([\w-]*)}`), "{http.regexp.$1.$2}"},
 		{regexp.MustCompile(`{vars\.([\w-]*)}`), "{http.vars.$1}"},
+		{regexp.MustCompile(`{rp\.([\w-\.]*)}`), "{http.reverse_proxy.$1}"},
 	}
 
 	for _, sb := range originalServerBlocks {

--- a/caddytest/integration/caddyfile_adapt/forward_auth_authelia.txt
+++ b/caddytest/integration/caddyfile_adapt/forward_auth_authelia.txt
@@ -1,0 +1,137 @@
+app.example.com {
+	forward_auth authelia:9091 {
+		uri /api/verify?rd=https://authelia.example.com
+		copy_headers Remote-User Remote-Groups Remote-Name Remote-Email
+	}
+
+	reverse_proxy backend:8080
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"app.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"handle_response": [
+														{
+															"match": {
+																"status_code": [
+																	2
+																]
+															},
+															"routes": [
+																{
+																	"handle": [
+																		{
+																			"handler": "headers",
+																			"request": {
+																				"set": {
+																					"Remote-Email": [
+																						"{http.reverse_proxy.header.Remote-Email}"
+																					],
+																					"Remote-Groups": [
+																						"{http.reverse_proxy.header.Remote-Groups}"
+																					],
+																					"Remote-Name": [
+																						"{http.reverse_proxy.header.Remote-Name}"
+																					],
+																					"Remote-User": [
+																						"{http.reverse_proxy.header.Remote-User}"
+																					]
+																				}
+																			}
+																		}
+																	]
+																}
+															]
+														},
+														{
+															"routes": [
+																{
+																	"handle": [
+																		{
+																			"exclude": [
+																				"Connection",
+																				"Keep-Alive",
+																				"Te",
+																				"Trailers",
+																				"Transfer-Encoding",
+																				"Upgrade"
+																			],
+																			"handler": "copy_response_headers"
+																		}
+																	]
+																},
+																{
+																	"handle": [
+																		{
+																			"handler": "copy_response"
+																		}
+																	]
+																}
+															]
+														}
+													],
+													"handler": "reverse_proxy",
+													"headers": {
+														"request": {
+															"set": {
+																"X-Forwarded-Method": [
+																	"{http.request.method}"
+																],
+																"X-Forwarded-Uri": [
+																	"{http.request.uri}"
+																]
+															}
+														}
+													},
+													"rewrite": {
+														"method": "GET",
+														"uri": "/api/verify?rd=https://authelia.example.com"
+													},
+													"upstreams": [
+														{
+															"dial": "authelia:9091"
+														}
+													]
+												},
+												{
+													"handler": "reverse_proxy",
+													"upstreams": [
+														{
+															"dial": "backend:8080"
+														}
+													]
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_options.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_options.txt
@@ -1,14 +1,11 @@
 
 https://example.com {
-	reverse_proxy /path http://localhost:54321 {
-		header_up Host {host}
-		header_up X-Real-IP {remote}
-		header_up X-Forwarded-For {remote}
-		header_up X-Forwarded-Port {server_port}
-		header_up X-Forwarded-Proto "http"
+	reverse_proxy /path https://localhost:54321 {
+		header_up Host {upstream_hostport}
+		header_up Foo bar
 
-		no_body
-		override_method GET
+		method GET
+		rewrite /rewritten?uri={uri}
 
 		buffer_requests
 
@@ -61,26 +58,19 @@ https://example.com {
 													"headers": {
 														"request": {
 															"set": {
+																"Foo": [
+																	"bar"
+																],
 																"Host": [
-																	"{http.request.host}"
-																],
-																"X-Forwarded-For": [
-																	"{http.request.remote}"
-																],
-																"X-Forwarded-Port": [
-																	"{server_port}"
-																],
-																"X-Forwarded-Proto": [
-																	"http"
-																],
-																"X-Real-Ip": [
-																	"{http.request.remote}"
+																	"{http.reverse_proxy.upstream.hostport}"
 																]
 															}
 														}
 													},
-													"no_body": true,
-													"override_method": "GET",
+													"rewrite": {
+														"method": "GET",
+														"uri": "/rewritten?uri={http.request.uri}"
+													},
 													"transport": {
 														"compression": false,
 														"dial_fallback_delay": 5000000000,
@@ -101,6 +91,7 @@ https://example.com {
 															]
 														},
 														"response_header_timeout": 8000000000,
+														"tls": {},
 														"versions": [
 															"h2c",
 															"2"

--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_options.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_options.txt
@@ -7,6 +7,9 @@ https://example.com {
 		header_up X-Forwarded-Port {server_port}
 		header_up X-Forwarded-Proto "http"
 
+		no_body
+		override_method GET
+
 		buffer_requests
 
 		transport http {
@@ -76,6 +79,8 @@ https://example.com {
 															}
 														}
 													},
+													"no_body": true,
+													"override_method": "GET",
 													"transport": {
 														"compression": false,
 														"dial_fallback_delay": 5000000000,

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -85,10 +85,12 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 //         buffer_responses
 //         max_buffer_size <size>
 //
-//         # header manipulation
+//         # request manipulation
 //         trusted_proxies [private_ranges] <ranges...>
 //         header_up   [+|-]<field> [<value|regexp> [<replacement>]]
 //         header_down [+|-]<field> [<value|regexp> [<replacement>]]
+//         override_method <method>
+//         no_body
 //
 //         # round trip
 //         transport <name> {
@@ -599,6 +601,18 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if err != nil {
 					return d.Err(err.Error())
 				}
+
+			case "override_method":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				h.OverrideMethod = d.Val()
+
+			case "no_body":
+				if d.NextArg() {
+					return d.ArgErr()
+				}
+				h.NoBody = true
 
 			case "transport":
 				if !d.NextArg() {

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -27,6 +27,7 @@ import (
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/headers"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp/rewrite"
 	"github.com/dustin/go-humanize"
 )
 
@@ -89,8 +90,8 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 //         trusted_proxies [private_ranges] <ranges...>
 //         header_up   [+|-]<field> [<value|regexp> [<replacement>]]
 //         header_down [+|-]<field> [<value|regexp> [<replacement>]]
-//         override_method <method>
-//         no_body
+//         method <method>
+//         rewrite <to>
 //
 //         # round trip
 //         transport <name> {
@@ -602,17 +603,29 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.Err(err.Error())
 				}
 
-			case "override_method":
+			case "method":
 				if !d.NextArg() {
 					return d.ArgErr()
 				}
-				h.OverrideMethod = d.Val()
-
-			case "no_body":
+				if h.Rewrite == nil {
+					h.Rewrite = &rewrite.Rewrite{}
+				}
+				h.Rewrite.Method = d.Val()
 				if d.NextArg() {
 					return d.ArgErr()
 				}
-				h.NoBody = true
+
+			case "rewrite":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				if h.Rewrite == nil {
+					h.Rewrite = &rewrite.Rewrite{}
+				}
+				h.Rewrite.URI = d.Val()
+				if d.NextArg() {
+					return d.ArgErr()
+				}
 
 			case "transport":
 				if !d.NextArg() {

--- a/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
@@ -196,7 +196,15 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 	// NOTE: we delete the tokens as we go so that the reverse_proxy
 	// unmarshal doesn't see these subdirectives which it cannot handle
 	for dispenser.Next() {
-		for dispenser.NextBlock(0) && dispenser.Nesting() == 1 {
+		for dispenser.NextBlock(0) {
+			// ignore any sub-subdirectives that might
+			// have the same name somewhere within
+			// the reverse_proxy passthrough tokens
+			if dispenser.Nesting() != 1 {
+				continue
+			}
+
+			// parse the php_fastcgi subdirectives
 			switch dispenser.Val() {
 			case "root":
 				if !dispenser.NextArg() {

--- a/modules/caddyhttp/reverseproxy/forwardauth/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/forwardauth/caddyfile.go
@@ -121,7 +121,15 @@ func parseCaddyfile(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error)
 	// NOTE: we delete the tokens as we go so that the reverse_proxy
 	// unmarshal doesn't see these subdirectives which it cannot handle
 	for dispenser.Next() {
-		for dispenser.NextBlock(0) && dispenser.Nesting() == 1 {
+		for dispenser.NextBlock(0) {
+			// ignore any sub-subdirectives that might
+			// have the same name somewhere within
+			// the reverse_proxy passthrough tokens
+			if dispenser.Nesting() != 1 {
+				continue
+			}
+
+			// parse the forward_auth subdirectives
 			switch dispenser.Val() {
 			case "uri":
 				if !dispenser.NextArg() {

--- a/modules/caddyhttp/reverseproxy/forwardauth/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/forwardauth/caddyfile.go
@@ -1,0 +1,261 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forwardauth
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig"
+	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp/headers"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp/rewrite"
+)
+
+func init() {
+	httpcaddyfile.RegisterDirective("forward_auth", parseCaddyfile)
+}
+
+// parseCaddyfile parses the forward_auth directive, which has the same syntax
+// as the reverse_proxy directive (in fact, the reverse_proxy's directive
+// Unmarshaler is invoked by this function) but the resulting proxy is specially
+// configured for most™️ auth gateways that support forward auth. The typical
+// config which looks something like this:
+//
+//     forward_auth auth-gateway:9091 {
+//         uri /authenticate?redirect=https://auth.example.com
+//         copy_headers Remote-User Remote-Email
+//     }
+//
+// is equivalent to a reverse_proxy directive like this:
+//
+//     reverse_proxy auth-gateway:9091 {
+//         method GET
+//         rewrite /authenticate?redirect=https://auth.example.com
+//
+//         header_up X-Forwarded-Method {method}
+//         header_up X-Forwarded-Uri {uri}
+//
+//         @good status 2xx
+//         handle_response @good {
+//             request_header {
+//                 Remote-User {http.reverse_proxy.header.Remote-User}
+//                 Remote-Email {http.reverse_proxy.header.Remote-Email}
+//             }
+//         }
+//
+//         handle_response {
+//             copy_response_headers {
+//                 exclude Connection Keep-Alive Te Trailers Transfer-Encoding Upgrade
+//             }
+//             copy_response
+//         }
+//     }
+//
+func parseCaddyfile(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error) {
+	if !h.Next() {
+		return nil, h.ArgErr()
+	}
+
+	// if the user specified a matcher token, use that
+	// matcher in a route that wraps both of our routes;
+	// either way, strip the matcher token and pass
+	// the remaining tokens to the unmarshaler so that
+	// we can gain the rest of the reverse_proxy syntax
+	userMatcherSet, err := h.ExtractMatcherSet()
+	if err != nil {
+		return nil, err
+	}
+
+	// make a new dispenser from the remaining tokens so that we
+	// can reset the dispenser back to this point for the
+	// reverse_proxy unmarshaler to read from it as well
+	dispenser := h.NewFromNextSegment()
+
+	// create the reverse proxy handler
+	rpHandler := &reverseproxy.Handler{
+		// set up defaults for header_up; reverse_proxy already deals with
+		// adding  the other three X-Forwarded-* headers, but for this flow,
+		// we want to also send along the incoming method and URI since this
+		// request will have a rewritten URI and method.
+		Headers: &headers.Handler{
+			Request: &headers.HeaderOps{
+				Set: http.Header{
+					"X-Forwarded-Method": []string{"{http.request.method}"},
+					"X-Forwarded-Uri":    []string{"{http.request.uri}"},
+				},
+			},
+		},
+
+		// we always rewrite the method to GET, which implicitly
+		// turns off sending the incoming request's body, which
+		// allows later middleware handlers to consume it
+		Rewrite: &rewrite.Rewrite{
+			Method: "GET",
+		},
+
+		HandleResponse: []caddyhttp.ResponseHandler{},
+	}
+
+	// collect the headers to copy from the auth response
+	// onto the original request, so they can get passed
+	// through to a backend app
+	headersToCopy := []string{}
+
+	// read the subdirectives for configuring the forward_auth shortcut
+	// NOTE: we delete the tokens as we go so that the reverse_proxy
+	// unmarshal doesn't see these subdirectives which it cannot handle
+	for dispenser.Next() {
+		for dispenser.NextBlock(0) && dispenser.Nesting() == 1 {
+			switch dispenser.Val() {
+			case "uri":
+				if !dispenser.NextArg() {
+					return nil, dispenser.ArgErr()
+				}
+				rpHandler.Rewrite.URI = dispenser.Val()
+				dispenser.Delete()
+				dispenser.Delete()
+
+			case "copy_headers":
+				args := dispenser.RemainingArgs()
+				dispenser.Delete()
+				for _, headerField := range args {
+					dispenser.Delete()
+					headersToCopy = append(headersToCopy, headerField)
+				}
+				if len(headersToCopy) == 0 {
+					return nil, dispenser.ArgErr()
+				}
+			}
+		}
+	}
+
+	// reset the dispenser after we're done so that the reverse_proxy
+	// unmarshaler can read it from the start
+	dispenser.Reset()
+
+	// the auth target URI must not be empty
+	if rpHandler.Rewrite.URI == "" {
+		return nil, dispenser.Errf("the 'uri' subdirective is required")
+	}
+
+	// set up handler for good responses; when a response
+	// has 2xx status, then we will copy some headers from
+	// the response onto the original request, and allow
+	// handling to continue down the middleware chain,
+	// by _not_ executing a terminal handler.
+	goodResponseHandler := caddyhttp.ResponseHandler{
+		Match: &caddyhttp.ResponseMatcher{
+			StatusCode: []int{2},
+		},
+		Routes: []caddyhttp.Route{},
+	}
+	if len(headersToCopy) > 0 {
+		handler := &headers.Handler{
+			Request: &headers.HeaderOps{
+				Set: http.Header{},
+			},
+		}
+
+		for _, headerField := range headersToCopy {
+			handler.Request.Set[headerField] = []string{
+				"{http.reverse_proxy.header." + headerField + "}",
+			}
+		}
+
+		goodResponseHandler.Routes = append(
+			goodResponseHandler.Routes,
+			caddyhttp.Route{
+				HandlersRaw: []json.RawMessage{caddyconfig.JSONModuleObject(
+					handler,
+					"handler",
+					"headers",
+					nil,
+				)},
+			},
+		)
+	}
+	rpHandler.HandleResponse = append(rpHandler.HandleResponse, goodResponseHandler)
+
+	// set up handler for denial responses; when a response
+	// has any other status than 2xx, then we copy the response
+	// back to the client, and terminate handling.
+	denialResponseHandler := caddyhttp.ResponseHandler{
+		Routes: []caddyhttp.Route{
+			{
+				HandlersRaw: []json.RawMessage{caddyconfig.JSONModuleObject(
+					&reverseproxy.CopyResponseHeadersHandler{
+						Exclude: []string{
+							"Connection",
+							"Keep-Alive",
+							"Te",
+							"Trailers",
+							"Transfer-Encoding",
+							"Upgrade",
+						},
+					},
+					"handler",
+					"copy_response_headers",
+					nil,
+				)},
+			},
+			{
+				HandlersRaw: []json.RawMessage{caddyconfig.JSONModuleObject(
+					&reverseproxy.CopyResponseHandler{},
+					"handler",
+					"copy_response",
+					nil,
+				)},
+			},
+		},
+	}
+	rpHandler.HandleResponse = append(rpHandler.HandleResponse, denialResponseHandler)
+
+	// the rest of the config is specified by the user
+	// using the reverse_proxy directive syntax
+	err = rpHandler.UnmarshalCaddyfile(dispenser)
+	if err != nil {
+		return nil, err
+	}
+	err = rpHandler.FinalizeUnmarshalCaddyfile(h)
+	if err != nil {
+		return nil, err
+	}
+
+	// create the final reverse proxy route
+	rpRoute := caddyhttp.Route{
+		HandlersRaw: []json.RawMessage{caddyconfig.JSONModuleObject(
+			rpHandler,
+			"handler",
+			"reverse_proxy",
+			nil,
+		)},
+	}
+
+	// apply the user's matcher if any
+	if userMatcherSet != nil {
+		rpRoute.MatcherSetsRaw = []caddy.ModuleMap{userMatcherSet}
+	}
+
+	return []httpcaddyfile.ConfigValue{
+		{
+			Class: "route",
+			Value: rpRoute,
+		},
+	}, nil
+}

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -704,10 +704,7 @@ func (h Handler) addForwardedHeaders(req *http.Request) error {
 	// we pass through the request Host as-is, but in situations
 	// where we proxy over HTTPS, the user may need to override
 	// Host themselves, so it's helpful to send the original too.
-	host, _, err := net.SplitHostPort(req.Host)
-	if err != nil {
-		host = req.Host // OK; there probably was no port
-	}
+	host := req.Host
 	prior, ok, omit = lastHeaderValue(req.Header, "X-Forwarded-Host")
 	if trusted && ok && prior != "" {
 		host = prior

--- a/modules/caddyhttp/rewrite/rewrite.go
+++ b/modules/caddyhttp/rewrite/rewrite.go
@@ -106,7 +106,7 @@ func (rewr Rewrite) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 		zap.Object("request", caddyhttp.LoggableHTTPRequest{Request: r}),
 	)
 
-	changed := rewr.rewrite(r, repl, logger)
+	changed := rewr.Rewrite(r, repl)
 
 	if changed {
 		logger.Debug("rewrote request",
@@ -121,7 +121,7 @@ func (rewr Rewrite) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 // rewrite performs the rewrites on r using repl, which should
 // have been obtained from r, but is passed in for efficiency.
 // It returns true if any changes were made to r.
-func (rewr Rewrite) rewrite(r *http.Request, repl *caddy.Replacer, logger *zap.Logger) bool {
+func (rewr Rewrite) Rewrite(r *http.Request, repl *caddy.Replacer) bool {
 	oldMethod := r.Method
 	oldURI := r.RequestURI
 

--- a/modules/caddyhttp/rewrite/rewrite_test.go
+++ b/modules/caddyhttp/rewrite/rewrite_test.go
@@ -292,7 +292,7 @@ func TestRewrite(t *testing.T) {
 			rep.re = re
 		}
 
-		changed := tc.rule.rewrite(tc.input, repl, nil)
+		changed := tc.rule.Rewrite(tc.input, repl)
 
 		if expected, actual := !reqEqual(originalInput, tc.input), changed; expected != actual {
 			t.Errorf("Test %d: Expected changed=%t but was %t", i, expected, actual)

--- a/modules/caddyhttp/standard/imports.go
+++ b/modules/caddyhttp/standard/imports.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/requestbody"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy/fastcgi"
+	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy/forwardauth"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/rewrite"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/templates"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/tracing"


### PR DESCRIPTION
So, this is _super cool_. We were just missing two small pieces plus a bug fix to make this pattern possible.

Recently, we found out that there's demand for integrating Caddy with Authelia https://github.com/authelia/authelia/issues/1241, so that Authelia can be used for acting as an auth gateway for apps served by Caddy. The way it's typically done with other proxies is with a built-in feature called [ForwardAuth in Traefik](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) and [auth_request in Nginx](https://nginx.org/en/docs/http/ngx_http_auth_request_module.html). TL;DR, an HTTP request is made to Authelia, and Authelia either responds with a `200` if the request authorized :+1: or with a `401` or redirect if auth is required :-1:

So that got me thinking, `reverse_proxy` can make requests (obviously) and we've recently implemented a quite flexible `handle_response` feature that makes is quite simple to interact with the proxy response and even ignore the response body if we need. So what if we just use `reverse_proxy` to perform ForwardAuth-like functionality? That means we don't need a plugin, and it would work basically out-of-the-box with Caddy.

The key bits that were missing though, is that we need a way to tell the proxy "don't use the request body" and "always make GET requests" so that the request body isn't consumed so it can be actually used by a later HTTP handler. That's pretty easy, so I added `no_body` and `override_method` subdirectives to do this. We'd also need a way let `reverse_proxy` not be a terminal HTTP handler... but... turns out, `handle_response` was already implemented to work that way!

Then I started testing it a bit. Turns out that `handle_response` had a small bug, it would pass the _cloned_ request to subsequent routes; that's bad, because then `header_up` manipulations would become permanent and apply to subsequent routes, and if we used `no_body`, we wouldn't have access to the body, etc. So I rewired things so that the _original_ request is passed through subsequent routes. Fixed!

So here's how I tested this:

Edit: Note that this is no longer how the config looks, read further comments below for the changes

```nginx
{
	debug
}

:8881 {
	log
	route {
		# pre-check request
		reverse_proxy :8882 {
			# setup, don't want to consume the body
			override_method GET
			no_body
			
			# just to prove that the later handlers
			# _don't_ see this header (see :8883)
			header_up Bar bar-header

			# handle the response, set a header on
			# the original request so subsequent
			# handlers can pass it through
			handle_response {
				request_header Foo foo-header
			}
		}

		# the "actual" handling, e.g. your app
		reverse_proxy :8883
	}
}

# pre-check, just responding with a 200 response
:8882 {
	log
	respond "We're good to go!"
}

# your app
:8883 {
	log
	respond "{header.Foo} {header.Bar}
{http.request.body}"
}
```

And then making a request like this; a `POST` to prove that `:8882` indeed sees a `GET`, and `:8883` sees the original `POST`, and the body:

```bash
$ curl -v http://localhost:8881 -H "Content-Type: application/json" -d '{"productId": 123456, "quantity": 100}'
*   Trying 127.0.0.1:8881...
* Connected to localhost (127.0.0.1) port 8881 (#0)
> POST / HTTP/1.1
> Host: localhost:8881
> User-Agent: curl/7.74.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 38
> 
* upload completely sent off: 38 out of 38 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Length: 51
< Date: Thu, 28 Apr 2022 03:37:48 GMT
< Server: Caddy
< Server: Caddy
< Content-Type: text/plain; charset=utf-8
< 
foo-header 
{"productId": 123456, "quantity": 100}
* Connection #0 to host localhost left intact
```

And the logs from this:

```
2022/04/28 04:22:21.924	DEBUG	http.handlers.reverse_proxy	selected upstream	{"dial": ":8882", "total_upstreams": 1}
2022/04/28 04:22:21.925	INFO	http.log.access	handled request	{"request": {"remote_ip": "127.0.0.1", "remote_port": "39378", "proto": "HTTP/1.1", "method": "GET", "host": "localhost:8881", "uri": "/", "headers": {"Accept": ["*/*"], "Bar": ["bar-header"], "X-Forwarded-For": ["127.0.0.1"], "X-Forwarded-Proto": ["http"], "User-Agent": ["curl/7.74.0"], "Content-Type": ["application/json"], "X-Forwarded-Host": ["localhost"], "Accept-Encoding": ["gzip"]}}, "user_id": "", "duration": 0.000050308, "size": 17, "status": 200, "resp_headers": {"Server": ["Caddy"], "Content-Type": []}}
2022/04/28 04:22:21.925	DEBUG	http.handlers.reverse_proxy	upstream roundtrip	{"upstream": ":8882", "duration": 0.000680542, "request": {"remote_ip": "127.0.0.1", "remote_port": "41778", "proto": "HTTP/1.1", "method": "GET", "host": "localhost:8881", "uri": "/", "headers": {"Content-Length": ["38"], "Content-Type": ["application/json"], "X-Forwarded-For": ["127.0.0.1"], "X-Forwarded-Proto": ["http"], "X-Forwarded-Host": ["localhost"], "User-Agent": ["curl/7.74.0"], "Accept": ["*/*"], "Bar": ["bar-header"]}}, "headers": {"Server": ["Caddy"], "Date": ["Thu, 28 Apr 2022 04:22:21 GMT"], "Content-Length": ["17"]}, "status": 200}
2022/04/28 04:22:21.925	DEBUG	http.handlers.reverse_proxy	handling response	{"handler": 0}
2022/04/28 04:22:21.925	DEBUG	http.handlers.reverse_proxy	selected upstream	{"dial": ":8883", "total_upstreams": 1}
2022/04/28 04:22:21.925	INFO	http.log.access	handled request	{"request": {"remote_ip": "127.0.0.1", "remote_port": "35452", "proto": "HTTP/1.1", "method": "POST", "host": "localhost:8881", "uri": "/", "headers": {"Content-Type": ["application/json"], "Foo": ["foo-header"], "X-Forwarded-For": ["127.0.0.1"], "Accept-Encoding": ["gzip"], "User-Agent": ["curl/7.74.0"], "Content-Length": ["38"], "Accept": ["*/*"], "X-Forwarded-Host": ["localhost"], "X-Forwarded-Proto": ["http"]}}, "user_id": "", "duration": 0.00009696, "size": 50, "status": 200, "resp_headers": {"Server": ["Caddy"], "Content-Type": []}}
2022/04/28 04:22:21.925	DEBUG	http.handlers.reverse_proxy	upstream roundtrip	{"upstream": ":8883", "duration": 0.000544203, "request": {"remote_ip": "127.0.0.1", "remote_port": "41778", "proto": "HTTP/1.1", "method": "POST", "host": "localhost:8881", "uri": "/", "headers": {"X-Forwarded-Host": ["localhost"], "User-Agent": ["curl/7.74.0"], "Accept": ["*/*"], "Content-Type": ["application/json"], "Content-Length": ["38"], "Foo": ["foo-header"], "X-Forwarded-For": ["127.0.0.1"], "X-Forwarded-Proto": ["http"]}}, "headers": {"Server": ["Caddy"], "Date": ["Thu, 28 Apr 2022 04:22:21 GMT"], "Content-Length": ["50"]}, "status": 200}
2022/04/28 04:22:21.926	INFO	http.log.access	handled request	{"request": {"remote_ip": "127.0.0.1", "remote_port": "41778", "proto": "HTTP/1.1", "method": "POST", "host": "localhost:8881", "uri": "/", "headers": {"Content-Type": ["application/json"], "Content-Length": ["38"], "User-Agent": ["curl/7.74.0"], "Accept": ["*/*"]}}, "user_id": "", "duration": 0.001739929, "size": 50, "status": 200, "resp_headers": {"Server": ["Caddy", "Caddy", "Caddy"], "Date": ["Thu, 28 Apr 2022 04:22:21 GMT", "Thu, 28 Apr 2022 04:22:21 GMT"], "Content-Length": ["50"]}}
```

So, the logs in order:
- Selected `:8882` as the upstream for the pre-check
- The `:8882` server `log`s the request, notice it's a `GET` here and there's no `Content-Length` header
- The `:8882` proxy logs its roundtrip
- The `handle_response` is selected and runs, then continues the handling chain
- Selected `:8883` as the upstream for the "actual" handling of the request
- The `:8883` server `log`s the request, notice it's a `POST` here and `Content-Length` is `38` (my dumb little JSON payload)
- The `:8883` proxy logs its roundtrip
- The `:8881` server finally `log`s the request and the `50` byte response (the `Foo` header value and echoed request body)

I just noticed as I write this though that the last log line has `Server: Caddy` _three_ times :thinking: there might be a bug with the response writer, I'll need to look into this more closely to see what's going on, but interestingly the response in `curl` only has _two_ (which is correct, i.e. `:8881` and `:8883` ultimately should be the only ones manipulating the response).

So with all this out of the way, this means that ForwardAuth can be done purely with `reverse_proxy`. But obviously this is _pretty_ verbose and has a lot of boilerplate, so we'll probably provide a `forward_auth` Caddyfile directive, similarly to `php_fastcgi` which is a shortcut/sugar over `reverse_proxy` to make it nicer to use, with good defaults.