### PR TITLE
caddytls: Loosen the warning for on-demand

### DIFF
--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"net/http"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"time"
 
@@ -259,7 +260,17 @@ func (t *TLS) Start() error {
 	if t.Automation.OnDemand == nil ||
 		(t.Automation.OnDemand.Ask == "" && t.Automation.OnDemand.RateLimit == nil) {
 		for _, ap := range t.Automation.Policies {
-			if ap.OnDemand {
+			isWildcardOrDefault := false
+			if len(ap.Subjects) == 0 {
+				isWildcardOrDefault = true
+			}
+			for _, sub := range ap.Subjects {
+				if strings.HasPrefix(sub, "*") {
+					isWildcardOrDefault = true
+					break
+				}
+			}
+			if ap.OnDemand && isWildcardOrDefault {
 				t.logger.Warn("YOUR SERVER MAY BE VULNERABLE TO ABUSE: on-demand TLS is enabled, but no protections are in place",
 					zap.String("docs", "https://caddyserver.com/docs/automatic-https#on-demand-tls"))
 				break


### PR DESCRIPTION
Closes #5383 

This warns about on-demand being vulnerable only if the automation policy is the default fallback (no subjects) or has any wildcard certs, because those are infinite cardinality.

If there's only single (non-wildcard) subjects, then the cardinality is limited to only the length of the subject list, so there's no risk of abuse.