### PR TITLE
cicd: add `--yes` to cosign arguments

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,7 +75,7 @@ signs:
   - cmd: cosign
     signature: "${artifact}.sig"
     certificate: '{{ trimsuffix (trimsuffix .Env.artifact ".zip") ".tar.gz" }}.pem'
-    args: ["sign-blob", "--output-signature=${signature}", "--output-certificate", "${certificate}", "${artifact}"]
+    args: ["sign-blob", "--yes", "--output-signature=${signature}", "--output-certificate", "${certificate}", "${artifact}"]
     artifacts: all
 
 sboms:


### PR DESCRIPTION
The `sign-blob` command of `cosign` now prompts the user at runtime and may fail with this:

```
  ⨯ release failed after 1m46s               error=sign: cosign failed: exit status 1: Using payload from: dist/artifact.tar.gz
Generating ephemeral keys...
Retrieving signed certificate...
Successfully verified SCT...

	Note that there may be personally identifiable information associated with this signed artifact.
	This may include the email address associated with the account with which you authenticate.
	This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later.

By typing 'y', you attest that you grant (or have permission to grant) and agree to have this information stored permanently in transparency logs.
Are you sure you would like to continue? [y/N]
```

Adding the `--yes` to avoid our releases failing. This is the second-to-last last thing want.