### PR TITLE
feat: better implementation of grid layout

### DIFF
--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -547,17 +547,15 @@ td .go-up {
 }
 
 .grid {
-	display: flex;
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(16em, 1fr));
+	justify-items: center;
 	gap: 2px;
-	flex-wrap: wrap;
 }
 
 .grid .entry {
 	position: relative;
-	width: 20%;
-	min-width: 250px;
-	max-width: 400px;
-	flex: 1;
+	width: 100%;
 }
 
 .grid .entry a {


### PR DESCRIPTION
The current "browse" listings grid layout is encountering a display problem where the last line of displayed files tends to occupy the entire line, leading to incorrect alignment. I have attempted to address this issue using grid layout, the effects of which can be seen in the second record. Each file is now better aligned and displays more appropriately across various screen aspect ratios.Thank you for your consideration.

Current (With flex layout)
https://github.com/caddyserver/caddy/assets/74791570/4744ba80-dcbf-4a42-9ec1-5f992b8c58c6

Updated (With grid layout)
https://github.com/caddyserver/caddy/assets/74791570/c638841c-be69-40cf-9f76-2b7f0a818d89

