### PR TITLE
log: make `sink` encodable

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -241,8 +241,9 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 		if _, ok := options["debug"]; ok {
 			customLogs = append(customLogs, namedCustomLog{
 				name: caddy.DefaultLoggerName,
-				log:  &caddy.CustomLog{Level: zap.DebugLevel.CapitalString()},
-			})
+				log: &caddy.CustomLog{
+					StandardLibLog: caddy.StandardLibLog{Level: zap.DebugLevel.CapitalString()},
+				}})
 		}
 	}
 

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -243,7 +243,8 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 				name: caddy.DefaultLoggerName,
 				log: &caddy.CustomLog{
 					BaseLog: caddy.BaseLog{Level: zap.DebugLevel.CapitalString()},
-				}})
+				},
+			})
 		}
 	}
 

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -242,7 +242,7 @@ func (st ServerType) Setup(inputServerBlocks []caddyfile.ServerBlock,
 			customLogs = append(customLogs, namedCustomLog{
 				name: caddy.DefaultLoggerName,
 				log: &caddy.CustomLog{
-					StandardLibLog: caddy.StandardLibLog{Level: zap.DebugLevel.CapitalString()},
+					BaseLog: caddy.BaseLog{Level: zap.DebugLevel.CapitalString()},
 				}})
 		}
 	}

--- a/logging.go
+++ b/logging.go
@@ -286,149 +286,26 @@ type StandardLibLog struct {
 	encoder      zapcore.Encoder
 	levelEnabler zapcore.LevelEnabler
 	core         zapcore.Core
-	logger       *zap.Logger
 }
 
-func (sll *StandardLibLog) provision(ctx Context, logging *Logging) error {
+func (cl *StandardLibLog) provisionCommon(ctx Context, logging *Logging) error {
 
-	if sll.WriterRaw != nil {
-		mod, err := ctx.LoadModule(sll, "WriterRaw")
+	if cl.WriterRaw != nil {
+		mod, err := ctx.LoadModule(cl, "WriterRaw")
 		if err != nil {
 			return fmt.Errorf("loading log writer module: %v", err)
 		}
-		sll.writerOpener = mod.(WriterOpener)
+		cl.writerOpener = mod.(WriterOpener)
 	}
-	if sll.writerOpener == nil {
-		sll.writerOpener = StderrWriter{}
+	if cl.writerOpener == nil {
+		cl.writerOpener = StderrWriter{}
 	}
 	var err error
-	sll.writer, _, err = logging.openWriter(sll.writerOpener)
+	cl.writer, _, err = logging.openWriter(cl.writerOpener)
 	if err != nil {
-		return fmt.Errorf("opening log writer using %#v: %v", sll.writerOpener, err)
+		return fmt.Errorf("opening log writer using %#v: %v", cl.writerOpener, err)
 	}
 
-	repl := NewReplacer()
-	level, err := repl.ReplaceOrErr(sll.Level, true, true)
-	if err != nil {
-		return fmt.Errorf("invalid log level: %v", err)
-	}
-	level = strings.ToLower(level)
-
-	// set up the log level
-	switch level {
-	case "debug":
-		sll.levelEnabler = zapcore.DebugLevel
-	case "", "info":
-		sll.levelEnabler = zapcore.InfoLevel
-	case "warn":
-		sll.levelEnabler = zapcore.WarnLevel
-	case "error":
-		sll.levelEnabler = zapcore.ErrorLevel
-	case "panic":
-		sll.levelEnabler = zapcore.PanicLevel
-	case "fatal":
-		sll.levelEnabler = zapcore.FatalLevel
-	default:
-		return fmt.Errorf("unrecognized log level: %s", sll.Level)
-	}
-
-	if sll.EncoderRaw != nil {
-		mod, err := ctx.LoadModule(sll, "EncoderRaw")
-		if err != nil {
-			return fmt.Errorf("loading log encoder module: %v", err)
-		}
-		sll.encoder = mod.(zapcore.Encoder)
-	}
-	if sll.encoder == nil {
-		// only allow colorized output if this log is going to stdout or stderr
-		var colorize bool
-		switch sll.writerOpener.(type) {
-		case StdoutWriter, StderrWriter,
-			*StdoutWriter, *StderrWriter:
-			colorize = true
-		}
-		sll.encoder = newDefaultProductionLogEncoder(colorize)
-	}
-	sll.buildCore()
-	sll.logger = zap.New(sll.core)
-	ctx.cleanupFuncs = append(ctx.cleanupFuncs, zap.RedirectStdLog(sll.logger))
-	return nil
-}
-
-func (sl *StandardLibLog) buildCore() {
-	// logs which only discard their output don't need
-	// to perform encoding or any other processing steps
-	// at all, so just shorcut to a nop core instead
-	if _, ok := sl.writerOpener.(*DiscardWriter); ok {
-		sl.core = zapcore.NewNopCore()
-		return
-	}
-	c := zapcore.NewCore(
-		sl.encoder,
-		zapcore.AddSync(sl.writer),
-		sl.levelEnabler,
-	)
-	if sl.Sampling != nil {
-		if sl.Sampling.Interval == 0 {
-			sl.Sampling.Interval = 1 * time.Second
-		}
-		if sl.Sampling.First == 0 {
-			sl.Sampling.First = 100
-		}
-		if sl.Sampling.Thereafter == 0 {
-			sl.Sampling.Thereafter = 100
-		}
-		c = zapcore.NewSamplerWithOptions(c, sl.Sampling.Interval,
-			sl.Sampling.First, sl.Sampling.Thereafter)
-	}
-	sl.core = c
-}
-
-// CustomLog represents a custom logger configuration.
-//
-// By default, a log will emit all log entries. Some entries
-// will be skipped if sampling is enabled. Further, the Include
-// and Exclude parameters define which loggers (by name) are
-// allowed or rejected from emitting in this log. If both Include
-// and Exclude are populated, their values must be mutually
-// exclusive, and longer namespaces have priority. If neither
-// are populated, all logs are emitted.
-type CustomLog struct {
-	// The writer defines where log entries are emitted.
-	WriterRaw json.RawMessage `json:"writer,omitempty" caddy:"namespace=caddy.logging.writers inline_key=output"`
-
-	// The encoder is how the log entries are formatted or encoded.
-	EncoderRaw json.RawMessage `json:"encoder,omitempty" caddy:"namespace=caddy.logging.encoders inline_key=format"`
-
-	// Level is the minimum level to emit, and is inclusive.
-	// Possible levels: DEBUG, INFO, WARN, ERROR, PANIC, and FATAL
-	Level string `json:"level,omitempty"`
-
-	// Sampling configures log entry sampling. If enabled,
-	// only some log entries will be emitted. This is useful
-	// for improving performance on extremely high-pressure
-	// servers.
-	Sampling *LogSampling `json:"sampling,omitempty"`
-
-	// Include defines the names of loggers to emit in this
-	// log. For example, to include only logs emitted by the
-	// admin API, you would include "admin.api".
-	Include []string `json:"include,omitempty"`
-
-	// Exclude defines the names of loggers that should be
-	// skipped by this log. For example, to exclude only
-	// HTTP access logs, you would exclude "http.log.access".
-	Exclude []string `json:"exclude,omitempty"`
-
-	writerOpener WriterOpener
-	writer       io.WriteCloser
-	encoder      zapcore.Encoder
-	levelEnabler zapcore.LevelEnabler
-	core         zapcore.Core
-}
-
-func (cl *CustomLog) provision(ctx Context, logging *Logging) error {
-	// Replace placeholder for log level
 	repl := NewReplacer()
 	level, err := repl.ReplaceOrErr(cl.Level, true, true)
 	if err != nil {
@@ -452,6 +329,92 @@ func (cl *CustomLog) provision(ctx Context, logging *Logging) error {
 		cl.levelEnabler = zapcore.FatalLevel
 	default:
 		return fmt.Errorf("unrecognized log level: %s", cl.Level)
+	}
+
+	if cl.EncoderRaw != nil {
+		mod, err := ctx.LoadModule(cl, "EncoderRaw")
+		if err != nil {
+			return fmt.Errorf("loading log encoder module: %v", err)
+		}
+		cl.encoder = mod.(zapcore.Encoder)
+	}
+	if cl.encoder == nil {
+		// only allow colorized output if this log is going to stdout or stderr
+		var colorize bool
+		switch cl.writerOpener.(type) {
+		case StdoutWriter, StderrWriter,
+			*StdoutWriter, *StderrWriter:
+			colorize = true
+		}
+		cl.encoder = newDefaultProductionLogEncoder(colorize)
+	}
+	cl.buildCore()
+	return nil
+}
+
+func (cl *StandardLibLog) buildCore() {
+	// logs which only discard their output don't need
+	// to perform encoding or any other processing steps
+	// at all, so just shorcut to a nop core instead
+	if _, ok := cl.writerOpener.(*DiscardWriter); ok {
+		cl.core = zapcore.NewNopCore()
+		return
+	}
+	c := zapcore.NewCore(
+		cl.encoder,
+		zapcore.AddSync(cl.writer),
+		cl.levelEnabler,
+	)
+	if cl.Sampling != nil {
+		if cl.Sampling.Interval == 0 {
+			cl.Sampling.Interval = 1 * time.Second
+		}
+		if cl.Sampling.First == 0 {
+			cl.Sampling.First = 100
+		}
+		if cl.Sampling.Thereafter == 0 {
+			cl.Sampling.Thereafter = 100
+		}
+		c = zapcore.NewSamplerWithOptions(c, cl.Sampling.Interval,
+			cl.Sampling.First, cl.Sampling.Thereafter)
+	}
+	cl.core = c
+}
+
+func (sll *StandardLibLog) provision(ctx Context, logging *Logging) error {
+	if err := sll.provisionCommon(ctx, logging); err != nil {
+		return err
+	}
+	ctx.cleanupFuncs = append(ctx.cleanupFuncs, zap.RedirectStdLog(zap.New(sll.core)))
+	return nil
+}
+
+// CustomLog represents a custom logger configuration.
+//
+// By default, a log will emit all log entries. Some entries
+// will be skipped if sampling is enabled. Further, the Include
+// and Exclude parameters define which loggers (by name) are
+// allowed or rejected from emitting in this log. If both Include
+// and Exclude are populated, their values must be mutually
+// exclusive, and longer namespaces have priority. If neither
+// are populated, all logs are emitted.
+type CustomLog struct {
+	StandardLibLog
+
+	// Include defines the names of loggers to emit in this
+	// log. For example, to include only logs emitted by the
+	// admin API, you would include "admin.api".
+	Include []string `json:"include,omitempty"`
+
+	// Exclude defines the names of loggers that should be
+	// skipped by this log. For example, to exclude only
+	// HTTP access logs, you would exclude "http.log.access".
+	Exclude []string `json:"exclude,omitempty"`
+}
+
+func (cl *CustomLog) provision(ctx Context, logging *Logging) error {
+	if err := cl.provisionCommon(ctx, logging); err != nil {
+		return err
 	}
 
 	// If both Include and Exclude lists are populated, then each item must
@@ -483,73 +446,7 @@ func (cl *CustomLog) provision(ctx Context, logging *Logging) error {
 			return fmt.Errorf("when both include and exclude are populated, each element must be a superspace or subspace of one in the other list; check '%s' in include", allow)
 		}
 	}
-
-	if cl.WriterRaw != nil {
-		mod, err := ctx.LoadModule(cl, "WriterRaw")
-		if err != nil {
-			return fmt.Errorf("loading log writer module: %v", err)
-		}
-		cl.writerOpener = mod.(WriterOpener)
-	}
-	if cl.writerOpener == nil {
-		cl.writerOpener = StderrWriter{}
-	}
-
-	cl.writer, _, err = logging.openWriter(cl.writerOpener)
-	if err != nil {
-		return fmt.Errorf("opening log writer using %#v: %v", cl.writerOpener, err)
-	}
-
-	if cl.EncoderRaw != nil {
-		mod, err := ctx.LoadModule(cl, "EncoderRaw")
-		if err != nil {
-			return fmt.Errorf("loading log encoder module: %v", err)
-		}
-		cl.encoder = mod.(zapcore.Encoder)
-	}
-	if cl.encoder == nil {
-		// only allow colorized output if this log is going to stdout or stderr
-		var colorize bool
-		switch cl.writerOpener.(type) {
-		case StdoutWriter, StderrWriter,
-			*StdoutWriter, *StderrWriter:
-			colorize = true
-		}
-		cl.encoder = newDefaultProductionLogEncoder(colorize)
-	}
-
-	cl.buildCore()
-
 	return nil
-}
-
-func (cl *CustomLog) buildCore() {
-	// logs which only discard their output don't need
-	// to perform encoding or any other processing steps
-	// at all, so just shorcut to a nop core instead
-	if _, ok := cl.writerOpener.(*DiscardWriter); ok {
-		cl.core = zapcore.NewNopCore()
-		return
-	}
-	c := zapcore.NewCore(
-		cl.encoder,
-		zapcore.AddSync(cl.writer),
-		cl.levelEnabler,
-	)
-	if cl.Sampling != nil {
-		if cl.Sampling.Interval == 0 {
-			cl.Sampling.Interval = 1 * time.Second
-		}
-		if cl.Sampling.First == 0 {
-			cl.Sampling.First = 100
-		}
-		if cl.Sampling.Thereafter == 0 {
-			cl.Sampling.Thereafter = 100
-		}
-		c = zapcore.NewSamplerWithOptions(c, cl.Sampling.Interval,
-			cl.Sampling.First, cl.Sampling.Thereafter)
-	}
-	cl.core = c
 }
 
 func (cl *CustomLog) matchesModule(moduleID string) bool {

--- a/logging.go
+++ b/logging.go
@@ -285,7 +285,6 @@ type BaseLog struct {
 }
 
 func (cl *BaseLog) provisionCommon(ctx Context, logging *Logging) error {
-
 	if cl.WriterRaw != nil {
 		mod, err := ctx.LoadModule(cl, "WriterRaw")
 		if err != nil {

--- a/logging.go
+++ b/logging.go
@@ -259,11 +259,7 @@ func (wdest writerDestructor) Destruct() error {
 	return wdest.Close()
 }
 
-// BaseLog configures the default Go standard library
-// global logger in the log package. This is necessary because
-// module dependencies which are not built specifically for
-// Caddy will use the standard logger. This is also known as
-// the "sink" logger.
+// BaseLog contains the common logging parameters for logging.
 type BaseLog struct {
 	// The module that writes out log entries for the sink.
 	WriterRaw json.RawMessage `json:"writer,omitempty" caddy:"namespace=caddy.logging.writers inline_key=output"`
@@ -381,6 +377,11 @@ func (cl *BaseLog) buildCore() {
 	cl.core = c
 }
 
+// SinkLog configures the default Go standard library
+// global logger in the log package. This is necessary because
+// module dependencies which are not built specifically for
+// Caddy will use the standard logger. This is also known as
+// the "sink" logger.
 type SinkLog struct {
 	BaseLog
 }

--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -134,7 +134,9 @@ func cmdFileServer(fs caddycmd.Flags) (int, error) {
 	if debug {
 		cfg.Logging = &caddy.Logging{
 			Logs: map[string]*caddy.CustomLog{
-				"default": {Level: zap.DebugLevel.CapitalString()},
+				"default": {
+					StandardLibLog: caddy.StandardLibLog{Level: zap.DebugLevel.CapitalString()},
+				},
 			},
 		}
 	}

--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -135,7 +135,7 @@ func cmdFileServer(fs caddycmd.Flags) (int, error) {
 		cfg.Logging = &caddy.Logging{
 			Logs: map[string]*caddy.CustomLog{
 				"default": {
-					StandardLibLog: caddy.StandardLibLog{Level: zap.DebugLevel.CapitalString()},
+					BaseLog: caddy.BaseLog{Level: zap.DebugLevel.CapitalString()},
 				},
 			},
 		}

--- a/modules/caddyhttp/reverseproxy/command.go
+++ b/modules/caddyhttp/reverseproxy/command.go
@@ -226,7 +226,7 @@ func cmdReverseProxy(fs caddycmd.Flags) (int, error) {
 	if debug {
 		cfg.Logging = &caddy.Logging{
 			Logs: map[string]*caddy.CustomLog{
-				"default": {Level: zap.DebugLevel.CapitalString()},
+				"default": {StandardLibLog: caddy.StandardLibLog{Level: zap.DebugLevel.CapitalString()}},
 			},
 		}
 	}

--- a/modules/caddyhttp/reverseproxy/command.go
+++ b/modules/caddyhttp/reverseproxy/command.go
@@ -226,7 +226,7 @@ func cmdReverseProxy(fs caddycmd.Flags) (int, error) {
 	if debug {
 		cfg.Logging = &caddy.Logging{
 			Logs: map[string]*caddy.CustomLog{
-				"default": {StandardLibLog: caddy.StandardLibLog{Level: zap.DebugLevel.CapitalString()}},
+				"default": {BaseLog: caddy.BaseLog{Level: zap.DebugLevel.CapitalString()}},
 			},
 		}
 	}

--- a/modules/caddyhttp/staticresp.go
+++ b/modules/caddyhttp/staticresp.go
@@ -407,7 +407,7 @@ func cmdRespond(fl caddycmd.Flags) (int, error) {
 	if debug {
 		cfg.Logging = &caddy.Logging{
 			Logs: map[string]*caddy.CustomLog{
-				"default": {Level: zap.DebugLevel.CapitalString()},
+				"default": {StandardLibLog: caddy.StandardLibLog{Level: zap.DebugLevel.CapitalString()}},
 			},
 		}
 	}

--- a/modules/caddyhttp/staticresp.go
+++ b/modules/caddyhttp/staticresp.go
@@ -407,7 +407,7 @@ func cmdRespond(fl caddycmd.Flags) (int, error) {
 	if debug {
 		cfg.Logging = &caddy.Logging{
 			Logs: map[string]*caddy.CustomLog{
-				"default": {StandardLibLog: caddy.StandardLibLog{Level: zap.DebugLevel.CapitalString()}},
+				"default": {BaseLog: caddy.BaseLog{Level: zap.DebugLevel.CapitalString()}},
 			},
 		}
 	}


### PR DESCRIPTION
`sink` logs have, thus far, been printed not encoded in any format. This does not play friendly with log parsers expecting a specific format from a particular source. In other words, it becomes a hassle to tell the log parser, e.g. Loki, Caddy logs are json-formated if some lines aren't.