### PR TITLE
change TrustedProxyVarKey type to caddy.CtxKey

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -797,5 +797,5 @@ const (
 	OriginalRequestCtxKey caddy.CtxKey = "original_request"
 
 	// For tracking whether the client is a trusted proxy
-	TrustedProxyVarKey string = "trusted_proxy"
+	TrustedProxyVarKey caddy.CtxKey = "trusted_proxy"
 )


### PR DESCRIPTION
per [context documentation](https://pkg.go.dev/context#WithValue) and other caddy context key type.