### PR TITLE
core: Wrap listeners with type that can pipe

### DIFF
--- a/listen.go
+++ b/listen.go
@@ -15,7 +15,7 @@ import (
 func ListenTimeout(network, addr string, keepAlivePeriod time.Duration) (net.Listener, error) {
 	// check to see if plugin provides listener
 	if ln, err := getListenerFromPlugin(network, addr); err != nil || ln != nil {
-		return acceptPipe(ln), err
+		return pipeable(ln), err
 	}
 
 	lnKey := listenerKey(network, addr)
@@ -29,7 +29,7 @@ func ListenTimeout(network, addr string, keepAlivePeriod time.Duration) (net.Lis
 			}
 			return nil, err
 		}
-		return &sharedListener{Listener: acceptPipe(ln), key: lnKey}, nil
+		return &sharedListener{Listener: pipeable(ln), key: lnKey}, nil
 	})
 	if err != nil {
 		return nil, err

--- a/listen.go
+++ b/listen.go
@@ -15,7 +15,7 @@ import (
 func ListenTimeout(network, addr string, keepAlivePeriod time.Duration) (net.Listener, error) {
 	// check to see if plugin provides listener
 	if ln, err := getListenerFromPlugin(network, addr); err != nil || ln != nil {
-		return ln, err
+		return acceptPipe(ln), err
 	}
 
 	lnKey := listenerKey(network, addr)
@@ -29,7 +29,7 @@ func ListenTimeout(network, addr string, keepAlivePeriod time.Duration) (net.Lis
 			}
 			return nil, err
 		}
-		return &sharedListener{Listener: ln, key: lnKey}, nil
+		return &sharedListener{Listener: acceptPipe(ln), key: lnKey}, nil
 	})
 	if err != nil {
 		return nil, err

--- a/listen_linux.go
+++ b/listen_linux.go
@@ -14,11 +14,12 @@ import (
 func ListenTimeout(network, addr string, keepalivePeriod time.Duration) (net.Listener, error) {
 	// check to see if plugin provides listener
 	if ln, err := getListenerFromPlugin(network, addr); err != nil || ln != nil {
-		return ln, err
+		return pipeable(ln), err
 	}
 
 	config := &net.ListenConfig{Control: reusePort, KeepAlive: keepalivePeriod}
-	return config.Listen(context.Background(), network, addr)
+	ln, err := config.Listen(context.Background(), network, addr)
+	return pipeable(ln), err
 }
 
 func reusePort(network, address string, conn syscall.RawConn) error {


### PR DESCRIPTION
Once a server has a listener, the only way for it to act on connections is to call `Accept()`. Unfortunately, the implementations of `Accept()` are opaque and hard-coded; that is, a server looping on a TCP listener can only accept real TCP connections. It's not really possible (AFAIK) to give that listener a virtual "connection" in user space, we have to open a real TCP socket through the kernel and proxy all the bytes.

This change allows servers to accept connections whether they be real or virtual. It exports a `Pipe()` method that allows other code to give a server a `net.Conn`. This means the server can still use real TCP connections, but also allows us to add our own connections if we have something we want it to do or act on.

For example, [the layer4 module could hand off a connection to the HTTP app without having to proxy](https://github.com/mholt/caddy-l4/issues/70). Very efficient!

This is an early-stages experiment and still WIP. Haven't even tested it yet.

(Currently, this functionality does not apply to PacketConn or quic.EarlyListener types.)