### PR TITLE
readme: darker variants of logos in dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 <p align="center">
-	<a href="https://caddyserver.com"><img src="https://user-images.githubusercontent.com/1128849/36338535-05fb646a-136f-11e8-987b-e6901e717d5a.png" alt="Caddy" width="450"></a>
+	<a href="https://caddyserver.com">
+		<picture>
+			<source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/55066419/206944919-98f9fc47-cc3b-49ef-a498-0ff74c625c0c.png">
+			<source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/1128849/36338535-05fb646a-136f-11e8-987b-e6901e717d5a.png">
+			<img src="https://user-images.githubusercontent.com/1128849/36338535-05fb646a-136f-11e8-987b-e6901e717d5a.png" alt="Caddy" width="450">
+		</picture>
+	</a>
 	<br>
 	<h3 align="center">a <a href="https://zerossl.com"><img src="https://caddyserver.com/resources/images/zerossl-logo.svg" height="28" valign="middle"></a> project</h3>
 </p>
@@ -40,7 +46,13 @@
 <p align="center">
 	<b>Powered by</b>
 	<br>
-	<a href="https://github.com/caddyserver/certmagic"><img src="https://user-images.githubusercontent.com/1128849/49704830-49d37200-fbd5-11e8-8385-767e0cd033c3.png" alt="CertMagic" width="250"></a>
+	<a href="https://github.com/caddyserver/certmagic">
+		<picture>
+			<source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/55066419/206946718-740b6371-3df3-4d72-a822-47e4c48af999.png">
+			<source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/1128849/49704830-49d37200-fbd5-11e8-8385-767e0cd033c3.png">
+			<img src="https://user-images.githubusercontent.com/1128849/49704830-49d37200-fbd5-11e8-8385-767e0cd033c3.png" alt="CertMagic" width="250">
+		</picture>
+	</a>
 </p>
 
 
@@ -78,7 +90,7 @@ Requirements:
 - [Go 1.18 or newer](https://golang.org/dl/)
 
 ### For development
- 
+
 _**Note:** These steps [will not embed proper version information](https://github.com/golang/go/issues/29228). For that, please follow the instructions in the next section._
 
 ```bash


### PR DESCRIPTION
Closes #4040

Quote from me https://github.com/caddyserver/caddy/issues/5245#issuecomment-1345608813:
> GitHub supports the `prefers-color-scheme` CSS media feature in `<picture>` HTML elements since a few months.
>
> https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to

@francislavoie provided me with the caddy logo and I edited the certmagic one and made the "certificate paper" solid white instead of a white-transparent gradient.

I did not modify the ZeroSSL logo yet, because that one is coming from https://caddyserver.com/resources/images/zerossl-logo.svg (https://github.com/caddyserver/website/blob/master/src/resources/images/zerossl-logo.svg)

So I will most likely end up pushing to https://github.com/caddyserver/website and add another commit to this PR here :woman_shrugging: 

Note: The diff also adds a blank final newline (to be more on par with the other files) and removes a trailing whitespace