### PR TITLE
core: add type registry to facilitate validation of type adherence to namespace requirements

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -34,7 +34,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -56,9 +55,7 @@ func init() {
 	if env, exists := os.LookupEnv("CADDY_ADMIN"); exists {
 		DefaultAdminListen = env
 	}
-	RegisterType("caddy.config_loaders", []reflect.Type{
-		reflect.TypeOf((*ConfigLoader)(nil)).Elem(),
-	})
+	RegisterType("caddy.config_loaders", []interface{}{(*ConfigLoader)(nil)})
 }
 
 // AdminConfig configures Caddy's API endpoint, which is used

--- a/admin.go
+++ b/admin.go
@@ -34,6 +34,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -55,6 +56,9 @@ func init() {
 	if env, exists := os.LookupEnv("CADDY_ADMIN"); exists {
 		DefaultAdminListen = env
 	}
+	RegisterType("caddy.config_loaders", []reflect.Type{
+		reflect.TypeOf((*ConfigLoader)(nil)).Elem(),
+	})
 }
 
 // AdminConfig configures Caddy's API endpoint, which is used

--- a/admin.go
+++ b/admin.go
@@ -55,7 +55,7 @@ func init() {
 	if env, exists := os.LookupEnv("CADDY_ADMIN"); exists {
 		DefaultAdminListen = env
 	}
-	RegisterType("caddy.config_loaders", []interface{}{(*ConfigLoader)(nil)})
+	RegisterNamespace("caddy.config_loaders", []interface{}{(*ConfigLoader)(nil)})
 }
 
 // AdminConfig configures Caddy's API endpoint, which is used

--- a/caddy.go
+++ b/caddy.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -40,6 +41,15 @@ import (
 
 	"github.com/caddyserver/caddy/v2/notify"
 )
+
+func init() {
+	RegisterType("", []reflect.Type{
+		reflect.TypeOf((*App)(nil)).Elem(),
+	})
+	RegisterType("caddy.storage", []reflect.Type{
+		reflect.TypeOf((*StorageConverter)(nil)).Elem(),
+	})
+}
 
 // Config is the top (or beginning) of the Caddy configuration structure.
 // Caddy config is expressed natively as a JSON document. If you prefer
@@ -72,11 +82,15 @@ type Config struct {
 	// module is `caddy.storage.file_system` (the local file system),
 	// and the default path
 	// [depends on the OS and environment](/docs/conventions#data-directory).
+	// A storage `module` should implement the following interfaces:
+	// - [StorageConverter](https://pkg.go.dev/github.com/caddyserver/caddy/v2#StorageConverter)
 	StorageRaw json.RawMessage `json:"storage,omitempty" caddy:"namespace=caddy.storage inline_key=module"`
 
 	// AppsRaw are the apps that Caddy will load and run. The
 	// app module name is the key, and the app's config is the
 	// associated value.
+	// An `app` should implement the following interfaces:
+	// - [caddy.App](https://pkg.go.dev/github.com/caddyserver/caddy/v2?tab=doc#App)
 	AppsRaw ModuleMap `json:"apps,omitempty" caddy:"namespace="`
 
 	apps    map[string]App

--- a/caddy.go
+++ b/caddy.go
@@ -42,10 +42,10 @@ import (
 )
 
 func init() {
-	RegisterType("", []interface{}{
+	RegisterNamespace("", []interface{}{
 		(*App)(nil),
 	})
-	RegisterType("caddy.storage", []interface{}{
+	RegisterNamespace("caddy.storage", []interface{}{
 		(*StorageConverter)(nil),
 	})
 }

--- a/caddy.go
+++ b/caddy.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -43,11 +42,11 @@ import (
 )
 
 func init() {
-	RegisterType("", []reflect.Type{
-		reflect.TypeOf((*App)(nil)).Elem(),
+	RegisterType("", []interface{}{
+		(*App)(nil),
 	})
-	RegisterType("caddy.storage", []reflect.Type{
-		reflect.TypeOf((*StorageConverter)(nil)).Elem(),
+	RegisterType("caddy.storage", []interface{}{
+		(*StorageConverter)(nil),
 	})
 }
 

--- a/caddytest/integration/types_test.go
+++ b/caddytest/integration/types_test.go
@@ -7,8 +7,8 @@ import (
 	_ "github.com/caddyserver/caddy/v2/modules/standard"
 )
 
-// Validates Caddy's the registered internal types implement the necessary interfaces of their
-// namespaces
+// Validates that Caddy's registered internal modules implement the necessary interfaces of their
+// respective namespaces
 func TestTypes(t *testing.T) {
 	var i int
 	for _, v := range caddy.Modules() {

--- a/caddytest/integration/types_test.go
+++ b/caddytest/integration/types_test.go
@@ -1,0 +1,22 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+	_ "github.com/caddyserver/caddy/v2/modules/standard"
+)
+
+// Validates Caddy's the registered internal types implement the necessary interfaces of their
+// namespaces
+func TestTypes(t *testing.T) {
+	var i int
+	for _, v := range caddy.Modules() {
+		mod, _ := caddy.GetModule(v)
+		if ok, err := caddy.ConformsToNamespace(mod.New(), mod.ID.Namespace()); !ok {
+			t.Errorf("%s", err)
+		}
+		i++
+	}
+	t.Logf("Passed through %d modules", i)
+}

--- a/listeners.go
+++ b/listeners.go
@@ -38,7 +38,7 @@ import (
 )
 
 func init() {
-	RegisterType("caddy.listeners", []interface{}{
+	RegisterNamespace("caddy.listeners", []interface{}{
 		(*ListenerWrapper)(nil),
 	})
 }

--- a/listeners.go
+++ b/listeners.go
@@ -24,7 +24,6 @@ import (
 	"net"
 	"net/netip"
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -39,8 +38,8 @@ import (
 )
 
 func init() {
-	RegisterType("caddy.listeners", []reflect.Type{
-		reflect.TypeOf((*ListenerWrapper)(nil)).Elem(),
+	RegisterType("caddy.listeners", []interface{}{
+		(*ListenerWrapper)(nil),
 	})
 }
 

--- a/listeners.go
+++ b/listeners.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/netip"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -36,6 +37,12 @@ import (
 
 	"github.com/caddyserver/caddy/v2/internal"
 )
+
+func init() {
+	RegisterType("caddy.listeners", []reflect.Type{
+		reflect.TypeOf((*ListenerWrapper)(nil)).Elem(),
+	})
+}
 
 // NetworkAddress represents one or more network addresses.
 // It contains the individual components for a parsed network

--- a/logging.go
+++ b/logging.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -34,11 +33,11 @@ func init() {
 	RegisterModule(StdoutWriter{})
 	RegisterModule(StderrWriter{})
 	RegisterModule(DiscardWriter{})
-	RegisterType("caddy.logging.encoders", []reflect.Type{
-		reflect.TypeOf((*zapcore.Encoder)(nil)).Elem(),
+	RegisterType("caddy.logging.encoders", []interface{}{
+		(*zapcore.Encoder)(nil),
 	})
-	RegisterType("caddy.logging.writers", []reflect.Type{
-		reflect.TypeOf((*WriterOpener)(nil)).Elem(),
+	RegisterType("caddy.logging.writers", []interface{}{
+		(*WriterOpener)(nil),
 	})
 }
 

--- a/logging.go
+++ b/logging.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +34,12 @@ func init() {
 	RegisterModule(StdoutWriter{})
 	RegisterModule(StderrWriter{})
 	RegisterModule(DiscardWriter{})
+	RegisterType("caddy.logging.encoders", []reflect.Type{
+		reflect.TypeOf((*zapcore.Encoder)(nil)).Elem(),
+	})
+	RegisterType("caddy.logging.writers", []reflect.Type{
+		reflect.TypeOf((*WriterOpener)(nil)).Elem(),
+	})
 }
 
 // Logging facilitates logging within Caddy. The default log is
@@ -265,6 +272,8 @@ type BaseLog struct {
 	WriterRaw json.RawMessage `json:"writer,omitempty" caddy:"namespace=caddy.logging.writers inline_key=output"`
 
 	// The encoder is how the log entries are formatted or encoded.
+	// An `encoder` should implement the following interfaces:
+	// - [zapcore.Encoder](https://pkg.go.dev/go.uber.org/zap/zapcore#Encoder)
 	EncoderRaw json.RawMessage `json:"encoder,omitempty" caddy:"namespace=caddy.logging.encoders inline_key=format"`
 
 	// Level is the minimum level to emit, and is inclusive.

--- a/logging.go
+++ b/logging.go
@@ -33,10 +33,10 @@ func init() {
 	RegisterModule(StdoutWriter{})
 	RegisterModule(StderrWriter{})
 	RegisterModule(DiscardWriter{})
-	RegisterType("caddy.logging.encoders", []interface{}{
+	RegisterNamespace("caddy.logging.encoders", []interface{}{
 		(*zapcore.Encoder)(nil),
 	})
-	RegisterType("caddy.logging.writers", []interface{}{
+	RegisterNamespace("caddy.logging.writers", []interface{}{
 		(*WriterOpener)(nil),
 	})
 }

--- a/modules/caddyhttp/caddyauth/basicauth.go
+++ b/modules/caddyhttp/caddyauth/basicauth.go
@@ -32,10 +32,10 @@ import (
 func init() {
 	caddy.RegisterModule(HTTPBasicAuth{})
 
-	caddy.RegisterType("http.authentication.hashes", []interface{}{
+	caddy.RegisterNamespace("http.authentication.hashes", []interface{}{
 		(*Comparer)(nil),
 	})
-	caddy.RegisterType("http.authentication.providers", []interface{}{
+	caddy.RegisterNamespace("http.authentication.providers", []interface{}{
 		(*Authenticator)(nil),
 	})
 }

--- a/modules/caddyhttp/caddyauth/basicauth.go
+++ b/modules/caddyhttp/caddyauth/basicauth.go
@@ -21,8 +21,10 @@ import (
 	"fmt"
 	weakrand "math/rand"
 	"net/http"
+	"reflect"
 	"strings"
 	"sync"
+	"time"
 
 	"golang.org/x/sync/singleflight"
 
@@ -31,6 +33,15 @@ import (
 
 func init() {
 	caddy.RegisterModule(HTTPBasicAuth{})
+
+	caddy.RegisterType("http.authentication.hashes", []reflect.Type{
+		reflect.TypeOf((*Comparer)(nil)).Elem(),
+	})
+	caddy.RegisterType("http.authentication.providers", []reflect.Type{
+		reflect.TypeOf((*Authenticator)(nil)).Elem(),
+	})
+
+	weakrand.Seed(time.Now().UnixNano())
 }
 
 // HTTPBasicAuth facilitates HTTP basic authentication.

--- a/modules/caddyhttp/caddyauth/basicauth.go
+++ b/modules/caddyhttp/caddyauth/basicauth.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"time"
 
 	"golang.org/x/sync/singleflight"
 
@@ -39,8 +38,6 @@ func init() {
 	caddy.RegisterType("http.authentication.providers", []interface{}{
 		(*Authenticator)(nil),
 	})
-
-	weakrand.Seed(time.Now().UnixNano())
 }
 
 // HTTPBasicAuth facilitates HTTP basic authentication.

--- a/modules/caddyhttp/caddyauth/basicauth.go
+++ b/modules/caddyhttp/caddyauth/basicauth.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	weakrand "math/rand"
 	"net/http"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -34,11 +33,11 @@ import (
 func init() {
 	caddy.RegisterModule(HTTPBasicAuth{})
 
-	caddy.RegisterType("http.authentication.hashes", []reflect.Type{
-		reflect.TypeOf((*Comparer)(nil)).Elem(),
+	caddy.RegisterType("http.authentication.hashes", []interface{}{
+		(*Comparer)(nil),
 	})
-	caddy.RegisterType("http.authentication.providers", []reflect.Type{
-		reflect.TypeOf((*Authenticator)(nil)).Elem(),
+	caddy.RegisterType("http.authentication.providers", []interface{}{
+		(*Authenticator)(nil),
 	})
 
 	weakrand.Seed(time.Now().UnixNano())

--- a/modules/caddyhttp/encode/encode.go
+++ b/modules/caddyhttp/encode/encode.go
@@ -26,6 +26,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -37,6 +38,9 @@ import (
 
 func init() {
 	caddy.RegisterModule(Encode{})
+	caddy.RegisterType("http.encoders", []reflect.Type{
+		reflect.TypeOf((*Encoding)(nil)).Elem(),
+	})
 }
 
 // Encode is a middleware which can encode responses.

--- a/modules/caddyhttp/encode/encode.go
+++ b/modules/caddyhttp/encode/encode.go
@@ -37,7 +37,7 @@ import (
 
 func init() {
 	caddy.RegisterModule(Encode{})
-	caddy.RegisterType("http.encoders", []interface{}{
+	caddy.RegisterNamespace("http.encoders", []interface{}{
 		(*Encoding)(nil),
 	})
 }

--- a/modules/caddyhttp/encode/encode.go
+++ b/modules/caddyhttp/encode/encode.go
@@ -26,7 +26,6 @@ import (
 	"math"
 	"net"
 	"net/http"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -38,8 +37,8 @@ import (
 
 func init() {
 	caddy.RegisterModule(Encode{})
-	caddy.RegisterType("http.encoders", []reflect.Type{
-		reflect.TypeOf((*Encoding)(nil)).Elem(),
+	caddy.RegisterType("http.encoders", []interface{}{
+		(*Encoding)(nil),
 	})
 }
 

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -42,8 +41,8 @@ import (
 func init() {
 	weakrand.Seed(time.Now().UnixNano())
 
-	caddy.RegisterType("http.precompressed", []reflect.Type{
-		reflect.TypeOf((*encode.Precompressed)(nil)).Elem(),
+	caddy.RegisterType("http.precompressed", []interface{}{
+		(*encode.Precompressed)(nil),
 	})
 
 	caddy.RegisterModule(FileServer{})

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -29,7 +29,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
 
 	"go.uber.org/zap"
 
@@ -39,8 +38,6 @@ import (
 )
 
 func init() {
-	weakrand.Seed(time.Now().UnixNano())
-
 	caddy.RegisterType("http.precompressed", []interface{}{
 		(*encode.Precompressed)(nil),
 	})

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -26,9 +26,11 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -38,6 +40,12 @@ import (
 )
 
 func init() {
+	weakrand.Seed(time.Now().UnixNano())
+
+	caddy.RegisterType("http.precompressed", []reflect.Type{
+		reflect.TypeOf((*encode.Precompressed)(nil)).Elem(),
+	})
+
 	caddy.RegisterModule(FileServer{})
 }
 

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -38,7 +38,7 @@ import (
 )
 
 func init() {
-	caddy.RegisterType("http.precompressed", []interface{}{
+	caddy.RegisterNamespace("http.precompressed", []interface{}{
 		(*encode.Precompressed)(nil),
 	})
 

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -214,7 +214,7 @@ func init() {
 	caddy.RegisterModule(MatchHeaderRE{})
 	caddy.RegisterModule(new(MatchProtocol))
 	caddy.RegisterModule(MatchNot{})
-	caddy.RegisterType("http.matchers", []interface{}{
+	caddy.RegisterNamespace("http.matchers", []interface{}{
 		(*RequestMatcher)(nil),
 	})
 }

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -197,6 +197,8 @@ type (
 	// where each of the array elements is a matcher set, i.e. an
 	// object keyed by matcher name.
 	MatchNot struct {
+		// A `matcher` should implement the following interfaces:
+		// - [caddyhttp.RequestMatcher](https://pkg.go.dev/github.com/caddyserver/caddy/v2/modules/caddyhttp?tab=doc#RequestMatcher)
 		MatcherSetsRaw []caddy.ModuleMap `json:"-" caddy:"namespace=http.matchers"`
 		MatcherSets    []MatcherSet      `json:"-"`
 	}
@@ -212,6 +214,9 @@ func init() {
 	caddy.RegisterModule(MatchHeaderRE{})
 	caddy.RegisterModule(new(MatchProtocol))
 	caddy.RegisterModule(MatchNot{})
+	caddy.RegisterType("http.matchers", []reflect.Type{
+		reflect.TypeOf((*RequestMatcher)(nil)).Elem(),
+	})
 }
 
 // CaddyModule returns the Caddy module information.

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -214,8 +214,8 @@ func init() {
 	caddy.RegisterModule(MatchHeaderRE{})
 	caddy.RegisterModule(new(MatchProtocol))
 	caddy.RegisterModule(MatchNot{})
-	caddy.RegisterType("http.matchers", []reflect.Type{
-		reflect.TypeOf((*RequestMatcher)(nil)).Elem(),
+	caddy.RegisterType("http.matchers", []interface{}{
+		(*RequestMatcher)(nil),
 	})
 }
 

--- a/modules/caddyhttp/matchers_test.go
+++ b/modules/caddyhttp/matchers_test.go
@@ -1145,3 +1145,9 @@ func BenchmarkHostMatcherWithPlaceholder(b *testing.B) {
 		match.Match(req)
 	}
 }
+
+func TestConformsToNamespace(t *testing.T) {
+	if ok, err := caddy.ConformsToNamespace(new(StaticResponse), "http.matchers"); !ok || err != nil {
+		t.Errorf("%s", err)
+	}
+}

--- a/modules/caddyhttp/matchers_test.go
+++ b/modules/caddyhttp/matchers_test.go
@@ -1145,9 +1145,3 @@ func BenchmarkHostMatcherWithPlaceholder(b *testing.B) {
 		match.Match(req)
 	}
 }
-
-func TestConformsToNamespace(t *testing.T) {
-	if ok, err := caddy.ConformsToNamespace(new(StaticResponse), "http.matchers"); !ok || err != nil {
-		t.Errorf("%s", err)
-	}
-}

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -27,6 +27,7 @@ import (
 	"net/netip"
 	"net/textproto"
 	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -45,6 +46,19 @@ import (
 
 func init() {
 	caddy.RegisterModule(Handler{})
+
+	caddy.RegisterType("http.reverse_proxy.circuit_breakers", []reflect.Type{
+		reflect.TypeOf((*CircuitBreaker)(nil)).Elem(),
+	})
+	caddy.RegisterType("http.reverse_proxy.selection_policies", []reflect.Type{
+		reflect.TypeOf((*Selector)(nil)).Elem(),
+	})
+	caddy.RegisterType("http.reverse_proxy.transport", []reflect.Type{
+		reflect.TypeOf((*http.RoundTripper)(nil)).Elem(),
+	})
+	caddy.RegisterType("http.reverse_proxy.upstreams", []reflect.Type{
+		reflect.TypeOf((*UpstreamSource)(nil)).Elem(),
+	})
 }
 
 // Handler implements a highly configurable and production-ready reverse proxy.

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -27,7 +27,6 @@ import (
 	"net/netip"
 	"net/textproto"
 	"net/url"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -47,17 +46,17 @@ import (
 func init() {
 	caddy.RegisterModule(Handler{})
 
-	caddy.RegisterType("http.reverse_proxy.circuit_breakers", []reflect.Type{
-		reflect.TypeOf((*CircuitBreaker)(nil)).Elem(),
+	caddy.RegisterType("http.reverse_proxy.circuit_breakers", []interface{}{
+		(*CircuitBreaker)(nil),
 	})
-	caddy.RegisterType("http.reverse_proxy.selection_policies", []reflect.Type{
-		reflect.TypeOf((*Selector)(nil)).Elem(),
+	caddy.RegisterType("http.reverse_proxy.selection_policies", []interface{}{
+		(*Selector)(nil),
 	})
-	caddy.RegisterType("http.reverse_proxy.transport", []reflect.Type{
-		reflect.TypeOf((*http.RoundTripper)(nil)).Elem(),
+	caddy.RegisterType("http.reverse_proxy.transport", []interface{}{
+		(*http.RoundTripper)(nil),
 	})
-	caddy.RegisterType("http.reverse_proxy.upstreams", []reflect.Type{
-		reflect.TypeOf((*UpstreamSource)(nil)).Elem(),
+	caddy.RegisterType("http.reverse_proxy.upstreams", []interface{}{
+		(*UpstreamSource)(nil),
 	})
 }
 

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -46,16 +46,16 @@ import (
 func init() {
 	caddy.RegisterModule(Handler{})
 
-	caddy.RegisterType("http.reverse_proxy.circuit_breakers", []interface{}{
+	caddy.RegisterNamespace("http.reverse_proxy.circuit_breakers", []interface{}{
 		(*CircuitBreaker)(nil),
 	})
-	caddy.RegisterType("http.reverse_proxy.selection_policies", []interface{}{
+	caddy.RegisterNamespace("http.reverse_proxy.selection_policies", []interface{}{
 		(*Selector)(nil),
 	})
-	caddy.RegisterType("http.reverse_proxy.transport", []interface{}{
+	caddy.RegisterNamespace("http.reverse_proxy.transport", []interface{}{
 		(*http.RoundTripper)(nil),
 	})
-	caddy.RegisterType("http.reverse_proxy.upstreams", []interface{}{
+	caddy.RegisterNamespace("http.reverse_proxy.upstreams", []interface{}{
 		(*UpstreamSource)(nil),
 	})
 }

--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -18,9 +18,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 
 	"github.com/caddyserver/caddy/v2"
 )
+
+func init() {
+	caddy.RegisterType("http.handlers", []reflect.Type{
+		reflect.TypeOf((*MiddlewareHandler)(nil)).Elem(),
+	})
+}
 
 // Route consists of a set of rules for matching HTTP requests,
 // a list of handlers to execute, and optional flow control

--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -18,14 +18,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 
 	"github.com/caddyserver/caddy/v2"
 )
 
 func init() {
-	caddy.RegisterType("http.handlers", []reflect.Type{
-		reflect.TypeOf((*MiddlewareHandler)(nil)).Elem(),
+	caddy.RegisterType("http.handlers", []interface{}{
+		(*MiddlewareHandler)(nil),
 	})
 }
 

--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -23,7 +23,7 @@ import (
 )
 
 func init() {
-	caddy.RegisterType("http.handlers", []interface{}{
+	caddy.RegisterNamespace("http.handlers", []interface{}{
 		(*MiddlewareHandler)(nil),
 	})
 }

--- a/modules/caddytls/automation.go
+++ b/modules/caddytls/automation.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -29,6 +30,18 @@ import (
 
 	"github.com/caddyserver/caddy/v2"
 )
+
+func init() {
+	caddy.RegisterType("dns.provider", []reflect.Type{
+		reflect.TypeOf((*acmez.Solver)(nil)).Elem(),
+	})
+	caddy.RegisterType("tls.get_certificate", []reflect.Type{
+		reflect.TypeOf((*certmagic.Manager)(nil)).Elem(),
+	})
+	caddy.RegisterType("tls.issuance", []reflect.Type{
+		reflect.TypeOf((*certmagic.Issuer)(nil)).Elem(),
+	})
+}
 
 // AutomationConfig governs the automated management of TLS certificates.
 type AutomationConfig struct {

--- a/modules/caddytls/automation.go
+++ b/modules/caddytls/automation.go
@@ -31,13 +31,13 @@ import (
 )
 
 func init() {
-	caddy.RegisterType("dns.provider", []interface{}{
+	caddy.RegisterNamespace("dns.provider", []interface{}{
 		(*acmez.Solver)(nil),
 	})
-	caddy.RegisterType("tls.get_certificate", []interface{}{
+	caddy.RegisterNamespace("tls.get_certificate", []interface{}{
 		(*certmagic.Manager)(nil),
 	})
-	caddy.RegisterType("tls.issuance", []interface{}{
+	caddy.RegisterNamespace("tls.issuance", []interface{}{
 		(*certmagic.Issuer)(nil),
 	})
 }

--- a/modules/caddytls/automation.go
+++ b/modules/caddytls/automation.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"time"
 
@@ -32,14 +31,14 @@ import (
 )
 
 func init() {
-	caddy.RegisterType("dns.provider", []reflect.Type{
-		reflect.TypeOf((*acmez.Solver)(nil)).Elem(),
+	caddy.RegisterType("dns.provider", []interface{}{
+		(*acmez.Solver)(nil),
 	})
-	caddy.RegisterType("tls.get_certificate", []reflect.Type{
-		reflect.TypeOf((*certmagic.Manager)(nil)).Elem(),
+	caddy.RegisterType("tls.get_certificate", []interface{}{
+		(*certmagic.Manager)(nil),
 	})
-	caddy.RegisterType("tls.issuance", []reflect.Type{
-		reflect.TypeOf((*certmagic.Issuer)(nil)).Elem(),
+	caddy.RegisterType("tls.issuance", []interface{}{
+		(*certmagic.Issuer)(nil),
 	})
 }
 

--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -33,7 +33,7 @@ import (
 
 func init() {
 	caddy.RegisterModule(LeafCertClientAuth{})
-	caddy.RegisterType("tls.handshake_match", []interface{}{
+	caddy.RegisterNamespace("tls.handshake_match", []interface{}{
 		(*ConnectionMatcher)(nil),
 	})
 }

--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/mholt/acmez"
@@ -33,6 +34,9 @@ import (
 
 func init() {
 	caddy.RegisterModule(LeafCertClientAuth{})
+	caddy.RegisterType("tls.handshake_match", []reflect.Type{
+		reflect.TypeOf((*ConnectionMatcher)(nil)).Elem(),
+	})
 }
 
 // ConnectionPolicies govern the establishment of TLS connections. It is

--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 
 	"github.com/mholt/acmez"
@@ -34,8 +33,8 @@ import (
 
 func init() {
 	caddy.RegisterModule(LeafCertClientAuth{})
-	caddy.RegisterType("tls.handshake_match", []reflect.Type{
-		reflect.TypeOf((*ConnectionMatcher)(nil)).Elem(),
+	caddy.RegisterType("tls.handshake_match", []interface{}{
+		(*ConnectionMatcher)(nil),
 	})
 }
 

--- a/modules/caddytls/sessiontickets.go
+++ b/modules/caddytls/sessiontickets.go
@@ -21,12 +21,19 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"reflect"
 	"runtime/debug"
 	"sync"
 	"time"
 
 	"github.com/caddyserver/caddy/v2"
 )
+
+func init() {
+	caddy.RegisterType("tls.stek", []reflect.Type{
+		reflect.TypeOf((*STEKProvider)(nil)).Elem(),
+	})
+}
 
 // SessionTicketService configures and manages TLS session tickets.
 type SessionTicketService struct {

--- a/modules/caddytls/sessiontickets.go
+++ b/modules/caddytls/sessiontickets.go
@@ -29,7 +29,7 @@ import (
 )
 
 func init() {
-	caddy.RegisterType("tls.stek", []interface{}{
+	caddy.RegisterNamespace("tls.stek", []interface{}{
 		(*STEKProvider)(nil),
 	})
 }

--- a/modules/caddytls/sessiontickets.go
+++ b/modules/caddytls/sessiontickets.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"reflect"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -30,8 +29,8 @@ import (
 )
 
 func init() {
-	caddy.RegisterType("tls.stek", []reflect.Type{
-		reflect.TypeOf((*STEKProvider)(nil)).Elem(),
+	caddy.RegisterType("tls.stek", []interface{}{
+		(*STEKProvider)(nil),
 	})
 }
 

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -36,7 +36,7 @@ func init() {
 	caddy.RegisterModule(TLS{})
 	caddy.RegisterModule(AutomateLoader{})
 
-	caddy.RegisterType("tls.certificates", []interface{}{
+	caddy.RegisterNamespace("tls.certificates", []interface{}{
 		(*CertificateLoader)(nil),
 	})
 }

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"reflect"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -35,6 +36,10 @@ import (
 func init() {
 	caddy.RegisterModule(TLS{})
 	caddy.RegisterModule(AutomateLoader{})
+
+	caddy.RegisterType("tls.certificates", []reflect.Type{
+		reflect.TypeOf((*CertificateLoader)(nil)).Elem(),
+	})
 }
 
 var (
@@ -650,6 +655,11 @@ func (AutomateLoader) CaddyModule() caddy.ModuleInfo {
 		ID:  "tls.certificates.automate",
 		New: func() caddy.Module { return new(AutomateLoader) },
 	}
+}
+
+// LoadCertificates is a stub so AutomateLoader can implement CertificateLoader
+func (AutomateLoader) LoadCertificates() ([]Certificate, error) {
+	return nil, nil
 }
 
 // CertCacheOptions configures the certificate cache.

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"reflect"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -37,8 +36,8 @@ func init() {
 	caddy.RegisterModule(TLS{})
 	caddy.RegisterModule(AutomateLoader{})
 
-	caddy.RegisterType("tls.certificates", []reflect.Type{
-		reflect.TypeOf((*CertificateLoader)(nil)).Elem(),
+	caddy.RegisterType("tls.certificates", []interface{}{
+		(*CertificateLoader)(nil),
 	})
 }
 

--- a/types.go
+++ b/types.go
@@ -7,7 +7,7 @@ import (
 
 var namespaceTypes map[string][]reflect.Type = make(map[string][]reflect.Type)
 
-func RegisterType(namespace string, vals []interface{}) {
+func RegisterNamespace(namespace string, vals []interface{}) {
 	var types []reflect.Type
 	for _, v := range vals {
 		reflect.TypeOf(v).Elem()

--- a/types.go
+++ b/types.go
@@ -1,0 +1,35 @@
+package caddy
+
+import (
+	"fmt"
+	"reflect"
+)
+
+var namespaceTypes map[string][]reflect.Type = make(map[string][]reflect.Type)
+
+func RegisterType(namespace string, types []reflect.Type) {
+	if _, ok := namespaceTypes[namespace]; ok {
+		panic("namespace is already registered")
+	}
+	namespaceTypes[namespace] = types
+}
+
+// NamespaceTypes returns a copy of Caddy's namespace->type registry
+func NamespaceTypes() map[string][]reflect.Type {
+	copy := make(map[string][]reflect.Type)
+	for namespace, typeSlice := range namespaceTypes {
+		copy[namespace] = typeSlice
+	}
+	return copy
+}
+
+// ConformsToNamespace validates the given module implements all the mandatory types of a given namespace
+func ConformsToNamespace(mod Module, namespace string) (bool, error) {
+	modType := reflect.TypeOf(mod)
+	for _, t := range namespaceTypes[namespace] {
+		if !modType.Implements(t) {
+			return false, fmt.Errorf("%s does not implement %s", modType, t)
+		}
+	}
+	return true, nil
+}

--- a/types.go
+++ b/types.go
@@ -7,7 +7,11 @@ import (
 
 var namespaceTypes map[string][]reflect.Type = make(map[string][]reflect.Type)
 
-func RegisterType(namespace string, types []reflect.Type) {
+func RegisterType(namespace string, vals []interface{}) {
+	var types []reflect.Type
+	for _, v := range vals {
+		reflect.TypeOf(v).Elem()
+	}
 	if _, ok := namespaceTypes[namespace]; ok {
 		panic("namespace is already registered")
 	}


### PR DESCRIPTION
This is an attempt at helping Caddy module developers to validate their module implement all the necessary interfaces to fulfill a namespace. Of course this requires opt-in of developers who introduce a namespace to declare what interfaces are required to be fulfilled.

This should help us with the documentation system once we wire everything up.

The question of `is it possible for a namespace to require more than implementation of interfaces?` and how to design the registry to fit this use-case is open, but I'm not sure if such possibility exists.

Namespaces of Caddy core:
- caddy.config_loaders
- caddy.listeners
- caddy.logging.encoders
- caddy.logging.writers
- caddy.storage
- dns.providers
- http.authentication.hashes
- http.authentication.providers
- http.encoders
- http.handlers
- http.matchers
- http.precompressed
- http.reverse_proxy.circuit_breakers
- http.reverse_proxy.selection_policies
- http.reverse_proxy.transport
- http.reverse_proxy.upstreams
- tls.certificates
- tls.get_certificate
- tls.handshake_match
- tls.issuance
- tls.stek