### PR TITLE
reverseproxy: Connection termination cleanup

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -1399,8 +1399,12 @@ type handleResponseContext struct {
 // intended for use when doing a RoundTrip where you don't
 // want a client disconnection to cancel the request during
 // the roundtrip.
-// This can be replaced with context.WithoutCancel once
-// the minimum required required version of Go is 1.21.
+// This context clears cancellation, error, and deadline methods,
+// but still allows values to pass through from its embedded
+// context.
+//
+// TODO: This can be replaced with context.WithoutCancel once
+// the minimum required version of Go is 1.21.
 type ignoreClientGoneContext struct {
 	context.Context
 }


### PR DESCRIPTION
This PR cleans up the situation with proxied connection termination after configuration reload under several circumstances.

## Before PR

To my best knowledge the situation before this PR is captured in the following table that summarizes when the connections are terminated on configuration reload:

<table cellspacing="0" cellpadding="0">
    <thead>
        <tr>
            <th>flush_interval</th>
            <th>Connection Type</th>
            <th>stream_close_delay</th>
            <th>Terminated</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td rowspan="3">-1</td>
            <td rowspan="2">Streaming</td>
            <td>0</td>
            <td>On Reload (1)</td>
        </tr>
        <tr>
            <td>&gt; 0</td>
            <td>On Reload (1) *</td>
        </tr>
        <tr>
            <td>Other</td>
            <td></td>
            <td>On Reload (1) *</td>
        </tr>
        <tr>
           <td rowspan="3">!= -1</td>
            <td rowspan="2">Streaming</td>
            <td>0</td>
            <td>On Reload (2)</td>
        </tr>
        <tr>
            <td>&gt; 0</td>
            <td>After Timeout</td>
        </tr>
        <tr>
            <td>Other</td>
            <td></td>
            <td>Naturally</td>
        </tr>
    </tbody>
</table>

The termination mechanisms require a bit of clarification:

- *Naturally* means the the connection terminates when either upstream or downstream connection is closed. Note that all connections can terminate naturally before any other termination mechanism takes place.
- *After Timeout* has effect on streaming connections (websockets). When the proxy is terminating (because of configuration reload) it sets up a timer that, when it fires, terminates all the remaining streaming connections.
- *On Reload (2)* is similar to *After Timeout* with the difference that the termination happens immediately without setting up any timer.
- *On Reload (1)* happens also when the proxy terminates but has different internal mechanism. It is related to the way the connections are naturally terminated. When `flush_interval != -1` the proxy creates the upstream connection with a context bound to the downstream request so when the downstream connection terminates the upstream one gets immediately closed as well. There were some subtle issues when `flush_interval == -1` (see #4922) that were resolved in #4952 by binding the context of upstream connections to the context of the proxy. The proxy context gets canceled when the configuration is reloaded thus effectively terminating all the connections.
- The behaviors marked with * are buggy.

## Effect

This PR changes the way how the connections are terminated when `flush_interval == -1`. Instead of binding the cancellation of upstream request to the context of the proxy, the cancellation is simply suppressed. It may seem that this may lead to connection leaks but it does not, because the connections will terminate whenever one of its parts (upstream or downstream) terminates and other tries to do some IO. So maybe there is a leak is in the sense that the termination happens later.

So the table from above looks like this after the PR, changed items are emphasized:

<table cellspacing="0" cellpadding="0">
    <thead>
        <tr>
            <th>flush_interval</th>
            <th>Connection Type</th>
            <th>stream_close_delay</th>
            <th>Terminated</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td rowspan="3">-1</td>
            <td rowspan="2">Streaming</td>
            <td>0</td>
            <td><strong>On Reload (2)</strong></td>
        </tr>
        <tr>
            <td>&gt; 0</td>
            <td><strong>After Timeout</strong></td>
        </tr>
        <tr>
            <td>Other</td>
            <td></td>
            <td><strong>Naturally</strong></td>
        </tr>
        <tr>
           <td rowspan="3">!= -1</td>
            <td rowspan="2">Streaming</td>
            <td>0</td>
            <td>On Reload (2)</td>
        </tr>
        <tr>
            <td>&gt; 0</td>
            <td>After Timeout</td>
        </tr>
        <tr>
            <td>Other</td>
            <td></td>
            <td>Naturally</td>
        </tr>
    </tbody>
</table>


## Notes

This PR follows the discussion in #5567. See also #5637 for more discussion on a related topic.

Hopefully this PR will clarify the whole situation.
