### PR TITLE
reverseproxy: Expand port ranges to multiple upstreams in CLI + Caddyfile

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_port_range.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_port_range.txt
@@ -1,0 +1,67 @@
+:8884 {
+	# Port range
+	reverse_proxy localhost:8001-8002
+
+	# Port range with placeholder
+	reverse_proxy {host}:8001-8002
+
+	# Port range with scheme
+	reverse_proxy https://localhost:8001-8002
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8884"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "reverse_proxy",
+									"upstreams": [
+										{
+											"dial": "localhost:8001"
+										},
+										{
+											"dial": "localhost:8002"
+										}
+									]
+								},
+								{
+									"handler": "reverse_proxy",
+									"upstreams": [
+										{
+											"dial": "{http.request.host}:8001"
+										},
+										{
+											"dial": "{http.request.host}:8002"
+										}
+									]
+								},
+								{
+									"handler": "reverse_proxy",
+									"transport": {
+										"protocol": "http",
+										"tls": {}
+									},
+									"upstreams": [
+										{
+											"dial": "localhost:8001"
+										},
+										{
+											"dial": "localhost:8002"
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/reverseproxy/addresses_test.go
+++ b/modules/caddyhttp/reverseproxy/addresses_test.go
@@ -150,6 +150,24 @@ func TestParseUpstreamDialAddress(t *testing.T) {
 			expectScheme:   "h2c",
 		},
 		{
+			input:          "localhost:1001-1009",
+			expectHostPort: "localhost:1001-1009",
+		},
+		{
+			input:          "{host}:1001-1009",
+			expectHostPort: "{host}:1001-1009",
+		},
+		{
+			input:          "http://localhost:1001-1009",
+			expectHostPort: "localhost:1001-1009",
+			expectScheme:   "http",
+		},
+		{
+			input:          "https://localhost:1001-1009",
+			expectHostPort: "localhost:1001-1009",
+			expectScheme:   "https",
+		},
+		{
 			input:          "unix//var/php.sock",
 			expectHostPort: "unix//var/php.sock",
 		},
@@ -194,6 +212,26 @@ func TestParseUpstreamDialAddress(t *testing.T) {
 		},
 		{
 			input:     "http://localhost#fragment",
+			expectErr: true,
+		},
+		{
+			input:     "http://localhost:8001-8002-8003",
+			expectErr: true,
+		},
+		{
+			input:     "http://localhost:8001-8002/foo:bar",
+			expectErr: true,
+		},
+		{
+			input:     "http://localhost:8001-8002/foo:1",
+			expectErr: true,
+		},
+		{
+			input:     "http://localhost:8001-8002/foo:1-2",
+			expectErr: true,
+		},
+		{
+			input:     "http://localhost:8001-8002#foo:1",
 			expectErr: true,
 		},
 		{

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -164,6 +164,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		}
 
 		if parsedAddr.StartPort == 0 && parsedAddr.EndPort == 0 {
+			// unix networks don't have ports
 			h.Upstreams = append(h.Upstreams, &Upstream{
 				Dial: dialAddr,
 			})

--- a/modules/caddyhttp/reverseproxy/command.go
+++ b/modules/caddyhttp/reverseproxy/command.go
@@ -159,6 +159,7 @@ func cmdReverseProxy(fs caddycmd.Flags) (int, error) {
 		}
 
 		if parsedAddr.StartPort == 0 && parsedAddr.EndPort == 0 {
+			// unix networks don't have ports
 			upstreamPool = append(upstreamPool, &Upstream{
 				Dial: toAddr,
 			})


### PR DESCRIPTION
See discussion in https://caddy.community/t/reverse-proxy-to-backend-over-range-of-ports/19602

This doesn't work for JSON configs because this expanding happens at config-adapt-time. See the forum thread for an explanation.