### PR TITLE
fileserver: add lazy image loading

### DIFF
--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -13,7 +13,7 @@
 	</svg>
 	{{- else if .HasExt ".jpg" ".jpeg" ".png" ".gif" ".webp" ".tiff" ".bmp" ".heif" ".heic"}}
 		{{- if eq .Tpl.Layout "grid"}}
-		<img src="{{html .Name}}">
+		<img loading="lazy" src="{{html .Name}}">
 		{{- else}}
 		<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-photo" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
 			<path stroke="none" d="M0 0h24v24H0z" fill="none"></path>


### PR DESCRIPTION
This adds lazy image loading to the grid view mode of the fileserver, to reduce traffic on large listings.