### PR TITLE
caddyhttp: Implement `caddy respond` command

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -971,9 +971,9 @@ func handleConfigID(w http.ResponseWriter, r *http.Request) error {
 	id := parts[2]
 
 	// map the ID to the expanded path
-	currentCfgMu.RLock()
+	currentCtxMu.RLock()
 	expanded, ok := rawCfgIndex[id]
-	defer currentCfgMu.RUnlock()
+	defer currentCtxMu.RUnlock()
 	if !ok {
 		return APIError{
 			HTTPStatus: http.StatusNotFound,
@@ -1008,7 +1008,7 @@ func handleStop(w http.ResponseWriter, r *http.Request) error {
 // the operation at path according to method, using body and out as
 // needed. This is a low-level, unsynchronized function; most callers
 // will want to use changeConfig or readConfig instead. This requires a
-// read or write lock on currentCfgMu, depending on method (GET needs
+// read or write lock on currentCtxMu, depending on method (GET needs
 // only a read lock; all others need a write lock).
 func unsyncedConfigAccess(method, path string, body []byte, out io.Writer) error {
 	var err error

--- a/caddy.go
+++ b/caddy.go
@@ -135,8 +135,8 @@ func changeConfig(method, path string, input []byte, forceReload bool) error {
 		return fmt.Errorf("method not allowed")
 	}
 
-	currentCfgMu.Lock()
-	defer currentCfgMu.Unlock()
+	currentCtxMu.Lock()
+	defer currentCtxMu.Unlock()
 
 	err := unsyncedConfigAccess(method, path, input, nil)
 	if err != nil {
@@ -202,15 +202,15 @@ func changeConfig(method, path string, input []byte, forceReload bool) error {
 // readConfig traverses the current config to path
 // and writes its JSON encoding to out.
 func readConfig(path string, out io.Writer) error {
-	currentCfgMu.RLock()
-	defer currentCfgMu.RUnlock()
+	currentCtxMu.RLock()
+	defer currentCtxMu.RUnlock()
 	return unsyncedConfigAccess(http.MethodGet, path, nil, out)
 }
 
 // indexConfigObjects recursively searches ptr for object fields named
 // "@id" and maps that ID value to the full configPath in the index.
 // This function is NOT safe for concurrent access; obtain a write lock
-// on currentCfgMu.
+// on currentCtxMu.
 func indexConfigObjects(ptr interface{}, configPath string, index map[string]string) error {
 	switch val := ptr.(type) {
 	case map[string]interface{}:
@@ -250,7 +250,7 @@ func indexConfigObjects(ptr interface{}, configPath string, index map[string]str
 // it as the new config, replacing any other current config.
 // It does NOT update the raw config state, as this is a
 // lower-level function; most callers will want to use Load
-// instead. A write lock on currentCfgMu is required! If
+// instead. A write lock on currentCtxMu is required! If
 // allowPersist is false, it will not be persisted to disk,
 // even if it is configured to.
 func unsyncedDecodeAndRun(cfgJSON []byte, allowPersist bool) error {
@@ -279,17 +279,17 @@ func unsyncedDecodeAndRun(cfgJSON []byte, allowPersist bool) error {
 	}
 
 	// run the new config and start all its apps
-	err = run(newCfg, true)
+	ctx, err := run(newCfg, true)
 	if err != nil {
 		return err
 	}
 
-	// swap old config with the new one
-	oldCfg := currentCfg
-	currentCfg = newCfg
+	// swap old context (including its config) with the new one
+	oldCtx := currentCtx
+	currentCtx = ctx
 
 	// Stop, Cleanup each old app
-	unsyncedStop(oldCfg)
+	unsyncedStop(oldCtx)
 
 	// autosave a non-nil config, if not disabled
 	if allowPersist &&
@@ -333,7 +333,7 @@ func unsyncedDecodeAndRun(cfgJSON []byte, allowPersist bool) error {
 // This is a low-level function; most callers
 // will want to use Run instead, which also
 // updates the config's raw state.
-func run(newCfg *Config, start bool) error {
+func run(newCfg *Config, start bool) (Context, error) {
 	// because we will need to roll back any state
 	// modifications if this function errors, we
 	// keep a single error value and scope all
@@ -364,8 +364,8 @@ func run(newCfg *Config, start bool) error {
 			cancel()
 
 			// also undo any other state changes we made
-			if currentCfg != nil {
-				certmagic.Default.Storage = currentCfg.storage
+			if currentCtx.cfg != nil {
+				certmagic.Default.Storage = currentCtx.cfg.storage
 			}
 		}
 	}()
@@ -377,14 +377,14 @@ func run(newCfg *Config, start bool) error {
 	}
 	err = newCfg.Logging.openLogs(ctx)
 	if err != nil {
-		return err
+		return ctx, err
 	}
 
 	// start the admin endpoint (and stop any prior one)
 	if start {
 		err = replaceLocalAdminServer(newCfg)
 		if err != nil {
-			return fmt.Errorf("starting caddy administration endpoint: %v", err)
+			return ctx, fmt.Errorf("starting caddy administration endpoint: %v", err)
 		}
 	}
 
@@ -413,7 +413,7 @@ func run(newCfg *Config, start bool) error {
 		return nil
 	}()
 	if err != nil {
-		return err
+		return ctx, err
 	}
 
 	// Load and Provision each app and their submodules
@@ -426,18 +426,18 @@ func run(newCfg *Config, start bool) error {
 		return nil
 	}()
 	if err != nil {
-		return err
+		return ctx, err
 	}
 
 	if !start {
-		return nil
+		return ctx, nil
 	}
 
 	// Provision any admin routers which may need to access
 	// some of the other apps at runtime
 	err = newCfg.Admin.provisionAdminRouters(ctx)
 	if err != nil {
-		return err
+		return ctx, err
 	}
 
 	// Start
@@ -462,12 +462,12 @@ func run(newCfg *Config, start bool) error {
 		return nil
 	}()
 	if err != nil {
-		return err
+		return ctx, err
 	}
 
 	// now that the user's config is running, finish setting up anything else,
 	// such as remote admin endpoint, config loader, etc.
-	return finishSettingUp(ctx, newCfg)
+	return ctx, finishSettingUp(ctx, newCfg)
 }
 
 // finishSettingUp should be run after all apps have successfully started.
@@ -572,10 +572,10 @@ type ConfigLoader interface {
 // stop the others. Stop should only be called
 // if not replacing with a new config.
 func Stop() error {
-	currentCfgMu.Lock()
-	defer currentCfgMu.Unlock()
-	unsyncedStop(currentCfg)
-	currentCfg = nil
+	currentCtxMu.Lock()
+	defer currentCtxMu.Unlock()
+	unsyncedStop(currentCtx)
+	currentCtx = Context{}
 	rawCfgJSON = nil
 	rawCfgIndex = nil
 	rawCfg[rawConfigKey] = nil
@@ -588,13 +588,13 @@ func Stop() error {
 // it is logged and the function continues stopping
 // the next app. This function assumes all apps in
 // cfg were successfully started first.
-func unsyncedStop(cfg *Config) {
-	if cfg == nil {
+func unsyncedStop(ctx Context) {
+	if ctx.cfg == nil {
 		return
 	}
 
 	// stop each app
-	for name, a := range cfg.apps {
+	for name, a := range ctx.cfg.apps {
 		err := a.Stop()
 		if err != nil {
 			log.Printf("[ERROR] stop %s: %v", name, err)
@@ -602,13 +602,13 @@ func unsyncedStop(cfg *Config) {
 	}
 
 	// clean up all modules
-	cfg.cancelFunc()
+	ctx.cfg.cancelFunc()
 }
 
 // Validate loads, provisions, and validates
 // cfg, but does not start running it.
 func Validate(cfg *Config) error {
-	err := run(cfg, false)
+	_, err := run(cfg, false)
 	if err == nil {
 		cfg.cancelFunc() // call Cleanup on all modules
 	}
@@ -783,16 +783,25 @@ func goModule(mod *debug.Module) *debug.Module {
 	return mod
 }
 
+func ActiveContext() Context {
+	currentCtxMu.RLock()
+	defer currentCtxMu.RUnlock()
+	return currentCtx
+}
+
 // CtxKey is a value type for use with context.WithValue.
 type CtxKey string
 
 // This group of variables pertains to the current configuration.
 var (
-	// currentCfgMu protects everything in this var block.
-	currentCfgMu sync.RWMutex
+	// currentCtxMu protects everything in this var block.
+	currentCtxMu sync.RWMutex
 
-	// currentCfg is the currently-running configuration.
-	currentCfg *Config
+	// currentCtx is the root context for the currently-running
+	// configuration, which can be accessed through this value.
+	// If the Config contained in this value is not nil, then
+	// a config is currently active/running.
+	currentCtx Context
 
 	// rawCfg is the current, generic-decoded configuration;
 	// we initialize it as a map with one field ("config")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -338,6 +338,7 @@ func flagHelp(fs *flag.FlagSet) string {
 
 	buf := new(bytes.Buffer)
 	fs.SetOutput(buf)
+	buf.Write([]byte("(NOTE: use -- instead of - for flags)\n\n"))
 	fs.PrintDefaults()
 	return buf.String()
 }
@@ -480,3 +481,16 @@ func CaddyVersion() string {
 	}
 	return ver
 }
+
+// StringSlice is a flag.Value that enables repeated use of a string flag.
+type StringSlice []string
+
+func (ss StringSlice) String() string { return "[" + strings.Join(ss, ", ") + "]" }
+
+func (ss *StringSlice) Set(value string) error {
+	*ss = append(*ss, value)
+	return nil
+}
+
+// Interface guard
+var _ flag.Value = (*StringSlice)(nil)

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -394,6 +394,8 @@ func (app *App) Start() error {
 
 				//nolint:errcheck
 				go s.Serve(ln)
+
+				srv.listeners = append(srv.listeners, ln)
 				app.servers = append(app.servers, s)
 			}
 		}

--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -117,8 +117,14 @@ func cmdFileServer(fs caddycmd.Flags) (int, error) {
 		Servers: map[string]*caddyhttp.Server{"static": server},
 	}
 
+	var false bool
 	cfg := &caddy.Config{
-		Admin: &caddy.AdminConfig{Disabled: true},
+		Admin: &caddy.AdminConfig{
+			Disabled: true,
+			Config: &caddy.ConfigSettings{
+				Persist: &false,
+			},
+		},
 		AppsRaw: caddy.ModuleMap{
 			"http": caddyconfig.JSON(httpApp, nil),
 		},

--- a/modules/caddyhttp/reverseproxy/command.go
+++ b/modules/caddyhttp/reverseproxy/command.go
@@ -172,8 +172,13 @@ func cmdReverseProxy(fs caddycmd.Flags) (int, error) {
 		appsRaw["tls"] = caddyconfig.JSON(tlsApp, nil)
 	}
 
+	var false bool
 	cfg := &caddy.Config{
-		Admin:   &caddy.AdminConfig{Disabled: true},
+		Admin: &caddy.AdminConfig{Disabled: true,
+			Config: &caddy.ConfigSettings{
+				Persist: &false,
+			},
+		},
 		AppsRaw: appsRaw,
 	}
 

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -132,6 +132,7 @@ type Server struct {
 	primaryHandlerChain Handler
 	errorHandlerChain   Handler
 	listenerWrappers    []caddy.ListenerWrapper
+	listeners           []net.Listener
 
 	tlsApp       *caddytls.TLS
 	logger       *zap.Logger

--- a/modules/caddyhttp/staticresp.go
+++ b/modules/caddyhttp/staticresp.go
@@ -283,7 +283,7 @@ func cmdRespond(fl caddycmd.Flags) (int, error) {
 	// build headers map
 	hdr := make(http.Header)
 	for i, h := range respondCmdHeaders {
-		key, val, found := strings.Cut(h, ":")
+		key, val, found := cut(h, ":") // TODO: use strings.Cut() once Go 1.18 is our minimum
 		key, val = strings.TrimSpace(key), strings.TrimSpace(val)
 		if !found || key == "" || val == "" {
 			return caddy.ExitCodeFailedStartup, fmt.Errorf("header %d: invalid format \"%s\" (expecting \"Field: value\")", i, h)
@@ -393,6 +393,14 @@ func cmdRespond(fl caddycmd.Flags) (int, error) {
 	}
 
 	select {}
+}
+
+// TODO: delete this and use strings.Cut() once Go 1.18 is our minimum
+func cut(s, sep string) (before, after string, found bool) {
+	if i := strings.Index(s, sep); i >= 0 {
+		return s[:i], s[i+len(sep):], true
+	}
+	return s, "", false
 }
 
 // respondCmdHeaders holds the parsed values from repeated use of the --header flag.

--- a/modules/caddyhttp/staticresp.go
+++ b/modules/caddyhttp/staticresp.go
@@ -15,16 +15,50 @@
 package caddyhttp
 
 import (
+	"bytes"
+	"encoding/json"
+	"flag"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
 	"strconv"
+	"text/template"
+	"time"
 
 	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 )
 
 func init() {
 	caddy.RegisterModule(StaticResponse{})
+	caddycmd.RegisterCommand(caddycmd.Command{
+		Name:  "respond",
+		Func:  cmdRespond,
+		Usage: "[--status <code>] <body>",
+		Short: "Simple, hard-coded HTTP responses for development and testing",
+		Long: `
+Spins up a quick-and-clean HTTP server for development and testing purposes.
+
+With no options specified, this command listens on a random available port
+and answers HTTP requests with an empty 200 response. The listen address can
+be customized with the --listen flag and will always be printed to stdout.
+
+The body may be specified as the final (and unnamed) argument to the command,
+or piped via stdin. Template evaluation is enabled, with the following extra
+variables available:
+`,
+		Flags: func() *flag.FlagSet {
+			fs := flag.NewFlagSet("respond", flag.ExitOnError)
+			fs.String("listen", ":0", "The address to which to bind the listener")
+			fs.Int("status", http.StatusOK, "The response status code")
+			fs.Bool("access-log", false, "Enable the access log")
+			fs.Bool("debug", false, "Enable more verbose debug-level logging")
+			return fs
+		}(),
+	})
 }
 
 // StaticResponse implements a simple responder for static responses.
@@ -163,6 +197,131 @@ func (s StaticResponse) ServeHTTP(w http.ResponseWriter, r *http.Request, _ Hand
 	}
 
 	return nil
+}
+
+func cmdRespond(fl caddycmd.Flags) (int, error) {
+	caddy.TrapSignals()
+
+	// get flag values
+	listen := fl.String("listen")
+	statusCode := fl.Int("status")
+	accessLog := fl.Bool("access-log")
+	debug := fl.Bool("debug")
+
+	// get response body, either from arg or piped in
+	body := fl.Arg(0)
+	if body == "" {
+		stdinInfo, err := os.Stdin.Stat()
+		if err != nil {
+			return caddy.ExitCodeFailedStartup, err
+		}
+		if stdinInfo.Mode()&os.ModeNamedPipe != 0 {
+			bodyBytes, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return caddy.ExitCodeFailedStartup, err
+			}
+			body = string(bodyBytes)
+		}
+	}
+
+	// expand listen address, if more than one port
+	listenAddr, err := caddy.ParseNetworkAddress(listen)
+	if err != nil {
+		return caddy.ExitCodeFailedStartup, err
+	}
+	listenAddrs := make([]string, 0, listenAddr.PortRangeSize())
+	for offset := uint(0); offset < listenAddr.PortRangeSize(); offset++ {
+		listenAddrs = append(listenAddrs, listenAddr.JoinHostPort(offset))
+	}
+
+	// build each HTTP server
+	httpApp := App{Servers: make(map[string]*Server)}
+
+	for i, addr := range listenAddrs {
+		var handlers []json.RawMessage
+
+		// response body supports a basic template; evaluate it
+		tplCtx := struct {
+			N       int    // server number
+			Port    uint   // only the port
+			Address string // listener address
+		}{
+			N:       i,
+			Port:    listenAddr.StartPort + uint(i),
+			Address: addr,
+		}
+		tpl, err := template.New("body").Parse(body)
+		if err != nil {
+			return caddy.ExitCodeFailedStartup, err
+		}
+		buf := new(bytes.Buffer)
+		err = tpl.Execute(buf, tplCtx)
+		if err != nil {
+			return caddy.ExitCodeFailedStartup, err
+		}
+
+		// create route with handler
+		handler := StaticResponse{Body: buf.String(), StatusCode: WeakString(fmt.Sprintf("%d", statusCode))}
+		handlers = append(handlers, caddyconfig.JSONModuleObject(handler, "handler", "static_response", nil))
+		route := Route{HandlersRaw: handlers}
+
+		server := &Server{
+			Listen:            []string{addr},
+			ReadHeaderTimeout: caddy.Duration(10 * time.Second),
+			IdleTimeout:       caddy.Duration(30 * time.Second),
+			MaxHeaderBytes:    1024 * 10,
+			Routes:            RouteList{route},
+			AutoHTTPS:         &AutoHTTPSConfig{DisableRedir: true},
+		}
+		if accessLog {
+			server.Logs = new(ServerLogConfig)
+		}
+
+		// save server
+		httpApp.Servers[fmt.Sprintf("static%d", i)] = server
+	}
+
+	// finish building the config
+	var false bool
+	cfg := &caddy.Config{
+		Admin: &caddy.AdminConfig{
+			Disabled: true,
+			Config: &caddy.ConfigSettings{
+				Persist: &false,
+			},
+		},
+		AppsRaw: caddy.ModuleMap{
+			"http": caddyconfig.JSON(httpApp, nil),
+		},
+	}
+	if debug {
+		cfg.Logging = &caddy.Logging{
+			Logs: map[string]*caddy.CustomLog{
+				"default": {Level: "DEBUG"},
+			},
+		}
+	}
+
+	// run it!
+	err = caddy.Run(cfg)
+	if err != nil {
+		return caddy.ExitCodeFailedStartup, err
+	}
+
+	// to print listener addresses, get the active HTTP app
+	loadedHTTPApp, err := caddy.ActiveContext().App("http")
+	if err != nil {
+		return caddy.ExitCodeFailedStartup, err
+	}
+
+	// print each listener address
+	for _, srv := range loadedHTTPApp.(*App).Servers {
+		for _, ln := range srv.listeners {
+			fmt.Printf("Server address: %s\n", ln.Addr())
+		}
+	}
+
+	select {}
 }
 
 // Interface guards

--- a/modules/caddyhttp/staticresp.go
+++ b/modules/caddyhttp/staticresp.go
@@ -395,16 +395,8 @@ func cmdRespond(fl caddycmd.Flags) (int, error) {
 	select {}
 }
 
-type StringSlice []string
-
-func (ss StringSlice) String() string { return "[" + strings.Join(ss, ", ") + "]" }
-
-func (ss *StringSlice) Set(value string) error {
-	*ss = append(*ss, value)
-	return nil
-}
-
-var respondCmdHeaders StringSlice
+// respondCmdHeaders holds the parsed values from repeated use of the --header flag.
+var respondCmdHeaders caddycmd.StringSlice
 
 // Interface guards
 var (


### PR DESCRIPTION
The `caddy respond` command is for simple HTTP servers that write hard-coded responses to the client. This is useful for testing, development, and maintenance.

This requires storing the current context instead of just the current config. The context gives access to the config and the loaded modules. This was needed so we can get the listener addresses if :0 is used.

Also disables config persistence on the file-server and reverse-proxy subcommands, since you'd probably never want `--resume` to use the last command you ran (you'd only want to use that to resume actual configs like from API requests).

This command supports port ranges to spin up multiple servers and pipes for input as well.

This enables some neat functionality, like:

```bash
$ caddy respond  # empty 200
```
```bash
$ caddy respond --status 404
```
```bash
$ caddy respond "Hello, world!"
```
```bash
$ echo "I'm server {{.N}} on port {{.Port}}" | caddy respond --listen :2000-2004

Server address: [::]:2000
Server address: [::]:2001
Server address: [::]:2002
Server address: [::]:2003
Server address: [::]:2004

$ curl 127.0.0.1:2002
I'm server 2 on port 2002
```
```bash
$ cat maintenance.html | caddy respond --status 503
```

So yeah, the body supports some very basic template functionality.

TODO:

- ~~Might rename to `caddy http` instead? Not sure. (nah)~~
- [x] For quick and easy empty bodies with a custom status code, support `caddy respond <code>`.
- [x] Ability to set headers.

Feedback welcomed!