### PR TITLE
Fixes parsing of source IP in case it's an ipv6 address

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -637,7 +637,13 @@ func (h Handler) prepareRequest(req *http.Request, repl *caddy.Replacer) (*http.
 	addrPort, err := netip.ParseAddrPort(address)
 	if err != nil {
 		// OK; probably didn't have a port
-		addrPort, _ = netip.ParseAddrPort(address + ":0")
+		addr, err := netip.ParseAddr(address)
+		if err != nil {
+			// Doesn't seem like a valid ip address at all
+		} else {
+			// Ok, only the port was missing
+			addrPort = netip.AddrPortFrom(addr, 0)
+		}
 	}
 	proxyProtocolInfo := ProxyProtocolInfo{AddrPort: addrPort}
 	caddyhttp.SetVar(req.Context(), proxyProtocolInfoVarKey, proxyProtocolInfo)


### PR DESCRIPTION
While testing with v2.7.0-beta.1: parsing of the source IP for the proxy protocol (introduced with #5424) fails with "ERROR   http.log.error  unexpected remote addr type in proxy protocol info" for IPv6 requests. The problem is how the dummy port was appended to the original source string "::1" + "0" -> "::1:0" which is not a proper IPv6 address.