### PR TITLE
reverseproxy: Support http1.1>h2c

### DIFF
--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -247,8 +247,8 @@ func (h *HTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	h.SetScheme(req)
 
 	// if H2C ("HTTP/2 over cleartext") is enabled and the upstream request is
-	// HTTP/2 without TLS, use the alternate H2C-capable transport instead
-	if req.ProtoMajor == 2 && req.URL.Scheme == "http" && h.h2cTransport != nil {
+	// HTTP without TLS, use the alternate H2C-capable transport instead
+	if req.URL.Scheme == "http" && h.h2cTransport != nil {
 		return h.h2cTransport.RoundTrip(req)
 	}
 


### PR DESCRIPTION
Not sure if this is right, but exploring the solution for #4777. Maybe this is good, I dunno yet.

Should close #4777