### PR TITLE
forwardauth: Canonicalize header fields (fix #5038)

### DIFF
--- a/modules/caddyhttp/reverseproxy/forwardauth/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/forwardauth/caddyfile.go
@@ -38,29 +38,28 @@ func init() {
 // configured for most™️ auth gateways that support forward auth. The typical
 // config which looks something like this:
 //
-//     forward_auth auth-gateway:9091 {
-//         uri /authenticate?redirect=https://auth.example.com
-//         copy_headers Remote-User Remote-Email
-//     }
+//	forward_auth auth-gateway:9091 {
+//	    uri /authenticate?redirect=https://auth.example.com
+//	    copy_headers Remote-User Remote-Email
+//	}
 //
 // is equivalent to a reverse_proxy directive like this:
 //
-//     reverse_proxy auth-gateway:9091 {
-//         method GET
-//         rewrite /authenticate?redirect=https://auth.example.com
+//	reverse_proxy auth-gateway:9091 {
+//	    method GET
+//	    rewrite /authenticate?redirect=https://auth.example.com
 //
-//         header_up X-Forwarded-Method {method}
-//         header_up X-Forwarded-Uri {uri}
+//	    header_up X-Forwarded-Method {method}
+//	    header_up X-Forwarded-Uri {uri}
 //
-//         @good status 2xx
-//         handle_response @good {
-//             request_header {
-//                 Remote-User {http.reverse_proxy.header.Remote-User}
-//                 Remote-Email {http.reverse_proxy.header.Remote-Email}
-//             }
-//         }
-//     }
-//
+//	    @good status 2xx
+//	    handle_response @good {
+//	        request_header {
+//	            Remote-User {http.reverse_proxy.header.Remote-User}
+//	            Remote-Email {http.reverse_proxy.header.Remote-Email}
+//	        }
+//	    }
+//	}
 func parseCaddyfile(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error) {
 	if !h.Next() {
 		return nil, h.ArgErr()
@@ -196,9 +195,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error)
 	// need at least one handler in the routes for the response handling
 	// logic in reverse_proxy to not skip this entry as empty.
 	for from, to := range headersToCopy {
-		handler.Request.Set[to] = []string{
-			"{http.reverse_proxy.header." + from + "}",
-		}
+		handler.Request.Set.Set(to, "{http.reverse_proxy.header."+http.CanonicalHeaderKey(from)+"}")
 	}
 
 	goodResponseHandler.Routes = append(


### PR DESCRIPTION
Seems simple enough to canonicalize the header field names.