### PR TITLE
logging: Perform filtering on arrays of strings (where possible)

### DIFF
--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -240,6 +240,7 @@ func (m IPMaskFilter) mask(s string) string {
 		ipAddr := net.ParseIP(host)
 		if ipAddr == nil {
 			output += value + ", "
+			continue
 		}
 		mask := m.v4Mask
 		if ipAddr.To4() == nil {

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -76,7 +77,10 @@ func hash(s string) string {
 }
 
 // HashFilter is a Caddy log field filter that
-// replaces the field with the initial 4 bytes of the SHA-256 hash of the content.
+// replaces the field with the initial 4 bytes
+// of the SHA-256 hash of the content. Operates
+// on string fields, or on arrays of strings
+// where each string is hashed.
 type HashFilter struct {
 }
 
@@ -95,7 +99,13 @@ func (f *HashFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 
 // Filter filters the input field with the replacement value.
 func (f *HashFilter) Filter(in zapcore.Field) zapcore.Field {
-	in.String = hash(in.String)
+	if array, ok := in.Interface.(caddyhttp.LoggableStringArray); ok {
+		for i, s := range array {
+			array[i] = hash(s)
+		}
+	} else {
+		in.String = hash(in.String)
+	}
 	return in
 }
 
@@ -131,7 +141,10 @@ func (f *ReplaceFilter) Filter(in zapcore.Field) zapcore.Field {
 }
 
 // IPMaskFilter is a Caddy log field filter that
-// masks IP addresses.
+// masks IP addresses in a string, or in an array
+// of strings. The string may be a comma separated
+// list of IP addresses, where all of the values
+// will be masked.
 type IPMaskFilter struct {
 	// The IPv4 mask, as an subnet size CIDR.
 	IPv4MaskRaw int `json:"ipv4_cidr,omitempty"`
@@ -205,25 +218,42 @@ func (m *IPMaskFilter) Provision(ctx caddy.Context) error {
 
 // Filter filters the input field.
 func (m IPMaskFilter) Filter(in zapcore.Field) zapcore.Field {
-	host, port, err := net.SplitHostPort(in.String)
-	if err != nil {
-		host = in.String // assume whole thing was IP address
-	}
-	ipAddr := net.ParseIP(host)
-	if ipAddr == nil {
-		return in
-	}
-	mask := m.v4Mask
-	if ipAddr.To4() == nil {
-		mask = m.v6Mask
-	}
-	masked := ipAddr.Mask(mask)
-	if port == "" {
-		in.String = masked.String()
+	if array, ok := in.Interface.(caddyhttp.LoggableStringArray); ok {
+		for i, s := range array {
+			array[i] = m.mask(s)
+		}
 	} else {
-		in.String = net.JoinHostPort(masked.String(), port)
+		in.String = m.mask(in.String)
 	}
+
 	return in
+}
+
+func (m IPMaskFilter) mask(s string) string {
+	output := ""
+	for _, value := range strings.Split(s, ",") {
+		value = strings.TrimSpace(value)
+		host, port, err := net.SplitHostPort(value)
+		if err != nil {
+			host = value // assume whole thing was IP address
+		}
+		ipAddr := net.ParseIP(host)
+		if ipAddr == nil {
+			output += value + ", "
+		}
+		mask := m.v4Mask
+		if ipAddr.To4() == nil {
+			mask = m.v6Mask
+		}
+		masked := ipAddr.Mask(mask)
+		if port == "" {
+			output += masked.String() + ", "
+			continue
+		}
+
+		output += net.JoinHostPort(masked.String(), port) + ", "
+	}
+	return strings.TrimSuffix(output, ", ")
 }
 
 type filterAction string
@@ -499,7 +529,10 @@ OUTER:
 }
 
 // RegexpFilter is a Caddy log field filter that
-// replaces the field matching the provided regexp with the indicated string.
+// replaces the field matching the provided regexp
+// with the indicated string. If the field is an
+// array of strings, each of them will have the
+// regexp replacement applied.
 type RegexpFilter struct {
 	// The regular expression pattern defining what to replace.
 	RawRegexp string `json:"regexp,omitempty"`
@@ -545,7 +578,13 @@ func (m *RegexpFilter) Provision(ctx caddy.Context) error {
 
 // Filter filters the input field with the replacement value if it matches the regexp.
 func (f *RegexpFilter) Filter(in zapcore.Field) zapcore.Field {
-	in.String = f.regexp.ReplaceAllString(in.String, f.Value)
+	if array, ok := in.Interface.(caddyhttp.LoggableStringArray); ok {
+		for i, s := range array {
+			array[i] = f.regexp.ReplaceAllString(s, f.Value)
+		}
+	} else {
+		in.String = f.regexp.ReplaceAllString(in.String, f.Value)
+	}
 
 	return in
 }
@@ -576,7 +615,6 @@ func (f *RenameFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 
 // Filter renames the input field with the replacement name.
 func (f *RenameFilter) Filter(in zapcore.Field) zapcore.Field {
-	in.Type = zapcore.StringType
 	in.Key = f.Name
 	return in
 }

--- a/modules/logging/filters_test.go
+++ b/modules/logging/filters_test.go
@@ -21,6 +21,11 @@ func TestIPMaskSingleValue(t *testing.T) {
 	if out.String != "ffff:ffff::" {
 		t.Fatalf("field has not been filtered: %s", out.String)
 	}
+
+	out = f.Filter(zapcore.Field{String: "not-an-ip"})
+	if out.String != "not-an-ip" {
+		t.Fatalf("field has been filtered: %s", out.String)
+	}
 }
 
 func TestIPMaskCommaValue(t *testing.T) {
@@ -34,6 +39,11 @@ func TestIPMaskCommaValue(t *testing.T) {
 
 	out = f.Filter(zapcore.Field{String: "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff, ff00:ffff:ffff:ffff:ffff:ffff:ffff:ffff"})
 	if out.String != "ffff:ffff::, ff00:ffff::" {
+		t.Fatalf("field has not been filtered: %s", out.String)
+	}
+
+	out = f.Filter(zapcore.Field{String: "not-an-ip, 255.255.255.255"})
+	if out.String != "not-an-ip, 255.255.0.0" {
 		t.Fatalf("field has not been filtered: %s", out.String)
 	}
 }


### PR DESCRIPTION
Thanks to @IndeedNotJames for reporting this problem.

When trying to filter HTTP headers in the logs, many filters don't work at all because they didn't handle fields that are array values, which all headers are because they can have multiple values.

These changes are mainly for HTTP headers, but it'll work in general for any `LoggableStringArray` type being logged.

Now, the `regexp`, `hash` and `ip_mask` filters will correctly iterate over each string in the `LoggableStringArray` and apply their filtering on those. 

Additionally, for `ip_mask`, we now split on commas and mask each segment that parses as an IP address. This should be useful for `X-Forwarded-For` type headers which may be a list of comma separated IPs.

And finally, I fixed a bug with `rename` where it would set the zap field type to String, which would totally clobber any array typed fields with an empty string instead. That was just a total oversight when I implemented that filter, because it was basically copy-paste from the `replace` filter.

As for the other filters, I didn't touch them for various reasons. `replace` doesn't iterate because it could be a valid usecase to change the type of a field to string... but also maybe not. I dunno about that one, you can probably just use `regexp` in its place. And for `delete`, it's not possible to delete a particular entry in an array; we'd need a new filter to do that, which is totally possible, but I'm not sure the usecase (when is there ever a guarantee that a particular index exists?). Also `cookie` and `query` already do their job; they're very specifically targeted at the `Cookie` header (and iterates itself just fine), and the `uri` field.