### PR TITLE
rewrite: Add option to force modifying the query

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_handle_response.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_handle_response.caddyfiletest
@@ -11,7 +11,9 @@ reverse_proxy 127.0.0.1:65535 {
 
 	@accel header X-Accel-Redirect *
 	handle_response @accel {
-		respond "Header X-Accel-Redirect!"
+		rewrite * {rp.header.X-Accel-Redirect} {
+			force_modify_query
+		}
 	}
 
 	@another {
@@ -104,10 +106,12 @@ reverse_proxy 127.0.0.1:65535 {
 											},
 											"routes": [
 												{
+													"group": "group0",
 													"handle": [
 														{
-															"body": "Header X-Accel-Redirect!",
-															"handler": "static_response"
+															"force_modify_query": true,
+															"handler": "rewrite",
+															"uri": "{http.reverse_proxy.header.X-Accel-Redirect}"
 														}
 													]
 												}

--- a/modules/caddyhttp/rewrite/caddyfile.go
+++ b/modules/caddyhttp/rewrite/caddyfile.go
@@ -34,7 +34,9 @@ func init() {
 
 // parseCaddyfileRewrite sets up a basic rewrite handler from Caddyfile tokens. Syntax:
 //
-//	rewrite [<matcher>] <to>
+//	rewrite [<matcher>] <to> {
+//		force_modify_query
+//	}
 //
 // Only URI components which are given in <to> will be set in the resulting URI.
 // See the docs for the rewrite handler for more information.
@@ -50,12 +52,30 @@ func parseCaddyfileRewrite(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue,
 		return nil, h.Errf("too many arguments; should only be a matcher and a URI")
 	}
 
+	parseBlock := func(rewr *Rewrite) error {
+		for nesting := h.Nesting(); h.NextBlock(nesting); {
+			switch h.Val() {
+			case "force_modify_query":
+				rewr.ForceModifyQuery = true
+
+			default:
+				return h.Errf("unknown subdirective: %s", h.Val())
+			}
+		}
+		return nil
+	}
+
 	// with only one arg, assume it's a rewrite URI with no matcher token
 	if argsCount == 1 {
 		if !h.NextArg() {
 			return nil, h.ArgErr()
 		}
-		return h.NewRoute(nil, Rewrite{URI: h.Val()}), nil
+		rewr := Rewrite{URI: h.Val()}
+		err := parseBlock(&rewr)
+		if err != nil {
+			return nil, err
+		}
+		return h.NewRoute(nil, rewr), nil
 	}
 
 	// parse the matcher token into a matcher set
@@ -66,7 +86,12 @@ func parseCaddyfileRewrite(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue,
 	h.Next() // consume directive name again, matcher parsing does a reset
 	h.Next() // advance to the rewrite URI
 
-	return h.NewRoute(userMatcherSet, Rewrite{URI: h.Val()}), nil
+	rewr := Rewrite{URI: h.Val()}
+	err = parseBlock(&rewr)
+	if err != nil {
+		return nil, err
+	}
+	return h.NewRoute(userMatcherSet, rewr), nil
 }
 
 // parseCaddyfileMethod sets up a basic method rewrite handler from Caddyfile tokens. Syntax:

--- a/modules/caddyhttp/rewrite/rewrite.go
+++ b/modules/caddyhttp/rewrite/rewrite.go
@@ -92,6 +92,17 @@ type Rewrite struct {
 	// Mutates the query string of the URI.
 	Query *queryOps `json:"query,omitempty"`
 
+	// If true, the rewrite will be forced to also apply to the
+	// query part of the URL. This is only needed if the configured
+	// URI does not include a '?' character which is normally used
+	// to determine whether the query should be modified. In other
+	// words, this allows rewriting both the path and query when
+	// using a placeholder as the replacement value, whereas otherwise
+	// only the path would be rewritten because the placeholder itself
+	// does not contain a '?' character. Only use this if the placeholder
+	// is trusted to not be vulnerable to query injections.
+	ForceModifyQuery bool `json:"force_modify_query,omitempty"`
+
 	logger *zap.Logger
 }
 
@@ -222,7 +233,8 @@ func (rewr Rewrite) Rewrite(r *http.Request, repl *caddy.Replacer) bool {
 			var injectedQuery string
 			newPath, injectedQuery = before, after
 			// don't overwrite explicitly-configured query string
-			if query == "" {
+			// unless configured explicitly to do so
+			if query == "" || rewr.ForceModifyQuery {
 				// the injected query came from the first-pass placeholder
 				// expansion above, which means any '{' or '}' bytes in it
 				// must have come from replacement values (e.g. a request
@@ -233,6 +245,9 @@ func (rewr Rewrite) Rewrite(r *http.Request, repl *caddy.Replacer) bool {
 				injectedQuery = strings.ReplaceAll(injectedQuery, "{", "%7B")
 				injectedQuery = strings.ReplaceAll(injectedQuery, "}", "%7D")
 				query = injectedQuery
+			}
+			if rewr.ForceModifyQuery {
+				qsStart = 0
 			}
 		}
 

--- a/modules/caddyhttp/rewrite/rewrite_test.go
+++ b/modules/caddyhttp/rewrite/rewrite_test.go
@@ -231,6 +231,23 @@ func TestRewrite(t *testing.T) {
 			input:  newRequest(t, "GET", "/api/admin%2Fpanel"),
 			expect: newRequest(t, "GET", "/api/admin/panel"),
 		},
+		{
+			rule:   Rewrite{URI: "{test.path_and_query}"},
+			input:  newRequest(t, "GET", "/"),
+			expect: newRequest(t, "GET", "/foo"),
+		},
+		{
+			// TODO: This might be an incorrect result, since it also replaces
+			// the path with empty string when that might not be the intent.
+			rule:   Rewrite{URI: "{test.query}", ForceModifyQuery: true},
+			input:  newRequest(t, "GET", "/foo"),
+			expect: newRequest(t, "GET", "?bar=1"),
+		},
+		{
+			rule:   Rewrite{URI: "{test.path_and_query}", ForceModifyQuery: true},
+			input:  newRequest(t, "GET", "/"),
+			expect: newRequest(t, "GET", "/foo?bar=1"),
+		},
 
 		{
 			rule:   Rewrite{StripPathPrefix: "/prefix"},
@@ -397,6 +414,9 @@ func TestRewrite(t *testing.T) {
 		repl.Set("http.request.uri", tc.input.RequestURI)
 		repl.Set("http.request.uri.path", tc.input.URL.Path)
 		repl.Set("http.request.uri.query", tc.input.URL.RawQuery)
+		repl.Set("test.path", "/foo")
+		repl.Set("test.query", "?bar=1")
+		repl.Set("test.path_and_query", "/foo?bar=1")
 		for field, vals := range tc.input.Header {
 			repl.Set("http.request.header."+field, strings.Join(vals, ","))
 		}


### PR DESCRIPTION
Fix #5208

When a user wants to rewrite the URI, if they use a placeholder which might contain both the path and query, currently only the path portion of the placeholder will be used and the query is discarded.

This isn't ideal when the placeholder input comes from, for example, a response header from upstream when doing `X-Accel-Redirect` style intercepting of the response.

To work around this, we can add an option to force-enable query modifications, essentially marking the configured placeholder input as "trusted" in the sense that it's expected to contain a valid query part and not an injected `?` via URL encoding.

I'm not sure the implementation is completely correct. There's a test case I'm not quite sure how we want to handle, i.e. the placeholder only having a query and no path. Is that something we care to support? If not I can remove that `TODO` comment.