### PR TITLE
caddyhttp: Fix shutdown delay on unix systems

### DIFF
--- a/listeners.go
+++ b/listeners.go
@@ -479,6 +479,9 @@ func ListenQUIC(ln net.PacketConn, tlsConf *tls.Config, activeRequests *int64) (
 }
 
 // ListenerUsage returns the current usage count of the given listener address.
+//
+// Deprecated: this is inaccurate on Unix servers because we now use
+// SO_REUSEPORT to reuse listeners instead of using the listener pool.
 func ListenerUsage(network, addr string) int {
 	count, _ := listenerPool.References(listenerKey(network, addr))
 	return count


### PR DESCRIPTION
Fixes #5393

Since the listener logic in Caddy was rewritten to no longer use the listener pool, using it as a way to check whether we're about to shut down no longer makes sense.

Instead, we can simply use an atomic HTTP app ref counter to detect if we're reloading or shutting down.

Deprecating `caddy.ListenerUsage` because it no longer works on unix platforms; should still work on other platforms, but its pretty much useless now.

I bumped the shutdown and grace log messages (when they trigger) from DEBUG to INFO for better visibility.