### PR TITLE
fastcgi: Fix `capture_stderr`

### DIFF
--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -171,6 +171,7 @@ func (t Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 		rwc:    conn,
 		reqID:  1,
 		logger: logger,
+		stderr: t.CaptureStderr,
 	}
 
 	// read/write timeouts


### PR DESCRIPTION
Hello, first of all I love Caddy! I hope this helps.

# THE PROBLEM:
In current 83b2697, the option "capture_stderr" is not working on the directive "php_fastcgi".

# HOW TO TEST THE PROBLEM:
If you want to test it, just create a php file with syntax error of any type and pass it over php_fastcgi.

# WHEN STARTED THE PROBLEM:
The problem started in the transition between the f2a7e7c commit, and the current 83b2697.

# WHY STARTED THE PROBLEM:
On 2022 Sept 2, it was launched the commit 83b2697 which changed some files on fastcgi.go.
These changes was titled: fastcgi: Optimize FastCGI transport (#4978).
It was changed a lot of internal functions and they were replaced with a more distributed logic into separate files (which is good).
On those changes was removed a conditional that evaluates "t.CaptureStderr" (line 164, f2a7e7c, [fastcgi.go](https://github.com/caddyserver/caddy/compare/f2a7e7c966c42b3a09bc8414136af0439fd7b630...83b26975bd9330c4cfc44d52b106da739240e72b#diff-3a7a275287ccf8af168eb64afaff75c8b96a1d231569609c35f2e5db488c1c8fL164)).
This conditional set the correct logger to be passed to the client (fcgiBackend in f2a7e7c, [fastcgi.go](https://github.com/caddyserver/caddy/compare/f2a7e7c966c42b3a09bc8414136af0439fd7b630...83b26975bd9330c4cfc44d52b106da739240e72b#diff-3a7a275287ccf8af168eb64afaff75c8b96a1d231569609c35f2e5db488c1c8fL165)) instance. So the logger was always set to "noopLogger" (83b2697, [client.go](https://github.com/caddyserver/caddy/blob/master/modules/caddyhttp/reverseproxy/fastcgi/client.go#L239)) and no matters if you set capture_stderr, it was never registered into log.

# HOW TECHNICALLY OCCURRED THE PROBLEM:
Those changes on the "t.CaptureStderr" (line 164, f2a7e7c) behaviour, probably were done because it was assumed that the evaluation of "c.stderr" (line 244, 83b2697, [client.go](https://github.com/caddyserver/caddy/blob/master/modules/caddyhttp/reverseproxy/fastcgi/client.go#L244)) on client.go (another change introduced on 83b2697) would have the same behaviour, and it is right in some way.
I mean, if "c.stderr" was set, it will work as expected.

**The problem** is that nowhere it was passed the value of "t.CaptureStderr" to the client instance created (line 170, 83b2697, [fastgci.go](https://github.com/caddyserver/caddy/blob/master/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go#L170)), and so, it was never evaluated on "c.stderr" (line 244, 83b2697).

# THE SOLUTION:
I must to say that, although it has taken me quite some time to find the solution, it is actually quite simple.
For fixing it I just pass the value in the creation of the client instance, as show in this pull request.


I hope this little enhancement could help a bit to us.
If you can cite me on the next commit 🥹