### PR TITLE
reverseproxy: Optimize the base case for `least_conn` policy

### DIFF
--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -185,7 +185,7 @@ func (LeastConnSelection) Select(pool UpstreamPool, _ *http.Request, _ http.Resp
 		// sample: https://en.wikipedia.org/wiki/Reservoir_sampling
 		if numReqs == leastReqs {
 			count++
-			if (weakrand.Int() % count) == 0 { //nolint:gosec
+			if count > 1 || (weakrand.Int()%count) == 0 { //nolint:gosec
 				bestHost = host
 			}
 		}
@@ -594,6 +594,9 @@ func leastRequests(upstreams []*Upstream) *Upstream {
 	}
 	if len(best) == 0 {
 		return nil
+	}
+	if len(best) == 1 {
+		return best[0]
 	}
 	return best[weakrand.Intn(len(best))] //nolint:gosec
 }


### PR DESCRIPTION
When only a single request has the least amount of requests, there's no need to compute a random number, because the modulo of 1 will always be 0 anyways.
