### PR TITLE
fileserver: better dark mode visited link contrast

### DIFF
--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -27,6 +27,10 @@ a:visited {
 	color: #800080;
 }
 
+a:visited:hover {
+	color: #b900b9;
+}
+
 header,
 #summary {
 	padding-left: 5%;
@@ -242,6 +246,14 @@ footer {
 	a:hover,
 	h1 a:hover {
 		color: #62b2fd;
+	}
+
+	a:visited {
+		color: #c269c2;
+	}
+
+	a:visited:hover {
+		color: #d03cd0;
 	}
 
 	tr {


### PR DESCRIPTION
PR #4066 added a dark color scheme to the file_server browse template. PR #4356 later set the links for the `:visited` pseudo-class, but did not set anything for the dark mode, resulting in poor contrast. I selected some new colors by feel.

This commit also adds an `a:visited:hover` for both, to go along with the normal blue hover colors.

![image](https://user-images.githubusercontent.com/52814/193428311-b7a56186-8a91-4b88-88a0-2cb6548c216a.png)
![image](https://user-images.githubusercontent.com/52814/193428325-563da5f6-e9b0-4936-8b3a-1ce6fae6e678.png)
