### PR TITLE
caddypki: use configured certificate instead of generating a new one

### DIFF
--- a/modules/caddypki/ca.go
+++ b/modules/caddypki/ca.go
@@ -240,6 +240,9 @@ func (ca *CA) NewAuthority(authorityConfig AuthorityConfig) (*authority.Authorit
 }
 
 func (ca CA) loadOrGenRoot() (rootCert *x509.Certificate, rootKey any, err error) {
+	if ca.Root != nil {
+		return ca.Root.Load()
+	}
 	rootCertPEM, err := ca.storage.Load(ca.ctx, ca.storageKeyRootCert())
 	if err != nil {
 		if !errors.Is(err, fs.ErrNotExist) {


### PR DESCRIPTION
instead of generating a new root certificate at the default location load the certificate from the configuration.
fixes: #5181