### PR TITLE
caddytls: Reuse issuer between PreCheck and Issue

### DIFF
--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -336,7 +336,7 @@ func (t *TLS) HandleHTTPChallenge(w http.ResponseWriter, r *http.Request) bool {
 	for _, iss := range ap.magic.Issuers {
 		if am, ok := iss.(acmeCapable); ok {
 			iss := am.GetACMEIssuer()
-			if certmagic.NewACMEIssuer(iss.magic, iss.template).HandleHTTPChallenge(w, r) {
+			if iss.issuer.HandleHTTPChallenge(w, r) {
 				return true
 			}
 		}

--- a/modules/caddytls/zerosslissuer.go
+++ b/modules/caddytls/zerosslissuer.go
@@ -162,8 +162,8 @@ func (iss *ZeroSSLIssuer) generateEABCredentials(ctx context.Context, acct acme.
 func (iss *ZeroSSLIssuer) initialize() {
 	iss.mu.Lock()
 	defer iss.mu.Unlock()
-	if iss.template.NewAccountFunc == nil {
-		iss.template.NewAccountFunc = iss.newAccountCallback
+	if iss.ACMEIssuer.issuer.NewAccountFunc == nil {
+		iss.ACMEIssuer.issuer.NewAccountFunc = iss.newAccountCallback
 	}
 }
 


### PR DESCRIPTION
This enables EAB reuse for ZeroSSLIssuer (which is now supported by ZeroSSL).

Calling `NewACMEIssuer()` destroys any state mutations in `PreCheck()` (or any of the other Issuer methods), which would also lose the email found by PreCheck's `getEmail()` call (in CertMagic; now called `setEmail`).

I ran this with the race detector, and it passed, so :man_shrugging:

I still wish the Config-Issuer dependency wasn't cyclical; not sure a better way to handle that right now. I tried adding the Config to the `ctx` which almost worked, except the `HandleHTTPChallenge` part doesn't have access to that context (darn). Back to the drawing board, I guess, if I want to make this more elegant than the whole `SetConfig()` dance...