### PR TITLE
ci: Fix goreleaser deprecation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -82,8 +82,14 @@ archives:
   - format_overrides:
       - goos: windows
         format: zip
-    replacements:
-      darwin: mac
+    name_template: >-
+      {{ .ProjectName }}_
+      {{ - .Version }}_
+      {{ - if eq .Os "darwin" }}mac{{ else }}{{ .Os }}{{ end }}_
+      {{ - .Arch }}
+      {{ - with .Arm }}v{{ . }}{{ end }}
+      {{ - with .Mips }}_{{ . }}{{ end }}
+      {{ - if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
 checksum:
   algorithm: sha512
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,18 +66,28 @@ builds:
   - -mod=readonly
   ldflags:
   - -s -w
+
 signs:
   - cmd: cosign
     signature: "${artifact}.sig"
     certificate: '{{ trimsuffix (trimsuffix .Env.artifact ".zip") ".tar.gz" }}.pem'
     args: ["sign-blob", "--output-signature=${signature}", "--output-certificate", "${certificate}", "${artifact}"]
     artifacts: all
+
 sboms:
   - artifacts: binary
     documents:
-    - '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{if .Arm}}v{{ .Arm }}{{end}}.sbom'
+      - >-
+        {{ .ProjectName }}_
+        {{- .Version }}_
+        {{- if eq .Os "darwin" }}mac{{ else }}{{ .Os }}{{ end }}_
+        {{- .Arch }}
+        {{- with .Arm }}v{{ . }}{{ end }}
+        {{- with .Mips }}_{{ . }}{{ end }}
+        {{- if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}.sbom
     cmd: syft
     args: ["$artifact", "--file", "${document}", "--output", "cyclonedx-json"]
+
 archives:
   - format_overrides:
       - goos: windows
@@ -90,6 +100,7 @@ archives:
       {{- with .Arm }}v{{ . }}{{ end }}
       {{- with .Mips }}_{{ . }}{{ end }}
       {{- if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
+
 checksum:
   algorithm: sha512
 
@@ -133,7 +144,6 @@ nfpms:
       postinstall: ./caddy-dist/scripts/postinstall.sh
       preremove: ./caddy-dist/scripts/preremove.sh
       postremove: ./caddy-dist/scripts/postremove.sh
-
 
 release:
   github:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -84,12 +84,12 @@ archives:
         format: zip
     name_template: >-
       {{ .ProjectName }}_
-      {{ - .Version }}_
-      {{ - if eq .Os "darwin" }}mac{{ else }}{{ .Os }}{{ end }}_
-      {{ - .Arch }}
-      {{ - with .Arm }}v{{ . }}{{ end }}
-      {{ - with .Mips }}_{{ . }}{{ end }}
-      {{ - if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
+      {{- .Version }}_
+      {{- if eq .Os "darwin" }}mac{{ else }}{{ .Os }}{{ end }}_
+      {{- .Arch }}
+      {{- with .Arm }}v{{ . }}{{ end }}
+      {{- with .Mips }}_{{ . }}{{ end }}
+      {{- if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
 checksum:
   algorithm: sha512
 


### PR DESCRIPTION
See https://goreleaser.com/deprecations/#archivesreplacements

I took the default for `name_template` documented at https://goreleaser.com/customization/archive/?h=archive#archives, turned it into a multi-line string using the "After" tab from https://goreleaser.com/deprecations/#archivesreplacements, then changed `{{ .Os }}` to be wrapped by an `if darwin` outputting `mac` instead.

Technically untested, the goreleaser_check seems to pass now but I didn't run it to see if the template has the expected result. I don't have it installed locally etc so would appreciate if you could test it out @mohammed90 😊 