### PR TITLE
reverseproxy: LeastConnSelection policy bug

### DIFF
--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -272,7 +272,7 @@ func (LeastConnSelection) Select(pool UpstreamPool, _ *http.Request, _ http.Resp
 		// sample: https://en.wikipedia.org/wiki/Reservoir_sampling
 		if numReqs == leastReqs {
 			count++
-			if count > 1 || (weakrand.Int()%count) == 0 { //nolint:gosec
+			if weakrand.Int()%count == 0 { //nolint:gosec
 				bestHost = host
 			}
 		}


### PR DESCRIPTION
LeastConnSelection policy is always selecting the last upstream in the pool with the least number of active requests, in fact it should select randomly from all the upstreams which have the least number of active request.
Have corrected the implementation of reservoir sampling in the select method of the LeastConnSelection struct.
Here is the link to the issue:
[caddy/issues/5609](https://github.com/caddyserver/caddy/issues/5609)