### PR TITLE
cmd: Fix reload with stdin

### DIFF
--- a/modules/caddypki/command.go
+++ b/modules/caddypki/command.go
@@ -113,7 +113,7 @@ func cmdTrust(fl caddycmd.Flags) (int, error) {
 	}
 
 	// Determine where we're sending the request to get the CA info
-	adminAddr, err := caddycmd.DetermineAdminAPIAddress(addrFlag, configFlag, configAdapterFlag)
+	adminAddr, err := caddycmd.DetermineAdminAPIAddress(addrFlag, nil, configFlag, configAdapterFlag)
 	if err != nil {
 		return caddy.ExitCodeFailedStartup, fmt.Errorf("couldn't determine admin API address: %v", err)
 	}
@@ -182,7 +182,7 @@ func cmdUntrust(fl caddycmd.Flags) (int, error) {
 	}
 
 	// Determine where we're sending the request to get the CA info
-	adminAddr, err := caddycmd.DetermineAdminAPIAddress(addrFlag, configFlag, configAdapterFlag)
+	adminAddr, err := caddycmd.DetermineAdminAPIAddress(addrFlag, nil, configFlag, configAdapterFlag)
 	if err != nil {
 		return caddy.ExitCodeFailedStartup, fmt.Errorf("couldn't determine admin API address: %v", err)
 	}


### PR DESCRIPTION
Fix #4899

The problem was that `LoadConfig` would be called twice, but when using `stdin` that isn't possible.

The fix is to pass in the already-loaded config if available to `DetermineAdminAPIAddress` (which only happens for `reload`) and `nil` otherwise, which makes it skip doing its own loading in that case.