### PR TITLE
config: keep track of import instead of modifying file name

### DIFF
--- a/caddyconfig/caddyfile/dispenser.go
+++ b/caddyconfig/caddyfile/dispenser.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"log"
 	"strconv"
+	"strings"
 )
 
 // Dispenser is a type that dispenses tokens, similarly to a lexer,
@@ -398,7 +399,7 @@ func (d *Dispenser) ArgErr() error {
 // SyntaxErr creates a generic syntax error which explains what was
 // found and what was expected.
 func (d *Dispenser) SyntaxErr(expected string) error {
-	msg := fmt.Sprintf("%s:%d - Syntax error: Unexpected token '%s', expecting '%s'", d.File(), d.Line(), d.Val(), expected)
+	msg := fmt.Sprintf("%s:%d - Syntax error: Unexpected token '%s', expecting '%s', import chain: ['%s']", d.File(), d.Line(), d.Val(), expected, strings.Join(d.Token().imports, "','"))
 	return errors.New(msg)
 }
 
@@ -420,7 +421,7 @@ func (d *Dispenser) Errf(format string, args ...any) error {
 
 // WrapErr takes an existing error and adds the Caddyfile file and line number.
 func (d *Dispenser) WrapErr(err error) error {
-	return fmt.Errorf("%s:%d - Error during parsing: %w", d.File(), d.Line(), err)
+	return fmt.Errorf("%s:%d - Error during parsing: %w, import chain: ['%s']", d.File(), d.Line(), err, strings.Join(d.Token().imports, "','"))
 }
 
 // Delete deletes the current token and returns the updated slice

--- a/caddyconfig/caddyfile/importargs.go
+++ b/caddyconfig/caddyfile/importargs.go
@@ -39,7 +39,7 @@ func parseVariadic(token Token, argCount int) (bool, int, int) {
 	if argRange == "" {
 		caddy.Log().Named("caddyfile").Warn(
 			"Placeholder "+token.Text+" cannot have an empty index",
-			zap.String("file", token.File+":"+strconv.Itoa(token.Line)))
+			zap.String("file", token.File+":"+strconv.Itoa(token.Line)), zap.Strings("import chain", token.imports))
 		return false, 0, 0
 	}
 
@@ -61,7 +61,7 @@ func parseVariadic(token Token, argCount int) (bool, int, int) {
 		if err != nil {
 			caddy.Log().Named("caddyfile").Warn(
 				"Variadic placeholder "+token.Text+" has an invalid start index",
-				zap.String("file", token.File+":"+strconv.Itoa(token.Line)))
+				zap.String("file", token.File+":"+strconv.Itoa(token.Line)), zap.Strings("import chain", token.imports))
 			return false, 0, 0
 		}
 	}
@@ -70,7 +70,7 @@ func parseVariadic(token Token, argCount int) (bool, int, int) {
 		if err != nil {
 			caddy.Log().Named("caddyfile").Warn(
 				"Variadic placeholder "+token.Text+" has an invalid end index",
-				zap.String("file", token.File+":"+strconv.Itoa(token.Line)))
+				zap.String("file", token.File+":"+strconv.Itoa(token.Line)), zap.Strings("import chain", token.imports))
 			return false, 0, 0
 		}
 	}
@@ -79,7 +79,7 @@ func parseVariadic(token Token, argCount int) (bool, int, int) {
 	if startIndex < 0 || startIndex > endIndex || endIndex > argCount {
 		caddy.Log().Named("caddyfile").Warn(
 			"Variadic placeholder "+token.Text+" indices are out of bounds, only "+strconv.Itoa(argCount)+" argument(s) exist",
-			zap.String("file", token.File+":"+strconv.Itoa(token.Line)))
+			zap.String("file", token.File+":"+strconv.Itoa(token.Line)), zap.Strings("import chain", token.imports))
 		return false, 0, 0
 	}
 	return true, startIndex, endIndex

--- a/caddyconfig/caddyfile/importargs.go
+++ b/caddyconfig/caddyfile/importargs.go
@@ -39,7 +39,7 @@ func parseVariadic(token Token, argCount int) (bool, int, int) {
 	if argRange == "" {
 		caddy.Log().Named("caddyfile").Warn(
 			"Placeholder "+token.Text+" cannot have an empty index",
-			zap.String("file", token.File+":"+strconv.Itoa(token.Line)), zap.Strings("import chain", token.imports))
+			zap.String("file", token.File+":"+strconv.Itoa(token.Line)), zap.Strings("import_chain", token.imports))
 		return false, 0, 0
 	}
 
@@ -61,7 +61,7 @@ func parseVariadic(token Token, argCount int) (bool, int, int) {
 		if err != nil {
 			caddy.Log().Named("caddyfile").Warn(
 				"Variadic placeholder "+token.Text+" has an invalid start index",
-				zap.String("file", token.File+":"+strconv.Itoa(token.Line)), zap.Strings("import chain", token.imports))
+				zap.String("file", token.File+":"+strconv.Itoa(token.Line)), zap.Strings("import_chain", token.imports))
 			return false, 0, 0
 		}
 	}
@@ -70,7 +70,7 @@ func parseVariadic(token Token, argCount int) (bool, int, int) {
 		if err != nil {
 			caddy.Log().Named("caddyfile").Warn(
 				"Variadic placeholder "+token.Text+" has an invalid end index",
-				zap.String("file", token.File+":"+strconv.Itoa(token.Line)), zap.Strings("import chain", token.imports))
+				zap.String("file", token.File+":"+strconv.Itoa(token.Line)), zap.Strings("import_chain", token.imports))
 			return false, 0, 0
 		}
 	}
@@ -79,7 +79,7 @@ func parseVariadic(token Token, argCount int) (bool, int, int) {
 	if startIndex < 0 || startIndex > endIndex || endIndex > argCount {
 		caddy.Log().Named("caddyfile").Warn(
 			"Variadic placeholder "+token.Text+" indices are out of bounds, only "+strconv.Itoa(argCount)+" argument(s) exist",
-			zap.String("file", token.File+":"+strconv.Itoa(token.Line)), zap.Strings("import chain", token.imports))
+			zap.String("file", token.File+":"+strconv.Itoa(token.Line)), zap.Strings("import_chain", token.imports))
 		return false, 0, 0
 	}
 	return true, startIndex, endIndex

--- a/caddyconfig/caddyfile/lexer.go
+++ b/caddyconfig/caddyfile/lexer.go
@@ -39,7 +39,7 @@ type (
 	// Token represents a single parsable unit.
 	Token struct {
 		File          string
-		origFile      string
+		imports       []string
 		Line          int
 		Text          string
 		wasQuoted     rune // enclosing quote character, if any
@@ -319,23 +319,6 @@ func (l *lexer) finalizeHeredoc(val []rune, marker string) ([]rune, error) {
 
 	// return the final value
 	return []rune(out), nil
-}
-
-// originalFile gets original filename before import modification.
-func (t Token) originalFile() string {
-	if t.origFile != "" {
-		return t.origFile
-	}
-	return t.File
-}
-
-// updateFile updates the token's source filename for error display
-// and remembers the original filename. Used during "import" processing.
-func (t *Token) updateFile(file string) {
-	if t.origFile == "" {
-		t.origFile = t.File
-	}
-	t.File = file
 }
 
 func (t Token) Quoted() bool {

--- a/caddyconfig/httpcaddyfile/builtins_test.go
+++ b/caddyconfig/httpcaddyfile/builtins_test.go
@@ -229,7 +229,7 @@ func TestImportErrorLine(t *testing.T) {
 					import t1 true
 				}`,
 			errorFunc: func(err error) bool {
-				return err != nil && strings.Contains(err.Error(), "Caddyfile:6 (import t1):2")
+				return err != nil && strings.Contains(err.Error(), "Caddyfile:6 (import t1)")
 			},
 		},
 		{
@@ -240,7 +240,7 @@ func TestImportErrorLine(t *testing.T) {
 					import t1 true
 				}`,
 			errorFunc: func(err error) bool {
-				return err != nil && strings.Contains(err.Error(), "Caddyfile:5 (import t1):2")
+				return err != nil && strings.Contains(err.Error(), "Caddyfile:5 (import t1)")
 			},
 		},
 		{


### PR DESCRIPTION
Previously when implementing variadic placeholders, caddy config token's `File` will be modified to reflect their import chain to help debug config error. One side effect is the [extra colon](https://github.com/caddyserver/caddy/issues/5538#issuecomment-1551609453) for imported files in file_server.

This patch uses a separate field to track import chain, and still keeps the error output the same.