### PR TITLE
Add a getter for Server.name

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -733,6 +733,9 @@ func (s *Server) protocol(proto string) bool {
 // EXPERIMENTAL: Subject to change or removal.
 func (s *Server) Listeners() []net.Listener { return s.listeners }
 
+// Name returns the server's name.
+func (s *Server) Name() string { return s.name }
+
 // PrepareRequest fills the request r for use in a Caddy HTTP handler chain. w and s can
 // be nil, but the handlers will lose response placeholders and access to the server.
 func PrepareRequest(r *http.Request, repl *caddy.Replacer, w http.ResponseWriter, s *Server) *http.Request {


### PR DESCRIPTION
Closes https://github.com/caddyserver/caddy/issues/5528

Does what it says on the tin! Given there's already a getter for `Server` I just went ahead with following that pseudo-convention rather than exporting, which also has the benefit of not having developers accidentally overwrite it in their custom middlewares.