### PR TITLE
caddyhttp: Add HTTP/3 port override for Alt-Svc header

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -192,6 +192,7 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 	httpApp := caddyhttp.App{
 		HTTPPort:      tryInt(options["http_port"], &warnings),
 		HTTPSPort:     tryInt(options["https_port"], &warnings),
+		HTTP3Port:     tryInt(options["http3_port"], &warnings),
 		GracePeriod:   tryDuration(options["grace_period"], &warnings),
 		ShutdownDelay: tryDuration(options["shutdown_delay"], &warnings),
 		Servers:       servers,

--- a/caddyconfig/httpcaddyfile/options.go
+++ b/caddyconfig/httpcaddyfile/options.go
@@ -27,8 +27,9 @@ import (
 
 func init() {
 	RegisterGlobalOption("debug", parseOptTrue)
-	RegisterGlobalOption("http_port", parseOptHTTPPort)
-	RegisterGlobalOption("https_port", parseOptHTTPSPort)
+	RegisterGlobalOption("http_port", parseOptPort)
+	RegisterGlobalOption("https_port", parseOptPort)
+	RegisterGlobalOption("http3_port", parseOptPort)
 	RegisterGlobalOption("default_bind", parseOptStringList)
 	RegisterGlobalOption("grace_period", parseOptDuration)
 	RegisterGlobalOption("shutdown_delay", parseOptDuration)
@@ -58,36 +59,20 @@ func init() {
 
 func parseOptTrue(d *caddyfile.Dispenser, _ any) (any, error) { return true, nil }
 
-func parseOptHTTPPort(d *caddyfile.Dispenser, _ any) (any, error) {
-	var httpPort int
+func parseOptPort(d *caddyfile.Dispenser, _ any) (any, error) {
+	var port int
 	for d.Next() {
-		var httpPortStr string
-		if !d.AllArgs(&httpPortStr) {
+		var portStr string
+		if !d.AllArgs(&portStr) {
 			return 0, d.ArgErr()
 		}
 		var err error
-		httpPort, err = strconv.Atoi(httpPortStr)
+		port, err = strconv.Atoi(portStr)
 		if err != nil {
-			return 0, d.Errf("converting port '%s' to integer value: %v", httpPortStr, err)
+			return 0, d.Errf("converting port '%s' to integer value: %v", portStr, err)
 		}
 	}
-	return httpPort, nil
-}
-
-func parseOptHTTPSPort(d *caddyfile.Dispenser, _ any) (any, error) {
-	var httpsPort int
-	for d.Next() {
-		var httpsPortStr string
-		if !d.AllArgs(&httpsPortStr) {
-			return 0, d.ArgErr()
-		}
-		var err error
-		httpsPort, err = strconv.Atoi(httpsPortStr)
-		if err != nil {
-			return 0, d.Errf("converting port '%s' to integer value: %v", httpsPortStr, err)
-		}
-	}
-	return httpsPort, nil
+	return port, nil
 }
 
 func parseOptOrder(d *caddyfile.Dispenser, _ any) (any, error) {
@@ -421,13 +406,13 @@ func parseOCSPStaplingOptions(d *caddyfile.Dispenser, _ any) (any, error) {
 
 // parseLogOptions parses the global log option. Syntax:
 //
-//     log [name] {
-//         output  <writer_module> ...
-//         format  <encoder_module> ...
-//         level   <level>
-//         include <namespaces...>
-//         exclude <namespaces...>
-//     }
+//	log [name] {
+//	    output  <writer_module> ...
+//	    format  <encoder_module> ...
+//	    level   <level>
+//	    include <namespaces...>
+//	    exclude <namespaces...>
+//	}
 //
 // When the name argument is unspecified, this directive modifies the default
 // logger.

--- a/caddytest/integration/caddyfile_adapt/global_options.txt
+++ b/caddytest/integration/caddyfile_adapt/global_options.txt
@@ -2,6 +2,7 @@
 	debug
 	http_port 8080
 	https_port 8443
+	http3_port 443
 	grace_period 5s
 	shutdown_delay 10s
 	default_sni localhost
@@ -45,6 +46,7 @@
 		"http": {
 			"http_port": 8080,
 			"https_port": 8443,
+			"http3_port": 443,
 			"grace_period": 5000000000,
 			"shutdown_delay": 10000000000,
 			"servers": {

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -471,7 +471,7 @@ func (s *Server) findLastRouteWithHostMatcher() int {
 // serveHTTP3 creates a QUIC listener, configures an HTTP/3 server if
 // not already done, and then uses that server to serve HTTP/3 over
 // the listener, with Server s as the handler.
-func (s *Server) serveHTTP3(hostport string, tlsCfg *tls.Config) error {
+func (s *Server) serveHTTP3(hostport string, h3Port int, tlsCfg *tls.Config) error {
 	h3ln, err := caddy.ListenQUIC(hostport, tlsCfg, &s.activeRequests)
 	if err != nil {
 		return fmt.Errorf("starting HTTP/3 QUIC listener: %v", err)
@@ -483,6 +483,7 @@ func (s *Server) serveHTTP3(hostport string, tlsCfg *tls.Config) error {
 			Handler:        s,
 			TLSConfig:      tlsCfg,
 			MaxHeaderBytes: s.MaxHeaderBytes,
+			Port:           h3Port,
 		}
 	}
 


### PR DESCRIPTION
Fix #4996
