### PR TITLE
caddyhttp: Clear out matcher error immediately after grabbing it

### DIFF
--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -205,7 +205,7 @@ func wrapRoute(route Route) Middleware {
 				err, ok := GetVar(req.Context(), MatcherErrorVarKey).(error)
 				if ok {
 					// clear out the error from context, otherwise
-					// it will cascade to the error routes
+					// it will cascade to the error routes (#4916)
 					SetVar(req.Context(), MatcherErrorVarKey, nil)
 					// return the matcher's error
 					return err

--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -204,6 +204,10 @@ func wrapRoute(route Route) Middleware {
 				// the request and trigger the error handling chain
 				err, ok := GetVar(req.Context(), MatcherErrorVarKey).(error)
 				if ok {
+					// clear out the error from context, otherwise
+					// it will cascade to the error routes
+					SetVar(req.Context(), MatcherErrorVarKey, nil)
+					// return the matcher's error
 					return err
 				}
 

--- a/modules/caddyhttp/vars.go
+++ b/modules/caddyhttp/vars.go
@@ -301,10 +301,20 @@ func GetVar(ctx context.Context, key string) interface{} {
 // SetVar sets a value in the context's variable table with
 // the given key. It overwrites any previous value with the
 // same key.
+//
+// If the value is nil (note: non-nil interface with nil
+// underlying value does not count) and the key exists in
+// the table, the key+value will be deleted from the table.
 func SetVar(ctx context.Context, key string, value interface{}) {
 	varMap, ok := ctx.Value(VarsCtxKey).(map[string]interface{})
 	if !ok {
 		return
+	}
+	if value == nil {
+		if _, ok := varMap[key]; ok {
+			delete(varMap, key)
+			return
+		}
 	}
 	varMap[key] = value
 }


### PR DESCRIPTION
Fixes a bug reported in https://caddy.community/t/error-handling-handler-error-with-multiple-handle-in-handle-errors/16692