### PR TITLE
reverseproxy: Fix panic when TLS is not configured

### DIFF
--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -297,7 +297,7 @@ func (h *HTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 // http.Transport requires a scheme to be set.
 func (h *HTTPTransport) SetScheme(req *http.Request) {
 	skipTLSport := false
-	if h.TLS.ExceptPorts != nil {
+	if h.TLS != nil && h.TLS.ExceptPorts != nil {
 		port := req.URL.Port()
 		for i := range h.TLS.ExceptPorts {
 			if h.TLS.ExceptPorts[i] == port {


### PR DESCRIPTION
There was a bug in https://github.com/caddyserver/caddy/pull/4843, it was only happening in s390x integration tests, causing a panic in active health checks.

The s390x tests don't run when the PR is done by a non-member of the org for security reasons, so we didn't notice it until I made another PR based on latest `master`. But I think this is the fix.