### PR TITLE
docs: Fix templates documentation, stray newline breaks godoc

### DIFF
--- a/modules/caddyhttp/templates/templates.go
+++ b/modules/caddyhttp/templates/templates.go
@@ -268,7 +268,6 @@ func init() {
 // {{humanize "time" "Fri, 05 May 2022 15:04:05 +0200"}}
 // {{humanize "time:2006-Jan-02" "2022-May-05"}}
 // ```
-
 type Templates struct {
 	// The root path from which to load files. Required if template functions
 	// accessing the file system are used (such as include). Default is


### PR DESCRIPTION
Oops. Docs aren't appearing here anymore because of the newline 🙈  https://caddyserver.com/docs/modules/http.handlers.templates

It got broken all the way back in May 😬 https://github.com/caddyserver/caddy/commit/6891f7f421eac71dac8f8687255ede5189e7eb3a