### PR TITLE
admin: set certmagic cache logger

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -587,6 +587,7 @@ func (ident *IdentityConfig) certmagicConfig(logger *zap.Logger, makeCache bool)
 			GetConfigForCert: func(certmagic.Certificate) (*certmagic.Config, error) {
 				return cmCfg, nil
 			},
+			Logger: logger.Named("cache"),
 		})
 	}
 	return certmagic.New(identityCertCache, *cmCfg)


### PR DESCRIPTION
same way it is set in modules/caddytls/tls.go