### PR TITLE
forwardauth: Support renaming copied headers, block support

### DIFF
--- a/caddytest/integration/caddyfile_adapt/forward_auth_rename_headers.txt
+++ b/caddytest/integration/caddyfile_adapt/forward_auth_rename_headers.txt
@@ -1,0 +1,116 @@
+:8881
+
+forward_auth localhost:9000 {
+	uri /auth
+	copy_headers A>1 B C>3 {
+		D
+		E>5
+	}
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8881"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handle_response": [
+										{
+											"match": {
+												"status_code": [
+													2
+												]
+											},
+											"routes": [
+												{
+													"handle": [
+														{
+															"handler": "headers",
+															"request": {
+																"set": {
+																	"1": [
+																		"{http.reverse_proxy.header.A}"
+																	],
+																	"3": [
+																		"{http.reverse_proxy.header.C}"
+																	],
+																	"5": [
+																		"{http.reverse_proxy.header.E}"
+																	],
+																	"B": [
+																		"{http.reverse_proxy.header.B}"
+																	],
+																	"D": [
+																		"{http.reverse_proxy.header.D}"
+																	]
+																}
+															}
+														}
+													]
+												}
+											]
+										},
+										{
+											"routes": [
+												{
+													"handle": [
+														{
+															"exclude": [
+																"Connection",
+																"Keep-Alive",
+																"Te",
+																"Trailers",
+																"Transfer-Encoding",
+																"Upgrade"
+															],
+															"handler": "copy_response_headers"
+														}
+													]
+												},
+												{
+													"handle": [
+														{
+															"handler": "copy_response"
+														}
+													]
+												}
+											]
+										}
+									],
+									"handler": "reverse_proxy",
+									"headers": {
+										"request": {
+											"set": {
+												"X-Forwarded-Method": [
+													"{http.request.method}"
+												],
+												"X-Forwarded-Uri": [
+													"{http.request.uri}"
+												]
+											}
+										}
+									},
+									"rewrite": {
+										"method": "GET",
+										"uri": "/auth"
+									},
+									"upstreams": [
+										{
+											"dial": "localhost:9000"
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This twitter thread https://twitter.com/coldmacchiato_/status/1524683154237407232 made me realize there were some shortcomings to `copy_headers`; it wasn't possible to rename response headers when copied to the request, and if the header names are long, it can get unwieldy to have it all on one line.

So to fix this, I'm adding a `>` syntax where if a token has a `>`, the left side is the response header name, and the right side is the "destination" request header name.

```
	copy_headers {
		Tailscale-User>X-Webauth-User
		Tailscale-Name>X-Webauth-Name
		Tailscale-Login>X-Webauth-Login
		Tailscale-Tailnet>X-Webauth-Tailnet
		Tailscale-Profile-Picture>X-Webauth-Profile-Picture
	}
```