### PR TITLE
caddyhttp: replace placeholders in map defaults

### DIFF
--- a/modules/caddyhttp/map/map.go
+++ b/modules/caddyhttp/map/map.go
@@ -169,7 +169,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhtt
 
 		// fall back to default if no match or if matched nil value
 		if len(h.Defaults) > destIdx {
-			return h.Defaults[destIdx], true
+			return repl.ReplaceAll(h.Defaults[destIdx], ""), true
 		}
 
 		return nil, true

--- a/modules/caddyhttp/map/map_test.go
+++ b/modules/caddyhttp/map/map_test.go
@@ -98,6 +98,28 @@ func TestHandler(t *testing.T) {
 				"output": "testing",
 			},
 		},
+		{
+			reqURI: "/foo",
+			handler: Handler{
+				Source:       "{http.request.uri.path}",
+				Destinations: []string{"{output}"},
+				Defaults:     []string{"default"},
+			},
+			expect: map[string]any{
+				"output": "default",
+			},
+		},
+		{
+			reqURI: "/foo",
+			handler: Handler{
+				Source:       "{http.request.uri.path}",
+				Destinations: []string{"{output}"},
+				Defaults:     []string{"{testvar}"},
+			},
+			expect: map[string]any{
+				"output": "testing",
+			},
+		},
 	} {
 		if err := tc.handler.Provision(caddy.Context{}); err != nil {
 			t.Fatalf("Test %d: Provisioning handler: %v", i, err)


### PR DESCRIPTION
This updates the map directive to replace placeholders in default values in the same way as matched values.

I'm trying to use the map directive to override the username for some users in the [Tailscale Caddy plugin](https://github.com/tailscale/caddy-tailscale).  For example, I want to set `webauth.user` to "willnorris" if `http.auth.user.tailscale_user` equals "will@tailscale.com", but to default to the value of `http.auth.user.tailscale_login` in all other cases.  Prior to this patch, the default value would be the literal string "{http.auth.user.tailscale_login}" instead of expanding the placeholder.

```
map {http.auth.user.tailscale_user} {webauth.user} {
    will@tailscale.com willnorris
    default {http.auth.user.tailscale_login}
}
```