### PR TITLE
fastcgi: allow users to log stderr output (#4967)

### DIFF
--- a/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
@@ -309,6 +309,14 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 				fcgiTransport.WriteTimeout = caddy.Duration(dur)
 				dispenser.Delete()
 				dispenser.Delete()
+
+			case "capture_stderr":
+				args := dispenser.RemainingArgs()
+				dispenser.Delete()
+				for range args {
+					dispenser.Delete()
+				}
+				fcgiTransport.CaptureStderr = true
 			}
 		}
 	}

--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -421,7 +421,7 @@ var headerNameReplacer = strings.NewReplacer(" ", "_", "-", "_")
 
 // Interface guards
 var (
-	_ zapcore.ObjectMarshaler = loggableEnv{}
+	_ zapcore.ObjectMarshaler = (*loggableEnv)(nil)
 
 	_ caddy.Provisioner = (*Transport)(nil)
 	_ http.RoundTripper = (*Transport)(nil)


### PR DESCRIPTION
Following the discussion in #4967 I've added support for logging any stderr messages sent by the upstream.

It is off by default and can be enabled with:
```
transport fastcgi {
    capture_stderr
}
```

Naming it `capture` gives us room to *not* buffer stderr records if it's off but it also isn't super clear that the main purpose is logging (at least right now). On the other hand, I don't know what else could be done with this *besides* logging. We should think whether this name makes sense.

Logging is done through the FastCGI transport logger.
Messages received on stderr are logged at WARN level by default, or ERROR level if the response status is >= 400.

The field name `body` was chosen instead of `message` because there's not really a clear definition of what a message is, there is no way for us to know, from a given stderr response, where one begins and another one ends. We cannot rely on fastcgi record boundaries alone (at least with PHP).

The output is messy but that's not something we can address, and this behaviour is pretty much equivalent to apache/nginx with the added bonus that formatting is preserved (albeit escaped) and we do not truncate the contents.

The logging in the fastcgi transport now also complies with `log_credentials` (also applies to logging of fastcgi params).
I'm not sure that we should be logging the fastcgi params though. It's somewhat redundant with the request data, but the alternative is telling users to do "printf debugging". I can see both sides so I defaulted to logging them, let me know what you think.

The changes could be a little cleaner (especially the handling of transfer encoding) but given that there's a PR to overhaul fastcgi as a whole I tried to keep the changeset as small as possible so that the merge is more obvious.
On that note, a test couldn't hurt, but I don't see how to output stderr records from a `net/http/fcgi` handler (what we use in the tests) so we'd pretty much just be asserting that the zap logger is called. Doesn't seem super worth it, especially since the overhaul is in progress, but since this got lost in the v1 -> v2 transition it's a good argument for doing it. Let me know what you think.

One thing I could not avoid were the comment formatting changes included in 1.19's gofmt.
I tried to fight it but it's painful. If this causes problems with our own parsing (for docs) let me know and I'll fix it up by hand.