### PR TITLE
cmd: Use newly-available version information

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -886,25 +886,9 @@ func Version() (simple, full string) {
 	return
 }
 
-// func goModule(mod *debug.Module) *debug.Module {
-// 	mod.Version = "unknown"
-// 	bi, ok := debug.ReadBuildInfo()
-// 	if ok {
-// 		mod.Path = bi.Main.Path
-// 		// The recommended way to build Caddy involves
-// 		// creating a separate main module, which
-// 		// TODO: track related Go issue: https://github.com/golang/go/issues/29228
-// 		// once that issue is fixed, we should just be able to use bi.Main... hopefully.
-// 		for _, dep := range bi.Deps {
-// 			if dep.Path == ImportPath {
-// 				return dep
-// 			}
-// 		}
-// 		return &bi.Main
-// 	}
-// 	return mod
-// }
-
+// ActiveContext returns the currently-active context.
+// This function is experimental and might be changed
+// or removed in the future.
 func ActiveContext() Context {
 	currentCtxMu.RLock()
 	defer currentCtxMu.RUnlock()

--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -331,30 +331,17 @@ func cmdReload(fl Flags) (int, error) {
 }
 
 func cmdVersion(_ Flags) (int, error) {
-	fmt.Println(CaddyVersion())
+	_, full := caddy.Version()
+	fmt.Println(full)
 	return caddy.ExitCodeSuccess, nil
 }
 
-func cmdBuildInfo(fl Flags) (int, error) {
+func cmdBuildInfo(_ Flags) (int, error) {
 	bi, ok := debug.ReadBuildInfo()
 	if !ok {
 		return caddy.ExitCodeFailedStartup, fmt.Errorf("no build information")
 	}
-
-	fmt.Printf("go_version: %s\n", runtime.Version())
-	fmt.Printf("go_os:      %s\n", runtime.GOOS)
-	fmt.Printf("go_arch:    %s\n", runtime.GOARCH)
-	fmt.Printf("path:       %s\n", bi.Path)
-	fmt.Printf("main:       %s %s %s\n", bi.Main.Path, bi.Main.Version, bi.Main.Sum)
-	fmt.Println("dependencies:")
-
-	for _, goMod := range bi.Deps {
-		fmt.Printf("%s %s %s", goMod.Path, goMod.Version, goMod.Sum)
-		if goMod.Replace != nil {
-			fmt.Printf(" => %s %s %s", goMod.Replace.Path, goMod.Replace.Version, goMod.Replace.Sum)
-		}
-		fmt.Println()
-	}
+	fmt.Println(bi)
 	return caddy.ExitCodeSuccess, nil
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,8 +38,8 @@ import (
 
 func init() {
 	// set a fitting User-Agent for ACME requests
-	goModule := caddy.GoModule()
-	cleanModVersion := strings.TrimPrefix(goModule.Version, "v")
+	version, _ := caddy.Version()
+	cleanModVersion := strings.TrimPrefix(version, "v")
 	certmagic.UserAgent = "Caddy/" + cleanModVersion
 
 	// by using Caddy, user indicates agreement to CA terms
@@ -441,11 +441,12 @@ func parseEnvFile(envInput io.Reader) (map[string]string, error) {
 }
 
 func printEnvironment() {
+	_, version := caddy.Version()
 	fmt.Printf("caddy.HomeDir=%s\n", caddy.HomeDir())
 	fmt.Printf("caddy.AppDataDir=%s\n", caddy.AppDataDir())
 	fmt.Printf("caddy.AppConfigDir=%s\n", caddy.AppConfigDir())
 	fmt.Printf("caddy.ConfigAutosavePath=%s\n", caddy.ConfigAutosavePath)
-	fmt.Printf("caddy.Version=%s\n", CaddyVersion())
+	fmt.Printf("caddy.Version=%s\n", version)
 	fmt.Printf("runtime.GOOS=%s\n", runtime.GOOS)
 	fmt.Printf("runtime.GOARCH=%s\n", runtime.GOARCH)
 	fmt.Printf("runtime.Compiler=%s\n", runtime.Compiler)
@@ -460,25 +461,6 @@ func printEnvironment() {
 	for _, v := range os.Environ() {
 		fmt.Println(v)
 	}
-}
-
-// CaddyVersion returns a detailed version string, if available.
-func CaddyVersion() string {
-	goModule := caddy.GoModule()
-	ver := goModule.Version
-	if goModule.Sum != "" {
-		ver += " " + goModule.Sum
-	}
-	if goModule.Replace != nil {
-		ver += " => " + goModule.Replace.Path
-		if goModule.Replace.Version != "" {
-			ver += "@" + goModule.Replace.Version
-		}
-		if goModule.Replace.Sum != "" {
-			ver += " " + goModule.Replace.Sum
-		}
-	}
-	return ver
 }
 
 // StringSlice is a flag.Value that enables repeated use of a string flag.

--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -94,10 +94,8 @@ func (t *Transport) Provision(ctx caddy.Context) error {
 		t.Root = "{http.vars.root}"
 	}
 
-	t.serverSoftware = "Caddy"
-	if mod := caddy.GoModule(); mod.Version != "" {
-		t.serverSoftware += "/" + mod.Version
-	}
+	version, _ := caddy.Version()
+	t.serverSoftware = "Caddy/" + version
 
 	// Set a relatively short default dial timeout.
 	// This is helpful to make load-balancer retries more speedy.

--- a/modules/caddyhttp/tracing/tracer.go
+++ b/modules/caddyhttp/tracing/tracer.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/caddyserver/caddy/v2"
 
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -52,7 +51,8 @@ func newOpenTelemetryWrapper(
 		spanName: spanName,
 	}
 
-	res, err := ot.newResource(webEngineName, caddycmd.CaddyVersion())
+	version, _ := caddy.Version()
+	res, err := ot.newResource(webEngineName, version)
 	if err != nil {
 		return ot, fmt.Errorf("creating resource error: %w", err)
 	}


### PR DESCRIPTION
Closes #4926

New Version() function returns simple and full version strings.

Go module information is still preferred. Then vcs info.

It's kind of weird, in that different ways of building Caddy give different outputs:

```
$ go run main.go version
unknown

$ go build && ./caddy version
496c88864c6b029b7d2c1017ec47ae86fe73045a (04 Aug 22 06:06 UTC)

$ xcaddy build --with github.com/caddyserver/caddy/v2=. && ./caddy version
v2.5.2 => /home/matt/Dev/caddyserver/caddy@(devel)
```

`go run` doesn't embed vcs in it, presumably because it runs from outside the git repo?

`go build` at least embeds commit info, so that's nice. That will still add a lot of helpful version info where we are currently lacking it in bug reports, etc.

`xcaddy build` of course builds Caddy as a dependency rather than as the main module, so we get the Go module version information, which is the most detailed as it gives us information about module replacements, etc.

So the `caddy version` command will print the full version string with a little more info.

The short form of the version string also returned by `Version()` looks like this if it uses VCS info: `63c7720e-20220802` -- it's a shortened SHA with the commit date, for convenience. This would be used for things like User-Agent strings, metrics, etc: `Caddy/63c7720e-20220802`

Overall, this is definitely an improvement. We're still waiting on https://github.com/golang/go/issues/29228 and https://github.com/golang/go/issues/50603 for a more ideal solution that always makes version info available for the Main module. But this'll do for now.

(Oh, totally forgot in the commit message, but we also just use `BuildInfo.String()` for `caddy build-info` now, instead of crafting our own output format. The `String()` output is quite nice!)