### PR TITLE
cmd: Unwrap adapter modules to get underlying modules

### DIFF
--- a/caddyconfig/configadapters.go
+++ b/caddyconfig/configadapters.go
@@ -135,4 +135,11 @@ func (am adapterModule) CaddyModule() caddy.ModuleInfo {
 	}
 }
 
+// UnwrapAdapter return the original Adapter, this method must be exported
+// to be type-assertable 🤷
+// hack, https://github.com/caddyserver/caddy/issues/5621
+func (am adapterModule) UnwrapAdapter() any {
+	return am.Adapter
+}
+
 var configAdapters = make(map[string]Adapter)


### PR DESCRIPTION
Fix [5621](https://github.com/caddyserver/caddy/issues/5621).

In addition, this also fixed several `add(remove)-package` related commands as they can't be used to add or remove adapter related modules.

Before,

![image](https://github.com/caddyserver/caddy/assets/28780594/5bdb06da-239b-43a8-93b3-c5a90c00d1ee)

After,

![image](https://github.com/caddyserver/caddy/assets/28780594/c8bdf1f1-ca2a-48db-9a59-3c851f71a488)
