### PR TITLE
cmd: make `caddy fmt` hints more clear

### DIFF
--- a/caddyconfig/caddyfile/adapter.go
+++ b/caddyconfig/caddyfile/adapter.go
@@ -88,7 +88,7 @@ func FormattingDifference(filename string, body []byte) (caddyconfig.Warning, bo
 	return caddyconfig.Warning{
 		File:    filename,
 		Line:    line,
-		Message: "Caddyfile input is not formatted; run the 'caddy fmt' command to fix inconsistencies",
+		Message: "Caddyfile input is not formatted; run 'caddy fmt --overwrite' to fix inconsistencies",
 	}, true
 }
 

--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -589,7 +589,10 @@ func cmdFmt(fl Flags) (int, error) {
 	}
 
 	if warning, diff := caddyfile.FormattingDifference(formatCmdConfigFile, input); diff {
-		return caddy.ExitCodeFailedStartup, fmt.Errorf("%s:%d: Caddyfile input is not formatted", warning.File, warning.Line)
+		return caddy.ExitCodeFailedStartup, fmt.Errorf(`%s:%d: Caddyfile input is not formatted; Tip: use '--overwrite' to update your Caddyfile in-place instead of previewing it. Consult '--help' for more options`,
+			warning.File,
+			warning.Line,
+		)
 	}
 
 	return caddy.ExitCodeSuccess, nil


### PR DESCRIPTION
An impressive amount of users misunderstand `caddy fmt`. 

This (tiny) PR slightly rephrases the hints to mention `--overwrite` (which a lot of users are unaware of) in an attempt to make it more clear what this command actually does (for users that don't check help pages that is)
