### PR TITLE
feat: better implementation of grid layout

### DIFF
--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -550,6 +550,7 @@ td .go-up {
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(16em, 1fr));
 	justify-items: center;
+	align-items: start;
 	gap: 2px;
 }
 

--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -547,17 +547,15 @@ td .go-up {
 }
 
 .grid {
-	display: flex;
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(16em, 1fr));
+	justify-items: center;
 	gap: 2px;
-	flex-wrap: wrap;
 }
 
 .grid .entry {
 	position: relative;
-	width: 20%;
-	min-width: 250px;
-	max-width: 400px;
-	flex: 1;
+	width: 100%;
 }
 
 .grid .entry a {


### PR DESCRIPTION
The current "browse" listings grid layout is encountering a display problem where the last line of displayed files tends to occupy the entire line, leading to incorrect alignment. I have attempted to address this issue using grid layout, the effects of which can be seen in the record 2. Each file is now better aligned and displays more appropriately across various screen aspect ratios.Thank you for your consideration.

## Current (With flex layout)
<img width="1679" alt="Capture d’écran, le 2023-06-04 à 17 55 21" src="https://github.com/caddyserver/caddy/assets/74791570/479ba9dc-85be-4ca0-ac74-e91312a1fdec">

Record 1:
[https://github.com/caddyserver/caddy/assets/74791570/4744ba80-dcbf-4a42-9ec1-5f992b8c58c6](https://github.com/caddyserver/caddy/assets/74791570/4744ba80-dcbf-4a42-9ec1-5f992b8c58c6)

## Updated (With grid layout)
<img width="1680" alt="Capture d’écran, le 2023-06-04 à 17 55 10" src="https://github.com/caddyserver/caddy/assets/74791570/03e75146-2233-4f1c-8727-d97be4ee0ab6">

Record 2:

https://github.com/caddyserver/caddy/assets/74791570/c87e6426-3270-4454-8321-fda00abc9d4a

