### PR TITLE
caddyhttp: Copy logger config to HTTP server during AutoHTTPS

### DIFF
--- a/modules/caddyhttp/autohttps.go
+++ b/modules/caddyhttp/autohttps.go
@@ -93,6 +93,9 @@ func (app *App) automaticHTTPSPhase1(ctx caddy.Context, repl *caddy.Replacer) er
 	// https://github.com/caddyserver/caddy/issues/3443)
 	redirDomains := make(map[string][]caddy.NetworkAddress)
 
+	// the configured logger for an HTTPS enabled server
+	var logger *ServerLogConfig
+
 	for srvName, srv := range app.Servers {
 		// as a prerequisite, provision route matchers; this is
 		// required for all routes on all servers, and must be
@@ -170,6 +173,11 @@ func (app *App) automaticHTTPSPhase1(ctx caddy.Context, repl *caddy.Replacer) er
 		// redirects, which we set up below; hence these two conditions
 		if len(serverDomainSet) == 0 && len(srv.TLSConnPolicies) == 0 {
 			continue
+		}
+
+		// clone the logger so we can apply it to the HTTP server
+		if srv.Logs != nil {
+			logger = srv.Logs.clone()
 		}
 
 		// for all the hostnames we found, filter them so we have
@@ -400,6 +408,7 @@ redirServersLoop:
 		app.Servers["remaining_auto_https_redirects"] = &Server{
 			Listen: redirServerAddrsList,
 			Routes: appendCatchAll(redirRoutes),
+			Logs:   logger,
 		}
 	}
 

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -663,6 +663,19 @@ func (slc ServerLogConfig) getLoggerName(host string) string {
 	return slc.DefaultLoggerName
 }
 
+func (slc *ServerLogConfig) clone() *ServerLogConfig {
+	clone := &ServerLogConfig{}
+	clone.DefaultLoggerName = slc.DefaultLoggerName
+	clone.LoggerNames = make(map[string]string)
+	for k, v := range slc.LoggerNames {
+		clone.LoggerNames[k] = v
+	}
+	clone.SkipHosts = append(clone.SkipHosts, slc.SkipHosts...)
+	clone.SkipUnmappedHosts = slc.SkipUnmappedHosts
+	clone.ShouldLogCredentials = slc.ShouldLogCredentials
+	return clone
+}
+
 // PrepareRequest fills the request r for use in a Caddy HTTP handler chain. w and s can
 // be nil, but the handlers will lose response placeholders and access to the server.
 func PrepareRequest(r *http.Request, repl *caddy.Replacer, w http.ResponseWriter, s *Server) *http.Request {


### PR DESCRIPTION
Fix #4982

I set up a clone function, because although it did work to assign the HTTP server to the same pointer for the logger as the HTTPS server, it worries me in case we later need to change it at runtime.