### PR TITLE
httpcaddyfile: Add shortcut for expression matchers

### DIFF
--- a/caddyconfig/caddyfile/lexer.go
+++ b/caddyconfig/caddyfile/lexer.go
@@ -191,3 +191,7 @@ func Tokenize(input []byte, filename string) ([]Token, error) {
 	}
 	return tokens, nil
 }
+
+func (t Token) Quoted() bool {
+	return t.wasQuoted > 0
+}

--- a/caddytest/integration/caddyfile_adapt/matcher_syntax.txt
+++ b/caddytest/integration/caddyfile_adapt/matcher_syntax.txt
@@ -19,27 +19,30 @@
 	@matcher6 vars_regexp "{http.request.uri}" `\.([a-f0-9]{6})\.(css|js)$`
 	respond @matcher6 "from vars_regexp matcher without name"
 
-	@matcher7 {
+	@matcher7 `path('/foo*') && method('GET')`
+	respond @matcher7 "inline expression matcher shortcut"
+
+	@matcher8 {
 		header Foo bar
 		header Foo foobar
 		header Bar foo
 	}
-	respond @matcher7 "header matcher merging values of the same field"
+	respond @matcher8 "header matcher merging values of the same field"
 
-	@matcher8 {
+	@matcher9 {
 		query foo=bar foo=baz bar=foo
 		query bar=baz
 	}
-	respond @matcher8 "query matcher merging pairs with the same keys"
+	respond @matcher9 "query matcher merging pairs with the same keys"
 
-	@matcher9 {
+	@matcher10 {
 		header !Foo
 		header Bar foo
 	}
-	respond @matcher9 "header matcher with null field matcher"
+	respond @matcher10 "header matcher with null field matcher"
 
-	@matcher10 remote_ip private_ranges
-	respond @matcher10 "remote_ip matcher with private ranges"
+	@matcher11 remote_ip private_ranges
+	respond @matcher11 "remote_ip matcher with private ranges"
 }
 ----------
 {
@@ -148,6 +151,19 @@
 							"handle": [
 								{
 									"body": "from vars_regexp matcher without name",
+									"handler": "static_response"
+								}
+							]
+						},
+						{
+							"match": [
+								{
+									"expression": "path('/foo*') \u0026\u0026 method('GET')"
+								}
+							],
+							"handle": [
+								{
+									"body": "inline expression matcher shortcut",
 									"handler": "static_response"
 								}
 							]


### PR DESCRIPTION
This is admittedly a bit of a wacky idea... but it's super cool!!

Since https://github.com/caddyserver/caddy/pull/4715 we have support for calling most matchers from within a CEL expression, I think we should also have a nicer syntax for defining a matcher with an expression. Typing out the word `expression` to get at this functionality is not as nice as it could be.

My first thought was maybe we make an alias like `expr`? That is better (6 less chars to type) but it still doesn't feel great.

Then I thought of the change we semi-recently made to the parser in https://github.com/caddyserver/caddy/pull/4643 which allows us to detect if a token was explicitly quoted in the config. Matcher names (i.e. the module name) should never be quoted (because... why?) so I think we can make the assumption that if we see something in the place of a matcher name that _is_ quoted, it's a CEL expression.

This reads quite naturally, because the only requirement is that you quote the CEL expression as a token, and it just works! It's true that quoting can be omitted for the long-form because of https://github.com/caddyserver/caddy/pull/4643, but explicitly quoting makes the shortcut possible!

Before:
```
@notFound expression {err.status_code} == 404
respond @notFound "Oops, not found"
```

After (also works with `"` quotes, and even multiline expressions work):
```
@notFound `{err.status_code} == 404`
respond @notFound "Oops, not found"
```

Pretty sweet! :rocket: 

The main concern is... are we shooting ourselves in the foot with making this assumption? Will we want to do something else with this case at some point in time? I think probably not. I think it would be pretty cool to push CEL expressions forwards as a more first-party feature rather than some "escape-hatch" feeling thing.

And this is fully backwards compatible, because this was previously impossible syntax since the first token was normally supposed to always be a matcher name.