### PR TITLE
core: Add optional unix socket file permissions

### DIFF
--- a/listeners.go
+++ b/listeners.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"net/netip"
 	"os"
@@ -148,11 +149,27 @@ func (na NetworkAddress) Listen(ctx context.Context, portOffset uint, config net
 func (na NetworkAddress) listen(ctx context.Context, portOffset uint, config net.ListenConfig) (any, error) {
 	var ln any
 	var err error
+	var address string
+	var unixFileMode fs.FileMode
 
-	address := na.JoinHostPort(portOffset)
+	// split unix socket addr early so lnKey
+	// is independent of permissions bits
+	if na.IsUnixNetwork() {
+		var err error
+		address, unixFileMode, err = splitUnixSocketPermissionsBits(na.Host)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		address = na.JoinHostPort(portOffset)
+	}
 
-	// if this is a unix socket, see if we already have it open
+	// if this is a unix socket, see if we already have it open,
+	// force socket permissions on it and return early
 	if socket, err := reuseUnixSocket(na.Network, address); socket != nil || err != nil {
+		if err := os.Chmod(address, unixFileMode); err != nil {
+			return nil, fmt.Errorf("unable to set permissions (%s) on %s: %v", unixFileMode, address, err)
+		}
 		return socket, err
 	}
 
@@ -191,6 +208,12 @@ func (na NetworkAddress) listen(ctx context.Context, portOffset uint, config net
 		one := int32(1)
 		ln = &unixConn{unix, address, lnKey, &one}
 		unixSockets[lnKey] = unix
+	}
+
+	if IsUnixNetwork(na.Network) {
+		if err := os.Chmod(address, unixFileMode); err != nil {
+			return nil, fmt.Errorf("unable to set permissions (%s) on %s: %v", unixFileMode, address, err)
+		}
 	}
 
 	return ln, nil
@@ -288,6 +311,33 @@ func IsUnixNetwork(netw string) bool {
 	return strings.HasPrefix(netw, "unix")
 }
 
+// Takes a unix socket address in the unusual "path|bits" format
+// (e.g. /run/caddy.sock|0222) and tries to split it into
+// socket path (host) and permissions bits (port). Colons (":")
+// can't be used as separator, as socket paths on Windows may
+// include a drive letter (e.g. `unix/c:\absolute\path.sock`).
+// Permission bits will default to 0200 if none are specified.
+// Symbolic permission representation (e.g. `u=w,g=w,o=w`)
+// is not supported and will throw an error for now!
+func splitUnixSocketPermissionsBits(addr string) (path string, fileMode fs.FileMode, err error) {
+	addrSplit := strings.SplitN(addr, "|", 2)
+
+	if len(addrSplit) == 2 {
+		// parse octal permission bit string as uint32
+		fileModeUInt64, err := strconv.ParseUint(addrSplit[1], 8, 32)
+		if err != nil {
+			return "", 0, fmt.Errorf("could not parse octal permission bits in %s: %v", addr, err)
+		}
+		fileMode = fs.FileMode(fileModeUInt64)
+
+		return addrSplit[0], fileMode, nil
+	}
+
+	// default to 0200 (symbolic: `u=w,g=,o=`)
+	// if no permission bits are specified
+	return addr, 0200, nil
+}
+
 // ParseNetworkAddress parses addr into its individual
 // components. The input string is expected to be of
 // the form "network/host:port-range" where any part is
@@ -312,10 +362,11 @@ func ParseNetworkAddressWithDefaults(addr, defaultNetwork string, defaultPort ui
 		network = defaultNetwork
 	}
 	if IsUnixNetwork(network) {
+		_, _, err := splitUnixSocketPermissionsBits(host)
 		return NetworkAddress{
 			Network: network,
 			Host:    host,
-		}, nil
+		}, err
 	}
 	var start, end uint64
 	if port == "" {

--- a/listeners_test.go
+++ b/listeners_test.go
@@ -628,6 +628,11 @@ func TestSplitUnixSocketPermissionsBits(t *testing.T) {
 			input:     "./foo.socket|123456|0660",
 			expectErr: true,
 		},
+		{
+			// owner is missing write perms
+			input:     "./foo.socket|0522",
+			expectErr: true,
+		},
 	} {
 		actualPath, actualFileMode, err := splitUnixSocketPermissionsBits(tc.input)
 		if tc.expectErr && err == nil {

--- a/listeners_test.go
+++ b/listeners_test.go
@@ -555,3 +555,83 @@ func TestExpand(t *testing.T) {
 		}
 	}
 }
+
+func TestSplitUnixSocketPermissionsBits(t *testing.T) {
+	for i, tc := range []struct {
+		input          string
+		expectNetwork  string
+		expectPath     string
+		expectFileMode string
+		expectErr      bool
+	}{
+		{
+			input:          "./foo.socket",
+			expectPath:     "./foo.socket",
+			expectFileMode: "--w-------",
+		},
+		{
+			// literal colon in resulting address
+			// and defaulting to 0200 bits
+			input:          "./foo.socket:0666",
+			expectPath:     "./foo.socket:0666",
+			expectFileMode: "--w-------",
+		},
+		{
+			input:          "./foo.socket|0220",
+			expectPath:     "./foo.socket",
+			expectFileMode: "--w--w----",
+		},
+		{
+			input:          "/var/run/foo|222",
+			expectPath:     "/var/run/foo",
+			expectFileMode: "--w--w--w-",
+		},
+		{
+			input:          "./foo.socket|0660",
+			expectPath:     "./foo.socket",
+			expectFileMode: "-rw-rw----",
+		},
+		{
+			input:          "./foo.socket|0666",
+			expectPath:     "./foo.socket",
+			expectFileMode: "-rw-rw-rw-",
+		},
+		{
+			input:          "/var/run/foo|666",
+			expectPath:     "/var/run/foo",
+			expectFileMode: "-rw-rw-rw-",
+		},
+		{
+			// symbolic permission representation is not supported for now
+			input:     "./foo.socket|u=rw,g=rw,o=rw",
+			expectErr: true,
+		},
+		{
+			// octal (base-8) permission representation has to be between
+			// `0` for no read, no write, no exec (`---`) and
+			// `7` for read (4), write (2), exec (1) (`rwx` => `4+2+1 = 7`)
+			input:     "./foo.socket|888",
+			expectErr: true,
+		},
+		{
+			// too many colons in address
+			input:     "./foo.socket|123456|0660",
+			expectErr: true,
+		},
+	} {
+		actualPath, actualFileMode, err := splitUnixSocketPermissionsBits(tc.input)
+		if tc.expectErr && err == nil {
+			t.Errorf("Test %d: Expected error but got: %v", i, err)
+		}
+		if !tc.expectErr && err != nil {
+			t.Errorf("Test %d: Expected no error but got: %v", i, err)
+		}
+		if actualPath != tc.expectPath {
+			t.Errorf("Test %d: Expected path '%s' but got '%s'", i, tc.expectPath, actualPath)
+		}
+		// fileMode.Perm().String() parses 0 to "----------"
+		if !tc.expectErr && actualFileMode.Perm().String() != tc.expectFileMode {
+			t.Errorf("Test %d: Expected perms '%s' but got '%s'", i, tc.expectFileMode, actualFileMode.Perm().String())
+		}
+	}
+}

--- a/listeners_test.go
+++ b/listeners_test.go
@@ -570,6 +570,11 @@ func TestSplitUnixSocketPermissionsBits(t *testing.T) {
 			expectFileMode: "--w-------",
 		},
 		{
+			input:          `.\relative\path.socket`,
+			expectPath:     `.\relative\path.socket`,
+			expectFileMode: "--w-------",
+		},
+		{
 			// literal colon in resulting address
 			// and defaulting to 0200 bits
 			input:          "./foo.socket:0666",
@@ -600,6 +605,11 @@ func TestSplitUnixSocketPermissionsBits(t *testing.T) {
 			input:          "/var/run/foo|666",
 			expectPath:     "/var/run/foo",
 			expectFileMode: "-rw-rw-rw-",
+		},
+		{
+			input:          `c:\absolute\path.socket|220`,
+			expectPath:     `c:\absolute\path.socket`,
+			expectFileMode: "--w--w----",
 		},
 		{
 			// symbolic permission representation is not supported for now


### PR DESCRIPTION
Closes #4675

Allows one to specify the wanted socket permissions like so:
- `unix//path/to/unix.sock:0666` (unix socket at `/path/to/unix.sock` with `0666` (`ugw=rw`)
The leading `0` is optional. `unix//path/to/unix.sock:666` would yield the same permissions.
Using `:u=rw,r=rw,=o=rw` will not work. This could, however, be added fairly easily later.

This commit also changes the default unix socket file permissions to `u=rw,g=rw,o=` (`0660`).
It used to default to the shell's umask.

However, the fact that caddy used to default to the umask hasn't been documented anywhere as far as I am aware.
The only mentions I know of are my two comments in https://caddy.community/t/new-user-cant-get-darkweb-site-host-working/15491/12 and #4675.
So I would argue this isn't strictly a deprecation :thinking: 
Though changing the default to `0600` might be more on par with the umask:

Excerpt taken [from the linked issue](https://github.com/caddyserver/caddy/issues/4675#issue-1190753400):

> ```bash
> ❯ umask -S # symbolic
> u=rwx,g=rx,o=rx
> ```
> 
> **:information_source: A user only needs `rw` (read/write) access to a socket to be able to use it. `x` (execute) is not required.**

---

I've also added a unit test for the new function `splitUnixSocketPermissionsBits()`.
I am not too happy with its name, but I think it gets the point across anyway :woman_shrugging: 

An addition integration test might make sense, since the actual `os.Chmod()` only happens at runtime.