### PR TITLE
remove trailing slash on fs filenames

### DIFF
--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -250,7 +250,8 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 
 	root := repl.ReplaceAll(fsrv.Root, ".")
 
-	filename := caddyhttp.SanitizedPathJoin(root, r.URL.Path)
+	// remove any trailing `/` as it breaks fs.ValidPath() in the stdlib
+	filename := strings.TrimSuffix(caddyhttp.SanitizedPathJoin(root, r.URL.Path), "/")
 
 	fsrv.logger.Debug("sanitized path join",
 		zap.String("site_root", root),


### PR DESCRIPTION
Minor change to fix https://github.com/caddyserver/caddy/issues/5416

Tested with `osFS` and [caddy-fs-s3](https://github.com/sagikazarmark/caddy-fs-s3), and confirmed that path canonicalization redirects still happen successfully. 