### PR TITLE
ci: fix integration tests

### DIFF
--- a/caddytest/caddytest.go
+++ b/caddytest/caddytest.go
@@ -237,7 +237,7 @@ func validateTestPrerequisites() error {
 
 	if isCaddyAdminRunning() != nil {
 		// start inprocess caddy server
-		os.Args = []string{"caddy", "run"}
+		os.Args = []string{"caddy", "run", "--config", "./test.init.config", "--adapter", "caddyfile"}
 		go func() {
 			caddycmd.Main()
 		}()

--- a/caddytest/integration/autohttps_test.go
+++ b/caddytest/integration/autohttps_test.go
@@ -11,6 +11,8 @@ func TestAutoHTTPtoHTTPSRedirectsImplicitPort(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`
 	{
+		admin localhost:2999
+		skip_install_trust
 		http_port     9080
 		https_port    9443
 	}
@@ -25,6 +27,8 @@ func TestAutoHTTPtoHTTPSRedirectsExplicitPortSameAsHTTPSPort(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`
 	{
+		skip_install_trust
+		admin localhost:2999
 		http_port     9080
 		https_port    9443
 	}
@@ -39,6 +43,8 @@ func TestAutoHTTPtoHTTPSRedirectsExplicitPortDifferentFromHTTPSPort(t *testing.T
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`
 	{
+		skip_install_trust
+		admin localhost:2999
 		http_port     9080
 		https_port    9443
 	}
@@ -53,6 +59,9 @@ func TestAutoHTTPRedirectsWithHTTPListenerFirstInAddresses(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`
 {
+  "admin": {
+	"listen": "localhost:2999"
+  },
   "apps": {
     "http": {
       "http_port": 9080,
@@ -74,7 +83,14 @@ func TestAutoHTTPRedirectsWithHTTPListenerFirstInAddresses(t *testing.T) {
           ]
         }
       }
-    }
+    },
+	"pki": {
+		"certificate_authorities": {
+			"local": {
+				"install_trust": false
+			}
+		}
+	}
   }
 }
 `, "json")
@@ -85,6 +101,8 @@ func TestAutoHTTPRedirectsInsertedBeforeUserDefinedCatchAll(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`
 	{
+		skip_install_trust
+		admin localhost:2999
 		http_port     9080
 		https_port    9443
 		local_certs
@@ -108,6 +126,8 @@ func TestAutoHTTPRedirectsInsertedBeforeUserDefinedCatchAllWithNoExplicitHTTPSit
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`
 	{
+		skip_install_trust
+		admin localhost:2999
 		http_port     9080
 		https_port    9443
 		local_certs

--- a/caddytest/integration/caddyfile_test.go
+++ b/caddytest/integration/caddyfile_test.go
@@ -14,9 +14,10 @@ func TestRespond(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(` 
   {
+    admin localhost:2999
     http_port     9080
     https_port    9443
-    grace_period  1
+    grace_period  1ns
   }
   
   localhost:9080 {
@@ -36,9 +37,10 @@ func TestRedirect(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`
   {
+    admin localhost:2999
     http_port     9080
     https_port    9443
-    grace_period  1
+    grace_period  1ns
   }
   
   localhost:9080 {
@@ -86,9 +88,11 @@ func TestReadCookie(t *testing.T) {
 	tester.Client.Jar.SetCookies(localhost, []*http.Cookie{&cookie})
 	tester.InitServer(` 
   {
+    skip_install_trust
+    admin localhost:2999
     http_port     9080
     https_port    9443
-    grace_period  1
+    grace_period  1ns
   }
   
   localhost:9080 {
@@ -110,9 +114,11 @@ func TestReplIndex(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`
   {
+    skip_install_trust
+    admin localhost:2999
     http_port     9080
     https_port    9443
-    grace_period  1
+    grace_period  1ns
   }
 
   localhost:9080 {

--- a/caddytest/integration/handler_test.go
+++ b/caddytest/integration/handler_test.go
@@ -11,9 +11,11 @@ func TestBrowse(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`
 	{
+		skip_install_trust
+		admin localhost:2999
 		http_port     9080
 		https_port    9443
-		grace_period  1
+		grace_period  1ns
 	}
 	http://localhost:9080 {
 		file_server browse

--- a/caddytest/integration/map_test.go
+++ b/caddytest/integration/map_test.go
@@ -11,9 +11,11 @@ func TestMap(t *testing.T) {
 	// arrange
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`{
+		skip_install_trust
+		admin localhost:2999
 		http_port     9080
 		https_port    9443
-		grace_period  1
+		grace_period  1ns
 	}
 
 	localhost:9080 {
@@ -39,6 +41,8 @@ func TestMapRespondWithDefault(t *testing.T) {
 	// arrange
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`{
+		skip_install_trust
+		admin localhost:2999
 		http_port     9080
 		https_port    9443
 		}
@@ -66,7 +70,17 @@ func TestMapAsJSON(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`
 	{
+		"admin": {
+			"listen": "localhost:2999"
+		},
 		"apps": {
+			"pki": {
+				"certificate_authorities" : {
+				  "local" : {
+					"install_trust": false
+				  }
+				}
+			},
 			"http": {
 				"http_port": 9080,
 				"https_port": 9443,

--- a/caddytest/integration/reverseproxy_test.go
+++ b/caddytest/integration/reverseproxy_test.go
@@ -16,7 +16,17 @@ func TestSRVReverseProxy(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`
 	{
+		"admin": {
+			"listen": "localhost:2999"
+		},
 		"apps": {
+			"pki": {
+				"certificate_authorities" : {
+					"local" : {
+					"install_trust": false
+					}
+				}
+			},
 		  "http": {
 			"grace_period": 1,
 			"servers": {
@@ -50,6 +60,13 @@ func TestSRVWithDial(t *testing.T) {
 	caddytest.AssertLoadError(t, `
 	{
 		"apps": {
+			"pki": {
+				"certificate_authorities" : {
+				  "local" : {
+					"install_trust": false
+				  }
+				}
+			  },
 		  "http": {
 			"grace_period": 1,
 			"servers": {
@@ -115,7 +132,17 @@ func TestDialWithPlaceholderUnix(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`
 	{
+		"admin": {
+			"listen": "localhost:2999"
+		},
 		"apps": {
+			"pki": {
+				"certificate_authorities" : {
+				  "local" : {
+					"install_trust": false
+				  }
+				}
+			  },
 		  "http": {
 			"grace_period": 1,
 			"servers": {
@@ -157,7 +184,17 @@ func TestReverseProxyWithPlaceholderDialAddress(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`
 	{
+		"admin": {
+			"listen": "localhost:2999"
+		},
 		"apps": {
+			"pki": {
+				"certificate_authorities" : {
+				  "local" : {
+					"install_trust": false
+				  }
+				}
+			  },
 			"http": {
 				"grace_period": 1,
 				"servers": {
@@ -241,7 +278,17 @@ func TestReverseProxyWithPlaceholderTCPDialAddress(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`
 	{
+		"admin": {
+			"listen": "localhost:2999"
+		},
 		"apps": {
+			"pki": {
+				"certificate_authorities" : {
+				  "local" : {
+					"install_trust": false
+				  }
+				}
+			  },
 			"http": {
 				"grace_period": 1,
 				"servers": {
@@ -325,6 +372,13 @@ func TestSRVWithActiveHealthcheck(t *testing.T) {
 	caddytest.AssertLoadError(t, `
 	{
 		"apps": {
+			"pki": {
+				"certificate_authorities" : {
+				  "local" : {
+					"install_trust": false
+				  }
+				}
+			  },
 		  "http": {
 			"grace_period": 1,
 			"servers": {
@@ -363,8 +417,11 @@ func TestReverseProxyHealthCheck(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`
 	{
+		skip_install_trust
+		admin localhost:2999
 		http_port     9080
 		https_port    9443
+		grace_period 1ns
 	}
 	http://localhost:2020 {
 		respond "Hello, World!"
@@ -424,8 +481,11 @@ func TestReverseProxyHealthCheckUnixSocket(t *testing.T) {
 
 	tester.InitServer(fmt.Sprintf(`
 	{
+		skip_install_trust
+		admin localhost:2999
 		http_port     9080
 		https_port    9443
+		grace_period 1ns
 	}
 	http://localhost:9080 {
 		reverse_proxy {
@@ -479,8 +539,11 @@ func TestReverseProxyHealthCheckUnixSocketWithoutPort(t *testing.T) {
 
 	tester.InitServer(fmt.Sprintf(`
 	{
+		skip_install_trust
+		admin localhost:2999
 		http_port     9080
 		https_port    9443
+		grace_period 1ns
 	}
 	http://localhost:9080 {
 		reverse_proxy {

--- a/caddytest/integration/sni_test.go
+++ b/caddytest/integration/sni_test.go
@@ -11,92 +11,95 @@ func TestDefaultSNI(t *testing.T) {
 	// arrange
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`{
-    "apps": {
-      "http": {
-        "http_port": 9080,
-        "https_port": 9443,
-        "grace_period": 1,
-        "servers": {
-          "srv0": {
-            "listen": [
-              ":9443"
-            ],
-            "routes": [
-              {
-                "handle": [
-                  {
-                    "handler": "subroute",
-                    "routes": [
-                      {
-                        "handle": [
-                          {
-                            "body": "hello from a.caddy.localhost",
-                            "handler": "static_response",
-                            "status_code": 200
-                          }
-                        ],
-                        "match": [
-                          {
-                            "path": [
-                              "/version"
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ],
-                "match": [
-                  {
-                    "host": [
-                      "127.0.0.1"
-                    ]
-                  }
-                ],
-                "terminal": true
-              }
-            ],
-            "tls_connection_policies": [
-              {
-                "certificate_selection": {
-                  "any_tag": ["cert0"]
-                },
-                "match": {
-                  "sni": [
-                    "127.0.0.1"
-                  ]
-                }
-              },
-              {
-                "default_sni": "*.caddy.localhost"
-              }
-            ]
-          }
-        }
-      },
-      "tls": {
-        "certificates": {
-          "load_files": [
-            {
-              "certificate": "/caddy.localhost.crt",
-              "key": "/caddy.localhost.key",
-              "tags": [
-                "cert0"
-              ]
-            }
-          ]
-        }
-      },
-      "pki": {
-        "certificate_authorities" : {
-          "local" : {
-            "install_trust": false
-          }
-        }
-      }
-    }
-  }
-  `, "json")
+		"admin": {
+			"listen": "localhost:2999"
+		},
+		"apps": {
+			"http": {
+				"http_port": 9080,
+				"https_port": 9443,
+				"grace_period": 1,
+				"servers": {
+					"srv0": {
+						"listen": [
+							":9443"
+						],
+						"routes": [
+							{
+								"handle": [
+									{
+										"handler": "subroute",
+										"routes": [
+											{
+												"handle": [
+													{
+														"body": "hello from a.caddy.localhost",
+														"handler": "static_response",
+														"status_code": 200
+													}
+												],
+												"match": [
+													{
+														"path": [
+															"/version"
+														]
+													}
+												]
+											}
+										]
+									}
+								],
+								"match": [
+									{
+										"host": [
+											"127.0.0.1"
+										]
+									}
+								],
+								"terminal": true
+							}
+						],
+						"tls_connection_policies": [
+							{
+								"certificate_selection": {
+									"any_tag": ["cert0"]
+								},
+								"match": {
+									"sni": [
+										"127.0.0.1"
+									]
+								}
+							},
+							{
+								"default_sni": "*.caddy.localhost"
+							}
+						]
+					}
+				}
+			},
+			"tls": {
+				"certificates": {
+					"load_files": [
+						{
+							"certificate": "/caddy.localhost.crt",
+							"key": "/caddy.localhost.key",
+							"tags": [
+								"cert0"
+							]
+						}
+					]
+				}
+			},
+			"pki": {
+				"certificate_authorities" : {
+					"local" : {
+						"install_trust": false
+					}
+				}
+			}
+		}
+	}
+	`, "json")
 
 	// act and assert
 	// makes a request with no sni
@@ -108,97 +111,100 @@ func TestDefaultSNIWithNamedHostAndExplicitIP(t *testing.T) {
 	// arrange
 	tester := caddytest.NewTester(t)
 	tester.InitServer(` 
-  {
-    "apps": {
-      "http": {
-        "http_port": 9080,
-        "https_port": 9443,
-        "grace_period": 1,
-        "servers": {
-          "srv0": {
-            "listen": [
-              ":9443"
-            ],
-            "routes": [
-              {
-                "handle": [
-                  {
-                    "handler": "subroute",
-                    "routes": [
-                      {
-                        "handle": [
-                          {
-                            "body": "hello from a",
-                            "handler": "static_response",
-                            "status_code": 200
-                          }
-                        ],
-                        "match": [
-                          {
-                            "path": [
-                              "/version"
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ],
-                "match": [
-                  {
-                    "host": [
-                      "a.caddy.localhost",
-                      "127.0.0.1"
-                    ]
-                  }
-                ],
-                "terminal": true
-              }
-            ],
-            "tls_connection_policies": [
-              {
-                "certificate_selection": {
-                  "any_tag": ["cert0"]
-                },
-                "default_sni": "a.caddy.localhost",
-                "match": {
-                  "sni": [
-                    "a.caddy.localhost",
-                    "127.0.0.1",
-                    ""
-                  ]
-                }
-              },
-              {
-                "default_sni": "a.caddy.localhost"
-              }
-            ]
-          }
-        }
-      },
-      "tls": {
-        "certificates": {
-          "load_files": [
-            {
-              "certificate": "/a.caddy.localhost.crt",
-              "key": "/a.caddy.localhost.key",
-              "tags": [
-                "cert0"
-              ]
-            }
-          ]
-        }
-      },
-      "pki": {
-        "certificate_authorities" : {
-          "local" : {
-            "install_trust": false
-          }
-        }
-      }
-    }
-  }
-  `, "json")
+	{
+		"admin": {
+			"listen": "localhost:2999"
+		},
+		"apps": {
+			"http": {
+				"http_port": 9080,
+				"https_port": 9443,
+				"grace_period": 1,
+				"servers": {
+					"srv0": {
+						"listen": [
+							":9443"
+						],
+						"routes": [
+							{
+								"handle": [
+									{
+										"handler": "subroute",
+										"routes": [
+											{
+												"handle": [
+													{
+														"body": "hello from a",
+														"handler": "static_response",
+														"status_code": 200
+													}
+												],
+												"match": [
+													{
+														"path": [
+															"/version"
+														]
+													}
+												]
+											}
+										]
+									}
+								],
+								"match": [
+									{
+										"host": [
+											"a.caddy.localhost",
+											"127.0.0.1"
+										]
+									}
+								],
+								"terminal": true
+							}
+						],
+						"tls_connection_policies": [
+							{
+								"certificate_selection": {
+									"any_tag": ["cert0"]
+								},
+								"default_sni": "a.caddy.localhost",
+								"match": {
+									"sni": [
+										"a.caddy.localhost",
+										"127.0.0.1",
+										""
+									]
+								}
+							},
+							{
+								"default_sni": "a.caddy.localhost"
+							}
+						]
+					}
+				}
+			},
+			"tls": {
+				"certificates": {
+					"load_files": [
+						{
+							"certificate": "/a.caddy.localhost.crt",
+							"key": "/a.caddy.localhost.key",
+							"tags": [
+								"cert0"
+							]
+						}
+					]
+				}
+			},
+			"pki": {
+				"certificate_authorities" : {
+					"local" : {
+						"install_trust": false
+					}
+				}
+			}
+		}
+	}
+	`, "json")
 
 	// act and assert
 	// makes a request with no sni
@@ -209,69 +215,72 @@ func TestDefaultSNIWithPortMappingOnly(t *testing.T) {
 	// arrange
 	tester := caddytest.NewTester(t)
 	tester.InitServer(` 
-  {
-    "apps": {
-      "http": {
-        "http_port": 9080,
-        "https_port": 9443,
-        "grace_period": 1,
-        "servers": {
-          "srv0": {
-            "listen": [
-              ":9443"
-            ],
-            "routes": [
-              {
-                "handle": [
-                  {
-                    "body": "hello from a.caddy.localhost",
-                    "handler": "static_response",
-                    "status_code": 200
-                  }
-                ],
-                "match": [
-                  {
-                    "path": [
-                      "/version"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "tls_connection_policies": [
-              {
-                "certificate_selection": {
-                  "any_tag": ["cert0"]
-                },
-                "default_sni": "a.caddy.localhost"
-              }
-            ]
-          }
-        }
-      },
-      "tls": {
-        "certificates": {
-          "load_files": [
-            {
-              "certificate": "/a.caddy.localhost.crt",
-              "key": "/a.caddy.localhost.key",
-              "tags": [
-                "cert0"
-              ]
-            }
-          ]
-        }
-      },
-      "pki": {
-        "certificate_authorities" : {
-          "local" : {
-            "install_trust": false
-          }
-        }
-      }
-    }
-  }
-  `, "json")
+	{
+		"admin": {
+			"listen": "localhost:2999"
+		},
+		"apps": {
+			"http": {
+				"http_port": 9080,
+				"https_port": 9443,
+				"grace_period": 1,
+				"servers": {
+					"srv0": {
+						"listen": [
+							":9443"
+						],
+						"routes": [
+							{
+								"handle": [
+									{
+										"body": "hello from a.caddy.localhost",
+										"handler": "static_response",
+										"status_code": 200
+									}
+								],
+								"match": [
+									{
+										"path": [
+											"/version"
+										]
+									}
+								]
+							}
+						],
+						"tls_connection_policies": [
+							{
+								"certificate_selection": {
+									"any_tag": ["cert0"]
+								},
+								"default_sni": "a.caddy.localhost"
+							}
+						]
+					}
+				}
+			},
+			"tls": {
+				"certificates": {
+					"load_files": [
+						{
+							"certificate": "/a.caddy.localhost.crt",
+							"key": "/a.caddy.localhost.key",
+							"tags": [
+								"cert0"
+							]
+						}
+					]
+				}
+			},
+			"pki": {
+				"certificate_authorities" : {
+					"local" : {
+						"install_trust": false
+					}
+				}
+			}
+		}
+	}
+	`, "json")
 
 	// act and assert
 	// makes a request with no sni
@@ -281,6 +290,7 @@ func TestDefaultSNIWithPortMappingOnly(t *testing.T) {
 func TestHttpOnlyOnDomainWithSNI(t *testing.T) {
 	caddytest.AssertAdapt(t, `
 	{
+		skip_install_trust
 		default_sni a.caddy.localhost
 	}
 	:80 {
@@ -314,6 +324,13 @@ func TestHttpOnlyOnDomainWithSNI(t *testing.T) {
 							]
 						}
 					]
+				}
+			}
+		},
+		"pki": {
+			"certificate_authorities": {
+				"local": {
+					"install_trust": false
 				}
 			}
 		}

--- a/caddytest/integration/stream_test.go
+++ b/caddytest/integration/stream_test.go
@@ -23,6 +23,9 @@ func TestH2ToH2CStream(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(` 
   {
+	"admin": {
+		"listen": "localhost:2999"
+	},
     "apps": {
       "http": {
         "http_port": 9080,
@@ -206,6 +209,9 @@ func TestH2ToH1ChunkedResponse(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(` 
 {
+	"admin": {
+		"listen": "localhost:2999"
+	},
   "logging": {
     "logs": {
       "default": {

--- a/caddytest/integration/test.init.config
+++ b/caddytest/integration/test.init.config
@@ -1,0 +1,3 @@
+{
+	admin localhost:2999
+}


### PR DESCRIPTION
The change in #5045 did as the message says, _hide_ the issue. The integration tests were not successful; they were skipped because the code did not receive confirmation the server was running, so it skipped it. There were 2 issues with it:
- The `grace_period` option in the caddyfile always expects a unit suffix, while the JSON is more graceful. I merely added the `ns` suffix to the caddyfile instead of fighting the unmarshaler.
- The admin listener endpoint got changed in the Go code, but it was never fed to the initial server. The code was not receiving a response. I included an initial config setting only the admin endpoint, and included the same endpoint in all the test config data.

I also added `skip_install_trust` and its corresponding adapted JSON format in all tests to avoid the root installation step when it encounters any `*.localhost` domain name, which triggers the automatic HTTPS behavior.