### PR TITLE
chore: use `--clean` instead of `--rm-dist` for goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v4
       with:
         version: latest
-        args: release --rm-dist --timeout 60m
+        args: release --clean --timeout 60m
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ steps.vars.outputs.version_tag }}


### PR DESCRIPTION
Apparently it's been deprecated [since January](https://goreleaser.com/deprecations/#-rm-dist).