### PR TITLE
reverseproxy: Add mention of which half a copyBuffer err comes from

### DIFF
--- a/modules/caddyhttp/reverseproxy/streaming.go
+++ b/modules/caddyhttp/reverseproxy/streaming.go
@@ -224,7 +224,7 @@ func (h Handler) copyBuffer(dst io.Writer, src io.Reader, buf []byte) (int64, er
 		}
 		if rerr != nil {
 			if rerr == io.EOF {
-				rerr = nil
+				return written, nil
 			}
 			return written, fmt.Errorf("reading: %v", rerr)
 		}

--- a/modules/caddyhttp/reverseproxy/streaming.go
+++ b/modules/caddyhttp/reverseproxy/streaming.go
@@ -20,6 +20,7 @@ package reverseproxy
 
 import (
 	"context"
+	"fmt"
 	"io"
 	weakrand "math/rand"
 	"mime"
@@ -215,7 +216,7 @@ func (h Handler) copyBuffer(dst io.Writer, src io.Reader, buf []byte) (int64, er
 				written += int64(nw)
 			}
 			if werr != nil {
-				return written, werr
+				return written, fmt.Errorf("writing: %v", werr)
 			}
 			if nr != nw {
 				return written, io.ErrShortWrite
@@ -225,7 +226,7 @@ func (h Handler) copyBuffer(dst io.Writer, src io.Reader, buf []byte) (int64, er
 			if rerr == io.EOF {
 				rerr = nil
 			}
-			return written, rerr
+			return written, fmt.Errorf("reading: %v", rerr)
 		}
 	}
 }

--- a/modules/caddyhttp/reverseproxy/streaming.go
+++ b/modules/caddyhttp/reverseproxy/streaming.go
@@ -216,7 +216,7 @@ func (h Handler) copyBuffer(dst io.Writer, src io.Reader, buf []byte) (int64, er
 				written += int64(nw)
 			}
 			if werr != nil {
-				return written, fmt.Errorf("writing: %v", werr)
+				return written, fmt.Errorf("writing: %w", werr)
 			}
 			if nr != nw {
 				return written, io.ErrShortWrite
@@ -226,7 +226,7 @@ func (h Handler) copyBuffer(dst io.Writer, src io.Reader, buf []byte) (int64, er
 			if rerr == io.EOF {
 				return written, nil
 			}
-			return written, fmt.Errorf("reading: %v", rerr)
+			return written, fmt.Errorf("reading: %w", rerr)
 		}
 	}
 }


### PR DESCRIPTION
Just a possible debug aid. It's not always obvious which half the error comes from.