### PR TITLE
reverseproxy: Add flag to short command to disable redirects

### DIFF
--- a/modules/caddyhttp/reverseproxy/command.go
+++ b/modules/caddyhttp/reverseproxy/command.go
@@ -64,6 +64,7 @@ default, all incoming headers are passed through unmodified.)
 			fs.Bool("insecure", false, "Disable TLS verification (WARNING: DISABLES SECURITY BY NOT VERIFYING SSL CERTIFICATES!)")
 			fs.Bool("internal-certs", false, "Use internal CA for issuing certs")
 			fs.Bool("debug", false, "Enable verbose debug logs")
+			fs.Bool("disable-redirects", false, "Disable HTTP->HTTPS redirects")
 			return fs
 		}(),
 	})
@@ -77,6 +78,7 @@ func cmdReverseProxy(fs caddycmd.Flags) (int, error) {
 	insecure := fs.Bool("insecure")
 	internalCerts := fs.Bool("internal-certs")
 	debug := fs.Bool("debug")
+	disableRedir := fs.Bool("disable-redirects")
 
 	httpPort := strconv.Itoa(caddyhttp.DefaultHTTPPort)
 	httpsPort := strconv.Itoa(caddyhttp.DefaultHTTPSPort)
@@ -174,6 +176,13 @@ func cmdReverseProxy(fs caddycmd.Flags) (int, error) {
 
 	if fromAddr.Scheme == "http" {
 		server.AutoHTTPS = &caddyhttp.AutoHTTPSConfig{Disabled: true}
+	}
+	if disableRedir {
+		if server.AutoHTTPS != nil {
+			server.AutoHTTPS = &caddyhttp.AutoHTTPSConfig{DisableRedir: true}
+		} else {
+			server.AutoHTTPS.DisableRedir = true
+		}
 	}
 
 	httpApp := caddyhttp.App{

--- a/modules/caddyhttp/reverseproxy/command.go
+++ b/modules/caddyhttp/reverseproxy/command.go
@@ -176,13 +176,8 @@ func cmdReverseProxy(fs caddycmd.Flags) (int, error) {
 
 	if fromAddr.Scheme == "http" {
 		server.AutoHTTPS = &caddyhttp.AutoHTTPSConfig{Disabled: true}
-	}
-	if disableRedir {
-		if server.AutoHTTPS != nil {
-			server.AutoHTTPS = &caddyhttp.AutoHTTPSConfig{DisableRedir: true}
-		} else {
-			server.AutoHTTPS.DisableRedir = true
-		}
+	} else if disableRedir {
+		server.AutoHTTPS = &caddyhttp.AutoHTTPSConfig{DisableRedir: true}
 	}
 
 	httpApp := caddyhttp.App{


### PR DESCRIPTION
* Fixes #5290

Add new flag --disable-redirects for reverseproxy.
https://github.com/caddyserver/caddy/issues/5290#issuecomment-1383449714
`Using a command is more convenient in my case.`