### PR TITLE
caddyhttp: Canonicalize header field names

### DIFF
--- a/modules/caddyhttp/staticresp.go
+++ b/modules/caddyhttp/staticresp.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/textproto"
 	"os"
 	"strconv"
 	"strings"
@@ -193,7 +194,7 @@ func (s StaticResponse) ServeHTTP(w http.ResponseWriter, r *http.Request, next H
 
 	// set all headers
 	for field, vals := range s.Headers {
-		field = repl.ReplaceAll(field, "")
+		field = textproto.CanonicalMIMEHeaderKey(repl.ReplaceAll(field, ""))
 		newVals := make([]string, len(vals))
 		for i := range vals {
 			newVals[i] = repl.ReplaceAll(vals[i], "")


### PR DESCRIPTION
This fixes #5175 by canonicalizing the header field names.