### PR TITLE
Drop requirement for filesystems to implement fs.StatFS

### DIFF
--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -210,7 +210,7 @@ func (fsrv *FileServer) isSymlinkTargetDir(f fs.FileInfo, root, urlPath string) 
 		return false
 	}
 	target := caddyhttp.SanitizedPathJoin(root, path.Join(urlPath, f.Name()))
-	targetInfo, err := fsrv.fileSystem.Stat(target)
+	targetInfo, err := fs.Stat(fsrv.fileSystem, target)
 	if err != nil {
 		return false
 	}

--- a/modules/caddyhttp/fileserver/browsetplcontext.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext.go
@@ -65,7 +65,7 @@ func (fsrv *FileServer) directoryListing(entries []fs.DirEntry, canGoUp bool, ro
 		fileIsSymlink := isSymlink(info)
 		if fileIsSymlink {
 			path := caddyhttp.SanitizedPathJoin(root, path.Join(urlPath, info.Name()))
-			fileInfo, err := fsrv.fileSystem.Stat(path)
+			fileInfo, err := fs.Stat(fsrv.fileSystem, path)
 			if err == nil {
 				size = fileInfo.Size()
 			}

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -77,11 +77,11 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 				if err != nil {
 					return nil, err
 				}
-				statFS, ok := unm.(fs.StatFS)
+				fsys, ok := unm.(fs.FS)
 				if !ok {
-					return nil, h.Errf("module %s (%T) is not a supported file system implementation (requires fs.StatFS)", modID, unm)
+					return nil, h.Errf("module %s (%T) is not a supported file system implementation (requires fs.FS)", modID, unm)
 				}
-				fsrv.FileSystemRaw = caddyconfig.JSONModuleObject(statFS, "backend", name, nil)
+				fsrv.FileSystemRaw = caddyconfig.JSONModuleObject(fsys, "backend", name, nil)
 
 			case "hide":
 				fsrv.Hide = h.RemainingArgs()

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -83,14 +83,14 @@ type FileServer struct {
 	// disk file system.
 	//
 	// File system modules used here must adhere to the following requirements:
-	// - Implement fs.StatFS interface.
+	// - Implement fs.FS interface.
 	// - Support seeking on opened files; i.e.returned fs.File values must
 	//   implement the io.Seeker interface. This is required for determining
 	//   Content-Length and satisfying Range requests.
 	// - fs.File values that represent directories must implement the
 	//   fs.ReadDirFile interface so that directory listings can be procured.
 	FileSystemRaw json.RawMessage `json:"file_system,omitempty" caddy:"namespace=caddy.fs inline_key=backend"`
-	fileSystem    fs.StatFS
+	fileSystem    fs.FS
 
 	// The path to the root of the site. Default is `{http.vars.root}` if set,
 	// or current working directory otherwise. This should be a trusted value.
@@ -175,7 +175,7 @@ func (fsrv *FileServer) Provision(ctx caddy.Context) error {
 		if err != nil {
 			return fmt.Errorf("loading file system module: %v", err)
 		}
-		fsrv.fileSystem = mod.(fs.StatFS)
+		fsrv.fileSystem = mod.(fs.FS)
 	}
 	if fsrv.fileSystem == nil {
 		fsrv.fileSystem = osFS{}
@@ -244,7 +244,7 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 		zap.String("result", filename))
 
 	// get information about the file
-	info, err := fsrv.fileSystem.Stat(filename)
+	info, err := fs.Stat(fsrv.fileSystem, filename)
 	if err != nil {
 		err = fsrv.mapDirOpenError(err, filename)
 		if errors.Is(err, fs.ErrNotExist) {
@@ -270,7 +270,7 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 				continue
 			}
 
-			indexInfo, err := fsrv.fileSystem.Stat(indexPath)
+			indexInfo, err := fs.Stat(fsrv.fileSystem, indexPath)
 			if err != nil {
 				continue
 			}
@@ -350,7 +350,7 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 			continue
 		}
 		compressedFilename := filename + precompress.Suffix()
-		compressedInfo, err := fsrv.fileSystem.Stat(compressedFilename)
+		compressedInfo, err := fs.Stat(fsrv.fileSystem, compressedFilename)
 		if err != nil || compressedInfo.IsDir() {
 			fsrv.logger.Debug("precompressed file not accessible", zap.String("filename", compressedFilename), zap.Error(err))
 			continue
@@ -490,7 +490,7 @@ func (fsrv *FileServer) mapDirOpenError(originalErr error, name string) error {
 		if parts[i] == "" {
 			continue
 		}
-		fi, err := fsrv.fileSystem.Stat(strings.Join(parts[:i+1], separator))
+		fi, err := fs.Stat(fsrv.fileSystem, strings.Join(parts[:i+1], separator))
 		if err != nil {
 			return originalErr
 		}
@@ -613,13 +613,13 @@ func (wr statusOverrideResponseWriter) WriteHeader(int) {
 	wr.ResponseWriter.WriteHeader(wr.code)
 }
 
-// osFS is a simple fs.StatFS implementation that uses the local
+// osFS is a simple fs.FS implementation that uses the local
 // file system. (We do not use os.DirFS because we do our own
 // rooting or path prefixing without being constrained to a single
 // root folder. The standard os.DirFS implementation is problematic
 // since roots can be dynamic in our application.)
 //
-// osFS also implements fs.GlobFS, fs.ReadDirFS, and fs.ReadFileFS.
+// osFS also implements fs.StatFS, fs.GlobFS, fs.ReadDirFS, and fs.ReadFileFS.
 type osFS struct{}
 
 func (osFS) Open(name string) (fs.File, error)          { return os.Open(name) }
@@ -640,6 +640,7 @@ var (
 	_ caddy.Provisioner           = (*FileServer)(nil)
 	_ caddyhttp.MiddlewareHandler = (*FileServer)(nil)
 
+	_ fs.StatFS     = (*osFS)(nil)
 	_ fs.GlobFS     = (*osFS)(nil)
 	_ fs.ReadDirFS  = (*osFS)(nil)
 	_ fs.ReadFileFS = (*osFS)(nil)


### PR DESCRIPTION
According to a brief conversation in [Slack](https://caddyserver.slack.com/archives/C4DLAAP36/p1662419130255019?thread_ts=1662418198.184659&cid=C4DLAAP36), the `fs.StatFS` requirement was chosen for performance reasons.

A filesystem that implements `fs.StatFS` doesn't necessarily perform any faster than a `fs.FS` that requires calling `Open` first. For example, some of the filesystems in [`hairyhenderson/go-fsimpl`](https://github.com/hairyhenderson/go-fsimpl) have a lazy `Open`, and so there's no effective performance hit for [`fs.Stat`](https://pkg.go.dev/io/fs#Stat)'s fallback (`Open` followed by `Read` on the resulting `fs.File`).

I've changed references to `fs.StatFS`, and replaced calls to `Stat` with calls to `fs.Stat` instead.

I think this will make adoption much easier!

Signed-off-by: Dave Henderson <dhenderson@gmail.com>