### PR TITLE
replacer: working directory global placeholder

### DIFF
--- a/replacer.go
+++ b/replacer.go
@@ -308,6 +308,10 @@ func globalDefaultReplacements(key string) (any, bool) {
 		return string(filepath.Separator), true
 	case "system.os":
 		return runtime.GOOS, true
+	case "system.wd":
+		// OK if there is an error; just return empty string
+		wd, _ := os.Getwd()
+		return wd, true
 	case "system.arch":
 		return runtime.GOARCH, true
 	case "time.now":

--- a/replacer_test.go
+++ b/replacer_test.go
@@ -372,6 +372,7 @@ func TestReplacerNew(t *testing.T) {
 	} else {
 		// test if default global replacements are added  as the first provider
 		hostname, _ := os.Hostname()
+		wd, _ := os.Getwd()
 		os.Setenv("CADDY_REPLACER_TEST", "envtest")
 		defer os.Setenv("CADDY_REPLACER_TEST", "")
 
@@ -394,6 +395,10 @@ func TestReplacerNew(t *testing.T) {
 			{
 				variable: "system.arch",
 				value:    runtime.GOARCH,
+			},
+			{
+				variable: "system.wd",
+				value:    wd,
 			},
 			{
 				variable: "env.CADDY_REPLACER_TEST",


### PR DESCRIPTION
Sometimes it can be useful to have access to the current working directory in the config file.
This patch adds a placeholder, `system.wd`, containing it.