### PR TITLE
reverseproxy: streaming timeouts

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -212,7 +212,7 @@ type Handler struct {
 
 	// Stores upgraded requests (hijacked connections) for proper cleanup
 	connections           map[io.ReadWriteCloser]openConnection
-	connectionsCloseTimer **time.Timer
+	connectionsCloseTimer *time.Timer
 	connectionsMu         *sync.Mutex
 
 	ctx    caddy.Context
@@ -239,8 +239,6 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 	h.logger = ctx.Logger()
 	h.connections = make(map[io.ReadWriteCloser]openConnection)
 	h.connectionsMu = new(sync.Mutex)
-	h.connectionsCloseTimer = new(*time.Timer)
-	*h.connectionsCloseTimer = nil
 
 	// TODO: remove deprecated fields sometime after v2.6.4
 	if h.DeprecatedBufferRequests {
@@ -909,7 +907,7 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, origRe
 }
 
 // finalizeResponse prepares and copies the response.
-func (h Handler) finalizeResponse(
+func (h *Handler) finalizeResponse(
 	rw http.ResponseWriter,
 	req *http.Request,
 	res *http.Response,

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -902,7 +902,7 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, origRe
 		repl.Set("http.reverse_proxy.status_code", res.StatusCode)
 		repl.Set("http.reverse_proxy.status_text", res.Status)
 
-		h.logger.Debug("handling response", zap.Int("handler", i))
+		logger.Debug("handling response", zap.Int("handler", i))
 
 		// we make some data available via request context to child routes
 		// so that they may inherit some options and functions from the
@@ -997,7 +997,7 @@ func (h Handler) finalizeResponse(
 		// there's nothing an error handler can do to recover at this point;
 		// the standard lib's proxy panics at this point, but we'll just log
 		// the error and abort the stream here
-		h.logger.Error("aborting with incomplete response", zap.Error(err))
+		logger.Error("aborting with incomplete response", zap.Error(err))
 		return nil
 	}
 


### PR DESCRIPTION
This PR adds two settings related to streaming connections to the reverse_proxy handler:

`stream_timeout` defines the maximum lifetime of a streaming connection in the reverse proxy; when the connection reaches this age it is closed
`stream_close_delay` defines the time for which the proxy waits before closing the streaming connections when it is cleaned up i.e. after a configuration change

#5471