### PR TITLE
caddyhttp: Honor grace period in background

### DIFF
--- a/caddytest/caddytest.go
+++ b/caddytest/caddytest.go
@@ -43,7 +43,7 @@ type Defaults struct {
 
 // Default testing values
 var Default = Defaults{
-	AdminPort:          2019,
+	AdminPort:          2999, // different from what a real server also running on a developer's machine might be
 	Certifcates:        []string{"/caddy.localhost.crt", "/caddy.localhost.key"},
 	TestRequestTimeout: 5 * time.Second,
 	LoadRequestTimeout: 5 * time.Second,

--- a/caddytest/integration/caddyfile_test.go
+++ b/caddytest/integration/caddyfile_test.go
@@ -16,6 +16,7 @@ func TestRespond(t *testing.T) {
   {
     http_port     9080
     https_port    9443
+    grace_period  1
   }
   
   localhost:9080 {
@@ -37,6 +38,7 @@ func TestRedirect(t *testing.T) {
   {
     http_port     9080
     https_port    9443
+    grace_period  1
   }
   
   localhost:9080 {
@@ -86,6 +88,7 @@ func TestReadCookie(t *testing.T) {
   {
     http_port     9080
     https_port    9443
+    grace_period  1
   }
   
   localhost:9080 {
@@ -109,6 +112,7 @@ func TestReplIndex(t *testing.T) {
   {
     http_port     9080
     https_port    9443
+    grace_period  1
   }
 
   localhost:9080 {

--- a/caddytest/integration/handler_test.go
+++ b/caddytest/integration/handler_test.go
@@ -13,6 +13,7 @@ func TestBrowse(t *testing.T) {
 	{
 		http_port     9080
 		https_port    9443
+		grace_period  1
 	}
 	http://localhost:9080 {
 		file_server browse

--- a/caddytest/integration/map_test.go
+++ b/caddytest/integration/map_test.go
@@ -13,6 +13,7 @@ func TestMap(t *testing.T) {
 	tester.InitServer(`{
 		http_port     9080
 		https_port    9443
+		grace_period  1
 	}
 
 	localhost:9080 {

--- a/caddytest/integration/reverseproxy_test.go
+++ b/caddytest/integration/reverseproxy_test.go
@@ -18,6 +18,7 @@ func TestSRVReverseProxy(t *testing.T) {
 	{
 		"apps": {
 		  "http": {
+			"grace_period": 1,
 			"servers": {
 			  "srv0": {
 				"listen": [
@@ -50,6 +51,7 @@ func TestSRVWithDial(t *testing.T) {
 	{
 		"apps": {
 		  "http": {
+			"grace_period": 1,
 			"servers": {
 			  "srv0": {
 				"listen": [
@@ -115,6 +117,7 @@ func TestDialWithPlaceholderUnix(t *testing.T) {
 	{
 		"apps": {
 		  "http": {
+			"grace_period": 1,
 			"servers": {
 			  "srv0": {
 				"listen": [
@@ -156,6 +159,7 @@ func TestReverseProxyWithPlaceholderDialAddress(t *testing.T) {
 	{
 		"apps": {
 			"http": {
+				"grace_period": 1,
 				"servers": {
 					"srv0": {
 						"listen": [
@@ -239,6 +243,7 @@ func TestReverseProxyWithPlaceholderTCPDialAddress(t *testing.T) {
 	{
 		"apps": {
 			"http": {
+				"grace_period": 1,
 				"servers": {
 					"srv0": {
 						"listen": [
@@ -321,6 +326,7 @@ func TestSRVWithActiveHealthcheck(t *testing.T) {
 	{
 		"apps": {
 		  "http": {
+			"grace_period": 1,
 			"servers": {
 			  "srv0": {
 				"listen": [

--- a/caddytest/integration/sni_test.go
+++ b/caddytest/integration/sni_test.go
@@ -15,6 +15,7 @@ func TestDefaultSNI(t *testing.T) {
       "http": {
         "http_port": 9080,
         "https_port": 9443,
+        "grace_period": 1,
         "servers": {
           "srv0": {
             "listen": [
@@ -112,6 +113,7 @@ func TestDefaultSNIWithNamedHostAndExplicitIP(t *testing.T) {
       "http": {
         "http_port": 9080,
         "https_port": 9443,
+        "grace_period": 1,
         "servers": {
           "srv0": {
             "listen": [
@@ -212,6 +214,7 @@ func TestDefaultSNIWithPortMappingOnly(t *testing.T) {
       "http": {
         "http_port": 9080,
         "https_port": 9443,
+        "grace_period": 1,
         "servers": {
           "srv0": {
             "listen": [

--- a/caddytest/integration/stream_test.go
+++ b/caddytest/integration/stream_test.go
@@ -27,6 +27,7 @@ func TestH2ToH2CStream(t *testing.T) {
       "http": {
         "http_port": 9080,
         "https_port": 9443,
+		"grace_period": 1,
         "servers": {
           "srv0": {
             "listen": [
@@ -216,6 +217,7 @@ func TestH2ToH1ChunkedResponse(t *testing.T) {
     "http": {
       "http_port": 9080,
       "https_port": 9443,
+	  "grace_period": 1,
       "servers": {
         "srv0": {
           "listen": [

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -505,37 +505,61 @@ func (app *App) Stop() error {
 		app.logger.Debug("servers shutting down with eternal grace period")
 	}
 
-	// stopServers stops all servers as gracefully as possible
-	stopServers := func() {
-		for _, server := range app.Servers {
+	// goroutines aren't guaranteed to be scheduled right away,
+	// so we'll use one WaitGroup to wait for all the goroutines
+	// to start their server shutdowns, and another to wait for
+	// them to finish; we'll always block for them to start so
+	// that when we return the caller can be confident* that the
+	// old servers are likely longer accepting new connections
+	// (* the scheduler might still pause them right before
+	// calling Shutdown(), but it's unlikely)
+	var startedShutdown, finishedShutdown sync.WaitGroup
+
+	for _, server := range app.Servers {
+		stopServer := func(server *Server) {
+			defer finishedShutdown.Done()
+			startedShutdown.Done()
+
 			if err := server.server.Shutdown(ctx); err != nil {
 				app.logger.Error("server shutdown",
 					zap.Error(err),
 					zap.Strings("addresses", server.Listen))
 			}
+		}
+		stopH3Server := func(server *Server) {
+			defer finishedShutdown.Done()
+			startedShutdown.Done()
 
-			if server.h3server != nil {
-				// TODO: CloseGracefully, once implemented upstream (see https://github.com/lucas-clemente/quic-go/issues/2103)
-				if err := server.h3server.Close(); err != nil {
-					app.logger.Error("HTTP/3 server shutdown",
-						zap.Error(err),
-						zap.Strings("addresses", server.Listen))
-				}
+			if server.h3server == nil {
+				return
+			}
+			// TODO: CloseGracefully, once implemented upstream (see https://github.com/lucas-clemente/quic-go/issues/2103)
+			if err := server.h3server.Close(); err != nil {
+				app.logger.Error("HTTP/3 server shutdown",
+					zap.Error(err),
+					zap.Strings("addresses", server.Listen))
 			}
 		}
+
+		startedShutdown.Add(2)
+		finishedShutdown.Add(2)
+		go stopServer(server)
+		go stopH3Server(server)
 	}
 
+	// block until all the goroutines have at least been scheduled;
+	// this means that they have likely called Shutdown() by now
+	startedShutdown.Wait()
+
 	// if the process is exiting, we need to block here and wait
-	// for the grace period to complete, otherwise the process will
+	// for the grace periods to complete, otherwise the process will
 	// terminate before the servers are finished shutting down; but
-	// however, we don't really need to wait for the grace period to
-	// finish if the process isn't exiting (but note that frequent
-	// config reloads with long grace periods for a sustained length
-	// of time may deplete resources)
+	// we don't really need to wait for the grace period to finish
+	// if the process isn't exiting (but note that frequent config
+	// reloads with long grace periods for a sustained length of time
+	// may deplete resources)
 	if caddy.Exiting() {
-		stopServers()
-	} else {
-		go stopServers()
+		finishedShutdown.Wait()
 	}
 
 	return nil

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -510,7 +510,7 @@ func (app *App) Stop() error {
 	// to start their server shutdowns, and another to wait for
 	// them to finish; we'll always block for them to start so
 	// that when we return the caller can be confident* that the
-	// old servers are likely longer accepting new connections
+	// old servers are no longer accepting new connections
 	// (* the scheduler might still pause them right before
 	// calling Shutdown(), but it's unlikely)
 	var startedShutdown, finishedShutdown sync.WaitGroup


### PR DESCRIPTION
This should make config reloads much faster. It avoids blocking from grace periods during config reloads by doing server shutdown in a goroutine. (We never returned any shutdown errors to the caller anyway.)

However, frequent config reloads with long grace periods can build up goroutines. This might be problematic if most/all of these are true:

- configs are being reloaded faster than the servers can shut down, for a sustained period of time,
- clients are slow to finish their requests, or requests are hijacked (WebSockets), and
- server resources are limited,

because obviously this will allow the next config to come in before the old one is out.

That might be OK, and it's probably just a matter of tuning to your actual requirements. If you meet the criteria above, shorten your grace period or do less frequent config changes. Otherwise I don't expect this behavior to be a problem.

Special case: if the process is exiting, the HTTP app's `Stop()` still blocks until the servers have shut down completely. This avoids an ungraceful shutdown by the process exiting too early.