### PR TITLE
Add protocol_min and protocol_max for reverseproxy transport http #4747

### DIFF
--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -317,6 +317,12 @@ type TLSConfig struct {
 
 	// The server name (SNI) to use in TLS handshakes.
 	ServerName string `json:"server_name,omitempty"`
+
+	// Minimum TLS protocol version to allow. Default: `tls1.2`
+	ProtocolMin string `json:"protocol_min,omitempty"`
+
+	// Maximum TLS protocol version to allow. Default: `tls1.3`
+	ProtocolMax string `json:"protocol_max,omitempty"`
 }
 
 // MakeTLSClientConfig returns a tls.Config usable by a client to a backend.
@@ -384,6 +390,17 @@ func (t TLSConfig) MakeTLSClientConfig(ctx caddy.Context) (*tls.Config, error) {
 
 		}
 		cfg.RootCAs = rootPool
+	}
+
+	// min and max protocol versions
+	if (t.ProtocolMin != "" && t.ProtocolMax != "") && t.ProtocolMin > t.ProtocolMax {
+		return nil, fmt.Errorf("protocol min (%x) cannot be greater than protocol max (%x)", t.ProtocolMin, t.ProtocolMax)
+	}
+	if t.ProtocolMin != "" {
+		cfg.MinVersion = caddytls.SupportedProtocols[t.ProtocolMin]
+	}
+	if t.ProtocolMax != "" {
+		cfg.MaxVersion = caddytls.SupportedProtocols[t.ProtocolMax]
 	}
 
 	// custom SNI

--- a/modules/caddytls/values.go
+++ b/modules/caddytls/values.go
@@ -115,6 +115,8 @@ var defaultCurves = []tls.CurveID{
 
 // SupportedProtocols is a map of supported protocols.
 var SupportedProtocols = map[string]uint16{
+	"tls1.0": tls.VersionTLS10,
+	"tls1.1": tls.VersionTLS11,
 	"tls1.2": tls.VersionTLS12,
 	"tls1.3": tls.VersionTLS13,
 }
@@ -124,8 +126,6 @@ var SupportedProtocols = map[string]uint16{
 var unsupportedProtocols = map[string]uint16{
 	//nolint:staticcheck
 	"ssl3.0": tls.VersionSSL30,
-	"tls1.0": tls.VersionTLS10,
-	"tls1.1": tls.VersionTLS11,
 }
 
 // publicKeyAlgorithms is the map of supported public key algorithms.


### PR DESCRIPTION
This PR add the tls protocol configuration option for the reverse proxy transport protocol http.
Related to #4747