### PR TITLE
reverseproxy: fix upstream scheme handling

### DIFF
--- a/modules/caddyhttp/reverseproxy/command.go
+++ b/modules/caddyhttp/reverseproxy/command.go
@@ -117,7 +117,7 @@ func cmdReverseProxy(fs caddycmd.Flags) (int, error) {
 		if err != nil {
 			return caddy.ExitCodeFailedStartup, fmt.Errorf("invalid upstream address %s: %v", toLoc, err)
 		}
-		if scheme != "" && toScheme != "" {
+		if scheme != "" && toScheme == "" {
 			toScheme = scheme
 		}
 		toAddresses[i] = addr


### PR DESCRIPTION
e338648fed3263200dfd6abc9f8100c6f1c0eb67 introduced multiple upstream addresses. A comment notes that mixing schemes isn't supported and therefore the first valid scheme is supposed to be used.

Fixes setting the first scheme.

fixes #5087