### PR TITLE
Fix file browser breadcrumb font

### DIFF
--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -364,7 +364,7 @@ header {
 
 h1 {
 	font-size: 20px;
-	font-family: Poppins;
+	font-family: Poppins, system-ui, sans-serif;
 	font-weight: normal;
 	white-space: nowrap;
 	overflow-x: hidden;


### PR DESCRIPTION
This PR aims to fix the font in the file browser's breadcrumb. It loads the Poppins font, but my system doesn't have that, so therefore I get Times New Roman, which is an alright font (if you're a teacher), but it looks very out of place here. I took the same approach as the body (load system-ui font as an alternative) which fits more. 

![image](https://github.com/caddyserver/caddy/assets/57069715/c26684f1-fc82-417a-ad38-41e71e1adbef)
![image](https://github.com/caddyserver/caddy/assets/57069715/6e466972-7675-4db6-bc22-4aae843df5f4)
