### PR TITLE
caddyhttp: Make metrics opt-in

### DIFF
--- a/caddyconfig/httpcaddyfile/serveroptions.go
+++ b/caddyconfig/httpcaddyfile/serveroptions.go
@@ -43,6 +43,7 @@ type serverOptions struct {
 	Protocols            []string
 	StrictSNIHost        *bool
 	ShouldLogCredentials bool
+	Metrics              *caddyhttp.Metrics
 }
 
 func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (any, error) {
@@ -175,6 +176,15 @@ func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (any, error) {
 				}
 				serverOpts.StrictSNIHost = &boolVal
 
+			case "metrics":
+				if d.NextArg() {
+					return nil, d.ArgErr()
+				}
+				if d.NextBlock(0) {
+					return nil, d.ArgErr()
+				}
+				serverOpts.Metrics = new(caddyhttp.Metrics)
+
 			// TODO: DEPRECATED. (August 2022)
 			case "protocol":
 				caddy.Log().Named("caddyfile").Warn("DEPRECATED: protocol sub-option will be removed soon")
@@ -259,6 +269,7 @@ func applyServerOptions(
 		server.MaxHeaderBytes = opts.MaxHeaderBytes
 		server.Protocols = opts.Protocols
 		server.StrictSNIHost = opts.StrictSNIHost
+		server.Metrics = opts.Metrics
 		if opts.ShouldLogCredentials {
 			if server.Logs == nil {
 				server.Logs = &caddyhttp.ServerLogConfig{}

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -263,7 +263,7 @@ func (app *App) Provision(ctx caddy.Context) error {
 		// route handler so that important security checks are done, etc.
 		primaryRoute := emptyHandler
 		if srv.Routes != nil {
-			err := srv.Routes.ProvisionHandlers(ctx)
+			err := srv.Routes.ProvisionHandlers(ctx, srv.Metrics)
 			if err != nil {
 				return fmt.Errorf("server %s: setting up route handlers: %v", srvName, err)
 			}

--- a/modules/caddyhttp/metrics.go
+++ b/modules/caddyhttp/metrics.go
@@ -11,6 +11,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+// Metrics configures metrics observations.
+// EXPERIMENTAL and subject to change or removal.
+type Metrics struct{}
+
 var httpMetrics = struct {
 	init             sync.Once
 	requestInFlight  *prometheus.GaugeVec

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -152,6 +152,10 @@ type Server struct {
 	// Default: `[h1 h2 h3]`
 	Protocols []string `json:"protocols,omitempty"`
 
+	// If set, metrics observations will be enabled.
+	// This setting is EXPERIMENTAL and subject to change.
+	Metrics *Metrics `json:"metrics,omitempty"`
+
 	name string
 
 	primaryHandlerChain Handler


### PR DESCRIPTION
Related to #4644

Metrics have accumulated an unfortunate performance regression and have some functionality limitations. Since we don't have the time or expertise on hand currently to address these issues in the more ideal way, I think we need to make metrics opt-in for now.

In the JSON, metrics are enabled by setting `"metrics": {}` in your server config, or in the Caddyfile, use global options:

```
{
	servers {
		metrics
	}
}
```

**This is EXPERIMENTAL and subject to change.**

Note that metrics for `handle_response` handlers (etc) will not be able to have metrics enabled, at least for now.

I think going forward a better long-term fix might be to have the `metrics` directive enable metrics, rather than a server-wide config. I'd also like to make certain aspects about metrics actually configurable, rather than having an empty struct.