### PR TITLE
context: Rename func to `AppIfConfigured`

### DIFF
--- a/context.go
+++ b/context.go
@@ -426,15 +426,20 @@ func (ctx Context) App(name string) (any, error) {
 	return modVal, nil
 }
 
-// AppIsConfigured returns whether an app named name has been
-// configured. Can be called before calling App() to avoid
+// AppIfConfigured returns an app by its name if it has been
+// configured. Can be called instead of App() to avoid
 // instantiating an empty app when that's not desirable.
-func (ctx Context) AppIsConfigured(name string) bool {
-	if _, ok := ctx.cfg.apps[name]; ok {
-		return true
+func (ctx Context) AppIfConfigured(name string) (any, error) {
+	app, ok := ctx.cfg.apps[name]
+	if !ok || app == nil {
+		return nil, nil
 	}
-	appRaw := ctx.cfg.AppsRaw[name]
-	return appRaw != nil
+
+	appModule, err := ctx.App(name)
+	if err != nil {
+		return nil, err
+	}
+	return appModule, nil
 }
 
 // Storage returns the configured Caddy storage implementation.

--- a/modules/caddypki/adminapi.go
+++ b/modules/caddypki/adminapi.go
@@ -49,20 +49,14 @@ func (a *adminAPI) Provision(ctx caddy.Context) error {
 	a.ctx = ctx
 	a.log = ctx.Logger(a) // TODO: passing in 'a' is a hack until the admin API is officially extensible (see #5032)
 
-	// First check if the PKI app was configured, because
-	// a.ctx.App() has the side effect of instantiating
-	// and provisioning an app even if it wasn't configured.
-	pkiAppConfigured := a.ctx.AppIsConfigured("pki")
-	if !pkiAppConfigured {
-		return nil
-	}
-
-	// Load the PKI app, so we can query it for information.
-	appModule, err := a.ctx.App("pki")
+	// Avoid initializing PKI if it wasn't configured
+	pkiApp, err := a.ctx.AppIfConfigured("pki")
 	if err != nil {
 		return err
 	}
-	a.pkiApp = appModule.(*PKI)
+	if pkiApp != nil {
+		a.pkiApp = pkiApp.(*PKI)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Closes https://github.com/caddyserver/caddy/issues/4893

I highly doubt anyone but ourselves used this API, so it should be safe to do this even though it's an exported function.