### PR TITLE
caddyhttp: Determine real client IP if trusted proxies configured

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -1328,6 +1328,7 @@ func placeholderShorthands() []string {
 		"{tls_client_certificate_pem}", "{http.request.tls.client.certificate_pem}",
 		"{tls_client_certificate_der_base64}", "{http.request.tls.client.certificate_der_base64}",
 		"{upstream_hostport}", "{http.reverse_proxy.upstream.hostport}",
+		"{client_ip}", "{http.vars.client_ip}",
 	}
 }
 

--- a/caddytest/integration/caddyfile_adapt/global_server_options_single.txt
+++ b/caddytest/integration/caddyfile_adapt/global_server_options_single.txt
@@ -15,6 +15,8 @@
 		protocols h1 h2 h2c h3
 		strict_sni_host
 		trusted_proxies static private_ranges
+		client_ip_headers Custom-Real-Client-IP X-Forwarded-For
+		client_ip_headers A-Third-One
 	}
 }
 
@@ -67,6 +69,11 @@ foo.com {
 						],
 						"source": "static"
 					},
+					"client_ip_headers": [
+						"Custom-Real-Client-IP",
+						"X-Forwarded-For",
+						"A-Third-One"
+					],
 					"logs": {
 						"should_log_credentials": true
 					},

--- a/caddytest/integration/caddyfile_adapt/matcher_syntax.txt
+++ b/caddytest/integration/caddyfile_adapt/matcher_syntax.txt
@@ -43,6 +43,9 @@
 
 	@matcher11 remote_ip private_ranges
 	respond @matcher11 "remote_ip matcher with private ranges"
+
+	@matcher12 client_ip private_ranges
+	respond @matcher12 "client_ip matcher with private ranges"
 }
 ----------
 {
@@ -247,6 +250,28 @@
 							"handle": [
 								{
 									"body": "remote_ip matcher with private ranges",
+									"handler": "static_response"
+								}
+							]
+						},
+						{
+							"match": [
+								{
+									"client_ip": {
+										"ranges": [
+											"192.168.0.0/16",
+											"172.16.0.0/12",
+											"10.0.0.0/8",
+											"127.0.0.1/8",
+											"fd00::/8",
+											"::1"
+										]
+									}
+								}
+							],
+							"handle": [
+								{
+									"body": "client_ip matcher with private ranges",
 									"handler": "static_response"
 								}
 							]

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -232,6 +232,11 @@ func (app *App) Provision(ctx caddy.Context) error {
 			srv.trustedProxies = val.(IPRangeSource)
 		}
 
+		// set the default client IP header to read from
+		if srv.ClientIPHeaders == nil {
+			srv.ClientIPHeaders = []string{"X-Forwarded-For"}
+		}
+
 		// process each listener address
 		for i := range srv.Listen {
 			lnOut, err := repl.ReplaceOrErr(srv.Listen[i], true, true)

--- a/modules/caddyhttp/ip_matchers.go
+++ b/modules/caddyhttp/ip_matchers.go
@@ -1,0 +1,344 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddyhttp
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"reflect"
+	"strings"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types/ref"
+	"go.uber.org/zap"
+)
+
+// MatchRemoteIP matches requests by the remote IP address,
+// i.e. the IP address of the direct connection to Caddy.
+type MatchRemoteIP struct {
+	// The IPs or CIDR ranges to match.
+	Ranges []string `json:"ranges,omitempty"`
+
+	// If true, prefer the first IP in the request's X-Forwarded-For
+	// header, if present, rather than the immediate peer's IP, as
+	// the reference IP against which to match. Note that it is easy
+	// to spoof request headers. Default: false
+	// DEPRECATED: This is insecure, MatchClientIP should be used instead.
+	Forwarded bool `json:"forwarded,omitempty"`
+
+	// cidrs and zones vars should aligned always in the same
+	// length and indexes for matching later
+	cidrs  []*netip.Prefix
+	zones  []string
+	logger *zap.Logger
+}
+
+// MatchClientIP matches requests by the client IP address,
+// i.e. the resolved address, considering trusted proxies.
+type MatchClientIP struct {
+	// The IPs or CIDR ranges to match.
+	Ranges []string `json:"ranges,omitempty"`
+
+	// cidrs and zones vars should aligned always in the same
+	// length and indexes for matching later
+	cidrs  []*netip.Prefix
+	zones  []string
+	logger *zap.Logger
+}
+
+func init() {
+	caddy.RegisterModule(MatchRemoteIP{})
+	caddy.RegisterModule(MatchClientIP{})
+}
+
+// CaddyModule returns the Caddy module information.
+func (MatchRemoteIP) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "http.matchers.remote_ip",
+		New: func() caddy.Module { return new(MatchRemoteIP) },
+	}
+}
+
+// UnmarshalCaddyfile implements caddyfile.Unmarshaler.
+func (m *MatchRemoteIP) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		for d.NextArg() {
+			if d.Val() == "forwarded" {
+				if len(m.Ranges) > 0 {
+					return d.Err("if used, 'forwarded' must be first argument")
+				}
+				m.Forwarded = true
+				continue
+			}
+			if d.Val() == "private_ranges" {
+				m.Ranges = append(m.Ranges, PrivateRangesCIDR()...)
+				continue
+			}
+			m.Ranges = append(m.Ranges, d.Val())
+		}
+		if d.NextBlock(0) {
+			return d.Err("malformed remote_ip matcher: blocks are not supported")
+		}
+	}
+	return nil
+}
+
+// CELLibrary produces options that expose this matcher for use in CEL
+// expression matchers.
+//
+// Example:
+//
+//	expression remote_ip('forwarded', '192.168.0.0/16', '172.16.0.0/12', '10.0.0.0/8')
+func (MatchRemoteIP) CELLibrary(ctx caddy.Context) (cel.Library, error) {
+	return CELMatcherImpl(
+		// name of the macro, this is the function name that users see when writing expressions.
+		"remote_ip",
+		// name of the function that the macro will be rewritten to call.
+		"remote_ip_match_request_list",
+		// internal data type of the MatchPath value.
+		[]*cel.Type{cel.ListType(cel.StringType)},
+		// function to convert a constant list of strings to a MatchPath instance.
+		func(data ref.Val) (RequestMatcher, error) {
+			refStringList := reflect.TypeOf([]string{})
+			strList, err := data.ConvertToNative(refStringList)
+			if err != nil {
+				return nil, err
+			}
+
+			m := MatchRemoteIP{}
+
+			for _, input := range strList.([]string) {
+				if input == "forwarded" {
+					if len(m.Ranges) > 0 {
+						return nil, errors.New("if used, 'forwarded' must be first argument")
+					}
+					m.Forwarded = true
+					continue
+				}
+				m.Ranges = append(m.Ranges, input)
+			}
+
+			err = m.Provision(ctx)
+			return m, err
+		},
+	)
+}
+
+// Provision parses m's IP ranges, either from IP or CIDR expressions.
+func (m *MatchRemoteIP) Provision(ctx caddy.Context) error {
+	m.logger = ctx.Logger()
+	cidrs, zones, err := provisionCidrsZonesFromRanges(m.Ranges)
+	if err != nil {
+		return err
+	}
+	m.cidrs = cidrs
+	m.zones = zones
+
+	if m.Forwarded {
+		m.logger.Warn("remote_ip's forwarded mode is deprecated; use the 'client_ip' matcher instead")
+	}
+
+	return nil
+}
+
+// Match returns true if r matches m.
+func (m MatchRemoteIP) Match(r *http.Request) bool {
+	address := r.RemoteAddr
+	if m.Forwarded {
+		if fwdFor := r.Header.Get("X-Forwarded-For"); fwdFor != "" {
+			address = strings.TrimSpace(strings.Split(fwdFor, ",")[0])
+		}
+	}
+	clientIP, zoneID, err := parseIPZoneFromString(address)
+	if err != nil {
+		m.logger.Error("getting remote IP", zap.Error(err))
+		return false
+	}
+	matches, zoneFilter := matchIPByCidrZones(clientIP, zoneID, m.cidrs, m.zones)
+	if !matches && !zoneFilter {
+		m.logger.Debug("zone ID from remote IP did not match", zap.String("zone", zoneID))
+	}
+	return matches
+}
+
+// CaddyModule returns the Caddy module information.
+func (MatchClientIP) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "http.matchers.client_ip",
+		New: func() caddy.Module { return new(MatchClientIP) },
+	}
+}
+
+// UnmarshalCaddyfile implements caddyfile.Unmarshaler.
+func (m *MatchClientIP) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		for d.NextArg() {
+			if d.Val() == "private_ranges" {
+				m.Ranges = append(m.Ranges, PrivateRangesCIDR()...)
+				continue
+			}
+			m.Ranges = append(m.Ranges, d.Val())
+		}
+		if d.NextBlock(0) {
+			return d.Err("malformed client_ip matcher: blocks are not supported")
+		}
+	}
+	return nil
+}
+
+// CELLibrary produces options that expose this matcher for use in CEL
+// expression matchers.
+//
+// Example:
+//
+//	expression client_ip('192.168.0.0/16', '172.16.0.0/12', '10.0.0.0/8')
+func (MatchClientIP) CELLibrary(ctx caddy.Context) (cel.Library, error) {
+	return CELMatcherImpl(
+		// name of the macro, this is the function name that users see when writing expressions.
+		"client_ip",
+		// name of the function that the macro will be rewritten to call.
+		"client_ip_match_request_list",
+		// internal data type of the MatchPath value.
+		[]*cel.Type{cel.ListType(cel.StringType)},
+		// function to convert a constant list of strings to a MatchPath instance.
+		func(data ref.Val) (RequestMatcher, error) {
+			refStringList := reflect.TypeOf([]string{})
+			strList, err := data.ConvertToNative(refStringList)
+			if err != nil {
+				return nil, err
+			}
+
+			m := MatchClientIP{
+				Ranges: strList.([]string),
+			}
+
+			err = m.Provision(ctx)
+			return m, err
+		},
+	)
+}
+
+// Provision parses m's IP ranges, either from IP or CIDR expressions.
+func (m *MatchClientIP) Provision(ctx caddy.Context) error {
+	m.logger = ctx.Logger()
+	cidrs, zones, err := provisionCidrsZonesFromRanges(m.Ranges)
+	if err != nil {
+		return err
+	}
+	m.cidrs = cidrs
+	m.zones = zones
+	return nil
+}
+
+// Match returns true if r matches m.
+func (m MatchClientIP) Match(r *http.Request) bool {
+	address := GetVar(r.Context(), ClientIPVarKey).(string)
+	clientIP, zoneID, err := parseIPZoneFromString(address)
+	if err != nil {
+		m.logger.Error("getting client IP", zap.Error(err))
+		return false
+	}
+	matches, zoneFilter := matchIPByCidrZones(clientIP, zoneID, m.cidrs, m.zones)
+	if !matches && !zoneFilter {
+		m.logger.Debug("zone ID from client IP did not match", zap.String("zone", zoneID))
+	}
+	return matches
+}
+
+func provisionCidrsZonesFromRanges(ranges []string) ([]*netip.Prefix, []string, error) {
+	cidrs := []*netip.Prefix{}
+	zones := []string{}
+	for _, str := range ranges {
+		// Exclude the zone_id from the IP
+		if strings.Contains(str, "%") {
+			split := strings.Split(str, "%")
+			str = split[0]
+			// write zone identifiers in m.zones for matching later
+			zones = append(zones, split[1])
+		} else {
+			zones = append(zones, "")
+		}
+		if strings.Contains(str, "/") {
+			ipNet, err := netip.ParsePrefix(str)
+			if err != nil {
+				return nil, nil, fmt.Errorf("parsing CIDR expression '%s': %v", str, err)
+			}
+			cidrs = append(cidrs, &ipNet)
+		} else {
+			ipAddr, err := netip.ParseAddr(str)
+			if err != nil {
+				return nil, nil, fmt.Errorf("invalid IP address: '%s': %v", str, err)
+			}
+			ipNew := netip.PrefixFrom(ipAddr, ipAddr.BitLen())
+			cidrs = append(cidrs, &ipNew)
+		}
+	}
+	return cidrs, zones, nil
+}
+
+func parseIPZoneFromString(address string) (netip.Addr, string, error) {
+	ipStr, _, err := net.SplitHostPort(address)
+	if err != nil {
+		ipStr = address // OK; probably didn't have a port
+	}
+
+	// Some IPv6-Adresses can contain zone identifiers at the end,
+	// which are separated with "%"
+	zoneID := ""
+	if strings.Contains(ipStr, "%") {
+		split := strings.Split(ipStr, "%")
+		ipStr = split[0]
+		zoneID = split[1]
+	}
+
+	ipAddr, err := netip.ParseAddr(ipStr)
+	if err != nil {
+		return netip.IPv4Unspecified(), "", err
+	}
+
+	return ipAddr, zoneID, nil
+}
+
+func matchIPByCidrZones(clientIP netip.Addr, zoneID string, cidrs []*netip.Prefix, zones []string) (bool, bool) {
+	zoneFilter := true
+	for i, ipRange := range cidrs {
+		if ipRange.Contains(clientIP) {
+			// Check if there are zone filters assigned and if they match.
+			if zones[i] == "" || zoneID == zones[i] {
+				return true, false
+			}
+			zoneFilter = false
+		}
+	}
+	return false, zoneFilter
+}
+
+// Interface guards
+var (
+	_ RequestMatcher        = (*MatchRemoteIP)(nil)
+	_ caddy.Provisioner     = (*MatchRemoteIP)(nil)
+	_ caddyfile.Unmarshaler = (*MatchRemoteIP)(nil)
+	_ CELLibraryProducer    = (*MatchRemoteIP)(nil)
+
+	_ RequestMatcher        = (*MatchClientIP)(nil)
+	_ caddy.Provisioner     = (*MatchClientIP)(nil)
+	_ caddyfile.Unmarshaler = (*MatchClientIP)(nil)
+	_ CELLibraryProducer    = (*MatchClientIP)(nil)
+)

--- a/modules/caddyhttp/marshalers.go
+++ b/modules/caddyhttp/marshalers.go
@@ -40,6 +40,7 @@ func (r LoggableHTTPRequest) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 
 	enc.AddString("remote_ip", ip)
 	enc.AddString("remote_port", port)
+	enc.AddString("client_ip", GetVar(r.Context(), ClientIPVarKey).(string))
 	enc.AddString("proto", r.Proto)
 	enc.AddString("method", r.Method)
 	enc.AddString("host", r.Host)


### PR DESCRIPTION
Followup on #5103 and #5328.

This introduces first-class support for determining the client IP, at the HTTP server level. Also adds a placeholder and writes it to the access logs.

I'm marking this as a draft for now, because this has a certain level of risk, and needs discussion. We need to be extra careful about the implementation.

I'm taking @adam-p's guidance on this from his excellent article https://adam-p.ca/blog/2022/03/x-forwarded-for/. There's a few different valid approaches to this. This implementation takes the left-most, first valid IP. I'm _not_ excluding private IPs, because actually it happens frequently that users want their LAN IP to be used as the real client IP, in home networking contexts.

~~Currently, the header used is not configurable, I have it just set to `X-Forwarded-For` which is typically good enough, but I think to be robust we'll need to make that configurable. Do we only allow a single header field, or do we allow a fallback list?~~ I implemented this as a fallback list of headers. This is configured on the server itself, alongside the `trusted_proxies`.

~~Another open question (also applicable to #5103, maybe we should figure this out before merging that), should we make trusted IP sources pluggable?~~ We did make it pluggable in #5328. We provide a "static" module by default. The argument for that is that proxies like Cloudflare have a ton of IP ranges, and users managing that in their config is annoying. So a plugin module would be able to periodically fetch and cache their IP list.

I decided that the `client_ip` should always be set (as long as the `RemoteAddr` is a valid IP address). So in the logs, it will be identical to the `remote_ip` unless trusted proxies is configured and the proxy passed the client IP in a trusted header.