### PR TITLE
headers: Allow `>` defer shortcut for replacements

### DIFF
--- a/caddytest/integration/caddyfile_adapt/header.txt
+++ b/caddytest/integration/caddyfile_adapt/header.txt
@@ -18,6 +18,7 @@
 		+Link "Bar"
 	}
 	header >Set Defer
+	header >Replace Deferred Replacement
 }
 ----------
 {
@@ -145,6 +146,20 @@
 										"set": {
 											"Set": [
 												"Defer"
+											]
+										}
+									}
+								},
+								{
+									"handler": "headers",
+									"response": {
+										"deferred": true,
+										"replace": {
+											"Replace": [
+												{
+													"replace": "Replacement",
+													"search_regexp": "Deferred"
+												}
 											]
 										}
 									}

--- a/modules/caddyhttp/headers/caddyfile.go
+++ b/modules/caddyhttp/headers/caddyfile.go
@@ -247,10 +247,14 @@ func applyHeaderOp(ops *HeaderOps, respHeaderOps *RespHeaderOps, field, value, r
 		respHeaderOps.Set.Set(field, value)
 
 	case replacement != "": // replace
+		// allow defer shortcut for replace syntax
+		if strings.HasPrefix(field, ">") && respHeaderOps != nil {
+			respHeaderOps.Deferred = true
+		}
 		if ops.Replace == nil {
 			ops.Replace = make(map[string][]Replacement)
 		}
-		field = strings.TrimLeft(field, "+-?")
+		field = strings.TrimLeft(field, "+-?>")
 		ops.Replace[field] = append(
 			ops.Replace[field],
 			Replacement{


### PR DESCRIPTION
Tiny followup to #5535 to make `>` work as a prefix for replacements (i.e. 2 args following the header field).

For example:

```
header >Set-Cookie (.*) "$1; SameSite=None;"
```

Defer is usually necessary for replacements, so it should be as easy as possible to set up.