### PR TITLE
chore: remove deprecated property `rlcp` in goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -110,7 +110,6 @@ archives:
   # allowing users to build the exact same set of files as ours.
   - id: source
     meta: true
-    rlcp: true
     name_template: "{{ .ProjectName }}_{{ .Version }}_buildable-artifact"
     files:
       - src: LICENSE
@@ -126,14 +125,6 @@ source:
   enabled: true
   name_template: '{{ .ProjectName }}_{{ .Version }}_src'
   format: 'tar.gz'
-
-  # This will make the destination paths be relative to the longest common
-  # path prefix between all the files matched and the source glob.
-  # Enabling this essentially mimic the behavior of nfpm's contents section.
-  # It will be the default by June 2023.
-  #
-  # Default: false
-  rlcp: true
 
   # Additional files/template/globs you want to add to the source archive.
   #


### PR DESCRIPTION
Fixes GH Actions failure reported in https://github.com/caddyserver/caddy/actions/runs/5420166639/jobs/9866067348.

The [goreleaser deprecation notice](https://goreleaser.com/deprecations/#sourcerlcp) recommends removal.