### PR TITLE
quic: enable 0-RTT

### DIFF
--- a/listeners.go
+++ b/listeners.go
@@ -441,6 +441,7 @@ func ListenQUIC(ln net.PacketConn, tlsConf *tls.Config, activeRequests *int64) (
 
 	sharedEarlyListener, _, err := listenerPool.LoadOrNew(lnKey, func() (Destructor, error) {
 		earlyLn, err := quic.ListenEarly(ln, http3.ConfigureTLSConfig(tlsConf), &quic.Config{
+			Allow0RTT: func(net.Addr) bool { return true },
 			RequireAddressValidation: func(clientAddr net.Addr) bool {
 				var highLoad bool
 				if activeRequests != nil {


### PR DESCRIPTION
[v0.32.0](https://github.com/quic-go/quic-go/releases/tag/v0.32.0) changed the 0-RTT API. It now has to be explicitly enabled.