### PR TITLE
caddyhttp: Introduce strict HTTP mode (WIP)

### DIFF
--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -111,6 +111,8 @@ type App struct {
 	// be forcefully closed.
 	GracePeriod caddy.Duration `json:"grace_period,omitempty"`
 
+	Strict *StrictOptions `json:"strict,omitempty"`
+
 	// Servers is the list of servers, keyed by arbitrary names chosen
 	// at your discretion for your own convenience; the keys do not
 	// affect functionality.
@@ -125,6 +127,13 @@ type App struct {
 
 	// used temporarily between phases 1 and 2 of auto HTTPS
 	allCertDomains []string
+}
+
+type StrictOptions struct {
+	Disabled            bool `json:"disable,omitempty"`
+	LenientQueryStrings bool `json:"lenient_query_strings,omitempty"`
+	LenientPaths        bool `json:"lenient_paths,omitempty"`
+	LenientHeaders      bool `json:"lenient_headers,omitempty"`
 }
 
 // CaddyModule returns the Caddy module information.
@@ -162,6 +171,7 @@ func (app *App) Provision(ctx caddy.Context) error {
 		srv.tlsApp = app.tlsApp
 		srv.logger = app.logger.Named("log")
 		srv.errorLogger = app.logger.Named("log.error")
+		srv.strict = app.Strict
 
 		// only enable access logs if configured
 		if srv.Logs != nil {

--- a/modules/caddyhttp/matchers_test.go
+++ b/modules/caddyhttp/matchers_test.go
@@ -624,9 +624,18 @@ func TestQueryMatcher(t *testing.T) {
 			input:    "/?somekey=1",
 			expect:   true,
 		},
+		{
+			scenario: "invalid query string",
+			match:    MatchQuery{"test": []string{"*"}},
+			input:    "/?test=1;",
+			expect:   false,
+		},
 	} {
-
-		u, _ := url.Parse(tc.input)
+		u, err := url.Parse(tc.input)
+		if err != nil {
+			t.Errorf("Test %d: Parsing URL: %v", i, err)
+			continue
+		}
 
 		req := &http.Request{URL: u}
 		repl := caddy.NewReplacer()

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -348,7 +348,7 @@ func (strict *StrictOptions) enforce(r *http.Request) error {
 
 	// Reject paths with // or ..
 	if strict == nil || !strict.LenientPaths {
-		if strings.Contains(r.URL.Path, "//") || strings.Contains(r.URL.Path, "..") {
+		if strings.Contains(r.URL.Path, "//") || strings.Contains(r.URL.Path, "..") || strings.Contains(r.URL.Path, "\x00") {
 			return Error(http.StatusBadRequest, fmt.Errorf("invalid request path: %s", r.URL.RawPath))
 		}
 	}


### PR DESCRIPTION
It has come up several times that across various parts of the HTTP app, malformed requests can cause problems. They're not necessarily direct security issues, but can have unintended consequences for upstream/backend applications that are being proxied to, or file systems with flimsy rules for filepaths, etc., when combined with the wrong configs.

In an effort to reduce possible misconfigurations and edge cases with various other systems like backend services and file systems, I'm proposing a kind of "strict HTTP mode" to be enabled by default. (**This PR is still in a draft/WIP state. Feedback and discussion is invited.**)

It will reject requests with HTTP 400 that have:

- Unencoded `;` in the query string
- `//`, `..`, or `NUL` (`%00` or `\x00`) in the path (see #4574 and #4743; would supersede #4614)
- Header fields with underscores (`_`) (see #4830)

Basically the idea of strict HTTP is to enforce clean, spec-compliant requests and reject all others.

To clarify, I'm not saying this is a good idea or that the web server/proxy should be responsible for this. In fact I am pretty sure this will break a few legitimate use cases and applications, which do want underscores in some header fields or which use semicolons in the query string or which require double slashes for some sort of semantic interpretation.

As mentioned, these qualities of an HTTP requests are not in and of themselves security vulnerabilities, but they can present problems from poorly-designed or buggy applications that depend on these parts of HTTP requests. (For example, a file server that does not sanitize the path could be vulnerable to directory traversal by blindly evaluating `..` components in the path. Or Django apps can be misled by clients adding a `HOST_HEADER` header field. Or Windows file systems do unexpected things with NUL bytes. Merely having `..` in a path is not a security problem for Caddy, nor is having a header called `HOST_HEADER`, and so on.)

This implementation is currently WIP. It enables the enforcement of these traits by default, but can be disabled entirely or piecewise by being lenient on query strings, paths, or headers according to your configuration.

Upsides:
- This change can prevent some subtle misconfigurations and security flaws when interacting with other systems. They do NOT patch any known vulnerability in Caddy itself.

Downsides:
- This will inevitably take some users by surprise and break legitimate use cases.
- Protections can't currently be overridden per-request; currently you can turn off strict mode (entirely or for certain request parts), but there's not necessarily a way to re-enable them in your HTTP routes for certain requests. You could probably get clever to re-implement them, for example using #4831 to drop headers that have underscores when going to a backend.
- This adds trivial latency to all requests.
- This doesn't actually solve any security issues, it just covers them.

The whole change is not my favorite, and that last point is really bothering me.

Instead of this change, I recommend that applications actually patch their vulnerabilities.