### PR TITLE
reverseproxy: Add `unix+h2c` Caddyfile network shortcut

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_h2c_shorthand.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_h2c_shorthand.txt
@@ -1,6 +1,8 @@
 :8884
 
 reverse_proxy h2c://localhost:8080
+
+reverse_proxy unix+h2c//run/app.sock
 ----------
 {
 	"apps": {
@@ -25,6 +27,21 @@ reverse_proxy h2c://localhost:8080
 									"upstreams": [
 										{
 											"dial": "localhost:8080"
+										}
+									]
+								},
+								{
+									"handler": "reverse_proxy",
+									"transport": {
+										"protocol": "http",
+										"versions": [
+											"h2c",
+											"2"
+										]
+									},
+									"upstreams": [
+										{
+											"dial": "unix//run/app.sock"
 										}
 									]
 								}

--- a/modules/caddyhttp/reverseproxy/addresses.go
+++ b/modules/caddyhttp/reverseproxy/addresses.go
@@ -96,6 +96,12 @@ func parseUpstreamDialAddress(upstreamAddr string) (string, string, error) {
 		}
 	}
 
+	// special case network to support both unix and h2c at the same time
+	if network == "unix+h2c" {
+		network = "unix"
+		scheme = "h2c"
+	}
+
 	// for simplest possible config, we only need to include
 	// the network portion if the user specified one
 	if network != "" {


### PR DESCRIPTION
As requested in https://github.com/caddyserver/caddy/issues/4498, just adding a little shorthand to make this work:

```
reverse_proxy unix+h2c//dev/shm/grpc
```

/cc @PaTTeeL