### PR TITLE
caddyhttp: Explicitly disallow multiple regexp matchers

### DIFF
--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -1001,6 +1001,12 @@ func (m *MatchHeaderRE) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			val = second
 		}
 
+		// If there's already a pattern for this field
+		// then we would end up overwriting the old one
+		if (*m)[field] != nil {
+			return d.Errf("header_regexp matcher can only be used once per named matcher, per header field: %s", field)
+		}
+
 		(*m)[field] = &MatchRegexp{Pattern: val, Name: name}
 
 		if d.NextBlock(0) {
@@ -1469,6 +1475,13 @@ func (mre *MatchRegexp) Match(input string, repl *caddy.Replacer) bool {
 // UnmarshalCaddyfile implements caddyfile.Unmarshaler.
 func (mre *MatchRegexp) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
+		// If this is the second iteration of the loop
+		// then there's more than one path_regexp matcher
+		// and we would end up overwriting the old one
+		if mre.Pattern != "" {
+			return d.Err("path_regexp matcher can only be used once per named matcher")
+		}
+
 		args := d.RemainingArgs()
 		switch len(args) {
 		case 1:

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -1479,7 +1479,7 @@ func (mre *MatchRegexp) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		// then there's more than one path_regexp matcher
 		// and we would end up overwriting the old one
 		if mre.Pattern != "" {
-			return d.Err("path_regexp matcher can only be used once per named matcher")
+			return d.Err("regular expression can only be used once per named matcher")
 		}
 
 		args := d.RemainingArgs()


### PR DESCRIPTION
Fix #5028

Since the matchers would overwrite eachother, we should error out to tell the user their config doesn't make sense.
