### PR TITLE
proxyprotocol: Add PROXY protocol support to `reverse_proxy`, add HTTP listener wrapper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/klauspost/compress v1.16.0
 	github.com/klauspost/cpuid/v2 v2.2.4
+	github.com/mastercactapus/proxyprotocol v0.0.3
 	github.com/mholt/acmez v1.1.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/quic-go/quic-go v0.33.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/klauspost/compress v1.16.0
 	github.com/klauspost/cpuid/v2 v2.2.4
-	github.com/mastercactapus/proxyprotocol v0.0.3
+	github.com/mastercactapus/proxyprotocol v0.0.4
 	github.com/mholt/acmez v1.1.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/quic-go/quic-go v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -443,6 +443,8 @@ github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0Q
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
+github.com/mastercactapus/proxyprotocol v0.0.3 h1:WpDMFKCYdF8NsoA6OrXyNKyZrzMURqqOP1PE7297RCE=
+github.com/mastercactapus/proxyprotocol v0.0.3/go.mod h1:X8FRVEDZz9FkrIoL4QYTBF4Ka4ELwTv0sah0/5NxCPw=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/go.sum
+++ b/go.sum
@@ -443,8 +443,8 @@ github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0Q
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
-github.com/mastercactapus/proxyprotocol v0.0.3 h1:WpDMFKCYdF8NsoA6OrXyNKyZrzMURqqOP1PE7297RCE=
-github.com/mastercactapus/proxyprotocol v0.0.3/go.mod h1:X8FRVEDZz9FkrIoL4QYTBF4Ka4ELwTv0sah0/5NxCPw=
+github.com/mastercactapus/proxyprotocol v0.0.4 h1:qSY75IZF30ZqIU9iW1ip3I7gTnm8wRAnGWqPxCBVgq0=
+github.com/mastercactapus/proxyprotocol v0.0.4/go.mod h1:X8FRVEDZz9FkrIoL4QYTBF4Ka4ELwTv0sah0/5NxCPw=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/modules/caddyhttp/proxyprotocol/listenerwrapper.go
+++ b/modules/caddyhttp/proxyprotocol/listenerwrapper.go
@@ -1,0 +1,68 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxyprotocol
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/mastercactapus/proxyprotocol"
+)
+
+// ListenerWrapper provides PROXY protocol support to Caddy by implementing
+// the caddy.ListenerWrapper interface. It must be loaded before the `tls` listener.
+//
+// Credit goes to https://github.com/mastercactapus/caddy2-proxyprotocol for having
+// initially implemented this as a plugin.
+type ListenerWrapper struct {
+	// Timeout specifies an optional maximum time for
+	// the PROXY header to be received.
+	// If zero, timeout is disabled. Default is 5s.
+	Timeout caddy.Duration `json:"timeout,omitempty"`
+
+	// Allow is an optional list of CIDR ranges to
+	// allow/require PROXY headers from.
+	Allow []string `json:"allow,omitempty"`
+
+	rules []proxyprotocol.Rule
+}
+
+// Provision sets up the listener wrapper.
+func (pp *ListenerWrapper) Provision(ctx caddy.Context) error {
+	rules := make([]proxyprotocol.Rule, 0, len(pp.Allow))
+	for _, s := range pp.Allow {
+		_, n, err := net.ParseCIDR(s)
+		if err != nil {
+			return fmt.Errorf("invalid subnet '%s': %w", s, err)
+		}
+		rules = append(rules, proxyprotocol.Rule{
+			Timeout: time.Duration(pp.Timeout),
+			Subnet:  n,
+		})
+	}
+
+	pp.rules = rules
+
+	return nil
+}
+
+// WrapListener adds PROXY protocol support to the listener.
+func (pp *ListenerWrapper) WrapListener(l net.Listener) net.Listener {
+	pl := proxyprotocol.NewListener(l, time.Duration(pp.Timeout))
+	pl.SetFilter(pp.rules)
+	return pl
+}

--- a/modules/caddyhttp/proxyprotocol/module.go
+++ b/modules/caddyhttp/proxyprotocol/module.go
@@ -1,0 +1,75 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxyprotocol
+
+import (
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+)
+
+func init() {
+	caddy.RegisterModule(ListenerWrapper{})
+}
+
+func (ListenerWrapper) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "caddy.listeners.proxy_protocol",
+		New: func() caddy.Module { return new(ListenerWrapper) },
+	}
+}
+
+// UnmarshalCaddyfile sets up the listener Listenerwrapper from Caddyfile tokens. Syntax:
+//
+//	proxy_protocol {
+//		timeout <duration>
+//		allow <IPs...>
+//	}
+func (w *ListenerWrapper) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		// No same-line options are supported
+		if d.NextArg() {
+			return d.ArgErr()
+		}
+
+		for d.NextBlock(0) {
+			switch d.Val() {
+			case "timeout":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				dur, err := caddy.ParseDuration(d.Val())
+				if err != nil {
+					return d.Errf("parsing proxy_protocol timeout duration: %v", err)
+				}
+				w.Timeout = caddy.Duration(dur)
+
+			case "allow":
+				w.Allow = append(w.Allow, d.RemainingArgs()...)
+
+			default:
+				return d.ArgErr()
+			}
+		}
+	}
+	return nil
+}
+
+// Interface guards
+var (
+	_ caddy.Provisioner     = (*ListenerWrapper)(nil)
+	_ caddy.Module          = (*ListenerWrapper)(nil)
+	_ caddy.ListenerWrapper = (*ListenerWrapper)(nil)
+	_ caddyfile.Unmarshaler = (*ListenerWrapper)(nil)
+)

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -918,6 +918,17 @@ func (h *HTTPTransport) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				}
 				h.MaxResponseHeaderSize = int64(size)
 
+			case "proxy_protocol":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				switch proxyProtocol := d.Val(); proxyProtocol {
+				case "v1", "v2":
+					h.ProxyProtocol = proxyProtocol
+				default:
+					return d.Errf("invalid proxy protocol version '%s'", proxyProtocol)
+				}
+
 			case "dial_timeout":
 				if !d.NextArg() {
 					return d.ArgErr()

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -259,3 +259,22 @@ var hosts = caddy.NewUsagePool()
 // dialInfoVarKey is the key used for the variable that holds
 // the dial info for the upstream connection.
 const dialInfoVarKey = "reverse_proxy.dial_info"
+
+// ProxyProtocolInfo contains information needed to write proxy protocol to a
+// connection to an upstream host.
+type ProxyProtocolInfo struct {
+	// assume network is tcp because golang http transport can only support tcp now
+	IP   net.IP
+	Port int
+}
+
+// GetProxyProtocolInfo gets the proxy protocol info out of the context,
+// and returns true if there was a valid value; false otherwise.
+func GetProxyProtocolInfo(ctx context.Context) (ProxyProtocolInfo, bool) {
+	proxyProtocolInfo, ok := caddyhttp.GetVar(ctx, proxyProtocolInfoVarKey).(ProxyProtocolInfo)
+	return proxyProtocolInfo, ok
+}
+
+// proxyProtocolInfoVarKey is the key used for the variable that holds
+// the proxy protocol info for the upstream connection.
+const proxyProtocolInfoVarKey = "reverse_proxy.proxy_protocol_info"

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -260,6 +260,10 @@ var hosts = caddy.NewUsagePool()
 // the dial info for the upstream connection.
 const dialInfoVarKey = "reverse_proxy.dial_info"
 
+// proxyProtocolInfoVarKey is the key used for the variable that holds
+// the proxy protocol info for the upstream connection.
+const proxyProtocolInfoVarKey = "reverse_proxy.proxy_protocol_info"
+
 // ProxyProtocolInfo contains information needed to write proxy protocol to a
 // connection to an upstream host.
 type ProxyProtocolInfo struct {
@@ -267,14 +271,3 @@ type ProxyProtocolInfo struct {
 	IP   net.IP
 	Port int
 }
-
-// GetProxyProtocolInfo gets the proxy protocol info out of the context,
-// and returns true if there was a valid value; false otherwise.
-func GetProxyProtocolInfo(ctx context.Context) (ProxyProtocolInfo, bool) {
-	proxyProtocolInfo, ok := caddyhttp.GetVar(ctx, proxyProtocolInfoVarKey).(ProxyProtocolInfo)
-	return proxyProtocolInfo, ok
-}
-
-// proxyProtocolInfoVarKey is the key used for the variable that holds
-// the proxy protocol info for the upstream connection.
-const proxyProtocolInfoVarKey = "reverse_proxy.proxy_protocol_info"

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/netip"
 	"strconv"
 	"sync/atomic"
 
@@ -267,7 +268,5 @@ const proxyProtocolInfoVarKey = "reverse_proxy.proxy_protocol_info"
 // ProxyProtocolInfo contains information needed to write proxy protocol to a
 // connection to an upstream host.
 type ProxyProtocolInfo struct {
-	// assume network is tcp because golang http transport can only support tcp now
-	IP   net.IP
-	Port int
+	AddrPort netip.AddrPort
 }

--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -220,6 +220,8 @@ func (h *HTTPTransport) NewTransport(caddyCtx caddy.Context) (*http.Transport, e
 				return nil, fmt.Errorf("unexpected remote addr type in proxy protocol info")
 			}
 
+			// TODO: We should probably migrate away from net.IP to use netip.Addr,
+			// but due to the upstream dependency, we can't do that yet.
 			switch h.ProxyProtocol {
 			case "v1":
 				header := proxyprotocol.HeaderV1{

--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -66,8 +66,8 @@ type HTTPTransport struct {
 	// Maximum number of connections per host. Default: 0 (no limit)
 	MaxConnsPerHost int `json:"max_conns_per_host,omitempty"`
 
-	// Which version of proxy protocol to send when connecting to
-	// an upstream. Default: `don't send proxy protocol`.
+	// If non-empty, which PROXY protocol version to send when
+	// connecting to an upstream. Default: off.
 	ProxyProtocol string `json:"proxy_protocol,omitempty"`
 
 	// How long to wait before timing out trying to connect to
@@ -298,7 +298,7 @@ func (h *HTTPTransport) NewTransport(caddyCtx caddy.Context) (*http.Transport, e
 	// So single connection must not be used for multiple requests, which can potentially
 	// come from different clients.
 	if !rt.DisableKeepAlives && h.ProxyProtocol != "" {
-		caddyCtx.Logger().Warn("disabling keepalive, because it is not supported when using the proxy protocol")
+		caddyCtx.Logger().Warn("disabling keepalives, they are incompatible with using PROXY protocol")
 		rt.DisableKeepAlives = true
 	}
 

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -74,6 +74,7 @@ func init() {
 // `{http.reverse_proxy.upstream.duration_ms}` | Same as 'upstream.duration', but in milliseconds.
 // `{http.reverse_proxy.duration}` | Total time spent proxying, including selecting an upstream, retries, and writing response.
 // `{http.reverse_proxy.duration_ms}` | Same as 'duration', but in milliseconds.
+
 type Handler struct {
 	// Configures the method of transport for the proxy. A transport
 	// is what performs the actual "round trip" to the backend.
@@ -568,6 +569,33 @@ func (h *Handler) proxyLoopIteration(r *http.Request, origReq *http.Request, w h
 	// this is necessary because the information cannot be sufficiently
 	// or satisfactorily represented in a URL
 	caddyhttp.SetVar(r.Context(), dialInfoVarKey, dialInfo)
+
+	var proxyProtocolInfo ProxyProtocolInfo
+	// using X-Forwarded-For header which is already filtered by trusted proxies
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// addForwardedHeaders ensures xff has at least remoteAddr
+		xff = strings.TrimSpace(strings.Split(xff, ",")[0])
+		ip := net.ParseIP(xff)
+		if ip != nil {
+			proxyProtocolInfo.IP = ip
+			// X-Forwarded-For is set by caddy, not by prefix matching because ipv6 remoteAddr starts with [
+			if strings.Contains(r.RemoteAddr, xff) {
+				// addForwardedHeaders already check this error
+				_, p, _ := net.SplitHostPort(r.RemoteAddr)
+
+				// however port is never checked
+				port, err := strconv.Atoi(p)
+				if err != nil {
+					return true, fmt.Errorf("making proxy protocol info: %v", err)
+				}
+				proxyProtocolInfo.Port = port
+			} else {
+				// set to zero for unknown
+				proxyProtocolInfo.Port = 0
+			}
+			caddyhttp.SetVar(r.Context(), proxyProtocolInfoVarKey, dialInfo)
+		}
+	}
 
 	// set placeholders with information about this upstream
 	repl.Set("http.reverse_proxy.upstream.address", dialInfo.String())

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -578,18 +578,12 @@ func (h *Handler) proxyLoopIteration(r *http.Request, origReq *http.Request, w h
 		remoteAddr = r.RemoteAddr
 	}
 
-	ipStr, portStr, err := net.SplitHostPort(remoteAddr)
+	addrPort, err := netip.ParseAddrPort(remoteAddr)
 	if err != nil { // probably didn't have a port
-		ipStr = remoteAddr
-		portStr = "0"
+		addrPort, _ = netip.ParseAddrPort(remoteAddr + ":0")
 	}
-	ip := net.ParseIP(ipStr)
-	port, _ := strconv.Atoi(portStr)
 
-	proxyProtocolInfo := ProxyProtocolInfo{
-		IP:   ip,
-		Port: port,
-	}
+	proxyProtocolInfo := ProxyProtocolInfo{AddrPort: addrPort}
 	caddyhttp.SetVar(r.Context(), proxyProtocolInfoVarKey, proxyProtocolInfo)
 
 	// set placeholders with information about this upstream

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -689,8 +689,6 @@ func (h Handler) prepareRequest(req *http.Request, repl *caddy.Replacer) (*http.
 	}
 
 	// Set up the PROXY protocol info
-	// TODO: We should probably migrate away from netip, but due to
-	// the upstream dependency, we can't do that yet.
 	address := caddyhttp.GetVar(req.Context(), caddyhttp.ClientIPVarKey).(string)
 	addrPort, err := netip.ParseAddrPort(address)
 	if err != nil {

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -74,7 +74,6 @@ func init() {
 // `{http.reverse_proxy.upstream.duration_ms}` | Same as 'upstream.duration', but in milliseconds.
 // `{http.reverse_proxy.duration}` | Total time spent proxying, including selecting an upstream, retries, and writing response.
 // `{http.reverse_proxy.duration_ms}` | Same as 'duration', but in milliseconds.
-
 type Handler struct {
 	// Configures the method of transport for the proxy. A transport
 	// is what performs the actual "round trip" to the backend.

--- a/modules/caddyhttp/standard/imports.go
+++ b/modules/caddyhttp/standard/imports.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/fileserver"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/headers"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/map"
+	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/proxyprotocol"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/push"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/requestbody"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"


### PR DESCRIPTION
This is an updated (rebased to the current master and improved) version of https://github.com/caddyserver/caddy/pull/4855. 

Please let me know if any changes are needed. Would be great to have this included in the next official release :-)