### PR TITLE
reverseproxy: Improve hostByHashing distribution

### DIFF
--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -528,7 +528,7 @@ func hostByHashing(pool []*Upstream, s string) *Upstream {
 		if !up.Available() {
 			continue
 		}
-		h := hash(s + up.String()) // important to hash key and server together
+		h := hash(up.String() + s) // important to hash key and server together
 		if h > highestHash {
 			highestHash = h
 			upstream = up

--- a/modules/caddyhttp/reverseproxy/selectionpolicies_test.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies_test.go
@@ -95,18 +95,18 @@ func TestIPHashPolicy(t *testing.T) {
 	// We should be able to predict where every request is routed.
 	req.RemoteAddr = "172.0.0.1:80"
 	h := ipHash.Select(pool, req, nil)
-	if h != pool[0] {
-		t.Error("Expected ip hash policy host to be the first host.")
+	if h != pool[1] {
+		t.Error("Expected ip hash policy host to be the second host.")
 	}
 	req.RemoteAddr = "172.0.0.2:80"
 	h = ipHash.Select(pool, req, nil)
-	if h != pool[0] {
-		t.Error("Expected ip hash policy host to be the first host.")
+	if h != pool[1] {
+		t.Error("Expected ip hash policy host to be the second host.")
 	}
 	req.RemoteAddr = "172.0.0.3:80"
 	h = ipHash.Select(pool, req, nil)
-	if h != pool[2] {
-		t.Error("Expected ip hash policy host to be the third host.")
+	if h != pool[1] {
+		t.Error("Expected ip hash policy host to be the second host.")
 	}
 	req.RemoteAddr = "172.0.0.4:80"
 	h = ipHash.Select(pool, req, nil)
@@ -117,18 +117,18 @@ func TestIPHashPolicy(t *testing.T) {
 	// we should get the same results without a port
 	req.RemoteAddr = "172.0.0.1"
 	h = ipHash.Select(pool, req, nil)
-	if h != pool[0] {
-		t.Error("Expected ip hash policy host to be the first host.")
+	if h != pool[1] {
+		t.Error("Expected ip hash policy host to be the second host.")
 	}
 	req.RemoteAddr = "172.0.0.2"
 	h = ipHash.Select(pool, req, nil)
-	if h != pool[0] {
-		t.Error("Expected ip hash policy host to be the first host.")
+	if h != pool[1] {
+		t.Error("Expected ip hash policy host to be the second host.")
 	}
 	req.RemoteAddr = "172.0.0.3"
 	h = ipHash.Select(pool, req, nil)
-	if h != pool[2] {
-		t.Error("Expected ip hash policy host to be the third host.")
+	if h != pool[1] {
+		t.Error("Expected ip hash policy host to be the second host.")
 	}
 	req.RemoteAddr = "172.0.0.4"
 	h = ipHash.Select(pool, req, nil)
@@ -141,8 +141,8 @@ func TestIPHashPolicy(t *testing.T) {
 	req.RemoteAddr = "172.0.0.4"
 	pool[1].setHealthy(false)
 	h = ipHash.Select(pool, req, nil)
-	if h != pool[2] {
-		t.Error("Expected ip hash policy host to be the third host.")
+	if h != pool[0] {
+		t.Error("Expected ip hash policy host to be the first host.")
 	}
 
 	req.RemoteAddr = "172.0.0.2"
@@ -172,8 +172,8 @@ func TestIPHashPolicy(t *testing.T) {
 	}
 	req.RemoteAddr = "172.0.0.1:80"
 	h = ipHash.Select(pool, req, nil)
-	if h != pool[1] {
-		t.Error("Expected ip hash policy host to be the second host.")
+	if h != pool[0] {
+		t.Error("Expected ip hash policy host to be the first host.")
 	}
 	req.RemoteAddr = "172.0.0.2:80"
 	h = ipHash.Select(pool, req, nil)
@@ -182,8 +182,8 @@ func TestIPHashPolicy(t *testing.T) {
 	}
 	req.RemoteAddr = "172.0.0.3:80"
 	h = ipHash.Select(pool, req, nil)
-	if h != pool[1] {
-		t.Error("Expected ip hash policy host to be the second host.")
+	if h != pool[0] {
+		t.Error("Expected ip hash policy host to be the first host.")
 	}
 	req.RemoteAddr = "172.0.0.4:80"
 	h = ipHash.Select(pool, req, nil)
@@ -252,8 +252,8 @@ func TestURIHashPolicy(t *testing.T) {
 
 	request := httptest.NewRequest(http.MethodGet, "/test", nil)
 	h := uriPolicy.Select(pool, request, nil)
-	if h != pool[2] {
-		t.Error("Expected uri policy host to be the third host.")
+	if h != pool[1] {
+		t.Error("Expected uri policy host to be the second host.")
 	}
 
 	pool[2].setHealthy(false)
@@ -264,8 +264,8 @@ func TestURIHashPolicy(t *testing.T) {
 
 	request = httptest.NewRequest(http.MethodGet, "/test_2", nil)
 	h = uriPolicy.Select(pool, request, nil)
-	if h != pool[1] {
-		t.Error("Expected uri policy host to be the second host.")
+	if h != pool[0] {
+		t.Error("Expected uri policy host to be the first host.")
 	}
 
 	// We should be able to resize the host pool and still be able to predict


### PR DESCRIPTION
Small change, but long story. It's not easy to explain, sorry if it's not clear, feel free to ask questions.

I recently upgraded caddy from 2.4.x to 2.6.2, unfortunately the load balancing becomes quite unbalanced as
you can see on this graph:

![image](https://user-images.githubusercontent.com/2316424/205262593-8a3c5362-e7e8-4012-8d66-fe19dd8c45c6.png)

I made some test code to expose this behaviour:
```go
	policy := new(HeaderHashSelection)
	policy.Field = "CF-Connecting-IP"

	pool := UpstreamPool{
		{Host: new(Host), Dial: "foobar:4001"},
		{Host: new(Host), Dial: "foobar:4002"},
		{Host: new(Host), Dial: "foobar:4003"},
		{Host: new(Host), Dial: "foobar:4004"},
		{Host: new(Host), Dial: "foobar:4005"},
		{Host: new(Host), Dial: "foobar:4006"},
		{Host: new(Host), Dial: "foobar:4007"},
		{Host: new(Host), Dial: "foobar:4008"},
	}

	var distribution []int = make([]int, len(pool))

	req, _ := http.NewRequest("GET", "/", nil)

	rand.Seed(0)
	for i := 0; i < 100; i++ {
		req.Header.Set("CF-Connecting-IP", fmt.Sprintf("%d.%d.%d.%d", rand.Intn(255), rand.Intn(255), rand.Intn(255), rand.Intn(255)))
		h := policy.Select(pool, req, nil)
		 for idx, up := range pool {
			if up == h {
				distribution[idx]++
			}
		 }
	}

	for idx, dis := range distribution {
		t.Logf("distribution %s=%d", pool[idx].String(), dis)
	}
```

Here the output
```
distribution foobar:4001=14
distribution foobar:4002=7
distribution foobar:4003=9
distribution foobar:4004=8
distribution foobar:4005=7
distribution foobar:4006=3
distribution foobar:4007=6
distribution foobar:4008=46
```

There is clearly something wrong, 46% of requests are going to same upstream.

I made another test code to pin point the issue:

```go
        // test to concat IP + upsteam
	for i := 1; i < 9; i++ {
		s := fmt.Sprintf("192.168.200.44foobar:400%c", int('0') + i);
		h := fnv.New32a()
		_, _ = h.Write([]byte(s))
		res := h.Sum32()
		fmt.Printf("%s %08x\n", s, res)
	}

        // test to concat upsteam + IP
	for i := 1; i < 9; i++ {
		s := fmt.Sprintf("foobar:400%c192.168.200.44", int('0') + i);
		h := fnv.New32a()
		_, _ = h.Write([]byte(s))
		res := h.Sum32()
		fmt.Printf("%s %08x\n", s, res)
	}
```

output
```
192.168.200.44foobar:4001 bc724e3c
192.168.200.44foobar:4002 bf7252f5
192.168.200.44foobar:4003 be725162
192.168.200.44foobar:4004 b9724983
192.168.200.44foobar:4005 b87247f0
192.168.200.44foobar:4006 bb724ca9
192.168.200.44foobar:4007 ba724b16
192.168.200.44foobar:4008 c5725c67

foobar:4001192.168.200.44 f26b0b92
foobar:4002192.168.200.44 6ae61c9f
foobar:4003192.168.200.44 bf67d194
foobar:4004192.168.200.44 5e8f33d9
foobar:4005192.168.200.44 a61bfa36
foobar:4006192.168.200.44 91a23fb3
foobar:4007192.168.200.44 75d0cec8
foobar:4008192.168.200.44 4d2967bd
```

As you can see when using same kind of concatenation between field and upstream as in hostByHashing() function
**lot of bits are the same between all hashes**
But if you swap the concatenation (as done in this commit) then hashes are well diffused.

My point is last byte push to FNV-1a tend to affect few bits in resulting hash, the idea is to change
the concatenation order between the key and the upstream strings, so the upstream last byte have
more impact on the hash diffusion.

I think there is little to no risk to do this change in term of performance.
Another solution would be to change the hash method but it could have more impact.

Some reference to support my point:
https://softwareengineering.stackexchange.com/questions/273809/should-changes-to-fnv-1as-input-exhibit-the-avalanche-effect
haproxy implements an avalanche algorithm on the
result of the hashing function : https://github.com/haproxy/haproxy/blob/master/doc/internals/hashing.txt