### PR TITLE
admin api: expect quoted ETags

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -919,7 +919,7 @@ func handleConfig(w http.ResponseWriter, r *http.Request) error {
 
 		// we could consider setting up a sync.Pool for the summed
 		// hashes to reduce GC pressure.
-		w.Header().Set("ETag", r.URL.Path+" "+hex.EncodeToString(hash.Sum(nil)))
+		w.Header().Set("ETag", "\""+r.URL.Path+" "+hex.EncodeToString(hash.Sum(nil))+"\"")
 
 		return nil
 

--- a/admin_test.go
+++ b/admin_test.go
@@ -15,8 +15,8 @@
 package caddy
 
 import (
-	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"reflect"
 	"sync"
@@ -158,10 +158,6 @@ func (fooModule) CaddyModule() ModuleInfo {
 func (fooModule) Start() error { return nil }
 func (fooModule) Stop() error  { return nil }
 
-func makeEtag(path, hash string) string {
-	return "\"" + path + " " + hash + "\""
-}
-
 func TestETags(t *testing.T) {
 	RegisterModule(fooModule{})
 
@@ -172,7 +168,7 @@ func TestETags(t *testing.T) {
 	const key = "/" + rawConfigKey + "/apps/foo"
 
 	// try update the config with the wrong etag
-	err := changeConfig(http.MethodPost, key, []byte(`{"strField": "abc", "intField": 1}}`), makeEtag("/"+rawConfigKey, "not_an_etag"), false)
+	err := changeConfig(http.MethodPost, key, []byte(`{"strField": "abc", "intField": 1}}`), fmt.Sprintf(`"/%s not_an_etag"`, rawConfigKey), false)
 	if apiErr, ok := err.(APIError); !ok || apiErr.HTTPStatus != http.StatusPreconditionFailed {
 		t.Fatalf("expected precondition failed; got %v", err)
 	}
@@ -184,13 +180,13 @@ func TestETags(t *testing.T) {
 	}
 
 	// do the same update with the correct key
-	err = changeConfig(http.MethodPost, key, []byte(`{"strField": "abc", "intField": 1}`), makeEtag(key, hex.EncodeToString(hash.Sum(nil))), false)
+	err = changeConfig(http.MethodPost, key, []byte(`{"strField": "abc", "intField": 1}`), makeEtag(key, hash), false)
 	if err != nil {
 		t.Fatalf("expected update to work; got %v", err)
 	}
 
 	// now try another update. The hash should no longer match and we should get precondition failed
-	err = changeConfig(http.MethodPost, key, []byte(`{"strField": "abc", "intField": 2}`), makeEtag(key, hex.EncodeToString(hash.Sum(nil))), false)
+	err = changeConfig(http.MethodPost, key, []byte(`{"strField": "abc", "intField": 2}`), makeEtag(key, hash), false)
 	if apiErr, ok := err.(APIError); !ok || apiErr.HTTPStatus != http.StatusPreconditionFailed {
 		t.Fatalf("expected precondition failed; got %v", err)
 	}

--- a/caddy.go
+++ b/caddy.go
@@ -145,8 +145,16 @@ func changeConfig(method, path string, input []byte, ifMatchHeader string, force
 	defer currentCfgMu.Unlock()
 
 	if ifMatchHeader != "" {
+		// expect the first and last character to be quotes
+		if len(ifMatchHeader) < 2 || ifMatchHeader[0] != '"' || ifMatchHeader[len(ifMatchHeader)-1] != '"' {
+			return APIError{
+				HTTPStatus: http.StatusBadRequest,
+				Err:        fmt.Errorf("malformed If-Match header; expect quoted string"),
+			}
+		}
+
 		// read out the parts
-		parts := strings.Fields(ifMatchHeader)
+		parts := strings.Fields(ifMatchHeader[1 : len(ifMatchHeader)-1])
 		if len(parts) != 2 {
 			return APIError{
 				HTTPStatus: http.StatusBadRequest,


### PR DESCRIPTION
Follow up from https://github.com/caddyserver/caddy/pull/4579#issuecomment-1179329165

Expects the `If-Match` HTTP header to be quoted, and will return the `ETag` HTTP header in quotes. 