### PR TITLE
fileserver: Add color-scheme meta tag

### DIFF
--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -94,6 +94,7 @@
 	<head>
 		<title>{{html .Name}}</title>
 		<meta charset="utf-8">
+		<meta name="color-scheme" content="light dark">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <style>
 * { padding: 0; margin: 0; box-sizing: border-box; }


### PR DESCRIPTION
Use [`<meta name="color-scheme">`](https://web.dev/color-scheme/) to mark the page compatible with both light and dark themes, and let browser adapt to the themes as well.

Before:

<img width="325" alt="image" src="https://user-images.githubusercontent.com/44045911/229339122-aeec3e61-fc05-468d-ab8d-d8f049ad76bd.png">

After:

<img width="313" alt="image" src="https://user-images.githubusercontent.com/44045911/229339144-53d1eb08-bbcf-4cea-9544-213cf0819cef.png">
