### PR TITLE
cmd: Add missing `\n` to HelpTemplate

### DIFF
--- a/cmd/cobra.go
+++ b/cmd/cobra.go
@@ -101,7 +101,7 @@ const fullDocsFooter = `Full documentation is available at:
 https://caddyserver.com/docs/command-line`
 
 func init() {
-	rootCmd.SetHelpTemplate(rootCmd.HelpTemplate() + "\n" + fullDocsFooter)
+	rootCmd.SetHelpTemplate(rootCmd.HelpTemplate() + "\n" + fullDocsFooter + "\n")
 }
 
 func caddyCmdToCoral(caddyCmd Command) *cobra.Command {


### PR DESCRIPTION
The help message footer lacks a `\n` to end the line. 

So when printing a help message, the footer is concatenated with shell prompt.

Before:

![](https://gcore.jsdelivr.net/gh/bakaft/hexo-blog-img@master/img/2022/10/17/before.png)



After:

![](https://gcore.jsdelivr.net/gh/bakaft/hexo-blog-img@master/img/2022/10/17/after.png)