### PR TITLE
core: Allow loopback hosts for admin endpoint (fix #5650)

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -318,7 +318,32 @@ func (admin AdminConfig) allowedOrigins(addr NetworkAddress) []*url.URL {
 				// messages. If the requested URI does not include an Internet host
 				// name for the service being requested, then the Host header field MUST
 				// be given with an empty value."
+				//
+				// UPDATE July 2023: Go broke this by patching a minor security bug in 1.20.6.
+				// Understandable, but frustrating. See:
+				// https://github.com/golang/go/issues/60374
+				// See also the discussion here:
+				// https://github.com/golang/go/issues/61431
+				//
+				// We can no longer conform to RFC 2616 Section 14.26 from either Go or curl
+				// in purity. (Curl allowed no host between 7.40 and 7.50, but now requires a
+				// bogus host; see https://superuser.com/a/925610.) If we disable Host/Origin
+				// security checks, the infosec community assures me that it is secure to do
+				// so, because:
+				// 1) Browsers do not allow access to unix sockets
+				// 2) DNS is irrelevant to unix sockets
+				//
+				// I am not quite ready to trust either of those external factors, so instead
+				// of disabling Host/Origin checks, we now allow specific Host values when
+				// accessing the admin endpoint over unix sockets. I definitely don't trust
+				// DNS (e.g. I don't trust 'localhost' to always resolve to the local host),
+				// and IP shouldn't even be used, but if it is for some reason, I think we can
+				// at least be reasonably assured that 127.0.0.1 and ::1 route to the local
+				// machine, meaning that a hypothetical browser origin would have to be on the
+				// local machine as well.
 				uniqueOrigins[""] = struct{}{}
+				uniqueOrigins["127.0.0.1"] = struct{}{}
+				uniqueOrigins["::1"] = struct{}{}
 			} else {
 				uniqueOrigins[net.JoinHostPort("localhost", addr.port())] = struct{}{}
 				uniqueOrigins[net.JoinHostPort("::1", addr.port())] = struct{}{}


### PR DESCRIPTION
This should actually be a non-breaking change, since previously we only allowed the empty Host for unix sockets. We still allow that, but turns out the most popular clients used with the admin API (Caddy's CLI and curl) don't allow empty hostnames anymore:

- Caddy's CLI starting with Go 1.20.6 (https://github.com/golang/go/issues/61431)
- Curl starting with 7.50 (https://superuser.com/a/925610) (but it worked starting with 7.40)

Anyway, this is mildly infuriating because we can no longer be compliant with RFC 2616 Section 14.26 as Go requires setting a host. But it's the best we can do.

We could disable the security checks completely for unix sockets -- and the [infosec community has assured me](https://infosec.exchange/@mholt/110794015397914193) that doing so would be safe -- but I am not ready to trust that, for instance, browsers won't always forbid access to unix sockets in the future (or maybe they have a bug). But as long as they enforce CORS we can at least have reasonable assurance that a host of `127.0.0.1` or `::1` mean the request comes from a local website. Additionally, unix sockets can have system permissions used to restrict access.

In #5650 I decided that we'd use 127.0.0.1 as a "bogus" host and continue to enforce our host/origin checks, while allowing 127.0.0.1 and ::1 as possible values.

I think this is relatively conservative, so if there's any major issues with good technical reasoning we can reconsider this approach if need be.

Ultimately I view this as a very minor regression due to an upstream patch that we're working around.