### PR TITLE
reverseproxy: Adjust new TLS Caddyfile directive names

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_options.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_options.txt
@@ -24,8 +24,9 @@ https://example.com {
 			max_conns_per_host 5
 			keepalive_idle_conns_per_host 2
 			keepalive_interval 30s
-			renegotiation freely
-			except_ports 8181 8182
+			
+			tls_renegotiation freely
+			tls_except_ports 8181 8182
 		}
 	}
 }


### PR DESCRIPTION
We recently merged PRs https://github.com/caddyserver/caddy/pull/4784 and https://github.com/caddyserver/caddy/pull/4843 to add `renegotiation` and `except_ports`. Both of these are actually options inside of the `TLS` struct, so they should be prefixed with `tls_` for the Caddyfile config.

I also just moved around the cases in the switch to better align with the documentation and order of the options.