### PR TITLE
fileserver: Reject ADS and short name paths; trim trailing dots and spaces on Windows

### DIFF
--- a/modules/caddyhttp/caddyhttp.go
+++ b/modules/caddyhttp/caddyhttp.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -230,6 +231,11 @@ func StatusCodeMatches(actual, configured int) bool {
 func SanitizedPathJoin(root, reqPath string) string {
 	if root == "" {
 		root = "."
+	}
+
+	// windows ignores trailing dots and spaces (sigh...)
+	if runtime.GOOS == "windows" {
+		reqPath = strings.TrimRight(reqPath, ". ")
 	}
 
 	path := filepath.Join(root, filepath.Clean("/"+reqPath))

--- a/modules/caddyhttp/caddyhttp.go
+++ b/modules/caddyhttp/caddyhttp.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -231,11 +230,6 @@ func StatusCodeMatches(actual, configured int) bool {
 func SanitizedPathJoin(root, reqPath string) string {
 	if root == "" {
 		root = "."
-	}
-
-	// windows ignores trailing dots and spaces (sigh...)
-	if runtime.GOOS == "windows" {
-		reqPath = strings.TrimRight(reqPath, ". ")
 	}
 
 	path := filepath.Join(root, filepath.Clean("/"+reqPath))

--- a/modules/caddyhttp/caddyhttp_test.go
+++ b/modules/caddyhttp/caddyhttp_test.go
@@ -94,9 +94,11 @@ func TestSanitizedPathJoin(t *testing.T) {
 			t.Fatalf("Test %d: invalid URL: %v", i, err)
 		}
 		actual := SanitizedPathJoin(tc.inputRoot, u.Path)
-		if runtime.GOOS == "windows" && tc.expectWin != "" && actual != tc.expectWin {
-			t.Errorf("Test %d: SanitizedPathJoin('%s', '%s') =>  '%s' (expected '%s')",
-				i, tc.inputRoot, tc.inputPath, actual, tc.expectWin)
+		if runtime.GOOS == "windows" && tc.expectWin != "" {
+			if actual != tc.expectWin {
+				t.Errorf("Test %d: SanitizedPathJoin('%s', '%s') =>  '%s' (expected '%s') (Windows-only)",
+					i, tc.inputRoot, tc.inputPath, actual, tc.expectWin)
+			}
 		} else if actual != tc.expect {
 			t.Errorf("Test %d: SanitizedPathJoin('%s', '%s') =>  '%s' (expected '%s')",
 				i, tc.inputRoot, tc.inputPath, actual, tc.expect)

--- a/modules/caddyhttp/caddyhttp_test.go
+++ b/modules/caddyhttp/caddyhttp_test.go
@@ -75,11 +75,6 @@ func TestSanitizedPathJoin(t *testing.T) {
 			inputPath: "/D:\\foo\\bar",
 			expect:    filepath.Join("C:\\www", "D:\\foo\\bar"),
 		},
-		{
-			inputRoot: "C:\\www",
-			inputPath: "/file.txt . ..",
-			expect:    "C:\\www/file.txt . ..",
-		},
 	} {
 		// we don't *need* to use an actual parsed URL, but it
 		// adds some authenticity to the tests since real-world

--- a/modules/caddyhttp/caddyhttp_test.go
+++ b/modules/caddyhttp/caddyhttp_test.go
@@ -3,7 +3,6 @@ package caddyhttp
 import (
 	"net/url"
 	"path/filepath"
-	"runtime"
 	"testing"
 )
 
@@ -16,7 +15,6 @@ func TestSanitizedPathJoin(t *testing.T) {
 		inputRoot string
 		inputPath string
 		expect    string
-		expectWin string
 	}{
 		{
 			inputPath: "",
@@ -81,7 +79,6 @@ func TestSanitizedPathJoin(t *testing.T) {
 			inputRoot: "C:\\www",
 			inputPath: "/file.txt . ..",
 			expect:    "C:\\www/file.txt . ..",
-			expectWin: "C:\\www\\file.txt",
 		},
 	} {
 		// we don't *need* to use an actual parsed URL, but it
@@ -94,12 +91,7 @@ func TestSanitizedPathJoin(t *testing.T) {
 			t.Fatalf("Test %d: invalid URL: %v", i, err)
 		}
 		actual := SanitizedPathJoin(tc.inputRoot, u.Path)
-		if runtime.GOOS == "windows" && tc.expectWin != "" {
-			if actual != tc.expectWin {
-				t.Errorf("Test %d: SanitizedPathJoin('%s', '%s') =>  '%s' (expected '%s') (Windows-only)",
-					i, tc.inputRoot, tc.inputPath, actual, tc.expectWin)
-			}
-		} else if actual != tc.expect {
+		if actual != tc.expect {
 			t.Errorf("Test %d: SanitizedPathJoin('%s', '%s') =>  '%s' (expected '%s')",
 				i, tc.inputRoot, tc.inputPath, actual, tc.expect)
 		}

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -231,6 +232,18 @@ func (fsrv *FileServer) Provision(ctx caddy.Context) error {
 
 func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+
+	if runtime.GOOS == "windows" {
+		// reject paths with Alternate Data Streams (ADS)
+		if strings.Contains(r.URL.Path, ":$") {
+			return caddyhttp.Error(http.StatusBadRequest, fmt.Errorf("illegal ADS path"))
+		}
+		// reject paths with "8.3" short names
+		if len(path.Base(r.URL.Path)) <= 12 && strings.Contains(r.URL.Path, "~") {
+			return caddyhttp.Error(http.StatusBadRequest, fmt.Errorf("illegal short name"))
+		}
+		// both of those could bypass file hiding or possibly leak information even if the file is not hidden
+	}
 
 	filesToHide := fsrv.transformHidePaths(repl)
 

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -235,11 +235,12 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 
 	if runtime.GOOS == "windows" {
 		// reject paths with Alternate Data Streams (ADS)
-		if strings.Contains(r.URL.Path, ":$") {
+		if (strings.Contains(r.URL.Path, ":") && strings.Contains(r.URL.Path, ".")) || strings.Contains(r.URL.Path, ":$") {
 			return caddyhttp.Error(http.StatusBadRequest, fmt.Errorf("illegal ADS path"))
 		}
 		// reject paths with "8.3" short names
-		if len(path.Base(r.URL.Path)) <= 12 && strings.Contains(r.URL.Path, "~") {
+		trimmedPath := strings.TrimRight(r.URL.Path, ". ") // Windows ignores trailing dots and spaces, sigh
+		if len(path.Base(trimmedPath)) <= 12 && strings.Contains(trimmedPath, "~") {
 			return caddyhttp.Error(http.StatusBadRequest, fmt.Errorf("illegal short name"))
 		}
 		// both of those could bypass file hiding or possibly leak information even if the file is not hidden

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -235,7 +235,7 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 
 	if runtime.GOOS == "windows" {
 		// reject paths with Alternate Data Streams (ADS)
-		if (strings.Contains(r.URL.Path, ":") && strings.Contains(r.URL.Path, ".")) || strings.Contains(r.URL.Path, ":$") {
+		if strings.Contains(r.URL.Path, ":") {
 			return caddyhttp.Error(http.StatusBadRequest, fmt.Errorf("illegal ADS path"))
 		}
 		// reject paths with "8.3" short names


### PR DESCRIPTION
I didn't even know about these Windows "features" (actually, I knew about short names as I grew up with them, but didn't know they were _still_ a thing... ugh) that, along with suffixing filenames with spaces and dots, allow an arbitrary number of variants to transparently refer to the same file on Windows NTFS.

Thanks to Adrian Denkiewicz of Doyensec for reporting this.