### PR TITLE
logging: Better `console` encoder defaults

### DIFF
--- a/modules/logging/encoders.go
+++ b/modules/logging/encoders.go
@@ -45,15 +45,21 @@ func (ConsoleEncoder) CaddyModule() caddy.ModuleInfo {
 
 // Provision sets up the encoder.
 func (ce *ConsoleEncoder) Provision(_ caddy.Context) error {
+	if ce.LevelFormat == "" {
+		ce.LevelFormat = "color"
+	}
+	if ce.TimeFormat == "" {
+		ce.TimeFormat = "wall_milli"
+	}
 	ce.Encoder = zapcore.NewConsoleEncoder(ce.ZapcoreEncoderConfig())
 	return nil
 }
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens. Syntax:
 //
-//     console {
-//         <common encoder config subdirectives...>
-//     }
+//	console {
+//	    <common encoder config subdirectives...>
+//	}
 //
 // See the godoc on the LogEncoderConfig type for the syntax of
 // subdirectives that are common to most/all encoders.
@@ -92,9 +98,9 @@ func (je *JSONEncoder) Provision(_ caddy.Context) error {
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens. Syntax:
 //
-//     json {
-//         <common encoder config subdirectives...>
-//     }
+//	json {
+//	    <common encoder config subdirectives...>
+//	}
 //
 // See the godoc on the LogEncoderConfig type for the syntax of
 // subdirectives that are common to most/all encoders.
@@ -127,19 +133,18 @@ type LogEncoderConfig struct {
 
 // UnmarshalCaddyfile populates the struct from Caddyfile tokens. Syntax:
 //
-//     {
-//         message_key     <key>
-//         level_key       <key>
-//         time_key        <key>
-//         name_key        <key>
-//         caller_key      <key>
-//         stacktrace_key  <key>
-//         line_ending     <char>
-//         time_format     <format>
-//         duration_format <format>
-//         level_format    <format>
-//     }
-//
+//	{
+//	    message_key     <key>
+//	    level_key       <key>
+//	    time_key        <key>
+//	    name_key        <key>
+//	    caller_key      <key>
+//	    stacktrace_key  <key>
+//	    line_ending     <char>
+//	    time_format     <format>
+//	    duration_format <format>
+//	    level_format    <format>
+//	}
 func (lec *LogEncoderConfig) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for nesting := d.Nesting(); d.NextBlock(nesting); {
 		subdir := d.Val()


### PR DESCRIPTION
This is something that has bothered me for a while, so I figured I'd do something about it now since I'm playing in the logging code lately.

The `console` encoder doesn't actually match the defaults that zap's default logger uses. This makes it match better with the rest of the logs when using the `console` encoder alongside somekind of filter, which requires you to configure an encoder to wrap.

Before:
![image](https://user-images.githubusercontent.com/2111701/193475701-bc99eca9-8410-4ba8-b0c8-38d628858e1c.png)

After:
![image](https://user-images.githubusercontent.com/2111701/193475714-02680e7a-c20f-413c-9839-3e8b51c0f62a.png)

As you can see, this colorizes + uppercases the level, and makes the timestamp not useless.

Worth saying, that technically zap's default logger sniffs the TTY to figure out whether it's interactive or not, and uses JSON if non-interactive, and a "modified" console encoder if interactive. I think it might turn off color if the terminal doesn't support it. But I don't think that's worth trying to do here for these defaults, because it only affects the log level and most people get the gist even if their terminal doesn't render the color shell escapes.