### PR TITLE
reverseproxy: PROXY protocol support for http transport

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/klauspost/compress v1.15.6
 	github.com/klauspost/cpuid/v2 v2.0.13
 	github.com/lucas-clemente/quic-go v0.27.2
+	github.com/mastercactapus/proxyprotocol v0.0.3
 	github.com/mholt/acmez v1.0.2
 	github.com/prometheus/client_golang v1.12.1
 	github.com/smallstep/certificates v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -741,6 +741,8 @@ github.com/marten-seemann/qtls-go1-17 v0.1.2 h1:JADBlm0LYiVbuSySCHeY863dNkcpMmDR
 github.com/marten-seemann/qtls-go1-17 v0.1.2/go.mod h1:C2ekUKcDdz9SDWxec1N/MvcXBpaX9l3Nx67XaR84L5s=
 github.com/marten-seemann/qtls-go1-18 v0.1.2 h1:JH6jmzbduz0ITVQ7ShevK10Av5+jBEKAHMntXmIV7kM=
 github.com/marten-seemann/qtls-go1-18 v0.1.2/go.mod h1:mJttiymBAByA49mhlNZZGrH5u1uXYZJ+RW28Py7f4m4=
+github.com/mastercactapus/proxyprotocol v0.0.3 h1:WpDMFKCYdF8NsoA6OrXyNKyZrzMURqqOP1PE7297RCE=
+github.com/mastercactapus/proxyprotocol v0.0.3/go.mod h1:X8FRVEDZz9FkrIoL4QYTBF4Ka4ELwTv0sah0/5NxCPw=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -803,6 +803,7 @@ func (h *Handler) FinalizeUnmarshalCaddyfile(helper httpcaddyfile.Helper) error 
 //         read_buffer             <size>
 //         write_buffer            <size>
 //         max_response_header     <size>
+//         proxy_protocol_version  [off|v1|v2]
 //         dial_timeout            <duration>
 //         dial_fallback_delay     <duration>
 //         response_header_timeout <duration>
@@ -857,6 +858,21 @@ func (h *HTTPTransport) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.Errf("invalid max response header size '%s': %v", d.Val(), err)
 				}
 				h.MaxResponseHeaderSize = int64(size)
+
+			case "proxy_protocol_version":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				switch proxyProtocolVersion := d.Val(); proxyProtocolVersion {
+				case "off":
+					h.ProxyProtocolVersion = 0
+				case "v1":
+					h.ProxyProtocolVersion = 1
+				case "v2":
+					h.ProxyProtocolVersion = 2
+				default:
+					return d.Errf("invalid proxy protocol version '%s'", proxyProtocolVersion)
+				}
 
 			case "dial_timeout":
 				if !d.NextArg() {

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -803,7 +803,7 @@ func (h *Handler) FinalizeUnmarshalCaddyfile(helper httpcaddyfile.Helper) error 
 //         read_buffer             <size>
 //         write_buffer            <size>
 //         max_response_header     <size>
-//         proxy_protocol_version  [off|v1|v2]
+//         proxy_protocol          v1|v2
 //         dial_timeout            <duration>
 //         dial_fallback_delay     <duration>
 //         response_header_timeout <duration>
@@ -859,19 +859,15 @@ func (h *HTTPTransport) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				}
 				h.MaxResponseHeaderSize = int64(size)
 
-			case "proxy_protocol_version":
+			case "proxy_protocol":
 				if !d.NextArg() {
 					return d.ArgErr()
 				}
-				switch proxyProtocolVersion := d.Val(); proxyProtocolVersion {
-				case "off":
-					h.ProxyProtocolVersion = 0
-				case "v1":
-					h.ProxyProtocolVersion = 1
-				case "v2":
-					h.ProxyProtocolVersion = 2
+				switch proxyProtocol := d.Val(); proxyProtocol {
+				case "v1", "v2":
+					h.ProxyProtocol = proxyProtocol
 				default:
-					return d.Errf("invalid proxy protocol version '%s'", proxyProtocolVersion)
+					return d.Errf("invalid proxy protocol version '%s'", proxyProtocol)
 				}
 
 			case "dial_timeout":

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -259,3 +259,22 @@ var hosts = caddy.NewUsagePool()
 // dialInfoVarKey is the key used for the variable that holds
 // the dial info for the upstream connection.
 const dialInfoVarKey = "reverse_proxy.dial_info"
+
+// ProxyProtocolInfo contains information needed to write proxy protocol to a
+// connection to an upstream host.
+type ProxyProtocolInfo struct {
+	// assume network is tcp because golang http transport can only support tcp now
+	IP   net.IP
+	Port int
+}
+
+// GetProxyProtocolInfo gets the proxy protocol info out of the context,
+// and returns true if there was a valid value; false otherwise.
+func GetProxyProtocolInfo(ctx context.Context) (ProxyProtocolInfo, bool) {
+	proxyProtocolInfo, ok := caddyhttp.GetVar(ctx, proxyProtocolInfoVarKey).(ProxyProtocolInfo)
+	return proxyProtocolInfo, ok
+}
+
+// proxyProtocolInfoVarKey is the key used for the variable that holds
+// the proxy protocol info for the upstream connection.
+const proxyProtocolInfoVarKey = "reverse_proxy.proxy_protocol_info"

--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -66,7 +66,7 @@ type HTTPTransport struct {
 
 	// Which version of proxy protocol to send when connecting to
 	// an upstream. Default: `don't send proxy protocol`.
-	ProxyProtocolVersion int `json:"proxy_protocol_version,omitempty"`
+	ProxyProtocol string `json:"proxy_protocol,omitempty"`
 
 	// How long to wait before timing out trying to connect to
 	// an upstream. Default: `3s`.
@@ -208,16 +208,16 @@ func (h *HTTPTransport) NewTransport(ctx caddy.Context) (*http.Transport, error)
 			}
 
 			if proxyProtocolInfo, ok := GetProxyProtocolInfo(ctx); ok {
-				switch h.ProxyProtocolVersion {
-				case 0:
+				switch h.ProxyProtocol {
+				case "":
 					return conn, nil
-				case 1:
+				case "v1":
 					var header proxyprotocol.HeaderV1
 					header.FromConn(conn, true)
 					header.SrcIP = proxyProtocolInfo.IP
 					header.SrcPort = proxyProtocolInfo.Port
 					_, err = header.WriteTo(conn)
-				case 2:
+				case "v2":
 					var header proxyprotocol.HeaderV2
 					header.FromConn(conn, true)
 					header.Src = &net.TCPAddr{

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -505,6 +505,8 @@ func (h *Handler) proxyLoopIteration(r *http.Request, origReq *http.Request, w h
 	var proxyProtocolInfo ProxyProtocolInfo
 	// using X-Forwarded-For header which is already filtered by trusted proxies
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// addForwardedHeaders ensures xff has at least remoteAddr
+		xff = strings.TrimSpace(strings.Split(xff, ",")[0])
 		ip := net.ParseIP(xff)
 		if ip != nil {
 			proxyProtocolInfo.IP = ip


### PR DESCRIPTION
Add proxy protocol support for reverseproxy http transport

fix [2724](https://github.com/caddyserver/caddy/issues/2724).