### PR TITLE
reverseproxy: Fix Caddyfile support for `replace_status`

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_handle_response.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_handle_response.txt
@@ -1,8 +1,13 @@
 :8884
 
 reverse_proxy 127.0.0.1:65535 {
-	@changeStatus status 500
-	replace_status @changeStatus 400
+	@500 status 500
+	replace_status @500 400
+
+	@all status 2xx 3xx 4xx 5xx
+	replace_status @all {http.error.status_code}
+
+	replace_status {http.error.status_code}
 
 	@accel header X-Accel-Redirect *
 	handle_response @accel {
@@ -77,6 +82,17 @@ reverse_proxy 127.0.0.1:65535 {
 												]
 											},
 											"status_code": 400
+										},
+										{
+											"match": {
+												"status_code": [
+													2,
+													3,
+													4,
+													5
+												]
+											},
+											"status_code": "{http.error.status_code}"
 										},
 										{
 											"match": {
@@ -227,6 +243,9 @@ reverse_proxy 127.0.0.1:65535 {
 													]
 												}
 											]
+										},
+										{
+											"status_code": "{http.error.status_code}"
 										},
 										{
 											"routes": [


### PR DESCRIPTION
As per https://caddy.community/t/small-problem-with-basicauth-and-handle-error/15708, apparently I made the Caddyfile parsing a bit too strict, which prevented legitimate uses of `replace_status`.

Notably, it wasn't allowing no matcher (I thought there was no usecase, but turns out there is 😅) and it was parsing the `int` up-front instead of allowing strings for placeholders.