### PR TITLE
Support default values in placeholders

### DIFF
--- a/replacer_test.go
+++ b/replacer_test.go
@@ -79,9 +79,13 @@ func TestReplacer(t *testing.T) {
 			input:  `\{\}`,
 			expect: `{}`,
 		},
-		{
+		{ // TODO currently failing, we might split using a regex or check last character of actual placeholder key not to be a backslash
+			input:  `{"json"\: "object"}`,
+			expect: ``,
+		},
+		{ // TODO currently not failing, is this expected behavior? I guess users would just need to escape the colon in future, see test above
 			input:  `{"json": "object"}`,
-			expect: "",
+			expect: ` "object"`, // placeholder defaulting happened
 		},
 		{
 			input:  `\{"json": "object"}`,
@@ -123,7 +127,7 @@ func TestReplacer(t *testing.T) {
 			input:  `{{}`,
 			expect: "",
 		},
-		{
+		{ // TODO currently failing, is this a parser bug? not a finished placeholder sequence
 			input:  `{"json": "object"\}`,
 			expect: "",
 		},
@@ -293,6 +297,21 @@ func TestReplacerReplaceKnown(t *testing.T) {
 			// test with non existing vars
 			testInput: "{test1} {nope} {1} ",
 			expected:  "val1 {nope} test-123 ",
+		},
+		{
+			// test with default
+			testInput: "{nope} {nope:default} {test1:default}",
+			expected:  "{nope} default val1",
+		},
+		{
+			// test with empty default
+			testInput: "{nope:}",
+			expected:  "",
+		},
+		{
+			// should not chain variable expands
+			testInput: "{nope:$test1}",
+			expected:  "$test1",
 		},
 	} {
 		actual := rep.ReplaceKnown(tc.testInput, "EMPTY")


### PR DESCRIPTION
Support variable expansion also in placeholders, like in `{unsetPlaceholder:default value}`. Implemented similarly to #3682, which provided defaults for environment variable expansion.

This PR seems to work fine already, but two or three minors should be discussed (see TODO in commit).

- [ ] `{"json"\: "object"}` : is this a case we need to handle? the behavior seems unspecified to me right now.
- [ ] `{"json": "object"}`:  defaulting to ` "object"` seems appropriate to me here, can you confirm?
- [ ] `{"json": "object"\}`: to me, this looks like a parser bug and should never have gone into the placeholder substitution code?

Closes #1793.

<sup>Jens Erat <jens.erat@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>