### PR TITLE
caddyhttp: Improve listen addr error message for IPv6

### DIFF
--- a/modules/caddyhttp/autohttps.go
+++ b/modules/caddyhttp/autohttps.go
@@ -222,11 +222,15 @@ func (app *App) automaticHTTPSPhase1(ctx caddy.Context, repl *caddy.Replacer) er
 		app.logger.Info("enabling automatic HTTP->HTTPS redirects", zap.String("server_name", srvName))
 
 		// create HTTP->HTTPS redirects
-		for _, addr := range srv.Listen {
+		for _, listenAddr := range srv.Listen {
 			// figure out the address we will redirect to...
-			addr, err := caddy.ParseNetworkAddress(addr)
+			addr, err := caddy.ParseNetworkAddress(listenAddr)
 			if err != nil {
-				return fmt.Errorf("%s: invalid listener address: %v", srvName, addr)
+				msg := "%s: invalid listener address: %v"
+				if strings.Count(listenAddr, ":") > 1 {
+					msg = msg + ", there are too many colons, so the port is ambiguous. Did you mean to wrap the IPv6 address with [] brackets?"
+				}
+				return fmt.Errorf(msg, srvName, listenAddr)
 			}
 
 			// this address might not have a hostname, i.e. might be a


### PR DESCRIPTION
Fixes an unclear message as per https://github.com/caddyserver/caddy/issues/4738

Old message:

```
validate: loading http app module: provision http: srv0: invalid listener address: :0
```

New message:

```
validate: loading http app module: provision http: srv0: invalid listener address: ::1:443, there are too many colons, so the port is ambiguous. Did you mean to wrap the IPv6 address with [] brackets?
```

Part of the issue is we were reusing the same variable before/after parsing, so `addr` would get clobbered with the empty `NetworkAddress` value, rendering it as `:0`. Not useful. I split up the variable name to fix that, and added a condition for when there's too many colons (kinda naive cause it doesn't look at whether `[]` was already there but whatever) to suggest a fix.