### PR TITLE
core: Plugins can register listener networks

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -571,6 +571,14 @@ func (s *Server) protocol(proto string) bool {
 	return false
 }
 
+// Listeners returns the server's listeners. These are active listeners,
+// so calling Accept() or Close() on them will probably break things.
+// They are made available here for read-only purposes (e.g. Addr())
+// and for type-asserting for purposes where you know what you're doing.
+//
+// EXPERIMENTAL: Subject to change or removal.
+func (s *Server) Listeners() []net.Listener { return s.listeners }
+
 // ServerLogConfig describes a server's logging configuration. If
 // enabled without customization, all requests to this server are
 // logged to the default logger; logger destinations may be


### PR DESCRIPTION
This can be useful for custom listeners. Plugins should simply register their network type during `init()`:

```go
func init() {
	caddy.RegisterNetwork("foo", newFooListener)
}

func newFooListener(network, addr string) (net.Listener, error) {
	// ...
}
```

Then in the Caddy config, users can listen on that network:

```json
{
	"listen": ["foo/:80"]
}
```

(It's a little unclear how this would work in the Caddyfile. Maybe something like `foo://` or `foo+http://` in the site address, I dunno.)

Multiple registrations are allowed if multiple network types need to be supported.

This feature/API is experimental and may change!

/cc @Xe @willnorris