### PR TITLE
reverseproxy: Health as a ratio of successful requests

### DIFF
--- a/modules/caddyhttp/caddyhttp.go
+++ b/modules/caddyhttp/caddyhttp.go
@@ -17,6 +17,7 @@ package caddyhttp
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -164,7 +165,7 @@ func (ws *WeakString) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// MarshalJSON marshals was a boolean if true or false,
+// MarshalJSON marshals as a boolean if true or false,
 // a number if an integer, or a string otherwise.
 func (ws WeakString) MarshalJSON() ([]byte, error) {
 	if ws == "true" {
@@ -202,6 +203,64 @@ func (ws WeakString) Bool() bool {
 // String returns ws as a string.
 func (ws WeakString) String() string {
 	return string(ws)
+}
+
+// Ratio is a type that unmarshals a valid numerical ratio string
+// with a format of "numerator/denominator" where both are integers,
+// into a float, or simply takes a float.
+type Ratio float64
+
+// UnmarshalJSON satisfies json.Unmarshaler according to
+// this type's documentation.
+func (r *Ratio) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 {
+		return io.EOF
+	}
+	if b[0] == byte('"') && b[len(b)-1] == byte('"') {
+		if !strings.Contains(string(b), "/") {
+			return fmt.Errorf("ratio string '%s' did not contain a slash", string(b[1:len(b)-1]))
+		}
+		left, right, _ := strings.Cut(string(b[1:len(b)-1]), "/")
+		num, err := strconv.Atoi(left)
+		if err != nil {
+			return fmt.Errorf("failed parsing numerator as integer %s: %v", left, err)
+		}
+		denom, err := strconv.Atoi(right)
+		if err != nil {
+			return fmt.Errorf("failed parsing denominator as integer %s: %v", right, err)
+		}
+		*r = Ratio(float64(num) / float64(denom))
+		return nil
+	}
+	if bytes.Equal(b, []byte("null")) {
+		return nil
+	}
+	float, err := strconv.ParseFloat(string(b), 64)
+	if err != nil {
+		return fmt.Errorf("failed parsing ratio as float %s: %v", b, err)
+	}
+	*r = Ratio(float)
+	return nil
+}
+
+func ParseRatio(r string) (Ratio, error) {
+	if strings.Contains(r, "/") {
+		left, right, _ := strings.Cut(r, "/")
+		num, err := strconv.Atoi(left)
+		if err != nil {
+			return 0, fmt.Errorf("failed parsing numerator as integer %s: %v", left, err)
+		}
+		denom, err := strconv.Atoi(right)
+		if err != nil {
+			return 0, fmt.Errorf("failed parsing denominator as integer %s: %v", right, err)
+		}
+		return Ratio(float64(num) / float64(denom)), nil
+	}
+	float, err := strconv.ParseFloat(r, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed parsing ratio as float %s: %v", r, err)
+	}
+	return Ratio(float), nil
 }
 
 // StatusCodeMatches returns true if a real HTTP status code matches

--- a/modules/caddyhttp/caddyhttp_test.go
+++ b/modules/caddyhttp/caddyhttp_test.go
@@ -149,3 +149,67 @@ func TestCleanPath(t *testing.T) {
 		}
 	}
 }
+
+func TestUnmarshalRatio(t *testing.T) {
+	for i, tc := range []struct {
+		input  []byte
+		expect float64
+		errMsg string
+	}{
+		{
+			input:  []byte("null"),
+			expect: 0,
+		},
+		{
+			input:  []byte(`"1/3"`),
+			expect: float64(1) / float64(3),
+		},
+		{
+			input:  []byte(`"1/100"`),
+			expect: float64(1) / float64(100),
+		},
+		{
+			input:  []byte(`0.1`),
+			expect: 0.1,
+		},
+		{
+			input:  []byte(`0.005`),
+			expect: 0.005,
+		},
+		{
+			input:  []byte(`0`),
+			expect: 0,
+		},
+		{
+			input:  []byte(`"0"`),
+			errMsg: `ratio string '0' did not contain a slash`,
+		},
+		{
+			input:  []byte(`a`),
+			errMsg: `failed parsing ratio as float a: strconv.ParseFloat: parsing "a": invalid syntax`,
+		},
+		{
+			input:  []byte(`"a/1"`),
+			errMsg: `failed parsing numerator as integer a: strconv.Atoi: parsing "a": invalid syntax`,
+		},
+		{
+			input:  []byte(`"1/a"`),
+			errMsg: `failed parsing denominator as integer a: strconv.Atoi: parsing "a": invalid syntax`,
+		},
+	} {
+		ratio := Ratio(0)
+		err := ratio.UnmarshalJSON(tc.input)
+		if err != nil {
+			if tc.errMsg != "" {
+				if tc.errMsg != err.Error() {
+					t.Fatalf("Test %d: expected error: %v, got: %v", i, tc.errMsg, err)
+				}
+				continue
+			}
+			t.Fatalf("Test %d: invalid ratio: %v", i, err)
+		}
+		if ratio != Ratio(tc.expect) {
+			t.Fatalf("Test %d: expected %v, got %v", i, tc.expect, ratio)
+		}
+	}
+}

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -79,6 +79,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 //	    fail_duration     <duration>
 //	    max_fails         <num>
 //	    success_duration  <duration>
+//	    min_success_ratio <ratio>
 //	    unhealthy_status  <status>
 //	    unhealthy_latency <duration>
 //	    unhealthy_request_count <num>
@@ -453,6 +454,22 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.Errf("bad duration value '%s': %v", d.Val(), err)
 				}
 				h.HealthChecks.Passive.SuccessDuration = caddy.Duration(dur)
+
+			case "min_success_ratio":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				if h.HealthChecks == nil {
+					h.HealthChecks = new(HealthChecks)
+				}
+				if h.HealthChecks.Passive == nil {
+					h.HealthChecks.Passive = new(PassiveHealthChecks)
+				}
+				ratio, err := caddyhttp.ParseRatio(d.Val())
+				if err != nil {
+					return d.Errf("bad ratio value '%s': %v", d.Val(), err)
+				}
+				h.HealthChecks.Passive.MinSuccessRatio = ratio
 
 			case "fail_duration":
 				if !d.NextArg() {

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -78,6 +78,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 //	    # passive health checking
 //	    fail_duration     <duration>
 //	    max_fails         <num>
+//	    success_duration  <duration>
 //	    unhealthy_status  <status>
 //	    unhealthy_latency <duration>
 //	    unhealthy_request_count <num>
@@ -436,6 +437,22 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.Errf("invalid maximum fail count '%s': %v", d.Val(), err)
 				}
 				h.HealthChecks.Passive.MaxFails = maxFails
+
+			case "success_duration":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				if h.HealthChecks == nil {
+					h.HealthChecks = new(HealthChecks)
+				}
+				if h.HealthChecks.Passive == nil {
+					h.HealthChecks.Passive = new(PassiveHealthChecks)
+				}
+				dur, err := caddy.ParseDuration(d.Val())
+				if err != nil {
+					return d.Errf("bad duration value '%s': %v", d.Val(), err)
+				}
+				h.HealthChecks.Passive.SuccessDuration = caddy.Duration(dur)
 
 			case "fail_duration":
 				if !d.NextArg() {

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -122,6 +122,11 @@ type PassiveHealthChecks struct {
 	// How long to remember a successful request to a backend. Default is 0.
 	SuccessDuration caddy.Duration `json:"success_duration,omitempty"`
 
+	// The minimum ratio of successful to failed requests necessary to
+	// consider a backend as healthy. Both fail and success durations
+	// must be configured for those stats to be counted. Default is 0 (no ratio).
+	MinSuccessRatio caddyhttp.Ratio `json:"min_success_ratio,omitempty"`
+
 	// Limits the number of simultaneous requests to a backend by
 	// marking the backend as "down" if it has this many concurrent
 	// requests or more.

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -110,14 +110,17 @@ type ActiveHealthChecks struct {
 // health checks (that is, health checks which occur during
 // the normal flow of request proxying).
 type PassiveHealthChecks struct {
-	// How long to remember a failed request to a backend. A duration > 0
-	// enables passive health checking. Default is 0.
+	// How long to remember a failed request to a backend.
+	// A duration > 0 enables passive health checking. Default is 0.
 	FailDuration caddy.Duration `json:"fail_duration,omitempty"`
 
 	// The number of failed requests within the FailDuration window to
 	// consider a backend as "down". Must be >= 1; default is 1. Requires
 	// that FailDuration be > 0.
 	MaxFails int `json:"max_fails,omitempty"`
+
+	// How long to remember a successful request to a backend. Default is 0.
+	SuccessDuration caddy.Duration `json:"success_duration,omitempty"`
 
 	// Limits the number of simultaneous requests to a backend by
 	// marking the backend as "down" if it has this many concurrent
@@ -360,6 +363,56 @@ func (h *Handler) doActiveHealthCheck(dialInfo DialInfo, hostAddr string, upstre
 	}
 
 	return nil
+}
+
+// countSuccess is used with passive health checks. It
+// remembers 1 success for upstream for the configured
+// duration. If passive health checks are disabled or
+// success expiry is 0, this is a no-op.
+func (h *Handler) countSuccess(upstream *Upstream) {
+	// only count successes if passive health checking is enabled
+	// and if successes are configured have a non-zero expiry
+	if h.HealthChecks == nil || h.HealthChecks.Passive == nil {
+		return
+	}
+	successDuration := time.Duration(h.HealthChecks.Passive.SuccessDuration)
+	if successDuration == 0 {
+		return
+	}
+
+	// count success immediately
+	err := upstream.Host.countSuccess(1)
+	if err != nil {
+		h.HealthChecks.Passive.logger.Error("could not count success",
+			zap.String("host", upstream.Dial),
+			zap.Error(err))
+		return
+	}
+
+	// forget it later
+	go func(host *Host, successDuration time.Duration) {
+		defer func() {
+			if err := recover(); err != nil {
+				h.HealthChecks.Passive.logger.Error("passive health check success forgetter panicked",
+					zap.Any("error", err),
+					zap.ByteString("stack", debug.Stack()))
+			}
+		}()
+		timer := time.NewTimer(successDuration)
+		select {
+		case <-h.ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+		case <-timer.C:
+		}
+		err := host.countSuccess(-1)
+		if err != nil {
+			h.HealthChecks.Passive.logger.Error("could not forget success",
+				zap.String("host", upstream.Dial),
+				zap.Error(err))
+		}
+	}(upstream.Host, successDuration)
 }
 
 // countFailure is used with passive health checks. It

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -162,12 +162,18 @@ func (u *Upstream) fillHost() {
 // Its fields are accessed atomically and Host values must not be copied.
 type Host struct {
 	numRequests int64 // must be 64-bit aligned on 32-bit systems (see https://golang.org/pkg/sync/atomic/#pkg-note-BUG)
+	successes   int64
 	fails       int64
 }
 
 // NumRequests returns the number of active requests to the upstream.
 func (h *Host) NumRequests() int {
 	return int(atomic.LoadInt64(&h.numRequests))
+}
+
+// Successes returns the number of recent successes with the upstream.
+func (h *Host) Successes() int {
+	return int(atomic.LoadInt64(&h.successes))
 }
 
 // Fails returns the number of recent failures with the upstream.
@@ -179,6 +185,16 @@ func (h *Host) Fails() int {
 // delta. It returns an error if the adjustment fails.
 func (h *Host) countRequest(delta int) error {
 	result := atomic.AddInt64(&h.numRequests, int64(delta))
+	if result < 0 {
+		return fmt.Errorf("count below 0: %d", result)
+	}
+	return nil
+}
+
+// countSuccess mutates the recent successes count by
+// delta. It returns an error if the adjustment fails.
+func (h *Host) countSuccess(delta int) error {
+	result := atomic.AddInt64(&h.successes, int64(delta))
 	if result < 0 {
 		return fmt.Errorf("count below 0: %d", result)
 	}


### PR DESCRIPTION
Closes #4949

This is WIP.

This makes it possible to keep track of successful requests over time for each upstream. Same mechanism as failure duration.

This also adds a minimum successful requests ratio, so if there's too many failures, the upstream is marked unhealthy. I think we might need a minimum total so that the ratio only applies after there's at least N requests in memory, otherwise a single failure at the start might take out the server. But maybe that's fine if the fail duration is low.