### PR TITLE
core: Refactor, improve listener logic

### DIFF
--- a/listeners.go
+++ b/listeners.go
@@ -55,8 +55,12 @@ type NetworkAddress struct {
 	EndPort   uint
 }
 
-// TODO: is this even useful? I might remove this.
-func (na NetworkAddress) ListenAll(ctx context.Context, portOffset uint, config net.ListenConfig) ([]any, error) {
+// ListenAll calls Listen() for all addresses represented by this struct, i.e. all ports in the range.
+// (If the address doesn't use ports or has 1 port only, then only 1 listener will be created.)
+// It returns an error if any listener failed to bind, and closes any listeners opened up to that point.
+//
+// TODO: Experimental API: subject to change or removal.
+func (na NetworkAddress) ListenAll(ctx context.Context, config net.ListenConfig) ([]any, error) {
 	var listeners []any
 	var err error
 
@@ -104,7 +108,7 @@ func (na NetworkAddress) ListenAll(ctx context.Context, portOffset uint, config 
 // The provided ListenConfig is used to create the listener. Its Control function,
 // if set, may be wrapped by an internally-used Control function. The provided
 // context may be used to cancel long operations early. The context is not used
-// to close the actual listener after it has been created.
+// to close the listener after it has been created.
 //
 // Caddy's listeners can overlap each other: multiple listeners may be created on
 // the same socket at the same time. This is useful because during config changes,

--- a/listeners.go
+++ b/listeners.go
@@ -626,7 +626,7 @@ func (uln *unixListener) Close() error {
 			unixSocketsMu.Lock()
 			delete(unixSockets, uln.mapKey)
 			unixSocketsMu.Unlock()
-			syscall.Unlink(addr)
+			_ = syscall.Unlink(addr)
 		}()
 	}
 	return uln.UnixListener.Close()
@@ -646,7 +646,7 @@ func (uc *unixConn) Close() error {
 			unixSocketsMu.Lock()
 			delete(unixSockets, uc.mapKey)
 			unixSocketsMu.Unlock()
-			syscall.Unlink(uc.filename)
+			_ = syscall.Unlink(uc.filename)
 		}()
 	}
 	return uc.UnixConn.Close()

--- a/listeners.go
+++ b/listeners.go
@@ -19,230 +19,183 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/netip"
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 
 	"github.com/lucas-clemente/quic-go"
 	"github.com/lucas-clemente/quic-go/http3"
 	"go.uber.org/zap"
 )
 
-// Listen is like net.Listen, except Caddy's listeners can overlap
-// each other: multiple listeners may be created on the same socket
-// at the same time. This is useful because during config changes,
-// the new config is started while the old config is still running.
-// When Caddy listeners are closed, the closing logic is virtualized
-// so the underlying socket isn't actually closed until all uses of
-// the socket have been finished. Always be sure to close listeners
-// when you are done with them, just like normal listeners.
-func Listen(network, addr string) (net.Listener, error) {
-	// a 0 timeout means Go uses its default
-	return ListenTimeout(network, addr, 0)
+// NetworkAddress represents one or more network addresses.
+// It contains the individual components for a parsed network
+// address of the form accepted by ParseNetworkAddress().
+type NetworkAddress struct {
+	// Should be a network value accepted by Go's net package or
+	// by a plugin providing a listener for that network type.
+	Network string
+
+	// The "main" part of the network address is the host, which
+	// often takes the form of a hostname, DNS name, IP address,
+	// or socket path.
+	Host string
+
+	// For addresses that contain a port, ranges are given by
+	// [StartPort, EndPort]; i.e. for a single port, StartPort
+	// and EndPort are the same. For no port, they are 0.
+	StartPort uint
+	EndPort   uint
 }
 
-// getListenerFromPlugin returns a listener on the given network and address
-// if a plugin has registered the network name. It may return (nil, nil) if
-// no plugin can provide a listener.
-func getListenerFromPlugin(network, addr string) (net.Listener, error) {
-	network = strings.TrimSpace(strings.ToLower(network))
+// TODO: is this even useful? I might remove this.
+func (na NetworkAddress) ListenAll(ctx context.Context, portOffset uint, config net.ListenConfig) ([]any, error) {
+	var listeners []any
+	var err error
 
-	// get listener from plugin if network type is registered
-	if getListener, ok := networkTypes[network]; ok {
-		Log().Debug("getting listener from plugin", zap.String("network", network))
-		return getListener(network, addr)
-	}
-
-	return nil, nil
-}
-
-// ListenPacket returns a net.PacketConn suitable for use in a Caddy module.
-// It is like Listen except for PacketConns.
-// Always be sure to close the PacketConn when you are done.
-func ListenPacket(network, addr string) (net.PacketConn, error) {
-	lnKey := listenerKey(network, addr)
-
-	sharedPc, _, err := listenerPool.LoadOrNew(lnKey, func() (Destructor, error) {
-		pc, err := net.ListenPacket(network, addr)
-		if err != nil {
-			// https://github.com/caddyserver/caddy/pull/4534
-			if isUnixNetwork(network) && isListenBindAddressAlreadyInUseError(err) {
-				return nil, fmt.Errorf("%w: this can happen if Caddy was forcefully killed", err)
+	// if one of the addresses has a failure, we need to close
+	// any that did open a socket to avoid leaking resources
+	defer func() {
+		if err == nil {
+			return
+		}
+		for _, ln := range listeners {
+			if cl, ok := ln.(io.Closer); ok {
+				cl.Close()
 			}
+		}
+	}()
+
+	// an address can contain a port range, which represents multiple addresses;
+	// some addresses don't use ports at all and have a port range size of 1;
+	// whatever the case, iterate each address represented and bind a socket
+	for portOffset := uint(0); portOffset < na.PortRangeSize(); portOffset++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		// create (or reuse) the listener ourselves
+		var ln any
+		ln, err = na.Listen(ctx, portOffset, config)
+		if err != nil {
 			return nil, err
 		}
-		return &sharedPacketConn{PacketConn: pc, key: lnKey}, nil
-	})
-	if err != nil {
-		return nil, err
+		listeners = append(listeners, ln)
 	}
 
-	return &fakeClosePacketConn{sharedPacketConn: sharedPc.(*sharedPacketConn)}, nil
+	return listeners, nil
 }
 
-// ListenQUIC returns a quic.EarlyListener suitable for use in a Caddy module.
-// Note that the context passed to Accept is currently ignored, so using
-// a context other than context.Background is meaningless.
-// This API is EXPERIMENTAL and may change.
-func ListenQUIC(addr string, tlsConf *tls.Config, activeRequests *int64) (quic.EarlyListener, error) {
-	lnKey := listenerKey("udp", addr)
+// Listen is similar to net.Listen, with a few differences:
+//
+// Listen announces on the network address using the port calculated by adding
+// portOffset to the start port. (For network types that do not use ports, the
+// portOffset is ignored.)
+//
+// The provided ListenConfig is used to create the listener. Its Control function,
+// if set, may be wrapped by an internally-used Control function. The provided
+// context may be used to cancel long operations early. The context is not used
+// to close the actual listener after it has been created.
+//
+// Caddy's listeners can overlap each other: multiple listeners may be created on
+// the same socket at the same time. This is useful because during config changes,
+// the new config is started while the old config is still running. How this is
+// accomplished varies by platform and network type. For example, on Unix, SO_REUSEPORT
+// is set except on Unix sockets, for which the file descriptor is duplicated and
+// reused; on Windows, the close logic is virtualized using timeouts. Like normal
+// listeners, be sure to Close() them when you are done.
+//
+// This method returns any type, as the implementations of listeners for various
+// network types are not interchangeable. The type of listener returned is switched
+// on the network type. Stream-based networks ("tcp", "unix", "unixpacket", etc.)
+// return a net.Listener; datagram-based networks ("udp", "unixgram", etc.) return
+// a net.PacketConn; and so forth. The actual concrete types are not guaranteed to
+// be standard, exported types (wrapping is necessary to provide graceful reloads).
+//
+// Unix sockets will be unlinked before being created, to ensure we can bind to
+// it even if the previous program using it exited uncleanly; it will also be
+// unlinked upon a graceful exit (or when a new config does not use that socket).
+//
+// TODO: Experimental API: subject to change or removal.
+func (na NetworkAddress) Listen(ctx context.Context, portOffset uint, config net.ListenConfig) (any, error) {
+	if na.IsUnixNetwork() {
+		unixSocketsMu.Lock()
+		defer unixSocketsMu.Unlock()
+	}
 
-	sharedEl, _, err := listenerPool.LoadOrNew(lnKey, func() (Destructor, error) {
-		el, err := quic.ListenAddrEarly(addr, http3.ConfigureTLSConfig(tlsConf), &quic.Config{
-			RequireAddressValidation: func(clientAddr net.Addr) bool {
-				var highLoad bool
-				if activeRequests != nil {
-					highLoad = atomic.LoadInt64(activeRequests) > 1000 // TODO: make tunable?
-				}
-				return highLoad
-			},
+	// check to see if plugin provides listener
+	if ln, err := getListenerFromPlugin(ctx, na.Network, na.JoinHostPort(portOffset), config); ln != nil || err != nil {
+		return ln, err
+	}
+
+	// create (or reuse) the listener ourselves
+	return na.listen(ctx, portOffset, config)
+}
+
+func (na NetworkAddress) listen(ctx context.Context, portOffset uint, config net.ListenConfig) (any, error) {
+	var ln any
+	var err error
+
+	address := na.JoinHostPort(portOffset)
+
+	// if this is a unix socket, see if we already have it open
+	if socket, err := reuseUnixSocket(na.Network, address); socket != nil || err != nil {
+		return socket, err
+	}
+
+	lnKey := listenerKey(na.Network, address)
+
+	switch na.Network {
+	case "tcp", "tcp4", "tcp6", "unix", "unixpacket":
+		ln, err = listenTCPOrUnix(ctx, lnKey, na.Network, address, config)
+	case "unixgram":
+		ln, err = config.ListenPacket(ctx, na.Network, address)
+	case "udp", "udp4", "udp6":
+		sharedPc, _, err := listenerPool.LoadOrNew(lnKey, func() (Destructor, error) {
+			pc, err := config.ListenPacket(ctx, na.Network, address)
+			if err != nil {
+				return nil, err
+			}
+			return &sharedPacketConn{PacketConn: pc, key: lnKey}, nil
 		})
 		if err != nil {
 			return nil, err
 		}
-		return &sharedQuicListener{EarlyListener: el, key: lnKey}, nil
-	})
+		ln = &fakeClosePacketConn{sharedPacketConn: sharedPc.(*sharedPacketConn)}
+	}
+	if strings.HasPrefix(na.Network, "ip") {
+		ln, err = config.ListenPacket(ctx, na.Network, address)
+	}
 	if err != nil {
 		return nil, err
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	return &fakeCloseQuicListener{
-		sharedQuicListener: sharedEl.(*sharedQuicListener),
-		context:            ctx,
-		contextCancel:      cancel,
-	}, nil
-}
-
-// ListenerUsage returns the current usage count of the given listener address.
-func ListenerUsage(network, addr string) int {
-	count, _ := listenerPool.References(listenerKey(network, addr))
-	return count
-}
-
-func listenerKey(network, addr string) string {
-	return network + "/" + addr
-}
-
-type fakeCloseQuicListener struct {
-	closed              int32 // accessed atomically; belongs to this struct only
-	*sharedQuicListener       // embedded, so we also become a quic.EarlyListener
-	context             context.Context
-	contextCancel       context.CancelFunc
-}
-
-// Currently Accept ignores the passed context, however a situation where
-// someone would need a hotswappable QUIC-only (not http3, since it uses context.Background here)
-// server on which Accept would be called with non-empty contexts
-// (mind that the default net listeners' Accept doesn't take a context argument)
-// sounds way too rare for us to sacrifice efficiency here.
-func (fcql *fakeCloseQuicListener) Accept(_ context.Context) (quic.EarlyConnection, error) {
-	conn, err := fcql.sharedQuicListener.Accept(fcql.context)
-	if err == nil {
-		return conn, nil
+	if ln == nil {
+		return nil, fmt.Errorf("unsupported network type: %s", na.Network)
 	}
 
-	// if the listener is "closed", return a fake closed error instead
-	if atomic.LoadInt32(&fcql.closed) == 1 && errors.Is(err, context.Canceled) {
-		return nil, fakeClosedErr(fcql)
+	// if new listener is a unix socket, make sure we can reuse it later
+	// (we do our own "unlink on close" -- not required, but more tidy)
+	one := int32(1)
+	switch unix := ln.(type) {
+	case *net.UnixListener:
+		unix.SetUnlinkOnClose(false)
+		ln = &unixListener{unix, lnKey, &one}
+		unixSockets[lnKey] = ln.(*unixListener)
+	case *net.UnixConn:
+		ln = &unixConn{unix, address, lnKey, &one}
+		unixSockets[lnKey] = ln.(*unixConn)
 	}
-	return nil, err
-}
 
-func (fcql *fakeCloseQuicListener) Close() error {
-	if atomic.CompareAndSwapInt32(&fcql.closed, 0, 1) {
-		fcql.contextCancel()
-		_, _ = listenerPool.Delete(fcql.sharedQuicListener.key)
-	}
-	return nil
-}
-
-// fakeClosedErr returns an error value that is not temporary
-// nor a timeout, suitable for making the caller think the
-// listener is actually closed
-func fakeClosedErr(l interface{ Addr() net.Addr }) error {
-	return &net.OpError{
-		Op:   "accept",
-		Net:  l.Addr().Network(),
-		Addr: l.Addr(),
-		Err:  errFakeClosed,
-	}
-}
-
-// ErrFakeClosed is the underlying error value returned by
-// fakeCloseListener.Accept() after Close() has been called,
-// indicating that it is pretending to be closed so that the
-// server using it can terminate, while the underlying
-// socket is actually left open.
-var errFakeClosed = fmt.Errorf("listener 'closed' 😉")
-
-// fakeClosePacketConn is like fakeCloseListener, but for PacketConns.
-type fakeClosePacketConn struct {
-	closed            int32 // accessed atomically; belongs to this struct only
-	*sharedPacketConn       // embedded, so we also become a net.PacketConn
-}
-
-func (fcpc *fakeClosePacketConn) Close() error {
-	if atomic.CompareAndSwapInt32(&fcpc.closed, 0, 1) {
-		_, _ = listenerPool.Delete(fcpc.sharedPacketConn.key)
-	}
-	return nil
-}
-
-// Supports QUIC implementation: https://github.com/caddyserver/caddy/issues/3998
-func (fcpc fakeClosePacketConn) SetReadBuffer(bytes int) error {
-	if conn, ok := fcpc.PacketConn.(interface{ SetReadBuffer(int) error }); ok {
-		return conn.SetReadBuffer(bytes)
-	}
-	return fmt.Errorf("SetReadBuffer() not implemented for %T", fcpc.PacketConn)
-}
-
-// Supports QUIC implementation: https://github.com/caddyserver/caddy/issues/3998
-func (fcpc fakeClosePacketConn) SyscallConn() (syscall.RawConn, error) {
-	if conn, ok := fcpc.PacketConn.(interface {
-		SyscallConn() (syscall.RawConn, error)
-	}); ok {
-		return conn.SyscallConn()
-	}
-	return nil, fmt.Errorf("SyscallConn() not implemented for %T", fcpc.PacketConn)
-}
-
-// sharedQuicListener is like sharedListener, but for quic.EarlyListeners.
-type sharedQuicListener struct {
-	quic.EarlyListener
-	key string
-}
-
-// Destruct closes the underlying QUIC listener.
-func (sql *sharedQuicListener) Destruct() error {
-	return sql.EarlyListener.Close()
-}
-
-// sharedPacketConn is like sharedListener, but for net.PacketConns.
-type sharedPacketConn struct {
-	net.PacketConn
-	key string
-}
-
-// Destruct closes the underlying socket.
-func (spc *sharedPacketConn) Destruct() error {
-	return spc.PacketConn.Close()
-}
-
-// NetworkAddress contains the individual components
-// for a parsed network address of the form accepted
-// by ParseNetworkAddress(). Network should be a
-// network value accepted by Go's net package. Port
-// ranges are given by [StartPort, EndPort].
-type NetworkAddress struct {
-	Network   string
-	Host      string
-	StartPort uint
-	EndPort   uint
+	return ln, nil
 }
 
 // IsUnixNetwork returns true if na.Network is
@@ -260,15 +213,25 @@ func (na NetworkAddress) JoinHostPort(offset uint) string {
 	return net.JoinHostPort(na.Host, strconv.Itoa(int(na.StartPort+offset)))
 }
 
+// Expand returns one NetworkAddress for each port in the port range.
+//
+// This is EXPERIMENTAL and subject to change or removal.
 func (na NetworkAddress) Expand() []NetworkAddress {
 	size := na.PortRangeSize()
 	addrs := make([]NetworkAddress, size)
 	for portOffset := uint(0); portOffset < size; portOffset++ {
-		na2 := na
-		na2.StartPort, na2.EndPort = na.StartPort+portOffset, na.StartPort+portOffset
-		addrs[portOffset] = na2
+		addrs[portOffset] = na.At(portOffset)
 	}
 	return addrs
+}
+
+// At returns a NetworkAddress with a port range of just 1
+// at the given port offset; i.e. a NetworkAddress that
+// represents precisely 1 address only.
+func (na NetworkAddress) At(portOffset uint) NetworkAddress {
+	na2 := na
+	na2.StartPort, na2.EndPort = na.StartPort+portOffset, na.StartPort+portOffset
+	return na2
 }
 
 // PortRangeSize returns how many ports are in
@@ -324,20 +287,6 @@ func (na NetworkAddress) String() string {
 
 func isUnixNetwork(netw string) bool {
 	return netw == "unix" || netw == "unixgram" || netw == "unixpacket"
-}
-
-func isListenBindAddressAlreadyInUseError(err error) bool {
-	switch networkOperationError := err.(type) {
-	case *net.OpError:
-		switch syscallError := networkOperationError.Err.(type) {
-		case *os.SyscallError:
-			if syscallError.Syscall == "bind" {
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 // ParseNetworkAddress parses addr into its individual
@@ -439,6 +388,209 @@ func JoinNetworkAddress(network, host, port string) string {
 	return a
 }
 
+// DEPRECATED: Use NetworkAddress.Listen instead. This function will likely be changed or removed in the future.
+func Listen(network, addr string) (net.Listener, error) {
+	// a 0 timeout means Go uses its default
+	return ListenTimeout(network, addr, 0)
+}
+
+// DEPRECATED: Use NetworkAddress.Listen instead. This function will likely be changed or removed in the future.
+func ListenTimeout(network, addr string, keepalivePeriod time.Duration) (net.Listener, error) {
+	netAddr, err := ParseNetworkAddress(JoinNetworkAddress(network, addr, ""))
+	if err != nil {
+		return nil, err
+	}
+
+	ln, err := netAddr.Listen(context.TODO(), 0, net.ListenConfig{KeepAlive: keepalivePeriod})
+	if err != nil {
+		return nil, err
+	}
+
+	return ln.(net.Listener), nil
+}
+
+// DEPRECATED: Use NetworkAddress.Listen instead. This function will likely be changed or removed in the future.
+func ListenPacket(network, addr string) (net.PacketConn, error) {
+	netAddr, err := ParseNetworkAddress(JoinNetworkAddress(network, addr, ""))
+	if err != nil {
+		return nil, err
+	}
+
+	ln, err := netAddr.Listen(context.TODO(), 0, net.ListenConfig{})
+	if err != nil {
+		return nil, err
+	}
+
+	return ln.(net.PacketConn), nil
+}
+
+// ListenQUIC returns a quic.EarlyListener suitable for use in a Caddy module.
+// The network will be transformed into a QUIC-compatible type (if unix, then
+// unixgram will be used; otherwise, udp will be used).
+//
+// NOTE: This API is EXPERIMENTAL and may be changed or removed.
+//
+// TODO: See if we can find a more elegant solution closer to the new NetworkAddress.Listen API.
+func ListenQUIC(ln net.PacketConn, tlsConf *tls.Config, activeRequests *int64) (quic.EarlyListener, error) {
+	lnKey := listenerKey(ln.LocalAddr().Network(), ln.LocalAddr().String())
+
+	sharedEarlyListener, _, err := listenerPool.LoadOrNew(lnKey, func() (Destructor, error) {
+		earlyLn, err := quic.ListenEarly(ln, http3.ConfigureTLSConfig(tlsConf), &quic.Config{
+			RequireAddressValidation: func(clientAddr net.Addr) bool {
+				var highLoad bool
+				if activeRequests != nil {
+					highLoad = atomic.LoadInt64(activeRequests) > 1000 // TODO: make tunable?
+				}
+				return highLoad
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return &sharedQuicListener{EarlyListener: earlyLn, key: lnKey}, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: to serve QUIC over a unix socket, currently we need to hold onto
+	// the underlying net.PacketConn (which we wrap as unixConn to keep count
+	// of closes) because closing the quic.EarlyListener doesn't actually close
+	// the underlying PacketConn, but we need to for unix sockets since we dup
+	// the file descriptor and thus need to close the original; track issue:
+	// https://github.com/lucas-clemente/quic-go/issues/3560#issuecomment-1258959608
+	var unix *unixConn
+	if uc, ok := ln.(*unixConn); ok {
+		unix = uc
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	return &fakeCloseQuicListener{
+		sharedQuicListener: sharedEarlyListener.(*sharedQuicListener),
+		uc:                 unix,
+		context:            ctx,
+		contextCancel:      cancel,
+	}, nil
+}
+
+// ListenerUsage returns the current usage count of the given listener address.
+func ListenerUsage(network, addr string) int {
+	count, _ := listenerPool.References(listenerKey(network, addr))
+	return count
+}
+
+// sharedQuicListener is like sharedListener, but for quic.EarlyListeners.
+type sharedQuicListener struct {
+	quic.EarlyListener
+	key string
+}
+
+// Destruct closes the underlying QUIC listener.
+func (sql *sharedQuicListener) Destruct() error {
+	return sql.EarlyListener.Close()
+}
+
+// sharedPacketConn is like sharedListener, but for net.PacketConns.
+type sharedPacketConn struct {
+	net.PacketConn
+	key string
+}
+
+// Destruct closes the underlying socket.
+func (spc *sharedPacketConn) Destruct() error {
+	return spc.PacketConn.Close()
+}
+
+// fakeClosedErr returns an error value that is not temporary
+// nor a timeout, suitable for making the caller think the
+// listener is actually closed
+func fakeClosedErr(l interface{ Addr() net.Addr }) error {
+	return &net.OpError{
+		Op:   "accept",
+		Net:  l.Addr().Network(),
+		Addr: l.Addr(),
+		Err:  errFakeClosed,
+	}
+}
+
+// errFakeClosed is the underlying error value returned by
+// fakeCloseListener.Accept() after Close() has been called,
+// indicating that it is pretending to be closed so that the
+// server using it can terminate, while the underlying
+// socket is actually left open.
+var errFakeClosed = fmt.Errorf("listener 'closed' 😉")
+
+// fakeClosePacketConn is like fakeCloseListener, but for PacketConns.
+type fakeClosePacketConn struct {
+	closed            int32 // accessed atomically; belongs to this struct only
+	*sharedPacketConn       // embedded, so we also become a net.PacketConn
+}
+
+func (fcpc *fakeClosePacketConn) Close() error {
+	if atomic.CompareAndSwapInt32(&fcpc.closed, 0, 1) {
+		_, _ = listenerPool.Delete(fcpc.sharedPacketConn.key)
+	}
+	return nil
+}
+
+// Supports QUIC implementation: https://github.com/caddyserver/caddy/issues/3998
+func (fcpc fakeClosePacketConn) SetReadBuffer(bytes int) error {
+	if conn, ok := fcpc.PacketConn.(interface{ SetReadBuffer(int) error }); ok {
+		return conn.SetReadBuffer(bytes)
+	}
+	return fmt.Errorf("SetReadBuffer() not implemented for %T", fcpc.PacketConn)
+}
+
+// Supports QUIC implementation: https://github.com/caddyserver/caddy/issues/3998
+func (fcpc fakeClosePacketConn) SyscallConn() (syscall.RawConn, error) {
+	if conn, ok := fcpc.PacketConn.(interface {
+		SyscallConn() (syscall.RawConn, error)
+	}); ok {
+		return conn.SyscallConn()
+	}
+	return nil, fmt.Errorf("SyscallConn() not implemented for %T", fcpc.PacketConn)
+}
+
+type fakeCloseQuicListener struct {
+	closed              int32     // accessed atomically; belongs to this struct only
+	*sharedQuicListener           // embedded, so we also become a quic.EarlyListener
+	uc                  *unixConn // underlying unix socket, if UDS
+	context             context.Context
+	contextCancel       context.CancelFunc
+}
+
+// Currently Accept ignores the passed context, however a situation where
+// someone would need a hotswappable QUIC-only (not http3, since it uses context.Background here)
+// server on which Accept would be called with non-empty contexts
+// (mind that the default net listeners' Accept doesn't take a context argument)
+// sounds way too rare for us to sacrifice efficiency here.
+func (fcql *fakeCloseQuicListener) Accept(_ context.Context) (quic.EarlyConnection, error) {
+	conn, err := fcql.sharedQuicListener.Accept(fcql.context)
+	if err == nil {
+		return conn, nil
+	}
+
+	// if the listener is "closed", return a fake closed error instead
+	if atomic.LoadInt32(&fcql.closed) == 1 && errors.Is(err, context.Canceled) {
+		return nil, fakeClosedErr(fcql)
+	}
+	return nil, err
+}
+
+func (fcql *fakeCloseQuicListener) Close() error {
+	if atomic.CompareAndSwapInt32(&fcql.closed, 0, 1) {
+		fcql.contextCancel()
+		_, _ = listenerPool.Delete(fcql.sharedQuicListener.key)
+		if fcql.uc != nil {
+			// unix sockets need to be closed ourselves because we dup() the file
+			// descriptor when we reuse them, so this avoids a resource leak
+			fcql.uc.Close()
+		}
+	}
+	return nil
+}
+
 // RegisterNetwork registers a network type with Caddy so that if a listener is
 // created for that network type, getListener will be invoked to get the listener.
 // This should be called during init() and will panic if the network type is standard
@@ -460,11 +612,77 @@ func RegisterNetwork(network string, getListener ListenerFunc) {
 	networkTypes[network] = getListener
 }
 
+type unixListener struct {
+	*net.UnixListener
+	mapKey string
+	count  *int32 // accessed atomically
+}
+
+func (uln *unixListener) Close() error {
+	newCount := atomic.AddInt32(uln.count, -1)
+	if newCount == 0 {
+		defer func() {
+			addr := uln.Addr().String()
+			unixSocketsMu.Lock()
+			delete(unixSockets, uln.mapKey)
+			unixSocketsMu.Unlock()
+			syscall.Unlink(addr)
+		}()
+	}
+	return uln.UnixListener.Close()
+}
+
+type unixConn struct {
+	*net.UnixConn
+	filename string
+	mapKey   string
+	count    *int32 // accessed atomically
+}
+
+func (uc *unixConn) Close() error {
+	newCount := atomic.AddInt32(uc.count, -1)
+	if newCount == 0 {
+		defer func() {
+			unixSocketsMu.Lock()
+			delete(unixSockets, uc.mapKey)
+			unixSocketsMu.Unlock()
+			syscall.Unlink(uc.filename)
+		}()
+	}
+	return uc.UnixConn.Close()
+}
+
+// unixSockets keeps track of the currently-active unix sockets
+// so we can transfer their FDs gracefully during reloads.
+var (
+	unixSockets = make(map[string]interface {
+		File() (*os.File, error)
+	})
+	unixSocketsMu sync.Mutex
+)
+
+// getListenerFromPlugin returns a listener on the given network and address
+// if a plugin has registered the network name. It may return (nil, nil) if
+// no plugin can provide a listener.
+func getListenerFromPlugin(ctx context.Context, network, addr string, config net.ListenConfig) (any, error) {
+	// get listener from plugin if network type is registered
+	if getListener, ok := networkTypes[network]; ok {
+		Log().Debug("getting listener from plugin", zap.String("network", network))
+		return getListener(ctx, network, addr, config)
+	}
+
+	return nil, nil
+}
+
+func listenerKey(network, addr string) string {
+	return network + "/" + addr
+}
+
 // ListenerFunc is a function that can return a listener given a network and address.
 // The listeners must be capable of overlapping: with Caddy, new configs are loaded
 // before old ones are unloaded, so listeners may overlap briefly if the configs
 // both need the same listener. EXPERIMENTAL and subject to change.
-type ListenerFunc func(network, addr string) (net.Listener, error)
+type ListenerFunc func(ctx context.Context, network, addr string, cfg net.ListenConfig) (any, error)
 
 var networkTypes = map[string]ListenerFunc{}
 

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -156,7 +156,9 @@ type (
 	MatchHeaderRE map[string]*MatchRegexp
 
 	// MatchProtocol matches requests by protocol. Recognized values are
-	// "http", "https", and "grpc".
+	// "http", "https", and "grpc" for broad protocol matches, or specific
+	// HTTP versions can be specified like so: "http/1", "http/1.1",
+	// "http/2", "http/3", or minimum versions: "http/2+", etc.
 	MatchProtocol string
 
 	// MatchRemoteIP matches requests by client IP (or CIDR range).

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -170,9 +170,10 @@ type Server struct {
 	errorLogger  *zap.Logger
 	ctx          caddy.Context
 
-	server    *http.Server
-	h3server  *http3.Server
-	addresses []caddy.NetworkAddress
+	server      *http.Server
+	h3server    *http3.Server
+	h3listeners []net.PacketConn // TODO: we have to hold these because quic-go won't close listeners it didn't create
+	addresses   []caddy.NetworkAddress
 
 	shutdownAt   time.Time
 	shutdownAtMu *sync.RWMutex
@@ -193,9 +194,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt64(&s.activeRequests, 1)
 		defer atomic.AddInt64(&s.activeRequests, -1)
 
-		err := s.h3server.SetQuicHeaders(w.Header())
-		if err != nil {
-			s.logger.Error("setting HTTP/3 Alt-Svc header", zap.Error(err))
+		if r.ProtoMajor < 3 {
+			err := s.h3server.SetQuicHeaders(w.Header())
+			if err != nil {
+				s.logger.Error("setting HTTP/3 Alt-Svc header", zap.Error(err))
+			}
 		}
 	}
 
@@ -493,8 +496,27 @@ func (s *Server) findLastRouteWithHostMatcher() int {
 // serveHTTP3 creates a QUIC listener, configures an HTTP/3 server if
 // not already done, and then uses that server to serve HTTP/3 over
 // the listener, with Server s as the handler.
-func (s *Server) serveHTTP3(hostport string, tlsCfg *tls.Config) error {
-	h3ln, err := caddy.ListenQUIC(hostport, tlsCfg, &s.activeRequests)
+func (s *Server) serveHTTP3(addr caddy.NetworkAddress, tlsCfg *tls.Config) error {
+	switch addr.Network {
+	case "unix":
+		addr.Network = "unixgram"
+	case "tcp":
+		addr.Network = "udp"
+	case "tcp4":
+		addr.Network = "udp4"
+	case "tcp6":
+		addr.Network = "udp6"
+	default:
+		return fmt.Errorf("unsure what network to use for HTTP/3 given network type: %s", addr.Network)
+	}
+
+	lnAny, err := addr.Listen(s.ctx, 0, net.ListenConfig{})
+	if err != nil {
+		return err
+	}
+	ln := lnAny.(net.PacketConn)
+
+	h3ln, err := caddy.ListenQUIC(ln, tlsCfg, &s.activeRequests)
 	if err != nil {
 		return fmt.Errorf("starting HTTP/3 QUIC listener: %v", err)
 	}
@@ -511,6 +533,8 @@ func (s *Server) serveHTTP3(hostport string, tlsCfg *tls.Config) error {
 			},
 		}
 	}
+
+	s.h3listeners = append(s.h3listeners, lnAny.(net.PacketConn))
 
 	//nolint:errcheck
 	go s.h3server.ServeListener(h3ln)


### PR DESCRIPTION
Deprecate:
- caddy.Listen
- caddy.ListenTimeout
- caddy.ListenPacket

Prefer caddy.NetworkAddress.Listen() instead.

Change:
- caddy.ListenQUIC (hopefully to remove later)
- caddy.ListenerFunc signature (add context and ListenConfig)

- Don't emit Alt-Svc header advertising h3 over HTTP/3

- Use quic.ListenEarly instead of quic.ListenEarlyAddr; this gives us more flexibility (e.g. possibility of HTTP/3 over UDS) but also introduces a new issue:
https://github.com/lucas-clemente/quic-go/issues/3560#issuecomment-1258959608

- Unlink unix socket before and after use

I'm not sure that `ListenAll()` will be useful. You'd think it would be, except the HTTP app, at least, sets up each listener one-by-one. That could probably be refactored and simplified with `ListenAll()`, but I haven't gotten there yet. EDIT: I haven't refactored the http app to use ListenAll, but I did find it to be quite convenient in the layer4 module so I think I'll at least keep it (experimentally) for now.

(I'm keeping it for now because I wrote it and then realized that wouldn't be suitable for this refactor. I kept it because I already wrote it. I might delete it before merging this PR though.)

This took several days. I've done fairly extensive testing on this, but also went through many phases of "oops, I broke it" eventually followed by "duh, that was stupid" or "argh, that's annoying" and found fixes or workarounds for all the problems I noticed.

**I have NO idea if this works on Windows or Mac yet.** I can only run tests on Linux here, so we'll see what the CI says. I did my best to at least ensure it builds on Windows.

This change was mostly motivated by HTTP/3 and Unix sockets and the interop there. HTTP/3 has to be disabled if a site binds to unix sockets and other HTTP versions are also enabled, because a unix socket can't be both STREAM and DGRAM. But if you enable only HTTP/3 and bind to a unix socket, it should work. However, I couldn't test this because no client I know of (Firefox, `curl --http3`, etc) supports HTTP/3 over unix sockets. And frankly, I don't blame them, because I can't think of why that'd ever be useful or necessary. Nonetheless, the code in this PR _should_ enable that use case, and the program runs with a config like that, but I haven't verified with a client.

Overall the refactor is mostly a welcome change, although it does deprecate some `Listen*` functions in the `caddy` package. I doubt these are used by any plugins other than my `layer4` app, so I'm not too worried about deprecating and eventually removing them.

Some things are frustrating about this though. Socket reuse is now dependent on OS and network type; so like, TCP sockets are reused differently on Windows and Linux, and different still for Unix sockets regardless of OS.

QUIC is a slight pain point still because although the listener is _basically_ just a net.PacketConn, API constraints and an [implementation choice in quic-go](https://github.com/lucas-clemente/quic-go/issues/3560#issuecomment-1258959608) make the Close behavior of listeners a little tricky/surprising. Actually, quic-go's implementation kind of makes sense in general, and would seem like a good idea, but in our case it does add a bit of bulk to the code.

Ideally, we'd get rid of ListenQUIC and just have our `serveHTTP()` method wrap the returned listener in a `quic.EarlyListener`. And maybe there's a way to do that already, I just haven't discovered it yet. We might need to wrap the EarlyListener with our own concrete type, but it'd still likely be cleaner than what we have now.

**This change also doesn't emit the Alt-Svc header on HTTP/3.** It [doesn't make sense](https://twitter.com/bagder/status/1574872458682834957) to advertise h3 when the client is already using it. I just hope clients won't _stop_ using it if the header disappears. I have noticed that Firefox likes to stop using HTTP/3 intermittently or randomly sometimes...

Anyway, there's a lot to unpack here. Overall I think this implementation of listeners is more reliable, flexible, and correct than what we had before, even if a little more complicated. I think some of the rough edges can be smoothed out with some cooperation and clever tinkering.

**Please test this out.** It'll probably get merged either way but the more field use it gets, the better! I'll deploy it to the Caddy website, for example, before tagging a release.