### PR TITLE
Fixes a reversion in c0f76e9 which caused the query-string to be removed from the redirect.

### DIFF
--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -70,7 +70,8 @@ func (fsrv *FileServer) serveBrowse(root, dirPath string, w http.ResponseWriter,
 	if r.URL.Path == "" || path.Base(origReq.URL.Path) == path.Base(r.URL.Path) {
 		if !strings.HasSuffix(origReq.URL.Path, "/") {
 			fsrv.logger.Debug("redirecting to trailing slash to preserve hrefs", zap.String("request_path", r.URL.Path))
-			return redirect(w, r, origReq.URL.Path+"/")
+			origReq.URL.Path += "/"
+			return redirect(w, r, origReq.URL.String())
 		}
 	}
 

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -339,13 +339,15 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 		origReq := r.Context().Value(caddyhttp.OriginalRequestCtxKey).(http.Request)
 		if path.Base(origReq.URL.Path) == path.Base(r.URL.Path) {
 			if implicitIndexFile && !strings.HasSuffix(origReq.URL.Path, "/") {
-				to := origReq.URL.Path + "/"
+				origReq.URL.Path += "/"
+				to := origReq.URL.String()
 				fsrv.logger.Debug("redirecting to canonical URI (adding trailing slash for directory)",
 					zap.String("from_path", origReq.URL.Path),
 					zap.String("to_path", to))
 				return redirect(w, r, to)
 			} else if !implicitIndexFile && strings.HasSuffix(origReq.URL.Path, "/") {
-				to := origReq.URL.Path[:len(origReq.URL.Path)-1]
+				origReq.URL.Path = origReq.URL.Path[:len(origReq.URL.Path)-1]
+				to := origReq.URL.String()
 				fsrv.logger.Debug("redirecting to canonical URI (removing trailing slash for file)",
 					zap.String("from_path", origReq.URL.Path),
 					zap.String("to_path", to))


### PR DESCRIPTION
You can test like this, with `curl`. The current caddy `v2.6.2` drops the query-string:

```
mkdir -p /tmp/caddy/example

caddy file-server --root /tmp/caddy --browse

curl http://127.0.0.1:80/example?query=preserved
<a href="/example/">Permanent Redirect</a>
```

but with the fix, the query-string is preserved:

```
mkdir -p /tmp/caddy/example

caddy file-server --root /tmp/caddy --browse

curl http://127.0.0.1:80/example?query=preserved
<a href="/example/?query=preserved">Permanent Redirect</a>.
```