### PR TITLE
admin: Implement /adapt endpoint (close #4465)

### DIFF
--- a/caddyconfig/load.go
+++ b/caddyconfig/load.go
@@ -58,6 +58,10 @@ func (al adminLoad) Routes() []caddy.AdminRoute {
 			Pattern: "/load",
 			Handler: caddy.AdminHandlerFunc(al.handleLoad),
 		},
+		{
+			Pattern: "/adapt",
+			Handler: caddy.AdminHandlerFunc(al.handleAdapt),
+		},
 	}
 }
 
@@ -122,7 +126,48 @@ func (adminLoad) handleLoad(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-// adaptByContentType adapts body to Caddy JSON using the adapter specified by contenType.
+// handleAdapt adapts the given Caddy config to JSON and responds with the result.
+func (adminLoad) handleAdapt(w http.ResponseWriter, r *http.Request) error {
+	if r.Method != http.MethodPost {
+		return caddy.APIError{
+			HTTPStatus: http.StatusMethodNotAllowed,
+			Err:        fmt.Errorf("method not allowed"),
+		}
+	}
+
+	buf := bufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer bufPool.Put(buf)
+
+	_, err := io.Copy(buf, r.Body)
+	if err != nil {
+		return caddy.APIError{
+			HTTPStatus: http.StatusBadRequest,
+			Err:        fmt.Errorf("reading request body: %v", err),
+		}
+	}
+
+	result, warnings, err := adaptByContentType(r.Header.Get("Content-Type"), buf.Bytes())
+	if err != nil {
+		return caddy.APIError{
+			HTTPStatus: http.StatusBadRequest,
+			Err:        err,
+		}
+	}
+
+	out := struct {
+		Warnings []Warning       `json:"warnings,omitempty"`
+		Result   json.RawMessage `json:"result"`
+	}{
+		Warnings: warnings,
+		Result:   result,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(out)
+}
+
+// adaptByContentType adapts body to Caddy JSON using the adapter specified by contentType.
 // If contentType is empty or ends with "/json", the input will be returned, as a no-op.
 func adaptByContentType(contentType string, body []byte) ([]byte, []Warning, error) {
 	// assume JSON as the default


### PR DESCRIPTION
Implements the feature requested by @adamburgess in #4465, an `/adapt` API endpoint for retrieving JSON config programmatically, without having to shell out to `caddy adapt` or POST an actual config to `/load` and then use a GET to retrieve it.

```bash
$ curl -v "http://localhost:2019/adapt" -H "Content-Type: text/caddyfile" --data-binary ':80 {
respond "Hello world!"
}' | jq
*   Trying 127.0.0.1:2019...
* Connected to localhost (127.0.0.1) port 2019 (#0)
> POST /adapt HTTP/1.1
> Host: localhost:2019
> User-Agent: curl/7.81.0
> Accept: */*
> Content-Type: text/caddyfile
> Content-Length: 30
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Mon, 20 Jun 2022 16:47:44 GMT
< Content-Length: 285
< 
{
  "warnings": [
    {
      "file": "Caddyfile",
      "line": 2,
      "message": "Caddyfile input is not formatted; run the caddy fmt command to fix inconsistencies"
    }
  ],
  "result": {
    "apps": {
      "http": {
        "servers": {
          "srv0": {
            "listen": [
              ":80"
            ],
            "routes": [
              {
                "handle": [
                  {
                    "body": "Hello world!",
                    "handler": "static_response"
                  }
                ]
              }
            ]
          }
        }
      }
    }
  }
}
```