### PR TITLE
caddyfile: Stricter parsing, error for brace on new line

### DIFF
--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -520,6 +520,9 @@ func (p *parser) directive() error {
 			if !p.isNextOnNewLine() && p.Token().wasQuoted == 0 {
 				return p.Err("Unexpected next token after '{' on same line")
 			}
+			if p.isNewLine() {
+				return p.Err("Unexpected '{' on a new line; did you mean to place the '{' on the previous line?")
+			}
 		} else if p.Val() == "{}" {
 			if p.isNextOnNewLine() && p.Token().wasQuoted == 0 {
 				return p.Err("Unexpected '{}' at end of line")

--- a/caddyconfig/caddyfile/parse_test.go
+++ b/caddyconfig/caddyfile/parse_test.go
@@ -293,6 +293,14 @@ func TestParseOneAndImport(t *testing.T) {
 		// Unexpected next token after '{' on same line
 		{`localhost
 		  dir1 { a b }`, true, []string{"localhost"}, []int{}},
+
+		// Unexpected '{' on a new line
+		{`localhost
+		dir1
+		{
+			a b
+		}`, true, []string{"localhost"}, []int{}},
+
 		// Workaround with quotes
 		{`localhost
 		  dir1 "{" a b "}"`, false, []string{"localhost"}, []int{5}},

--- a/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
@@ -373,6 +373,7 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 
 	// the rest of the config is specified by the user
 	// using the reverse_proxy directive syntax
+	dispenser.Next() // consume the directive name
 	err = rpHandler.UnmarshalCaddyfile(dispenser)
 	if err != nil {
 		return nil, err

--- a/modules/caddyhttp/reverseproxy/forwardauth/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/forwardauth/caddyfile.go
@@ -216,6 +216,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error)
 
 	// the rest of the config is specified by the user
 	// using the reverse_proxy directive syntax
+	dispenser.Next() // consume the directive name
 	err = rpHandler.UnmarshalCaddyfile(dispenser)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Feedback from https://caddy.community/t/caddy-as-an-authentication-proxy-to-secure-endpoint/19691 made me realize we should be a bit stricter with parsing braces.

This makes this config cause an error:

```
:8001 {
    reverse_proxy https://example.com 
    {
        header_up Host {upstream_hostport}
    }
}
```

```
Error: Caddyfile.test3:3 - Error during parsing: Unexpected '{' on a new line; did you mean to place the '{' on the previous line?
```

The other changes to `reverse_proxy`/`php_fastcgi`/`forward_auth` were to fix the error `expecting 'https://' but got '://'` from that thread; essentially, the upstreams were being parsed for each iteration of the unmarshal loop with `RemainingArgs()` but that doesn't make sense. Changing the loop means both the shortcut directives would misbehave due to the dispenser cursor being in the wrong place, so they need to be advanced before calling down.