### PR TITLE
httpcaddyfile: Fix `protocols` global option parsing

### DIFF
--- a/admin_test.go
+++ b/admin_test.go
@@ -161,7 +161,7 @@ func (fooModule) Stop() error  { return nil }
 func TestETags(t *testing.T) {
 	RegisterModule(fooModule{})
 
-	if err := Load([]byte(`{"apps": {"foo": {"strField": "abc", "intField": 0}}}`), true); err != nil {
+	if err := Load([]byte(`{"admin": {"listen": "localhost:2999"}, "apps": {"foo": {"strField": "abc", "intField": 0}}}`), true); err != nil {
 		t.Fatalf("loading: %s", err)
 	}
 

--- a/caddyconfig/httpcaddyfile/serveroptions.go
+++ b/caddyconfig/httpcaddyfile/serveroptions.go
@@ -162,7 +162,7 @@ func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (any, error) {
 					}
 					serverOpts.Protocols = append(serverOpts.Protocols, proto)
 				}
-				if d.NextBlock(0) {
+				if nesting := d.Nesting(); d.NextBlock(nesting) {
 					return nil, d.ArgErr()
 				}
 

--- a/caddytest/integration/caddyfile_adapt/global_server_options_single.txt
+++ b/caddytest/integration/caddyfile_adapt/global_server_options_single.txt
@@ -12,8 +12,8 @@
 		}
 		max_header_size 100MB
 		log_credentials
-		strict_sni_host
 		protocols h1 h2 h2c h3
+		strict_sni_host
 	}
 }
 


### PR DESCRIPTION
Fix #5053

When checking for a block, the current nesting must be used, otherwise it returns the wrong thing.