### PR TITLE
fileserver: add `export-template` sub-command to `file-server`

### DIFF
--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -16,7 +16,9 @@ package fileserver
 
 import (
 	"encoding/json"
+	"io"
 	"log"
+	"os"
 	"strconv"
 	"time"
 
@@ -57,6 +59,15 @@ respond with a file listing.`,
 			cmd.Flags().BoolP("access-log", "", false, "Enable the access log")
 			cmd.Flags().BoolP("debug", "v", false, "Enable verbose debug logs")
 			cmd.RunE = caddycmd.WrapCommandFuncForCobra(cmdFileServer)
+			cmd.AddCommand(&cobra.Command{
+				Use:     "export-template",
+				Short:   "Exports the default file browser template",
+				Example: "caddy file-server export-template > browse.html",
+				RunE: func(cmd *cobra.Command, args []string) error {
+					_, err := io.WriteString(os.Stdout, defaultBrowseTemplate)
+					return err
+				},
+			})
 		},
 	})
 }


### PR DESCRIPTION
I've seen a few requests for guidance on how to customize the default file browser template. The template file is stored in this repository. Users might find the reference to the template [here](https://caddyserver.com/docs/caddyfile/directives/file_server#browse) in the documentation of the `browse` sub-directive of the `file_server` directive, which many users seem to miss or glance over. Adding the sub-command allows the user to not leave the terminal or search through the interwebz on how to find the template. They can run `caddy file-server export-template` right from the terminal where they are. This feels more ergonomic.

If accepted, I'll update the website docs accordingly.