### PR TITLE
reverseproxy: Fix reinitialize upstream healthy metrics

### DIFF
--- a/modules/caddyhttp/reverseproxy/metrics.go
+++ b/modules/caddyhttp/reverseproxy/metrics.go
@@ -39,6 +39,8 @@ func newMetricsUpstreamsHealthyUpdater(handler *Handler) *metricsUpstreamsHealth
 		initReverseProxyMetrics(handler)
 	})
 
+	reverseProxyMetrics.upstreamsHealthy.Reset()
+
 	return &metricsUpstreamsHealthyUpdater{handler}
 }
 


### PR DESCRIPTION
Fixes: #5496 

We can find this `sync.Once` in `newMetricsUpstreamsHealthyUpdater` is unnecessary which is called by `reverseproxy.Provision` exactly once per `caddy run/start`. Thus it never call by `caddy reload` because it has already called in `caddy run/start` at only once.

https://github.com/caddyserver/caddy/blob/998c6e06a75030cccabcc08790bc32642791aff7/modules/caddyhttp/reverseproxy/reverseproxy.go#L419-L420

https://github.com/caddyserver/caddy/blob/998c6e06a75030cccabcc08790bc32642791aff7/modules/caddyhttp/reverseproxy/metrics.go#L38-L40

And moreover, It is necessary to reinitialize with prometheus.Unregister.

https://github.com/prometheus/client_golang/issues/475#issuecomment-428142144

Note: We can be prepared our workaround patches which seems to work fine, but it might have cover only our particular usecase. 