### PR TITLE
httpcaddyfile: Add persist_config global option

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -286,6 +286,17 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 	if adminConfig, ok := options["admin"].(*caddy.AdminConfig); ok && adminConfig != nil {
 		cfg.Admin = adminConfig
 	}
+
+	if pc, ok := options["persist_config"].(string); ok && pc == "off" {
+		if cfg.Admin == nil {
+			cfg.Admin = new(caddy.AdminConfig)
+		}
+		if cfg.Admin.Config == nil {
+			cfg.Admin.Config = new(caddy.ConfigSettings)
+		}
+		cfg.Admin.Config.Persist = new(bool)
+	}
+
 	if len(customLogs) > 0 {
 		if cfg.Logging == nil {
 			cfg.Logging = &caddy.Logging{

--- a/caddyconfig/httpcaddyfile/options.go
+++ b/caddyconfig/httpcaddyfile/options.go
@@ -54,6 +54,7 @@ func init() {
 	RegisterGlobalOption("ocsp_stapling", parseOCSPStaplingOptions)
 	RegisterGlobalOption("log", parseLogOptions)
 	RegisterGlobalOption("preferred_chains", parseOptPreferredChains)
+	RegisterGlobalOption("persist_config", parseOptPersistConfig)
 }
 
 func parseOptTrue(d *caddyfile.Dispenser, _ any) (any, error) { return true, nil }
@@ -384,6 +385,21 @@ func parseOptOnDemand(d *caddyfile.Dispenser, _ any) (any, error) {
 		return nil, d.Err("expected at least one config parameter for on_demand_tls")
 	}
 	return ond, nil
+}
+
+func parseOptPersistConfig(d *caddyfile.Dispenser, _ any) (any, error) {
+	d.Next() // consume parameter name
+	if !d.Next() {
+		return "", d.ArgErr()
+	}
+	val := d.Val()
+	if d.Next() {
+		return "", d.ArgErr()
+	}
+	if val != "off" {
+		return "", d.Errf("persist_config must be one of 'off'")
+	}
+	return val, nil
 }
 
 func parseOptAutoHTTPS(d *caddyfile.Dispenser, _ any) (any, error) {

--- a/caddyconfig/httpcaddyfile/options.go
+++ b/caddyconfig/httpcaddyfile/options.go
@@ -397,7 +397,7 @@ func parseOptPersistConfig(d *caddyfile.Dispenser, _ any) (any, error) {
 		return "", d.ArgErr()
 	}
 	if val != "off" {
-		return "", d.Errf("persist_config must be one of 'off'")
+		return "", d.Errf("persist_config must be 'off'")
 	}
 	return val, nil
 }

--- a/caddytest/integration/caddyfile_adapt/global_options_admin_with_persist_config_off.txt
+++ b/caddytest/integration/caddyfile_adapt/global_options_admin_with_persist_config_off.txt
@@ -1,0 +1,36 @@
+{
+	http_port 8080
+	persist_config off
+	admin {
+		origins localhost:2019 [::1]:2019 127.0.0.1:2019 192.168.10.128
+	}
+}
+
+:80
+----------
+{
+	"admin": {
+		"listen": "localhost:2019",
+		"origins": [
+			"localhost:2019",
+			"[::1]:2019",
+			"127.0.0.1:2019",
+			"192.168.10.128"
+		],
+		"config": {
+			"persist": false
+		}
+	},
+	"apps": {
+		"http": {
+			"http_port": 8080,
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					]
+				}
+			}
+		}
+	}
+}

--- a/caddytest/integration/caddyfile_adapt/global_options_persist_config.txt
+++ b/caddytest/integration/caddyfile_adapt/global_options_persist_config.txt
@@ -1,0 +1,25 @@
+{
+	persist_config off
+}
+
+:8881 {
+}
+----------
+{
+	"admin": {
+		"config": {
+			"persist": false
+		}
+	},
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8881"
+					]
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
* Fixes #5209
* `persist_config off` disables configuration persist explictly in Caddyfile
* if it sets, Admin.Config.Persist becomes false