### PR TITLE
caddyfile: Shortcut for `remote_ip` for private IP ranges

### DIFF
--- a/caddytest/integration/caddyfile_adapt/matcher_syntax.txt
+++ b/caddytest/integration/caddyfile_adapt/matcher_syntax.txt
@@ -37,6 +37,9 @@
 		header Bar foo
 	}
 	respond @matcher9 "header matcher with null field matcher"
+
+	@matcher10 remote_ip private_ranges
+	respond @matcher10 "remote_ip matcher with private ranges"
 }
 ----------
 {
@@ -206,6 +209,28 @@
 							"handle": [
 								{
 									"body": "header matcher with null field matcher",
+									"handler": "static_response"
+								}
+							]
+						},
+						{
+							"match": [
+								{
+									"remote_ip": {
+										"ranges": [
+											"192.168.0.0/16",
+											"172.16.0.0/12",
+											"10.0.0.0/8",
+											"127.0.0.1/8",
+											"fd00::/8",
+											"::1"
+										]
+									}
+								}
+							],
+							"handle": [
+								{
+									"body": "remote_ip matcher with private ranges",
 									"handler": "static_response"
 								}
 							]

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -867,6 +867,17 @@ func (m *MatchRemoteIP) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				m.Forwarded = true
 				continue
 			}
+			if d.Val() == "private_ranges" {
+				m.Ranges = append(m.Ranges, []string{
+					"192.168.0.0/16",
+					"172.16.0.0/12",
+					"10.0.0.0/8",
+					"127.0.0.1/8",
+					"fd00::/8",
+					"::1",
+				}...)
+				continue
+			}
 			m.Ranges = append(m.Ranges, d.Val())
 		}
 		if d.NextBlock(0) {


### PR DESCRIPTION
When I implemented trust for proxy headers in https://github.com/caddyserver/caddy/pull/4507, I added this shortcut, since it's a really common usecase to want to list out all private IP ranges. I figured I should port this to the `remote_ip` matcher for the Caddyfile as well.  

This adds a new `private_ranges` option. I'm not doing anything fancy to remove duplicates or whatever, this is just a simple value which expands out to multiple range entries.

It's a nice win, makes config a lot shorter and less arcane to read. Compare:

```
@deny-public not remote_ip 192.168.0.0/16 172.16.0.0/12 10.0.0.0/8 127.0.0.1/8 fd00::/8 ::1
abort @deny-public
```

With the shortcut:

```
@deny-public not remote_ip private_ranges
abort @deny-public
```

Much nicer!