### PR TITLE
fastcgi: Redirect using original URI path (fix #5073)

### DIFF
--- a/caddytest/integration/caddyfile_adapt/php_fastcgi_expanded_form.txt
+++ b/caddytest/integration/caddyfile_adapt/php_fastcgi_expanded_form.txt
@@ -8,7 +8,7 @@ route {
 		}
 		not path */
 	}
-	redir @canonicalPath {path}/ 308
+	redir @canonicalPath {http.request.orig_uri.path}/ 308
 
 	# If the requested file does not exist, try index files
 	@indexFiles {
@@ -50,7 +50,7 @@ route {
 													"handler": "static_response",
 													"headers": {
 														"Location": [
-															"{http.request.uri.path}/"
+															"{http.request.orig_uri.path}/"
 														]
 													},
 													"status_code": 308

--- a/caddytest/integration/caddyfile_adapt/php_fastcgi_handle_response.txt
+++ b/caddytest/integration/caddyfile_adapt/php_fastcgi_handle_response.txt
@@ -42,7 +42,7 @@
 									"handler": "static_response",
 									"headers": {
 										"Location": [
-											"{http.request.uri.path}/"
+											"{http.request.orig_uri.path}/"
 										]
 									},
 									"status_code": 308

--- a/caddytest/integration/caddyfile_adapt/php_fastcgi_matcher.txt
+++ b/caddytest/integration/caddyfile_adapt/php_fastcgi_matcher.txt
@@ -30,7 +30,7 @@ php_fastcgi @api localhost:9000
 													"handler": "static_response",
 													"headers": {
 														"Location": [
-															"{http.request.uri.path}/"
+															"{http.request.orig_uri.path}/"
 														]
 													},
 													"status_code": 308

--- a/caddytest/integration/caddyfile_adapt/php_fastcgi_subdirectives.txt
+++ b/caddytest/integration/caddyfile_adapt/php_fastcgi_subdirectives.txt
@@ -43,7 +43,7 @@ php_fastcgi localhost:9000 {
 									"handler": "static_response",
 									"headers": {
 										"Location": [
-											"{http.request.uri.path}/"
+											"{http.request.orig_uri.path}/"
 										]
 									},
 									"status_code": 308

--- a/caddytest/integration/caddyfile_adapt/php_fastcgi_try_files_override.txt
+++ b/caddytest/integration/caddyfile_adapt/php_fastcgi_try_files_override.txt
@@ -46,7 +46,7 @@ php_fastcgi localhost:9000 {
 									"handler": "static_response",
 									"headers": {
 										"Location": [
-											"{http.request.uri.path}/"
+											"{http.request.orig_uri.path}/"
 										]
 									},
 									"status_code": 308

--- a/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
@@ -348,7 +348,7 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 		}
 		redirHandler := caddyhttp.StaticResponse{
 			StatusCode: caddyhttp.WeakString(strconv.Itoa(http.StatusPermanentRedirect)),
-			Headers:    http.Header{"Location": []string{"{http.request.uri.path}/"}},
+			Headers:    http.Header{"Location": []string{"{http.request.orig_uri.path}/"}},
 		}
 		redirRoute := caddyhttp.Route{
 			MatcherSetsRaw: []caddy.ModuleMap{redirMatcherSet},

--- a/modules/caddyhttp/rewrite/rewrite.go
+++ b/modules/caddyhttp/rewrite/rewrite.go
@@ -383,8 +383,13 @@ func trimPathPrefix(escapedPath, prefix string) string {
 		iPrefix++
 	}
 
-	// found matching prefix, trim it
-	return escapedPath[iPath:]
+	// if we iterated through the entire prefix, we found it, so trim it
+	if iPath >= len(prefix) {
+		return escapedPath[iPath:]
+	}
+
+	// otherwise we did not find the prefix
+	return escapedPath
 }
 
 func reverse(s string) string {

--- a/modules/caddyhttp/rewrite/rewrite_test.go
+++ b/modules/caddyhttp/rewrite/rewrite_test.go
@@ -227,6 +227,16 @@ func TestRewrite(t *testing.T) {
 		},
 		{
 			rule:   Rewrite{StripPathPrefix: "/prefix"},
+			input:  newRequest(t, "GET", "/prefix"),
+			expect: newRequest(t, "GET", ""),
+		},
+		{
+			rule:   Rewrite{StripPathPrefix: "/prefix"},
+			input:  newRequest(t, "GET", "/"),
+			expect: newRequest(t, "GET", "/"),
+		},
+		{
+			rule:   Rewrite{StripPathPrefix: "/prefix"},
 			input:  newRequest(t, "GET", "/prefix/foo%2Fbar"),
 			expect: newRequest(t, "GET", "/foo%2Fbar"),
 		},


### PR DESCRIPTION
This seems to make more sense: if the path is rewritten internally before getting to `php_fastcgi`, then the external-facing HTTP redirect should use the original URI path, right?

In issue #5073, this is as follows:

- Request is for `/app`
- `handle_path` strips the `/app` prefix, leaving the URI path as empty string
- `php_fastcgi` sees that the path being requested (the site root) is a folder, and it has `index.php` in it, so it issues redirect to `{http.request.uri.path}/` which is now just `/` because `{http.request.uri.path}` is empty string
- I think it should use `{http.request.orig_uri.path}/` for the redirect instead. This makes it redirect to `/app/`.

Is this sound logic? @ArabCoders can you test this please?