### PR TITLE
caddyhttp: Support `respond` with HTTP 103 Early Hints

### DIFF
--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -1121,6 +1121,22 @@ func (m MatchProtocol) Match(r *http.Request) bool {
 		return r.TLS != nil
 	case "http":
 		return r.TLS == nil
+	case "http/1.0":
+		return r.ProtoMajor == 1 && r.ProtoMinor == 0
+	case "http/1.0+":
+		return r.ProtoAtLeast(1, 0)
+	case "http/1.1":
+		return r.ProtoMajor == 1 && r.ProtoMinor == 1
+	case "http/1.1+":
+		return r.ProtoAtLeast(1, 1)
+	case "http/2":
+		return r.ProtoMajor == 2
+	case "http/2+":
+		return r.ProtoAtLeast(2, 0)
+	case "http/3":
+		return r.ProtoMajor == 3
+	case "http/3+":
+		return r.ProtoAtLeast(3, 0)
 	}
 	return false
 }

--- a/modules/caddyhttp/push/handler.go
+++ b/modules/caddyhttp/push/handler.go
@@ -29,10 +29,24 @@ func init() {
 	caddy.RegisterModule(Handler{})
 }
 
-// Handler is a middleware for manipulating the request body.
+// Handler is a middleware for HTTP/2 server push. Note that
+// HTTP/2 server push has been deprecated by some clients and
+// its use is discouraged unless you can accurately predict
+// which resources actually need to be pushed to the client;
+// it can be difficult to know what the client already has
+// cached. Pushing unnecessary resources results in worse
+// performance. Consider using HTTP 103 Early Hints instead.
+//
+// This handler supports pushing from Link headers; in other
+// words, if the eventual response has Link headers, this
+// handler will push the resources indicated by those headers,
+// even without specifying any resources in its config.
 type Handler struct {
-	Resources []Resource    `json:"resources,omitempty"`
-	Headers   *HeaderConfig `json:"headers,omitempty"`
+	// The resources to push.
+	Resources []Resource `json:"resources,omitempty"`
+
+	// Headers to modify for the push requests.
+	Headers *HeaderConfig `json:"headers,omitempty"`
 
 	logger *zap.Logger
 }


### PR DESCRIPTION
This adds support for early hints in the static_response handler.

It implements my initial proposal. If accepted, it closes #5005.

A practical Caddyfile example, assuming that the endpoints behind `/heavy-pages/` take a while to load on the backend:

```
@hint {
	protocol http2+
	path     /heavy-pages/*
}
route @hint {
	header  Link "</style.css>; rel=preload; as=style"
	header  Link "</script.js>; rel=preload; as=script"
	respond 103
}
reverse_proxy ...
```

(The HTTP/2 requirement is to try to protect old, incompatible clients. It is optional if your clients are modern or you don't care.)

Early hints are best used when the final response may not be ready for a while (a "while" being, perhaps, 2-3 RTTs, so still on the order of ms).

I had considered an implementation that automatically dispatches early hints from our `file_server` since we can parse HTML and get an idea of the subresources before sending the whole document to the client. However, by the time we've parsed the HTML, we might as well be streaming it to the client anyway, and they can read the `<head>` of the HTML document and start requesting its subresources. Even if we cached the result of parsing the HTML, it's probably still faster to just send it to the client without hints.

Anyway, this seems simple enough and I'm inclined to merge it in after a few more tests.