### PR TITLE
listen_unix.go: Use consts to set SO_REUSEPORT_LB on FreeBSD

### DIFF
--- a/listen_unix.go
+++ b/listen_unix.go
@@ -119,7 +119,7 @@ func reusePort(network, address string, conn syscall.RawConn) error {
 		return nil
 	}
 	return conn.Control(func(descriptor uintptr) {
-		if err := unix.SetsockoptInt(int(descriptor), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
+		if err := unix.SetsockoptInt(int(descriptor), unix.SOL_SOCKET, unixSOREUSEPORT, 1); err != nil {
 			Log().Error("setting SO_REUSEPORT",
 				zap.String("network", network),
 				zap.String("address", address),

--- a/listen_unix_setopt.go
+++ b/listen_unix_setopt.go
@@ -1,0 +1,7 @@
+//go:build unix && !freebsd
+
+package caddy
+
+import "golang.org/x/sys/unix"
+
+const unixSOREUSEPORT = unix.SO_REUSEPORT

--- a/listen_unix_setopt_freebsd.go
+++ b/listen_unix_setopt_freebsd.go
@@ -1,0 +1,7 @@
+//go:build freebsd
+
+package caddy
+
+import "golang.org/x/sys/unix"
+
+const unixSOREUSEPORT = unix.SO_REUSEPORT_LB


### PR DESCRIPTION
This option is preferable on FreeBSD as it uses a hash to balance load between threads.