### PR TITLE
caddyhttp: Impl `ResponseWriter.Unwrap()`, prep for Go 1.20's `ResponseController`

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -66,3 +66,9 @@ func (d *delegator) WriteHeader(code int) {
 	d.status = code
 	d.ResponseWriter.WriteHeader(code)
 }
+
+// Unwrap returns the underlying ResponseWriter, necessary for
+// http.ResponseController to work correctly.
+func (d *delegator) Unwrap() http.ResponseWriter {
+	return d.ResponseWriter
+}

--- a/modules/caddyhttp/encode/encode.go
+++ b/modules/caddyhttp/encode/encode.go
@@ -299,6 +299,11 @@ func (rw *responseWriter) Close() error {
 	return err
 }
 
+// Unwrap returns the underlying ResponseWriter.
+func (rw *responseWriter) Unwrap() http.ResponseWriter {
+	return rw.HTTPInterfaces
+}
+
 // init should be called before we write a response, if rw.buf has contents.
 func (rw *responseWriter) init() {
 	if rw.Header().Get("Content-Encoding") == "" && isEncodeAllowed(rw.Header()) &&

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -636,6 +636,12 @@ func (wr statusOverrideResponseWriter) WriteHeader(int) {
 	wr.ResponseWriter.WriteHeader(wr.code)
 }
 
+// Unwrap returns the underlying ResponseWriter, necessary for
+// http.ResponseController to work correctly.
+func (wr statusOverrideResponseWriter) Unwrap() http.ResponseWriter {
+	return wr.ResponseWriter
+}
+
 // osFS is a simple fs.FS implementation that uses the local
 // file system. (We do not use os.DirFS because we do our own
 // rooting or path prefixing without being constrained to a single

--- a/modules/caddyhttp/responsewriter.go
+++ b/modules/caddyhttp/responsewriter.go
@@ -72,6 +72,11 @@ func (rww *ResponseWriterWrapper) ReadFrom(r io.Reader) (n int64, err error) {
 	return io.Copy(rww.ResponseWriter, r)
 }
 
+// Unwrap returns the underlying ResponseWriter.
+func (rww *ResponseWriterWrapper) Unwrap() http.ResponseWriter {
+	return rww.ResponseWriter
+}
+
 // HTTPInterfaces mix all the interfaces that middleware ResponseWriters need to support.
 type HTTPInterfaces interface {
 	http.ResponseWriter

--- a/modules/caddyhttp/responsewriter_test.go
+++ b/modules/caddyhttp/responsewriter_test.go
@@ -95,6 +95,14 @@ func TestResponseWriterWrapperReadFrom(t *testing.T) {
 	}
 }
 
+func TestResponseWriterWrapperUnwrap(t *testing.T) {
+	w := &ResponseWriterWrapper{&baseRespWriter{}}
+
+	if _, ok := w.Unwrap().(*baseRespWriter); !ok {
+		t.Errorf("Unwrap() doesn't return the underlying ResponseWriter")
+	}
+}
+
 func TestResponseRecorderReadFrom(t *testing.T) {
 	tests := map[string]struct {
 		responseWriter responseWriterSpy


### PR DESCRIPTION
[Go 1.20 added a new `"net/http".ResponseController` type](https://tip.golang.org/doc/go1.20#http_responsecontroller) that allows, among other things, to set per-request timeouts.

This patch adds support for this new type. This will improve the stability of Mercure, and simplify its code: https://github.com/dunglas/mercure/pull/764