### PR TITLE
caddyhttp: Fix for nil `handlerErr.Err`

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -528,7 +528,11 @@ func (*HTTPErrorConfig) WithError(r *http.Request, err error) *http.Request {
 		repl.Set("http.error.status_text", http.StatusText(handlerErr.StatusCode))
 		repl.Set("http.error.id", handlerErr.ID)
 		repl.Set("http.error.trace", handlerErr.Trace)
-		repl.Set("http.error.message", handlerErr.Err.Error())
+		if handlerErr.Err != nil {
+			repl.Set("http.error.message", handlerErr.Err.Error())
+		} else {
+			repl.Set("http.error.message", http.StatusText(handlerErr.StatusCode))
+		}
 	}
 
 	return r


### PR DESCRIPTION
Followup to #4971, need to check that there actually is a wrapped error before trying to grab its message.
