### PR TITLE
httpcaddyfile: Add `{err.*}` placeholder shortcut

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -107,6 +107,7 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 		{regexp.MustCompile(`{re\.([\w-]*)\.([\w-]*)}`), "{http.regexp.$1.$2}"},
 		{regexp.MustCompile(`{vars\.([\w-]*)}`), "{http.vars.$1}"},
 		{regexp.MustCompile(`{rp\.([\w-\.]*)}`), "{http.reverse_proxy.$1}"},
+		{regexp.MustCompile(`{err\.([\w-\.]*)}`), "{http.error.$1}"},
 	}
 
 	for _, sb := range originalServerBlocks {


### PR DESCRIPTION
Before:
```
handle_errors {
	respond "{http.error.status_code} {http.error.status_text}"
}
```

After:
```
handle_errors {
	respond "{err.status_code} {err.status_text}"
}
```

Nice little win for the common pattern of [error handling](https://caddyserver.com/docs/caddyfile/directives/handle_errors) :blush: 