### PR TITLE
reverseproxy: do not close streams when explicitly configured

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -163,7 +163,8 @@ type Handler struct {
 
 	// If nonzero, streaming requests such as WebSockets will not be
 	// closed when the proxy config is unloaded, and instead the stream
-	// will remain open until the delay is complete. In other words,
+	// will remain open until the delay is complete. If explicitly set
+	// to -1, the stream will not be closed. In other words,
 	// enabling this prevents streams from closing when Caddy's config
 	// is reloaded. Enabling this may be a good idea to avoid a thundering
 	// herd of reconnecting clients which had their connections closed

--- a/modules/caddyhttp/reverseproxy/streaming.go
+++ b/modules/caddyhttp/reverseproxy/streaming.go
@@ -304,7 +304,8 @@ func (h *Handler) cleanupConnections() error {
 	defer h.connectionsMu.Unlock()
 	// the handler is shut down, no new connection can appear,
 	// so we can skip setting up the timer when there are no connections
-	if len(h.connections) > 0 {
+	// or if explicitly configured not to close streams
+	if len(h.connections) > 0 || h.StreamCloseDelay != -1 {
 		delay := time.Duration(h.StreamCloseDelay)
 		h.connectionsCloseTimer = time.AfterFunc(delay, func() {
 			h.logger.Debug("closing streaming connections after delay",


### PR DESCRIPTION
`stream_close_delay` of -1 now means streams will not be closed by caddy.