### PR TITLE
Update adminapi.go

### DIFF
--- a/modules/caddypki/adminapi.go
+++ b/modules/caddypki/adminapi.go
@@ -52,7 +52,7 @@ func (a *adminAPI) Provision(ctx caddy.Context) error {
 	// First check if the PKI app was configured, because
 	// a.ctx.App() has the side effect of instantiating
 	// and provisioning an app even if it wasn't configured.
-	pkiAppConfigured := a.ctx.AppIsConfigured("pki")
+	pkiAppConfigured := a.ctx.AppIfConfigured("pki")
 	if !pkiAppConfigured {
 		return nil
 	}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19MYPGOe1kRwA0KUmx9xl0vVP2r9FPTw%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=ozoGNik)
The caddy.Context.AppIsConfigured() method returns true if the named app is present in the config. This is useful to know if an app has been explicitly configured, because calling App() will instantiate an app module even if it's not configured.

However, if the primary use case is to get an app instance only if it has been configured, then maybe we should actually have a method, AppIfConfigured() instead. One-letter change.

This method would return nil if the app is not configured, so if you need the bool value, there you have it; otherwise it returns the configured app module. It would be less clunky than this: