### PR TITLE
TCP Keepalive configuration

### DIFF
--- a/caddyconfig/httpcaddyfile/serveroptions.go
+++ b/caddyconfig/httpcaddyfile/serveroptions.go
@@ -38,6 +38,7 @@ type serverOptions struct {
 	ReadHeaderTimeout    caddy.Duration
 	WriteTimeout         caddy.Duration
 	IdleTimeout          caddy.Duration
+	KeepAliveInterval    caddy.Duration
 	MaxHeaderBytes       int
 	AllowH2C             bool
 	ExperimentalHTTP3    bool
@@ -123,6 +124,15 @@ func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (interface{}, error
 						return nil, d.Errf("unrecognized timeouts option '%s'", d.Val())
 					}
 				}
+			case "keepalive_interval":
+				if !d.NextArg() {
+					return nil, d.ArgErr()
+				}
+				dur, err := caddy.ParseDuration(d.Val())
+				if err != nil {
+					return nil, d.Errf("parsing keepalive interval duration: %v", err)
+				}
+				serverOpts.KeepAliveInterval = caddy.Duration(dur)
 
 			case "max_header_size":
 				var sizeStr string
@@ -228,6 +238,7 @@ func applyServerOptions(
 		server.ReadHeaderTimeout = opts.ReadHeaderTimeout
 		server.WriteTimeout = opts.WriteTimeout
 		server.IdleTimeout = opts.IdleTimeout
+		server.KeepAliveInterval = opts.KeepAliveInterval
 		server.MaxHeaderBytes = opts.MaxHeaderBytes
 		server.AllowH2C = opts.AllowH2C
 		server.ExperimentalHTTP3 = opts.ExperimentalHTTP3

--- a/listen.go
+++ b/listen.go
@@ -78,10 +78,12 @@ func (fcl *fakeCloseListener) Accept() (net.Conn, error) {
 		// and if the connection allows setting KeepAlive, set it
 		if tconn, ok := conn.(canSetKeepAlive); ok && fcl.keepalivePeriod != 0 {
 			if fcl.keepalivePeriod > 0 {
-				tconn.SetKeepAlivePeriod(fcl.keepalivePeriod)
+				err = tconn.SetKeepAlivePeriod(fcl.keepalivePeriod)
 			} else { // negative
-				tconn.SetKeepAlive(false)
+				err = tconn.SetKeepAlive(false)
 			}
+			// FIXME: how to deal with these errors, on one hand, this keepalive setting is not critical
+			// on the other, the user should be informed if theses some error
 		}
 		return conn, nil
 	}

--- a/listen.go
+++ b/listen.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 // Listen is like net.Listen, except Caddy's listeners can overlap
@@ -82,8 +84,9 @@ func (fcl *fakeCloseListener) Accept() (net.Conn, error) {
 			} else { // negative
 				err = tconn.SetKeepAlive(false)
 			}
-			// FIXME: how to deal with these errors, on one hand, this keepalive setting is not critical
-			// on the other, the user should be informed if theses some error
+			if err != nil {
+				Log().With(zap.String("server", fcl.sharedListener.key)).Warn("unable to set keepalive for new connection:", zap.Error(err))
+			}
 		}
 		return conn, nil
 	}

--- a/listen_linux.go
+++ b/listen_linux.go
@@ -4,13 +4,19 @@ import (
 	"context"
 	"net"
 	"syscall"
+	"time"
 
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 )
 
 func Listen(network, addr string) (net.Listener, error) {
-	config := &net.ListenConfig{Control: reusePort}
+	// 0 timeout means Go picks the default
+	return ListenTimeout(network, addr, 0)
+}
+
+func ListenTimeout(network, addr string, keepalivePeriod time.Duration) (net.Listener, error) {
+	config := &net.ListenConfig{Control: reusePort, KeepAlive: keepalivePeriod}
 	return config.Listen(context.Background(), network, addr)
 }
 

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -324,7 +324,7 @@ func (app *App) Start() error {
 			for portOffset := uint(0); portOffset < listenAddr.PortRangeSize(); portOffset++ {
 				// create the listener for this socket
 				hostport := listenAddr.JoinHostPort(portOffset)
-				ln, err := caddy.Listen(listenAddr.Network, hostport)
+				ln, err := caddy.ListenTimeout(listenAddr.Network, hostport, time.Duration(srv.KeepAliveInterval))
 				if err != nil {
 					return fmt.Errorf("%s: listening on %s: %v", listenAddr.Network, hostport, err)
 				}

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -65,6 +65,8 @@ type Server struct {
 	// 5m is applied to help avoid resource exhaustion.
 	IdleTimeout caddy.Duration `json:"idle_timeout,omitempty"`
 
+	KeepAliveInterval caddy.Duration `json:"keepalive_interval,omitempty"`
+
 	// MaxHeaderBytes is the maximum size to parse from a client's
 	// HTTP request headers.
 	MaxHeaderBytes int `json:"max_header_bytes,omitempty"`

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -65,6 +65,9 @@ type Server struct {
 	// 5m is applied to help avoid resource exhaustion.
 	IdleTimeout caddy.Duration `json:"idle_timeout,omitempty"`
 
+	// KeepAliveInterval is the interval at which TCP keepalive packets
+	// are sent to keep the connection alive at the TCP layer when no other
+	// data is being transmitted. The default is 15s.
 	KeepAliveInterval caddy.Duration `json:"keepalive_interval,omitempty"`
 
 	// MaxHeaderBytes is the maximum size to parse from a client's


### PR DESCRIPTION
See #4863  for more info

### Implementation

This is implemented at the `fakeCloseListener` layer, because during configuration reload it's unique. However,  reloading the keepalive interval does not update it for existing connections that are being proxied. It's only set when new connections are `Accept`ed.

Why not use the obvious approach with ListenConfig? Because when reloading, it would have to stop the existing listener and start a new one with the new ListenConfig. There wouldn't be a seamless switch between the old and new listeners, since only one can bind at one time. There's no way of updating the keepalive period after creating a `net.TCPListener` afaict.

I created a new function `ListenTimeout` to avoid breaking the API to `Listen` for modules.

Does this approach work? If so, I will proceed to add comments, documentation, tests, etc.


Fixes #4863