### PR TITLE
readme: white ZeroSSL text color in dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 		</picture>
 	</a>
 	<br>
-	<h3 align="center">a <a href="https://zerossl.com"><img src="https://user-images.githubusercontent.com/55066419/208327323-2770dc16-ec09-43a0-9035-c5b872c2ad7f.svg" height="28" style="vertical-align: -7.7px"></a> project</h3>
+	<h3 align="center">a <a href="https://zerossl.com"><img src="https://user-images.githubusercontent.com/55066419/208327323-2770dc16-ec09-43a0-9035-c5b872c2ad7f.svg" height="28" style="vertical-align: -7.7px" valign="middle"></a> project</h3>
 </p>
 <hr>
 <h3 align="center">Every site on HTTPS</h3>


### PR DESCRIPTION
Follow up to #5248 as discussed in Slack.

The SVG uploaded at https://user-images.githubusercontent.com/55066419/208327323-2770dc16-ec09-43a0-9035-c5b872c2ad7f.svg is the one https://github.com/caddyserver/website/blob/54af42121fc54a6334d85b57297725d13ce70a26/src/resources/images/zerossl-logo.svg with 2 main changes:

Added `prefers-color-scheme` to dynamically change based on the theme:
```html
<style>
    .text {
        fill: #000
    }

    @media (prefers-color-scheme:dark) {
        .text {
            fill: #fff
        }
    }
</style>
```

and minified it with the help of https://github.com/svg/svgo (`inlineStyles` plugin disabled, because it would ignore/remove the `@media`)

Has been tested by me and @francislavoie on Firefox and Chrome (desktop and Android) and GitHub mobile.
The official GitHub mobile app does not seem to understand `style="vertical-align: -7.7px"`, so that's why we keep the old `valign`.
I added the `vertical-align` so the SVG stops floating on Firefox.

That `7.7px` is somewhat inherited by the SVG itself.
One of the elements in the SVG (`<rect>`) defines `height="20.3"` and the `<img>` tag uses `height="28"`.
`28px - 20.3px = 7.7px`, so the text "a" and "project" aligns perfectly with the "ZeroSSL" in the SVG :sweat_smile:

The special keyword `bottom` is pretty close, but seems to be slightly different across Chrome and Firefox. So I just settled on that hard-coded sub-pixel value