### PR TITLE
Make grid entires take up full width on mobile view and fix breadcrumb colors in dark mode mobile view (fileserver)

### DIFF
--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -652,6 +652,10 @@ footer {
 		color: white;
 	}
 
+	h1 {
+		color: white;
+	}
+
 	h1 a:hover {
 		background: hsl(213deg 100% 73% / 20%);
 	}
@@ -720,11 +724,6 @@ footer {
 	}
 }
 
-@media (prefers-color-scheme: dark) and (max-width: 600px) {
-	h1 {
-		color: #fff;
-	}
-}
 </style>
 {{- if eq .Layout "grid"}}
 <style>.wrapper { max-width: none; } main { margin-top: 1px; }</style>

--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -621,7 +621,12 @@ footer {
 	#filter {
 		max-width: 100px;
 	}
+
+	.grid .entry {
+		max-width: initial;
+	}
 }
+
 
 @media (prefers-color-scheme: dark) {
 	html {
@@ -714,15 +719,21 @@ footer {
 		stroke: #ccc !important;
 	}
 }
+
+@media (prefers-color-scheme: dark) and (max-width: 600px) {
+	h1 {
+		color: #fff;
+	}
+}
 </style>
 {{- if eq .Layout "grid"}}
 <style>.wrapper { max-width: none; } main { margin-top: 1px; }</style>
 {{- end}}
-	</head>
-	<body onload="initPage()">
-		<header>
-			<div class="wrapper">
-				<div class="breadcrumbs">Folder Path</div>
+</head>
+<body onload="initPage()">
+	<header>
+		<div class="wrapper">
+			<div class="breadcrumbs">Folder Path</div>
 				<h1>
 					{{range $i, $crumb := .Breadcrumbs}}<a href="{{html $crumb.Link}}">{{html $crumb.Text}}</a>{{if ne $i 0}}/{{end}}{{end}}
 				</h1>


### PR DESCRIPTION
Title explains this PR. Here's how the grid view looks like on mobile with this PR: 
![image](https://github.com/caddyserver/caddy/assets/57069715/1419612a-79c8-4b6f-a344-1b3046bf29b2)

Here's how it looks like without these changes: 
![image](https://github.com/caddyserver/caddy/assets/57069715/5a86ab61-e1a3-4863-9166-082f2f8737d2)

I don't know if the grid entry width thing is something you guys want (personally I think it looks better), but the breadcrumbs should not be black on mobile at least. 