### PR TITLE
caddytls: Add `dns_ttl` config, improve Caddyfile `tls` options

### DIFF
--- a/caddytest/integration/caddyfile_adapt/tls_dns_ttl.txt
+++ b/caddytest/integration/caddyfile_adapt/tls_dns_ttl.txt
@@ -1,0 +1,70 @@
+localhost
+
+respond "hello from localhost"
+tls {
+	issuer acme {
+		dns_ttl 5m10s
+	}
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"localhost"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "hello from localhost",
+													"handler": "static_response"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		},
+		"tls": {
+			"automation": {
+				"policies": [
+					{
+						"subjects": [
+							"localhost"
+						],
+						"issuers": [
+							{
+								"challenges": {
+									"dns": {
+										"ttl": 310000000000
+									}
+								},
+								"module": "acme"
+							}
+						]
+					}
+				]
+			}
+		}
+	}
+}

--- a/modules/caddytls/acmeissuer.go
+++ b/modules/caddytls/acmeissuer.go
@@ -266,6 +266,7 @@ func (iss *ACMEIssuer) GetACMEIssuer() *ACMEIssuer { return iss }
 //	    propagation_delay <duration>
 //	    propagation_timeout <duration>
 //	    resolvers <dns_servers...>
+//	    dns_ttl <duration>
 //	    dns_challenge_override_domain <domain>
 //	    preferred_chains [smallest] {
 //	        root_common_name <common_names...>
@@ -444,6 +445,23 @@ func (iss *ACMEIssuer) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if len(iss.Challenges.DNS.Resolvers) == 0 {
 					return d.ArgErr()
 				}
+
+			case "dns_ttl":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				ttlStr := d.Val()
+				ttl, err := caddy.ParseDuration(ttlStr)
+				if err != nil {
+					return d.Errf("invalid dns_ttl duration %s: %v", ttlStr, err)
+				}
+				if iss.Challenges == nil {
+					iss.Challenges = new(ChallengesConfig)
+				}
+				if iss.Challenges.DNS == nil {
+					iss.Challenges.DNS = new(DNSChallengeConfig)
+				}
+				iss.Challenges.DNS.TTL = caddy.Duration(ttl)
 
 			case "dns_challenge_override_domain":
 				arg := d.RemainingArgs()


### PR DESCRIPTION
My DNS provider (INWX) requires the TTL of a TXT record to be at least 300 seconds. Currently there is no way to configure this in a Caddyfile, if I see it correctly.

In addition, the `propagation_delay` and `propagation_timeout` options have also been added to the `tls` directive.