### PR TITLE
ci: add `id-token` permission and update the signing command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,12 @@ jobs:
           GO_SEMVER: '~1.19.0'
 
     runs-on: ${{ matrix.os }}
+    # https://github.com/sigstore/cosign/issues/1258#issuecomment-1002251233
+    # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
+    permissions:
+      id-token: write
+      # https://docs.github.com/en/rest/overview/permissions-required-for-github-apps#permission-on-contents
+      contents: read
 
     steps:
     - name: Install Go

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,7 +68,7 @@ builds:
 signs:
   - cmd: cosign
     signature: "${artifact}.sig"
-    args: ["sign-blob", "--oidc-issuer=https://token.actions.githubusercontent.com", "--output=${signature}", "${artifact}"]
+    args: ["sign-blob", "--output-signature=${signature}", "--output-certificate", "${signature}.pem", "${artifact}"]
     artifacts: all
 sboms:
   - artifacts: binary


### PR DESCRIPTION
The release workflow was missing the `id-token` permission for GitHub Actions to allow `cosign` to fetch an OIDC token. 