### PR TITLE
cmd: Fix unix socket addresses for admin API requests

### DIFF
--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -669,7 +669,7 @@ func AdminAPIRequest(adminAddr, method, uri string, headers http.Header, body io
 	}
 	origin := "http://" + parsedAddr.JoinHostPort(0)
 	if parsedAddr.IsUnixNetwork() {
-		origin = "unixsocket" // hack so that http.NewRequest() is happy
+		origin = "http://unixsocket" // hack so that http.NewRequest() is happy
 	}
 
 	// form the request


### PR DESCRIPTION
Fixes a regression in https://github.com/caddyserver/caddy/commit/c2327161f725c820826587381f37d651a2b9736d

Reported in https://caddy.community/t/using-ip-mask-filter-with-2-5-actually-an-init-script-issue/15786