### PR TITLE
templates: Add custom template function registration

### DIFF
--- a/modules/caddyhttp/templates/templates.go
+++ b/modules/caddyhttp/templates/templates.go
@@ -272,8 +272,8 @@ func (Templates) CaddyModule() caddy.ModuleInfo {
 
 // Provision provisions t.
 func (t *Templates) Provision(ctx caddy.Context) error {
-	var customFuncs []template.FuncMap
 	fnModInfos := caddy.GetModules("http.handlers.templates.functions")
+	customFuncs := make([]template.FuncMap, len(fnModInfos), 0)
 	for _, modInfo := range fnModInfos {
 		mod := modInfo.New()
 		fnMod, ok := mod.(CustomFunctions)

--- a/modules/caddyhttp/templates/templates.go
+++ b/modules/caddyhttp/templates/templates.go
@@ -254,8 +254,8 @@ type Templates struct {
 	customFuncs []template.FuncMap
 }
 
-type TemplateFunctions interface {
-	GetTemplateFunctions() template.FuncMap
+type CustomFunctions interface {
+	CustomTemplateFunctions() template.FuncMap
 }
 
 // CaddyModule returns the Caddy module information.
@@ -272,11 +272,11 @@ func (t *Templates) Provision(ctx caddy.Context) error {
 	fnModInfos := caddy.GetModules("http.handlers.templates.functions")
 	for _, modInfo := range fnModInfos {
 		mod := modInfo.New()
-		fnMod, ok := mod.(TemplateFunctions)
+		fnMod, ok := mod.(CustomFunctions)
 		if !ok {
 			return fmt.Errorf("module %q does not satisfy the TemplateFunctions interface", modInfo.ID)
 		}
-		customFuncs = append(customFuncs, fnMod.GetTemplateFunctions())
+		customFuncs = append(customFuncs, fnMod.CustomTemplateFunctions())
 	}
 	t.customFuncs = customFuncs
 

--- a/modules/caddyhttp/templates/templates.go
+++ b/modules/caddyhttp/templates/templates.go
@@ -37,6 +37,8 @@ func init() {
 //
 // ⚠️ Template functions/actions are still experimental, so they are subject to change.
 //
+// Custom template functions can be registered by creating a plugin module under the `http.handlers.templates.functions.*` namespace that implements the `CustomFunctions` interface.
+//
 // [All Sprig functions](https://masterminds.github.io/sprig/) are supported.
 //
 // In addition to the standard functions and the Sprig library, Caddy adds

--- a/modules/caddyhttp/templates/templates.go
+++ b/modules/caddyhttp/templates/templates.go
@@ -278,7 +278,7 @@ func (t *Templates) Provision(ctx caddy.Context) error {
 		mod := modInfo.New()
 		fnMod, ok := mod.(CustomFunctions)
 		if !ok {
-			return fmt.Errorf("module %q does not satisfy the TemplateFunctions interface", modInfo.ID)
+			return fmt.Errorf("module %q does not satisfy the CustomFunctions interface", modInfo.ID)
 		}
 		customFuncs = append(customFuncs, fnMod.CustomTemplateFunctions())
 	}

--- a/modules/caddyhttp/templates/templates.go
+++ b/modules/caddyhttp/templates/templates.go
@@ -256,7 +256,9 @@ type Templates struct {
 	customFuncs []template.FuncMap
 }
 
+// Customfunctions is the interface for registering custom template functions.
 type CustomFunctions interface {
+	// CustomTemplateFunctions should return the mapping from custom function names to implementations.
 	CustomTemplateFunctions() template.FuncMap
 }
 

--- a/modules/caddyhttp/templates/tplcontext.go
+++ b/modules/caddyhttp/templates/tplcontext.go
@@ -44,7 +44,7 @@ type TemplateContext struct {
 	Req         *http.Request
 	Args        []interface{} // defined by arguments to funcInclude
 	RespHeader  WrappedHeader
-	CustomFuncs []template.FuncMap
+	CustomFuncs []template.FuncMap // functions added by plugins
 
 	config *Templates
 	tpl    *template.Template

--- a/modules/caddyhttp/templates/tplcontext.go
+++ b/modules/caddyhttp/templates/tplcontext.go
@@ -40,10 +40,11 @@ import (
 
 // TemplateContext is the TemplateContext with which HTTP templates are executed.
 type TemplateContext struct {
-	Root       http.FileSystem
-	Req        *http.Request
-	Args       []interface{} // defined by arguments to funcInclude
-	RespHeader WrappedHeader
+	Root        http.FileSystem
+	Req         *http.Request
+	Args        []interface{} // defined by arguments to funcInclude
+	RespHeader  WrappedHeader
+	CustomFuncs []template.FuncMap
 
 	config *Templates
 	tpl    *template.Template
@@ -61,6 +62,11 @@ func (c *TemplateContext) NewTemplate(tplName string) *template.Template {
 
 	// add sprig library
 	c.tpl.Funcs(sprigFuncMap)
+
+	// add all custom functions
+	for _, funcMap := range c.CustomFuncs {
+		c.tpl.Funcs(funcMap)
+	}
 
 	// add our own library
 	c.tpl.Funcs(template.FuncMap{


### PR DESCRIPTION
Fixes #4568

This allows plugins to add functions to the template execution engine. Such plugin modules must be placed under `http.handlers.templates.functions.*`, e.g. `http.handlers.templates.functions.foo`. The interface `templates.CustomFunctions` must be implemented by the plugin module in order to provide those functions.