### PR TITLE
Fix inverted logic in Windows service detection

### DIFF
--- a/service_windows.go
+++ b/service_windows.go
@@ -21,7 +21,7 @@ import (
 
 func init() {
 	isService, err := svc.IsWindowsService()
-	if err != nil || isService {
+	if err != nil || !isService {
 		return
 	}
 	go func() {


### PR DESCRIPTION
Wanted to test the Windows service manager integration, promptly failed,
because the check is inverted :D

With this fixed, Caddy starts as a Windows service, but doesn't find an
"adjacent" Caddyfile, because all Windows services have their working directory
set to `C:\WINDOWS\SYSTEM32`... Should we chdir in this case? (And if that
sounds like a good idea, is the init method in `service_windows.go` early
enough to do this safely?)
