### PR TITLE
Fix file browser footer while in grid mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Caddyfile.*
 # build artifacts and helpers
 cmd/caddy/caddy
 cmd/caddy/caddy.exe
+cmd/caddy/tmp/*.exe
 
 # mac specific
 .DS_Store

--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -104,6 +104,7 @@ body {
 	font-size: 16px;
 	text-rendering: optimizespeed;
 	background-color: #f3f6f7;
+	min-height: 100vh;
 }
 
 img,
@@ -424,6 +425,8 @@ footer {
 	padding: 40px 20px;
 	font-size: 12px;
 	text-align: center;
+	position: sticky;
+	top: 100vh;
 }
 
 .caddy-logo {

--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -425,8 +425,6 @@ footer {
 	padding: 40px 20px;
 	font-size: 12px;
 	text-align: center;
-	position: sticky;
-	top: 100vh;
 }
 
 .caddy-logo {


### PR DESCRIPTION
I looked at the new file browser template and found it to be pretty good looking. Nice job! I tried it locally and found that the footer looked something like this: 
![Screenshot 2023-05-16 at 19-38-12 samsungsd](https://github.com/caddyserver/caddy/assets/57069715/1c691ed7-3ee4-4e8e-bae7-def225a9e891)
The black space after the footer looks kinda awkward, so I decided to fix it. With this PR, it looks like this: 
![Screenshot 2023-05-16 at 19-38-43 samsungsd](https://github.com/caddyserver/caddy/assets/57069715/5cb8873d-3573-41a4-9933-1d1081f1dd07)