### PR TITLE
Switch to program directory when running as Windows service

### DIFF
--- a/service_windows.go
+++ b/service_windows.go
@@ -15,6 +15,9 @@
 package caddy
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/caddyserver/caddy/v2/notify"
 	"golang.org/x/sys/windows/svc"
 )
@@ -24,6 +27,14 @@ func init() {
 	if err != nil || !isService {
 		return
 	}
+
+	// Windows services always start in the system32 directory, try to
+	// switch into the directory where the caddy executable is.
+	execPath, err := os.Executable()
+	if err == nil {
+		_ = os.Chdir(filepath.Dir(execPath))
+	}
+
 	go func() {
 		_ = svc.Run("", runner{})
 	}()


### PR DESCRIPTION
As noted in #5106, when installing Caddy as a native Windows service (For reference, the PowerShell command for that is `New-Service -Name caddy -BinaryPathName "C:\caddy\caddy.exe run"`), caddy starts up in `C:\WINDOWS\SYSTEM32` - I think this is a bad idea for multiple reasons:
- You obviously cannot put an "adjacent" `Caddyfile` into `system32` (well, you technically can, but that sound like a bad idea all around) and as an alternative, you have to run caddy with a much longer command line (Like `New-Service -Name caddy -BinaryPathName "C:\caddy\caddy.exe run --config C:\caddy\Caddyfile"`
- If somebody tries to use relative paths in the `Caddyfile`, those will be relative to the `system32` directory, which will lead to hard-to-debug problems...

This is a "prototype" of a simple fix: When we are running as a Windows service, try to chdir into the caddy program directory - It works for me[tm] in a Windows 10 VM...