### PR TITLE
version: don't panic if read build info doesn't work

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -864,13 +864,21 @@ func Version() (simple, full string) {
 	// bi.Main... hopefully.
 	var module *debug.Module
 	bi, ok := debug.ReadBuildInfo()
-	if ok {
-		// find the Caddy module in the dependency list
-		for _, dep := range bi.Deps {
-			if dep.Path == ImportPath {
-				module = dep
-				break
-			}
+	if !ok {
+		if CustomVersion != "" {
+			full = CustomVersion
+			simple = CustomVersion
+			return
+		}
+		full = "unknown"
+		simple = "unknown"
+		return
+	}
+	// find the Caddy module in the dependency list
+	for _, dep := range bi.Deps {
+		if dep.Path == ImportPath {
+			module = dep
+			break
 		}
 	}
 	if module != nil {
@@ -890,7 +898,7 @@ func Version() (simple, full string) {
 		}
 	}
 
-	if full == "" && bi != nil {
+	if full == "" {
 		var vcsRevision string
 		var vcsTime time.Time
 		var vcsModified bool

--- a/caddy.go
+++ b/caddy.go
@@ -890,7 +890,7 @@ func Version() (simple, full string) {
 		}
 	}
 
-	if full == "" {
+	if full == "" && bi != nil {
 		var vcsRevision string
 		var vcsTime time.Time
 		var vcsModified bool


### PR DESCRIPTION
If `debug.ReadBuildInfo()` doesn't return the build information we should not try to access it. Especially if users only want to build with the `CustomVersion` we should not assume access to `debug.ReadBuildInfo()`.

The build environment where this isn't available for me is when building with bazel.