### PR TITLE
Significant variable naming changes and unit test code additions on the metric side

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -5,12 +5,12 @@ import (
 	"strconv"
 )
 
-func SanitizeCode(s int) string {
-	switch s {
+func SanitizeCode(statusCode int) string {
+	switch statusCode {
 	case 0, 200:
 		return "200"
 	default:
-		return strconv.Itoa(s)
+		return strconv.Itoa(statusCode)
 	}
 }
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -26,3 +26,29 @@ func TestSanitizeMethod(t *testing.T) {
 		}
 	}
 }
+
+func TestSanitizeCode(t *testing.T) {
+	tests := []struct {
+		statusCode int
+		want       string
+	}{
+		{
+			statusCode: 200,
+			want:       "200",
+		},
+		{
+			statusCode: 400,
+			want:       "400",
+		},
+		{
+			statusCode: 500,
+			want:       "500",
+		},
+	}
+	for _, test := range tests {
+		got := SanitizeCode(test.statusCode)
+		if got != test.want {
+			t.Errorf("Not same: expected %#v, but got %#v", test.want, got)
+		}
+	}
+}


### PR DESCRIPTION
Hi, I'm raising a PR to add meaningful variable naming changes and unit test code on the metric side. I've also raised a git issue, which is numbered #5699.

So, I added and modified the following code.


1. Renaming a parameter variable
The parameter is named s. I suggest changing it to statusCode, because it's hard to tell if it stands for string or statusCode.

```go
func SanitizeCode(statusCode int) string {
	switch statusCode {
	case 0, 200:
		return "200"
	default:
		return strconv.Itoa(statusCode)
	}
}
```

2. Adding the SanitizeCode test code
There is no unit test code for SanitizeCode, so we added it.
```go
func TestSanitizeCode(t *testing.T) {
	tests := []struct {
		statusCode int
		want       string
	}{
		{
			statusCode: 200,
			want:       "200",
		},
		{
			statusCode: 400,
			want:       "400",
		},
		{
			statusCode: 500,
			want:       "500",
		},
	}
	for _, test := range tests {
		got := SanitizeCode(test.statusCode)
		if got != test.want {
			t.Errorf("Not same: expected %#v, but got %#v", test.want, got)
		}
	}
}
```
