### PR TITLE
replacer: Add HTTP time format

### DIFF
--- a/replacer.go
+++ b/replacer.go
@@ -16,6 +16,7 @@ package caddy
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -317,7 +318,7 @@ func globalDefaultReplacements(key string) (any, bool) {
 	case "time.now":
 		return nowFunc(), true
 	case "time.now.http":
-		return nowFunc().Format("Mon, 02 Jan 2006 15:04:05 GMT"), true
+		return nowFunc().Format(http.TimeFormat), true
 	case "time.now.common_log":
 		return nowFunc().Format("02/Jan/2006:15:04:05 -0700"), true
 	case "time.now.year":

--- a/replacer.go
+++ b/replacer.go
@@ -316,6 +316,8 @@ func globalDefaultReplacements(key string) (any, bool) {
 		return runtime.GOARCH, true
 	case "time.now":
 		return nowFunc(), true
+	case "time.now.http":
+		return nowFunc().Format("Mon, 02 Jan 2006 15:04:05 GMT"), true
 	case "time.now.common_log":
 		return nowFunc().Format("02/Jan/2006:15:04:05 -0700"), true
 	case "time.now.year":


### PR DESCRIPTION
This is the same as Go stdlib http.TimeFormat, but I didn't want to pull in a dependency to this file just for that.

Context: https://caddy.community/t/equivalent-to-nginx-date-gmt/19408, this would be helpful to fill some HTTP headers like `Last-Modified` that take this format.