### PR TITLE
caddytest: internalize init config into '.go' file

### DIFF
--- a/caddytest/integration/test.init.config
+++ b/caddytest/integration/test.init.config
@@ -1,3 +1,0 @@
-{
-	admin localhost:2999
-}


### PR DESCRIPTION
Go module distribution excludes files that are not of a specific list of types. In other words,`.go` files are retained in the downloaded modules, but others are not for sure[^1]. This causes pain, e.g. #5187. The workaround in this PR is to write the init config to a temp file, and set the cleanup func to delete the file at the end of the test run.

For the record, I tried passing the init config t o`os.Stdin` by creating a `os.Pipe`, writing to the writer end, and setting `os.Stdin = reader`. However, this seems to slow down the run to the extent of test timeouts. It did work sometimes when the timeout value is set for very long period. It's probably a race condition. I don't believe forcefully going down that route is worth it. Writing the init config to a temp file is much simpler and easier to maintain, unless I'm blind to some aspect.

Updates #5187 

[^1]: I couldn't find a definite list of excluded files. If any knows of a reference, please share it!