### PR TITLE
ci/cd: ship tarballs with vendored deps

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,9 @@ before:
     # This is so we can run goreleaser on tag without Git complaining of being dirty. The main.go in cmd/caddy directory 
     # cannot be built within that directory due to changes necessary for the build causing Git to be dirty, which
     # subsequently causes gorleaser to refuse running.
-    - rm -rf caddy-build caddy-dist
+    - rm -rf caddy-build caddy-dist vendor
+    # vendor Caddy deps
+    - go mod vendor
     - mkdir -p caddy-build
     - cp cmd/caddy/main.go caddy-build/main.go
     - /bin/sh -c 'cd ./caddy-build && go mod init caddy'
@@ -14,6 +16,8 @@ before:
     # as of Go 1.16, `go` commands no longer automatically change go.{mod,sum}. We now have to explicitly
     # run `go mod tidy`. The `/bin/sh -c '...'` is because goreleaser can't find cd in PATH without shell invocation.
     - /bin/sh -c 'cd ./caddy-build && go mod tidy'
+    # vendor the deps of the prepared to-build module
+    - /bin/sh -c 'cd ./caddy-build && go mod vendor'
     - git clone --depth 1 https://github.com/caddyserver/dist caddy-dist
     - mkdir -p caddy-dist/man
     - go mod download
@@ -89,7 +93,8 @@ sboms:
     args: ["$artifact", "--file", "${document}", "--output", "cyclonedx-json"]
 
 archives:
-  - format_overrides:
+  - id: default
+    format_overrides:
       - goos: windows
         format: zip
     name_template: >-
@@ -100,6 +105,42 @@ archives:
       {{- with .Arm }}v{{ . }}{{ end }}
       {{- with .Mips }}_{{ . }}{{ end }}
       {{- if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
+  
+  # packge the 'caddy-build' directory into a tarball,
+  # allowing users to build the exact same set of files as ours.
+  - id: source
+    meta: true
+    rlcp: true
+    name_template: "{{ .ProjectName }}_{{ .Version }}_buildable-artifact"
+    files:
+      - src: LICENSE
+        dst: ./LICENSE
+      - src: README.md
+        dst: ./README.md
+      - src: AUTHORS
+        dst: ./AUTHORS
+      - src: ./caddy-build
+        dst: ./
+
+source:
+  enabled: true
+  name_template: '{{ .ProjectName }}_{{ .Version }}_src'
+  format: 'tar.gz'
+
+  # This will make the destination paths be relative to the longest common
+  # path prefix between all the files matched and the source glob.
+  # Enabling this essentially mimic the behavior of nfpm's contents section.
+  # It will be the default by June 2023.
+  #
+  # Default: false
+  rlcp: true
+
+  # Additional files/template/globs you want to add to the source archive.
+  #
+  # Default: empty.
+  files:
+    - vendor
+
 
 checksum:
   algorithm: sha512


### PR DESCRIPTION
This adds 2 tarballs in the release:
- `caddy_{{ .Version }}_buildable-artifact.tar.gz`: this contains a `main.go`, `go.mod`, and `go.sum` along with a `vendor/` tree containing all the deps, including Caddy's own source tree as a dep. This allows the user to run `go build` against the exact files used to build our releases.
- `caddy_{{ .Version }}_src`: this packages Caddy's git tree as-is along with the `vendor/` directory of vendored deps.

To test, run:
`TAG=master goreleaser release --skip-publish --snapshot --clean`

Closes #4573 