### PR TITLE
ci: fix the name template of singing certificate and sboms

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,14 +68,13 @@ builds:
 signs:
   - cmd: cosign
     signature: "${artifact}.sig"
-    certificate: '{{ trimsuffix .Env.artifact ".tar.gz" }}.pem'
+    certificate: '{{ trimsuffix (trimsuffix .Env.artifact ".zip") ".tar.gz" }}.pem'
     args: ["sign-blob", "--output-signature=${signature}", "--output-certificate", "${certificate}", "${artifact}"]
     artifacts: all
 sboms:
   - artifacts: binary
-    # defaults to
-    # documents:
-    # - "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.sbom"
+    documents:
+    - '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{if .Arm}}v{{ .Arm }}{{end}}.sbom'
     cmd: syft
     args: ["$artifact", "--file", "${document}", "--output", "cyclonedx-json"]
 archives:


### PR DESCRIPTION
The earlier template of SBOM document names was `"{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.sbom"`, which does not account for the varying versions of arm architecture. In other words, binaries of `armv5` and `armv6` end up having document ending with `[...]arm.sbom`, which causes an error on upload for both having the same name. We should further namespace the document names with the arm version.

Another issue with template naming is for signing certificate on Windows. The earlier template trims `.tar.gz`, but our Windows archives are suffixed with `.zip`. We should trim `.zip` as wll.

This PR does both.

Test results: https://github.com/gactions-playground/merry-go-round/releases/tag/v0.0.11