### PR TITLE
map: Remove infinite recursion check

### DIFF
--- a/modules/caddyhttp/map/map.go
+++ b/modules/caddyhttp/map/map.go
@@ -109,22 +109,13 @@ func (h *Handler) Validate() error {
 		}
 		seen[input] = i
 
-		// prevent infinite recursion
-		for _, out := range m.Outputs {
-			for _, dest := range h.Destinations {
-				if strings.Contains(caddy.ToString(out), dest) ||
-					strings.Contains(m.Input, dest) {
-					return fmt.Errorf("mapping %d requires value of {%s} to define value of {%s}: infinite recursion", i, dest, dest)
-				}
-			}
-		}
-
 		// ensure mappings have 1:1 output-to-destination correspondence
 		nOut := len(m.Outputs)
 		if nOut != nDest {
 			return fmt.Errorf("mapping %d has %d outputs but there are %d destinations defined", i, nOut, nDest)
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
It was not accurate and would block valid configurations. Placeholders could be used in outputs that are defined in the same mapping as long as that placeholder does not do the same.

Example of a valid config that was blocked:

```
respond "Hello world: {bar}"
map {host} {foo} {bar} {
	localhost A {foo}
}
```

It would give the error: `mapping 0 requires value of {foo} to define value of {foo}: infinite recursion` - which isn't really true nor does it make sense (it should probably say "mapping 0 requires value of {foo} to define value of {bar}" -- which isn't infinitely recursive).

For a request to `localhost`, the response is "Hello world: A" as expected, because although `{foo}` does get mapped to `{bar}`, the value of `{bar}` is simply "A". The recursion stops after 1 call (2 total).

---

A more general solution would be to detect it at run-time in the replacer directly, but that's a bit tedious and will require allocations. (See below.)

A better implementation of this check could still be done, but I don't know if it would always be accurate. Could be a "best-effort" thing? But I've also never heard of an actual case where someone configured infinite recursion...

I did come up with this general solution, to be used in `replacer.go` in the `replace()` method - it allows you to go about 10 replacement calls deep:

```go
// we'd want to pool these buffers
callers := make([]uintptr, 128) // could probably get away with 64
n := runtime.Callers(1, callers)
frames := runtime.CallersFrames(callers[:n])
var depth int
for {
	frame, more := frames.Next()
	if strings.HasSuffix(frame.File, "replacer.go") &&
		strings.HasSuffix(frame.Function, ".replace") {
		depth++
	}
	if depth >= 10 {
		return "", fmt.Errorf("infinite recursion detected")
	}
	if !more {
		break
	}
}
```

Obviously this has a performance impact and is a little janky, but is an example of a more general solution to prevent infinite recursion through placeholders. Again, this would require a faulty configuration from an administrator (i.e. this is not a security vulnerability -- just a normal bug).

Since I don't have a better solution quite yet, I'll just leave this here, but let's see if it actually happens in the wild for a non-obvious case before we add complexity to our code.