### PR TITLE
Do not replace import tokens if they are part of a snippet

### DIFF
--- a/caddyconfig/caddyfile/importargs.go
+++ b/caddyconfig/caddyfile/importargs.go
@@ -87,14 +87,8 @@ func parseVariadic(token Token, argCount int) (bool, int, int) {
 
 // makeArgsReplacer prepares a Replacer which can replace
 // non-variadic args placeholders in imported tokens.
-func makeArgsReplacer(args []string, tokens []Token) *caddy.Replacer {
+func makeArgsReplacer(args []string) *caddy.Replacer {
 	repl := caddy.NewEmptyReplacer()
-	// record text and corresponding snippet name to not output warning during imports
-	// which import other snippets.
-	textToSnippetMap := make(map[string]string, len(tokens))
-	for _, token := range tokens {
-		textToSnippetMap[token.Text] = token.snippetName
-	}
 	repl.Map(func(key string) (any, bool) {
 		// TODO: Remove the deprecated {args.*} placeholder
 		// support at some point in the future
@@ -103,9 +97,6 @@ func makeArgsReplacer(args []string, tokens []Token) *caddy.Replacer {
 			if err != nil {
 				caddy.Log().Named("caddyfile").Warn(
 					"Placeholder {args." + matches[1] + "} has an invalid index")
-				return nil, false
-			}
-			if textToSnippetMap[key] == "" {
 				return nil, false
 			}
 			if value >= len(args) {
@@ -121,19 +112,14 @@ func makeArgsReplacer(args []string, tokens []Token) *caddy.Replacer {
 		// Handle args[*] form
 		if matches := argsRegexpIndex.FindStringSubmatch(key); len(matches) > 0 {
 			if strings.Contains(matches[1], ":") {
-				if textToSnippetMap[key] != "" {
-					caddy.Log().Named("caddyfile").Warn(
-						"Variadic placeholder {args[" + matches[1] + "]} must be a token on its own")
-				}
+				caddy.Log().Named("caddyfile").Warn(
+					"Variadic placeholder {args[" + matches[1] + "]} must be a token on its own")
 				return nil, false
 			}
 			value, err := strconv.Atoi(matches[1])
 			if err != nil {
 				caddy.Log().Named("caddyfile").Warn(
 					"Placeholder {args[" + matches[1] + "]} has an invalid index")
-				return nil, false
-			}
-			if textToSnippetMap[key] == "" {
 				return nil, false
 			}
 			if value >= len(args) {

--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -214,7 +214,7 @@ func (p *parser) addresses() error {
 
 		// special case: import directive replaces tokens during parse-time
 		if tkn == "import" && p.isNewLine() {
-			err := p.doImport()
+			err := p.doImport(0)
 			if err != nil {
 				return err
 			}
@@ -314,7 +314,7 @@ func (p *parser) directives() error {
 
 		// special case: import directive replaces tokens during parse-time
 		if p.Val() == "import" {
-			err := p.doImport()
+			err := p.doImport(1)
 			if err != nil {
 				return err
 			}
@@ -340,7 +340,7 @@ func (p *parser) directives() error {
 // is on the token before where the import directive was. In
 // other words, call Next() to access the first token that was
 // imported.
-func (p *parser) doImport() error {
+func (p *parser) doImport(nesting int) error {
 	// syntax checks
 	if !p.NextArg() {
 		return p.ArgErr()
@@ -443,10 +443,16 @@ func (p *parser) doImport() error {
 	// copy the tokens so we don't overwrite p.definedSnippets
 	tokensCopy := make([]Token, 0, len(importedTokens))
 
+	var (
+		maybeSnippet   bool
+		maybeSnippetId bool
+		index          int
+	)
+
 	// run the argument replacer on the tokens
 	// golang for range slice return a copy of value
 	// similarly, append also copy value
-	for _, token := range importedTokens {
+	for i, token := range importedTokens {
 		// set the token's file to refer to import directive line number and snippet name
 		if token.snippetName != "" {
 			token.updateFile(fmt.Sprintf("%s:%d (import %s)", token.File, p.Line(), token.snippetName))
@@ -454,10 +460,36 @@ func (p *parser) doImport() error {
 			token.updateFile(fmt.Sprintf("%s:%d (import)", token.File, p.Line()))
 		}
 
-		// if snippet is in an imported file, snippetName is not set in the first pass.
-		// The token should be treated as is.
-		if token.snippetName == "" {
-			token.Text = repl.ReplaceKnown(token.Text, "")
+		// naive way of determine snippets, as snippets definition can only follow name + block
+		// format, won't check for nesting correctness or any other error, that's what parser does.
+		if !maybeSnippet && nesting == 0 {
+			// first of the line
+			if i == 0 || importedTokens[i-1].originalFile() != token.originalFile() || importedTokens[i-1].Line+importedTokens[i-1].NumLineBreaks() < token.Line {
+				index = 0
+			} else {
+				index++
+			}
+
+			if index == 0 && len(token.Text) >= 3 && strings.HasPrefix(token.Text, "(") && strings.HasSuffix(token.Text, ")") {
+				maybeSnippetId = true
+			}
+		}
+
+		switch token.Text {
+		case "{":
+			nesting++
+			if index == 1 && maybeSnippetId && nesting == 1 {
+				maybeSnippet = true
+				maybeSnippetId = false
+			}
+		case "}":
+			nesting--
+			if nesting == 0 && maybeSnippet {
+				maybeSnippet = false
+			}
+		}
+
+		if maybeSnippet {
 			tokensCopy = append(tokensCopy, token)
 			continue
 		}
@@ -561,7 +593,7 @@ func (p *parser) directive() error {
 		} else if p.Val() == "}" && p.nesting == 0 {
 			return p.Err("Unexpected '}' because no matching opening brace")
 		} else if p.Val() == "import" && p.isNewLine() {
-			if err := p.doImport(); err != nil {
+			if err := p.doImport(1); err != nil {
 				return err
 			}
 			p.cursor-- // cursor is advanced when we continue, so roll back one more

--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -353,6 +353,9 @@ func (p *parser) doImport() error {
 	// grab remaining args as placeholder replacements
 	args := p.RemainingArgs()
 
+	// set up a replacer for non-variadic args replacement
+	repl := makeArgsReplacer(args)
+
 	// splice out the import directive and its arguments
 	// (2 tokens, plus the length of args)
 	tokensBefore := p.tokens[:p.cursor-1-len(args)]
@@ -439,9 +442,6 @@ func (p *parser) doImport() error {
 
 	// copy the tokens so we don't overwrite p.definedSnippets
 	tokensCopy := make([]Token, 0, len(importedTokens))
-
-	// set up a replacer for non-variadic args replacement
-	repl := makeArgsReplacer(args, importedTokens)
 
 	// run the argument replacer on the tokens
 	// golang for range slice return a copy of value

--- a/caddyconfig/httpcaddyfile/builtins_test.go
+++ b/caddyconfig/httpcaddyfile/builtins_test.go
@@ -243,6 +243,27 @@ func TestImportErrorLine(t *testing.T) {
 				return err != nil && strings.Contains(err.Error(), "Caddyfile:5 (import t1):2")
 			},
 		},
+		{
+			input: `
+				import testdata/import_variadic_snippet.txt
+				:8080 {
+					import t1 true
+				}`,
+			errorFunc: func(err error) bool {
+				return err == nil
+			},
+		},
+		{
+			input: `
+				import testdata/import_variadic_with_import.txt
+				:8080 {
+					import t1 true
+					import t2 true
+				}`,
+			errorFunc: func(err error) bool {
+				return err == nil
+			},
+		},
 	} {
 		adapter := caddyfile.Adapter{
 			ServerType: ServerType{},

--- a/caddyconfig/httpcaddyfile/testdata/import_variadic.txt
+++ b/caddyconfig/httpcaddyfile/testdata/import_variadic.txt
@@ -1,0 +1,9 @@
+(t2) {
+    respond 200 {
+        body {args[:]}
+    }
+}
+
+:8082 {
+    import t2 false
+}

--- a/caddyconfig/httpcaddyfile/testdata/import_variadic_snippet.txt
+++ b/caddyconfig/httpcaddyfile/testdata/import_variadic_snippet.txt
@@ -1,0 +1,9 @@
+(t1) {
+    respond 200 {
+        body {args[:]}
+    }
+}
+
+:8081 {
+    import t1 false
+}

--- a/caddyconfig/httpcaddyfile/testdata/import_variadic_with_import.txt
+++ b/caddyconfig/httpcaddyfile/testdata/import_variadic_with_import.txt
@@ -1,0 +1,15 @@
+(t1) {
+    respond 200 {
+        body {args[:]}
+    }
+}
+
+:8081 {
+    import t1 false
+}
+
+import import_variadic.txt
+
+:8083 {
+    import t2 true
+}


### PR DESCRIPTION
~~As discussed in slack, if an imported file also has a snippet with variadic placeholders and imports this snippet, parsing will fail saying not enough arguments.~~

~~Added tests show what the problem is.~~

When importing, caddy will always replace tokens placeholders. However, when importing a file that contains snippets definition, caddy will replace **them**. For `{args[n]}` type token, they will either be replaced or dropped, which is undesirable since they are part of a snippet.

Implement a naive algorithm to skip replacing tokens if they are part of a snippet. It **does not** check for syntax error, that will be done later when caddy finished importing all the tokens.