### PR TITLE
import: check that matched key is not a substring of the replacement key

### DIFF
--- a/caddyconfig/caddyfile/importargs.go
+++ b/caddyconfig/caddyfile/importargs.go
@@ -93,6 +93,11 @@ func makeArgsReplacer(args []string) *caddy.Replacer {
 		// TODO: Remove the deprecated {args.*} placeholder
 		// support at some point in the future
 		if matches := argsRegexpIndexDeprecated.FindStringSubmatch(key); len(matches) > 0 {
+			// What's matched may be a substring of the key
+			if matches[0] != key {
+				return nil, false
+			}
+
 			value, err := strconv.Atoi(matches[1])
 			if err != nil {
 				caddy.Log().Named("caddyfile").Warn(
@@ -111,6 +116,11 @@ func makeArgsReplacer(args []string) *caddy.Replacer {
 
 		// Handle args[*] form
 		if matches := argsRegexpIndex.FindStringSubmatch(key); len(matches) > 0 {
+			// What's matched may be a substring of the key
+			if matches[0] != key {
+				return nil, false
+			}
+
 			if strings.Contains(matches[1], ":") {
 				caddy.Log().Named("caddyfile").Warn(
 					"Variadic placeholder {args[" + matches[1] + "]} must be a token on its own")

--- a/caddyconfig/caddyfile/parse_test.go
+++ b/caddyconfig/caddyfile/parse_test.go
@@ -718,6 +718,36 @@ func TestEnvironmentReplacement(t *testing.T) {
 	}
 }
 
+func TestImportReplacementInJSONWithBrace(t *testing.T) {
+	for i, test := range []struct {
+		args   []string
+		input  string
+		expect string
+	}{
+		{
+			args:   []string{"123"},
+			input:  "{args[0]}",
+			expect: "123",
+		},
+		{
+			args:   []string{"123"},
+			input:  `{"key":"{args[0]}"}`,
+			expect: `{"key":"123"}`,
+		},
+		{
+			args:   []string{"123", "123"},
+			input:  `{"key":[{args[0]},{args[1]}]}`,
+			expect: `{"key":[123,123]}`,
+		},
+	} {
+		repl := makeArgsReplacer(test.args)
+		actual := repl.ReplaceKnown(test.input, "")
+		if actual != test.expect {
+			t.Errorf("Test %d: Expected: '%s' but got '%s'", i, test.expect, actual)
+		}
+	}
+}
+
 func TestSnippets(t *testing.T) {
 	p := testParser(`
 		(common) {


### PR DESCRIPTION
Fix [issue reported on community](https://caddy.community/t/problem-after-upgrading-to-2-7-2/20687).

When importing arguments, regex will usually match a substring of the key, this change detects if it's a substring match.

Personally I think caddy shouldn't allow braces in the replacer as it has other implications. But this will do for now.