### PR TITLE
headers: Add `>` Caddyfile shortcut for enabling `defer`

### DIFF
--- a/caddytest/integration/caddyfile_adapt/header.txt
+++ b/caddytest/integration/caddyfile_adapt/header.txt
@@ -17,6 +17,7 @@
 		+Link "Foo"
 		+Link "Bar"
 	}
+	header >Set Defer
 }
 ----------
 {
@@ -133,6 +134,17 @@
 											"Link": [
 												"Foo",
 												"Bar"
+											]
+										}
+									}
+								},
+								{
+									"handler": "headers",
+									"response": {
+										"deferred": true,
+										"set": {
+											"Set": [
+												"Defer"
 											]
 										}
 									}


### PR DESCRIPTION
Something that I've thought about a few times, I find the syntax awkward for setting a response header operation to be deferred since it requires opening a block to enable `defer` in simple cases.

So my solution is to add another prefix similarly to our existing ones, `>` meaning "set with defer", think an arrow meaning "later".

Before:
```
header {
	Field value
	defer
}
```

After:
```
header >Field value
```