### PR TITLE
reverseproxy: Don't enable auto-https when `--from` flag is http

### DIFF
--- a/modules/caddyhttp/reverseproxy/command.go
+++ b/modules/caddyhttp/reverseproxy/command.go
@@ -172,6 +172,10 @@ func cmdReverseProxy(fs caddycmd.Flags) (int, error) {
 		Listen: []string{":" + fromAddr.Port},
 	}
 
+	if fromAddr.Scheme == "http" {
+		server.AutoHTTPS = &caddyhttp.AutoHTTPSConfig{Disabled: true}
+	}
+
 	httpApp := caddyhttp.App{
 		Servers: map[string]*caddyhttp.Server{"proxy": server},
 	}


### PR DESCRIPTION
While playing around with `caddy reverse-proxy` (for https://caddy.community/t/unexpected-bind-address-already-in-use-for-unrelated-port/18238) I noticed that `http://localhost:8080` in `caddy reverse-proxy --from http://localhost:8080 [--to <upstream>]` enabled auto-https features.

Essentially ignoring the `http://` and turning `:8080` into a `https://` server with the usual redirects from `:80`.
Using `--from localhost:80` worked as expected, though.

This PR disables auto-https for `fromAddr.Scheme == "http"`, which also includes `:80` due to
https://github.com/caddyserver/caddy/blob/b166b9008344786e7cfe5715b7e8a4cd3ec1bd76/modules/caddyhttp/reverseproxy/command.go#L96-L98