### PR TITLE
chore: use revive linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,8 +8,7 @@ linters:
   enable:
     - bodyclose
     - errcheck
-    - gofmt
-    - goimports
+    - gofumpt
     - gosec
     - gosimple
     - govet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -89,8 +89,6 @@ output:
   print-linter-name: true
 
 issues:
-  max-issues-per-linter: 10000
-  max-same-issues: 10000
   exclude-rules:
     # we aren't calling unknown URL
     - text: 'G107' # G107: Url provided to HTTP request as taint input

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,9 +4,9 @@ linters-settings:
     ignoretests: true
   gci:
     sections:
-      - prefix(github.com/caddyserver/caddy/v2/cmd) # ensure that this is always at the top and always has a line break.
       - standard # Standard section: captures all standard packages.
       - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/caddyserver/caddy/v2/cmd) # ensure that this is always at the top and always has a line break.
       - prefix(github.com/caddyserver/caddy) # Custom section: groups all imports with the specified Prefix.
     # Skip generated files.
     # Default: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
     - ineffassign
     - misspell
     - prealloc
+    - revive
     - staticcheck
     - typecheck
     - unconvert

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,58 @@
 linters-settings:
+  revive:
+    enable-all-rules: true
+    # Do NOT whine about the following, full explanation found in:
+    # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#description-of-available-rules
+    rules:
+      - name: use-any
+        disabled: true
+      - name: if-return
+        disabled: true
+      - name: max-public-structs
+        disabled: true
+      - name: cognitive-complexity
+        disabled: true
+      - name: argument-limit
+        disabled: true
+      - name: cyclomatic
+        disabled: true
+      - name: file-header
+        disabled: true
+      - name: function-length
+        disabled: true
+      - name: function-result-limit
+        disabled: true
+      - name: line-length-limit
+        disabled: true
+      - name: flag-parameter
+        disabled: true
+      - name: add-constant
+        disabled: true
+      - name: empty-lines
+        disabled: true
+      - name: banned-characters
+        disabled: true
+      - name: deep-exit
+        disabled: true
+      - name: confusing-results
+        disabled: true
+      - name: unused-parameter
+        disabled: true
+      - name: modifies-value-receiver
+        disabled: true
+      - name: early-return
+        disabled: true
+      - name: confusing-naming
+        disabled: true
+      - name: defer
+        disabled: true
+      - name: unhandled-error
+        disabled: false
+        arguments:
+          - 'fmt.Printf'
+          - 'fmt.Print'
+          - 'fmt.Println'
+          - 'myFunction'
   errcheck:
     ignore: fmt:.*,go.uber.org/zap/zapcore:^Add.*
     ignoretests: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -89,6 +89,8 @@ output:
   print-linter-name: true
 
 issues:
+  max-issues-per-linter: 10000
+  max-same-issues: 10000
   exclude-rules:
     # we aren't calling unknown URL
     - text: 'G107' # G107: Url provided to HTTP request as taint input

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
   enable:
     - bodyclose
     - errcheck
+    - gci
     - gofumpt
     - gosec
     - gosimple

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters:
     - prealloc
     - revive
     - staticcheck
+    - thelper
     - typecheck
     - unconvert
     - unused
@@ -52,7 +53,6 @@ linters:
   # - godot
   # - godox
   # - goerr113
-  # - gofumpt
   # - goheader
   # - golint
   # - gomnd

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,19 @@ linters-settings:
   errcheck:
     ignore: fmt:.*,go.uber.org/zap/zapcore:^Add.*
     ignoretests: true
+  gci:
+    sections:
+      - prefix(github.com/caddyserver/caddy/v2/cmd) # ensure that this is always at the top and always has a line break.
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/caddyserver/caddy) # Custom section: groups all imports with the specified Prefix.
+    # Skip generated files.
+    # Default: true
+    skip-generated: true
+    # Enable custom order of sections.
+    # If `true`, make the section order the same as the order of `sections`.
+    # Default: false
+    custom-order: true
 
 linters:
   disable-all: true
@@ -77,23 +90,23 @@ output:
 issues:
   exclude-rules:
     # we aren't calling unknown URL
-    - text: "G107" # G107: Url provided to HTTP request as taint input
+    - text: 'G107' # G107: Url provided to HTTP request as taint input
       linters:
         - gosec
     # as a web server that's expected to handle any template, this is totally in the hands of the user.
-    - text: "G203" # G203: Use of unescaped data in HTML templates
+    - text: 'G203' # G203: Use of unescaped data in HTML templates
       linters:
         - gosec
     # we're shelling out to known commands, not relying on user-defined input.
-    - text: "G204" # G204: Audit use of command execution
+    - text: 'G204' # G204: Audit use of command execution
       linters:
         - gosec
     # the choice of weakrand is deliberate, hence the named import "weakrand"
     - path: modules/caddyhttp/reverseproxy/selectionpolicies.go
-      text: "G404" # G404: Insecure random number source (rand)
+      text: 'G404' # G404: Insecure random number source (rand)
       linters:
         - gosec
     - path: modules/caddyhttp/reverseproxy/streaming.go
-      text: "G404" # G404: Insecure random number source (rand)
+      text: 'G404' # G404: Insecure random number source (rand)
       linters:
         - gosec

--- a/admin.go
+++ b/admin.go
@@ -1346,7 +1346,7 @@ var (
 // will get deleted before the process gracefully exits.
 func PIDFile(filename string) error {
 	pid := []byte(strconv.Itoa(os.Getpid()) + "\n")
-	err := os.WriteFile(filename, pid, 0600)
+	err := os.WriteFile(filename, pid, 0o600)
 	if err != nil {
 		return err
 	}

--- a/admin.go
+++ b/admin.go
@@ -1022,7 +1022,7 @@ func handleConfig(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func handleConfigID(w http.ResponseWriter, r *http.Request) error {
+func handleConfigID(_ http.ResponseWriter, r *http.Request) error {
 	idPath := r.URL.Path
 
 	parts := strings.Split(idPath, "/")
@@ -1058,7 +1058,7 @@ func handleConfigID(w http.ResponseWriter, r *http.Request) error {
 	return errInternalRedir
 }
 
-func handleStop(w http.ResponseWriter, r *http.Request) error {
+func handleStop(_ http.ResponseWriter, r *http.Request) error {
 	if r.Method != http.MethodPost {
 		return APIError{
 			HTTPStatus: http.StatusMethodNotAllowed,

--- a/admin.go
+++ b/admin.go
@@ -1022,7 +1022,7 @@ func handleConfig(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func handleConfigID(_ http.ResponseWriter, r *http.Request) error {
+func handleConfigID(w http.ResponseWriter, r *http.Request) error {
 	idPath := r.URL.Path
 
 	parts := strings.Split(idPath, "/")
@@ -1058,7 +1058,7 @@ func handleConfigID(_ http.ResponseWriter, r *http.Request) error {
 	return errInternalRedir
 }
 
-func handleStop(_ http.ResponseWriter, r *http.Request) error {
+func handleStop(w http.ResponseWriter, r *http.Request) error {
 	if r.Method != http.MethodPost {
 		return APIError{
 			HTTPStatus: http.StatusMethodNotAllowed,

--- a/admin.go
+++ b/admin.go
@@ -915,7 +915,7 @@ func (h adminHandler) checkOrigin(r *http.Request) (string, error) {
 	return origin.String(), nil
 }
 
-func (h adminHandler) getOrigin(r *http.Request) (string, *url.URL) {
+func (adminHandler) getOrigin(r *http.Request) (string, *url.URL) {
 	origin := r.Header.Get("Origin")
 	if origin == "" {
 		origin = r.Header.Get("Referer")

--- a/caddy.go
+++ b/caddy.go
@@ -356,13 +356,13 @@ func unsyncedDecodeAndRun(cfgJSON []byte, allowPersist bool) error {
 			newCfg.Admin.Config.Persist == nil ||
 			*newCfg.Admin.Config.Persist) {
 		dir := filepath.Dir(ConfigAutosavePath)
-		err := os.MkdirAll(dir, 0700)
+		err := os.MkdirAll(dir, 0o700)
 		if err != nil {
 			Log().Error("unable to create folder for config autosave",
 				zap.String("dir", dir),
 				zap.Error(err))
 		} else {
-			err := os.WriteFile(ConfigAutosavePath, cfgJSON, 0600)
+			err := os.WriteFile(ConfigAutosavePath, cfgJSON, 0o600)
 			if err == nil {
 				Log().Info("autosaved config (load with --resume flag)", zap.String("file", ConfigAutosavePath))
 			} else {
@@ -831,7 +831,7 @@ func InstanceID() (uuid.UUID, error) {
 		if err != nil {
 			return uuid, err
 		}
-		err = os.WriteFile(uuidFilePath, []byte(uuid.String()), 0600)
+		err = os.WriteFile(uuidFilePath, []byte(uuid.String()), 0o600)
 		return uuid, err
 	} else if err != nil {
 		return [16]byte{}, err

--- a/caddy.go
+++ b/caddy.go
@@ -34,10 +34,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/caddyserver/caddy/v2/notify"
 	"github.com/caddyserver/certmagic"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2/notify"
 )
 
 // Config is the top (or beginning) of the Caddy configuration structure.

--- a/caddyconfig/caddyfile/dispenser.go
+++ b/caddyconfig/caddyfile/dispenser.go
@@ -236,8 +236,8 @@ func (d *Dispenser) ScalarVal() any {
 	if num, err := strconv.ParseFloat(text, 64); err == nil {
 		return num
 	}
-	if bool, err := strconv.ParseBool(text); err == nil {
-		return bool
+	if boolean, err := strconv.ParseBool(text); err == nil {
+		return boolean
 	}
 	return text
 }

--- a/caddyconfig/caddyfile/formatter.go
+++ b/caddyconfig/caddyfile/formatter.go
@@ -81,10 +81,10 @@ func Format(input []byte) []byte {
 				space = true
 				nextLine()
 				continue
-			} else {
-				write(ch)
-				continue
 			}
+			write(ch)
+			continue
+
 		}
 
 		if !escaped && ch == '\\' {

--- a/caddyconfig/caddyfile/importargs.go
+++ b/caddyconfig/caddyfile/importargs.go
@@ -19,8 +19,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/caddyserver/caddy/v2"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 // parseVariadic determines if the token is a variadic placeholder,

--- a/caddyconfig/caddyfile/importgraph.go
+++ b/caddyconfig/caddyfile/importgraph.go
@@ -34,6 +34,7 @@ func (i *importGraph) addNode(name string) {
 	}
 	i.nodes[name] = true
 }
+
 func (i *importGraph) addNodes(names []string) {
 	for _, name := range names {
 		i.addNode(name)
@@ -43,6 +44,7 @@ func (i *importGraph) addNodes(names []string) {
 func (i *importGraph) removeNode(name string) {
 	delete(i.nodes, name)
 }
+
 func (i *importGraph) removeNodes(names []string) {
 	for _, name := range names {
 		i.removeNode(name)
@@ -73,6 +75,7 @@ func (i *importGraph) addEdge(from, to string) error {
 	i.edges[from] = append(i.edges[from], to)
 	return nil
 }
+
 func (i *importGraph) addEdges(from string, tos []string) error {
 	for _, to := range tos {
 		err := i.addEdge(from, to)

--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -22,8 +22,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/caddyserver/caddy/v2"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 // Parse parses the input just enough to group tokens, in

--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -565,7 +565,6 @@ func (p *parser) doSingleImport(importFile string) ([]Token, error) {
 // are loaded into the current server block for later use
 // by directive setup functions.
 func (p *parser) directive() error {
-
 	// a segment is a list of tokens associated with this directive
 	var segment Segment
 

--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -446,7 +446,7 @@ func (p *parser) doImport(nesting int) error {
 
 	var (
 		maybeSnippet   bool
-		maybeSnippetId bool
+		maybeSnippetID bool
 		index          int
 	)
 
@@ -472,16 +472,16 @@ func (p *parser) doImport(nesting int) error {
 			}
 
 			if index == 0 && len(token.Text) >= 3 && strings.HasPrefix(token.Text, "(") && strings.HasSuffix(token.Text, ")") {
-				maybeSnippetId = true
+				maybeSnippetID = true
 			}
 		}
 
 		switch token.Text {
 		case "{":
 			nesting++
-			if index == 1 && maybeSnippetId && nesting == 1 {
+			if index == 1 && maybeSnippetID && nesting == 1 {
 				maybeSnippet = true
-				maybeSnippetId = false
+				maybeSnippetID = false
 			}
 		case "}":
 			nesting--

--- a/caddyconfig/httpcaddyfile/addresses.go
+++ b/caddyconfig/httpcaddyfile/addresses.go
@@ -24,10 +24,11 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/caddyserver/certmagic"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	"github.com/caddyserver/certmagic"
 )
 
 // mapAddressToServerBlocks returns a map of listener address to list of server

--- a/caddyconfig/httpcaddyfile/addresses.go
+++ b/caddyconfig/httpcaddyfile/addresses.go
@@ -77,7 +77,8 @@ import (
 // multiple addresses to the same lists of server blocks (a many:many mapping).
 // (Doing this is essentially a map-reduce technique.)
 func (st *ServerType) mapAddressToServerBlocks(originalServerBlocks []serverBlock,
-	options map[string]any) (map[string][]serverBlock, error) {
+	options map[string]any,
+) (map[string][]serverBlock, error) {
 	sbmap := make(map[string][]serverBlock)
 
 	for i, sblock := range originalServerBlocks {
@@ -187,7 +188,8 @@ func (st *ServerType) consolidateAddrMappings(addrToServerBlocks map[string][]se
 // listenerAddrsForServerBlockKey essentially converts the Caddyfile
 // site addresses to Caddy listener addresses for each server block.
 func (st *ServerType) listenerAddrsForServerBlockKey(sblock serverBlock, key string,
-	options map[string]any) ([]string, error) {
+	options map[string]any,
+) ([]string, error) {
 	addr, err := ParseAddress(key)
 	if err != nil {
 		return nil, fmt.Errorf("parsing key: %v", err)

--- a/caddyconfig/httpcaddyfile/addresses.go
+++ b/caddyconfig/httpcaddyfile/addresses.go
@@ -150,7 +150,7 @@ func (st *ServerType) mapAddressToServerBlocks(originalServerBlocks []serverBloc
 // entries are deleted from the addrToServerBlocks map. Essentially, each pairing (each
 // association from multiple addresses to multiple server blocks; i.e. each element of
 // the returned slice) becomes a server definition in the output JSON.
-func (st *ServerType) consolidateAddrMappings(addrToServerBlocks map[string][]serverBlock) []sbAddrAssociation {
+func (*ServerType) consolidateAddrMappings(addrToServerBlocks map[string][]serverBlock) []sbAddrAssociation {
 	sbaddrs := make([]sbAddrAssociation, 0, len(addrToServerBlocks))
 	for addr, sblocks := range addrToServerBlocks {
 		// we start with knowing that at least this address
@@ -188,7 +188,7 @@ func (st *ServerType) consolidateAddrMappings(addrToServerBlocks map[string][]se
 
 // listenerAddrsForServerBlockKey essentially converts the Caddyfile
 // site addresses to Caddy listener addresses for each server block.
-func (st *ServerType) listenerAddrsForServerBlockKey(sblock serverBlock, key string,
+func (*ServerType) listenerAddrsForServerBlockKey(sblock serverBlock, key string,
 	options map[string]any,
 ) ([]string, error) {
 	addr, err := ParseAddress(key)

--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -26,14 +26,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/caddyserver/certmagic"
+	"github.com/mholt/acmez/acme"
+	"go.uber.org/zap/zapcore"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
-	"github.com/caddyserver/certmagic"
-	"github.com/mholt/acmez/acme"
-	"go.uber.org/zap/zapcore"
 )
 
 func init() {

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -217,7 +217,8 @@ func (h Helper) ExtractMatcherSet() (caddy.ModuleMap, error) {
 
 // NewRoute returns config values relevant to creating a new HTTP route.
 func (h Helper) NewRoute(matcherSet caddy.ModuleMap,
-	handler caddyhttp.MiddlewareHandler) []ConfigValue {
+	handler caddyhttp.MiddlewareHandler,
+) []ConfigValue {
 	mod, err := caddy.GetModule(caddy.GetModuleID(handler))
 	if err != nil {
 		*h.warnings = append(*h.warnings, caddyconfig.Warning{

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -272,7 +272,7 @@ func (h Helper) GroupRoutes(vals []ConfigValue) {
 
 // NewBindAddresses returns config values relevant to adding
 // listener bind addresses to the config.
-func (h Helper) NewBindAddresses(addrs []string) []ConfigValue {
+func (Helper) NewBindAddresses(addrs []string) []ConfigValue {
 	return []ConfigValue{{Class: "bind", Value: addrs}}
 }
 

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -23,14 +23,15 @@ import (
 	"strconv"
 	"strings"
 
+	"go.uber.org/zap"
+	"golang.org/x/exp/slices"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddypki"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
-	"go.uber.org/zap"
-	"golang.org/x/exp/slices"
 )
 
 func init() {

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -49,8 +49,7 @@ type App struct {
 }
 
 // ServerType can set up a config from an HTTP Caddyfile.
-type ServerType struct {
-}
+type ServerType struct{}
 
 // Setup makes a config from the tokens.
 func (st ServerType) Setup(
@@ -1059,8 +1058,8 @@ func appendSubrouteToRouteList(routeList caddyhttp.RouteList,
 	subroute *caddyhttp.Subroute,
 	matcherSetsEnc []caddy.ModuleMap,
 	p sbAddrAssociation,
-	warnings *[]caddyconfig.Warning) caddyhttp.RouteList {
-
+	warnings *[]caddyconfig.Warning,
+) caddyhttp.RouteList {
 	// nothing to do if... there's nothing to do
 	if len(matcherSetsEnc) == 0 && len(subroute.Routes) == 0 && subroute.Errors == nil {
 		return routeList
@@ -1608,8 +1607,10 @@ type sbAddrAssociation struct {
 	serverBlocks []serverBlock
 }
 
-const matcherPrefix = "@"
-const namedRouteKey = "named_route"
+const (
+	matcherPrefix = "@"
+	namedRouteKey = "named_route"
+)
 
 // Interface guard
 var _ caddyfile.ServerType = (*ServerType)(nil)

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -1284,7 +1284,7 @@ func matcherSetFromMatcherToken(
 	return nil, false, nil
 }
 
-func (st *ServerType) compileEncodedMatcherSets(sblock serverBlock) ([]caddy.ModuleMap, error) {
+func (*ServerType) compileEncodedMatcherSets(sblock serverBlock) ([]caddy.ModuleMap, error) {
 	type hostPathPair struct {
 		hostm caddyhttp.MatchHost
 		pathm caddyhttp.MatchPath

--- a/caddyconfig/httpcaddyfile/options.go
+++ b/caddyconfig/httpcaddyfile/options.go
@@ -17,12 +17,13 @@ package httpcaddyfile
 import (
 	"strconv"
 
+	"github.com/caddyserver/certmagic"
+	"github.com/mholt/acmez/acme"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
-	"github.com/caddyserver/certmagic"
-	"github.com/mholt/acmez/acme"
 )
 
 func init() {

--- a/caddyconfig/httpcaddyfile/options.go
+++ b/caddyconfig/httpcaddyfile/options.go
@@ -59,7 +59,7 @@ func init() {
 	RegisterGlobalOption("persist_config", parseOptPersistConfig)
 }
 
-func parseOptTrue(d *caddyfile.Dispenser, _ any) (any, error) { return true, nil }
+func parseOptTrue(_ *caddyfile.Dispenser, _ any) (any, error) { return true, nil }
 
 func parseOptHTTPPort(d *caddyfile.Dispenser, _ any) (any, error) {
 	var httpPort int

--- a/caddyconfig/httpcaddyfile/options.go
+++ b/caddyconfig/httpcaddyfile/options.go
@@ -59,7 +59,7 @@ func init() {
 	RegisterGlobalOption("persist_config", parseOptPersistConfig)
 }
 
-func parseOptTrue(_ *caddyfile.Dispenser, _ any) (any, error) { return true, nil }
+func parseOptTrue(d *caddyfile.Dispenser, _ any) (any, error) { return true, nil }
 
 func parseOptHTTPPort(d *caddyfile.Dispenser, _ any) (any, error) {
 	var httpPort int

--- a/caddyconfig/httpcaddyfile/pkiapp.go
+++ b/caddyconfig/httpcaddyfile/pkiapp.go
@@ -174,7 +174,6 @@ func (st ServerType) buildPKIApp(
 	options map[string]any,
 	warnings []caddyconfig.Warning,
 ) (*caddypki.PKI, []caddyconfig.Warning, error) {
-
 	skipInstallTrust := false
 	if _, ok := options["skip_install_trust"]; ok {
 		skipInstallTrust = true

--- a/caddyconfig/httpcaddyfile/pkiapp.go
+++ b/caddyconfig/httpcaddyfile/pkiapp.go
@@ -47,7 +47,7 @@ func init() {
 //	}
 //
 // When the CA ID is unspecified, 'local' is assumed.
-func parsePKIApp(d *caddyfile.Dispenser, _ any) (any, error) {
+func parsePKIApp(d *caddyfile.Dispenser, existingVal any) (any, error) {
 	pki := &caddypki.PKI{CAs: make(map[string]*caddypki.CA)}
 
 	for d.Next() {

--- a/caddyconfig/httpcaddyfile/pkiapp.go
+++ b/caddyconfig/httpcaddyfile/pkiapp.go
@@ -169,7 +169,7 @@ func parsePKIApp(d *caddyfile.Dispenser, existingVal any) (any, error) {
 	return pki, nil
 }
 
-func (st ServerType) buildPKIApp(
+func (ServerType) buildPKIApp(
 	pairings []sbAddrAssociation,
 	options map[string]any,
 	warnings []caddyconfig.Warning,

--- a/caddyconfig/httpcaddyfile/pkiapp.go
+++ b/caddyconfig/httpcaddyfile/pkiapp.go
@@ -47,7 +47,7 @@ func init() {
 //	}
 //
 // When the CA ID is unspecified, 'local' is assumed.
-func parsePKIApp(d *caddyfile.Dispenser, existingVal any) (any, error) {
+func parsePKIApp(d *caddyfile.Dispenser, _ any) (any, error) {
 	pki := &caddypki.PKI{CAs: make(map[string]*caddypki.CA)}
 
 	for d.Next() {

--- a/caddyconfig/httpcaddyfile/serveroptions.go
+++ b/caddyconfig/httpcaddyfile/serveroptions.go
@@ -18,11 +18,12 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/dustin/go-humanize"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	"github.com/dustin/go-humanize"
 )
 
 // serverOptions collects server config overrides parsed from Caddyfile global options

--- a/caddyconfig/httpcaddyfile/serveroptions.go
+++ b/caddyconfig/httpcaddyfile/serveroptions.go
@@ -284,7 +284,7 @@ func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (any, error) {
 func applyServerOptions(
 	servers map[string]*caddyhttp.Server,
 	options map[string]any,
-	_ *[]caddyconfig.Warning,
+	warnings *[]caddyconfig.Warning,
 ) error {
 	serverOpts, ok := options["servers"].([]serverOptions)
 	if !ok {

--- a/caddyconfig/httpcaddyfile/serveroptions.go
+++ b/caddyconfig/httpcaddyfile/serveroptions.go
@@ -284,7 +284,7 @@ func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (any, error) {
 func applyServerOptions(
 	servers map[string]*caddyhttp.Server,
 	options map[string]any,
-	warnings *[]caddyconfig.Warning,
+	_ *[]caddyconfig.Warning,
 ) error {
 	serverOpts, ok := options["servers"].([]serverOptions)
 	if !ok {

--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -23,12 +23,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/caddyserver/certmagic"
+	"github.com/mholt/acmez/acme"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
-	"github.com/caddyserver/certmagic"
-	"github.com/mholt/acmez/acme"
 )
 
 func (st ServerType) buildTLSApp(

--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -36,7 +36,6 @@ func (st ServerType) buildTLSApp(
 	options map[string]any,
 	warnings []caddyconfig.Warning,
 ) (*caddytls.TLS, []caddyconfig.Warning, error) {
-
 	tlsApp := &caddytls.TLS{CertificatesRaw: make(caddy.ModuleMap)}
 	var certLoaders []caddytls.CertificateLoader
 

--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -485,7 +485,7 @@ func fillInGlobalACMEDefaults(issuer certmagic.Issuer, options map[string]any) e
 // for any other automation policies. A nil policy (and no error) will be
 // returned if there are no default/global options. However, if always is
 // true, a non-nil value will always be returned (unless there is an error).
-func newBaseAutomationPolicy(options map[string]any, _ []caddyconfig.Warning, always bool) (*caddytls.AutomationPolicy, error) {
+func newBaseAutomationPolicy(options map[string]any, warnings []caddyconfig.Warning, always bool) (*caddytls.AutomationPolicy, error) {
 	issuers, hasIssuers := options["cert_issuer"]
 	_, hasLocalCerts := options["local_certs"]
 	keyType, hasKeyType := options["key_type"]

--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -485,7 +485,7 @@ func fillInGlobalACMEDefaults(issuer certmagic.Issuer, options map[string]any) e
 // for any other automation policies. A nil policy (and no error) will be
 // returned if there are no default/global options. However, if always is
 // true, a non-nil value will always be returned (unless there is an error).
-func newBaseAutomationPolicy(options map[string]any, warnings []caddyconfig.Warning, always bool) (*caddytls.AutomationPolicy, error) {
+func newBaseAutomationPolicy(options map[string]any, _ []caddyconfig.Warning, always bool) (*caddytls.AutomationPolicy, error) {
 	issuers, hasIssuers := options["cert_issuer"]
 	_, hasLocalCerts := options["local_certs"]
 	keyType, hasKeyType := options["key_type"]

--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -32,7 +32,7 @@ import (
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
 )
 
-func (st ServerType) buildTLSApp(
+func (ServerType) buildTLSApp(
 	pairings []sbAddrAssociation,
 	options map[string]any,
 	warnings []caddyconfig.Warning,

--- a/caddyconfig/httploader.go
+++ b/caddyconfig/httploader.go
@@ -105,7 +105,7 @@ func (hl HTTPLoader) LoadConfig(ctx caddy.Context) ([]byte, error) {
 		}
 	}
 
-	resp, err := doHttpCallWithRetries(ctx, client, req)
+	resp, err := doHTTPCallWithRetries(ctx, client, req)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (hl HTTPLoader) LoadConfig(ctx caddy.Context) ([]byte, error) {
 	return result, nil
 }
 
-func attemptHttpCall(client *http.Client, request *http.Request) (*http.Response, error) {
+func attemptHTTPCall(client *http.Client, request *http.Request) (*http.Response, error) {
 	resp, err := client.Do(request)
 	if err != nil {
 		return nil, fmt.Errorf("problem calling http loader url: %v", err)
@@ -146,13 +146,13 @@ func attemptHttpCall(client *http.Client, request *http.Request) (*http.Response
 	return resp, nil
 }
 
-func doHttpCallWithRetries(ctx caddy.Context, client *http.Client, request *http.Request) (*http.Response, error) {
+func doHTTPCallWithRetries(ctx caddy.Context, client *http.Client, request *http.Request) (*http.Response, error) {
 	var resp *http.Response
 	var err error
 	const maxAttempts = 10
 
 	for i := 0; i < maxAttempts; i++ {
-		resp, err = attemptHttpCall(client, request)
+		resp, err = attemptHTTPCall(client, request)
 		if err != nil && i < maxAttempts-1 {
 			select {
 			case <-time.After(time.Millisecond * 500):

--- a/caddytest/caddytest.go
+++ b/caddytest/caddytest.go
@@ -63,7 +63,6 @@ type Tester struct {
 
 // NewTester will create a new testing client with an attached cookie jar
 func NewTester(t *testing.T) *Tester {
-
 	jar, err := cookiejar.New(nil)
 	if err != nil {
 		t.Fatalf("failed to create cookiejar: %s", err)
@@ -94,7 +93,6 @@ func timeElapsed(start time.Time, name string) {
 // InitServer this will configure the server with a configurion of a specific
 // type. The configType must be either "json" or the adapter type.
 func (tc *Tester) InitServer(rawConfig string, configType string) {
-
 	if err := tc.initServer(rawConfig, configType); err != nil {
 		tc.t.Logf("failed to load config: %s", err)
 		tc.t.Fail()
@@ -108,7 +106,6 @@ func (tc *Tester) InitServer(rawConfig string, configType string) {
 // InitServer this will configure the server with a configurion of a specific
 // type. The configType must be either "json" or the adapter type.
 func (tc *Tester) initServer(rawConfig string, configType string) error {
-
 	if testing.Short() {
 		tc.t.SkipNow()
 		return nil
@@ -232,7 +229,6 @@ const initConfig = `{
 // validateTestPrerequisites ensures the certificates are available in the
 // designated path and Caddy sub-process is running.
 func validateTestPrerequisites(t *testing.T) error {
-
 	// check certificates are found
 	for _, certName := range Default.Certifcates {
 		if _, err := os.Stat(getIntegrationDir() + certName); os.IsNotExist(err) {
@@ -284,7 +280,6 @@ func isCaddyAdminRunning() error {
 }
 
 func getIntegrationDir() string {
-
 	_, filename, _, ok := runtime.Caller(1)
 	if !ok {
 		panic("unable to determine the current file path")
@@ -304,7 +299,6 @@ func prependCaddyFilePath(rawConfig string) string {
 
 // CreateTestingTransport creates a testing transport that forces call dialing connections to happen locally
 func CreateTestingTransport() *http.Transport {
-
 	dialer := net.Dialer{
 		Timeout:   5 * time.Second,
 		KeepAlive: 5 * time.Second,
@@ -332,7 +326,6 @@ func CreateTestingTransport() *http.Transport {
 
 // AssertLoadError will load a config and expect an error
 func AssertLoadError(t *testing.T, rawConfig string, configType string, expectedError string) {
-
 	tc := NewTester(t)
 
 	err := tc.initServer(rawConfig, configType)
@@ -343,7 +336,6 @@ func AssertLoadError(t *testing.T, rawConfig string, configType string, expected
 
 // AssertRedirect makes a request and asserts the redirection happens
 func (tc *Tester) AssertRedirect(requestURI string, expectedToLocation string, expectedStatusCode int) *http.Response {
-
 	redirectPolicyFunc := func(req *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
@@ -381,7 +373,6 @@ func (tc *Tester) AssertRedirect(requestURI string, expectedToLocation string, e
 
 // CompareAdapt adapts a config and then compares it against an expected result
 func CompareAdapt(t *testing.T, filename, rawConfig string, adapterName string, expectedResponse string) bool {
-
 	cfgAdapter := caddyconfig.GetAdapter(adapterName)
 	if cfgAdapter == nil {
 		t.Logf("unrecognized config adapter '%s'", adapterName)
@@ -469,7 +460,6 @@ func applyHeaders(t *testing.T, req *http.Request, requestHeaders []string) {
 
 // AssertResponseCode will execute the request and verify the status code, returns a response for additional assertions
 func (tc *Tester) AssertResponseCode(req *http.Request, expectedStatusCode int) *http.Response {
-
 	resp, err := tc.Client.Do(req)
 	if err != nil {
 		tc.t.Fatalf("failed to call server %s", err)
@@ -484,7 +474,6 @@ func (tc *Tester) AssertResponseCode(req *http.Request, expectedStatusCode int) 
 
 // AssertResponse request a URI and assert the status code and the body contains a string
 func (tc *Tester) AssertResponse(req *http.Request, expectedStatusCode int, expectedBody string) (*http.Response, string) {
-
 	resp := tc.AssertResponseCode(req, expectedStatusCode)
 
 	defer resp.Body.Close()
@@ -506,7 +495,6 @@ func (tc *Tester) AssertResponse(req *http.Request, expectedStatusCode int, expe
 
 // AssertGetResponse GET a URI and expect a statusCode and body text
 func (tc *Tester) AssertGetResponse(requestURI string, expectedStatusCode int, expectedBody string) (*http.Response, string) {
-
 	req, err := http.NewRequest("GET", requestURI, nil)
 	if err != nil {
 		tc.t.Fatalf("unable to create request %s", err)
@@ -517,7 +505,6 @@ func (tc *Tester) AssertGetResponse(requestURI string, expectedStatusCode int, e
 
 // AssertDeleteResponse request a URI and expect a statusCode and body text
 func (tc *Tester) AssertDeleteResponse(requestURI string, expectedStatusCode int, expectedBody string) (*http.Response, string) {
-
 	req, err := http.NewRequest("DELETE", requestURI, nil)
 	if err != nil {
 		tc.t.Fatalf("unable to create request %s", err)
@@ -528,7 +515,6 @@ func (tc *Tester) AssertDeleteResponse(requestURI string, expectedStatusCode int
 
 // AssertPostResponseBody POST to a URI and assert the response code and body
 func (tc *Tester) AssertPostResponseBody(requestURI string, requestHeaders []string, requestBody *bytes.Buffer, expectedStatusCode int, expectedBody string) (*http.Response, string) {
-
 	req, err := http.NewRequest("POST", requestURI, requestBody)
 	if err != nil {
 		tc.t.Errorf("failed to create request %s", err)
@@ -542,7 +528,6 @@ func (tc *Tester) AssertPostResponseBody(requestURI string, requestHeaders []str
 
 // AssertPutResponseBody PUT to a URI and assert the response code and body
 func (tc *Tester) AssertPutResponseBody(requestURI string, requestHeaders []string, requestBody *bytes.Buffer, expectedStatusCode int, expectedBody string) (*http.Response, string) {
-
 	req, err := http.NewRequest("PUT", requestURI, requestBody)
 	if err != nil {
 		tc.t.Errorf("failed to create request %s", err)
@@ -556,7 +541,6 @@ func (tc *Tester) AssertPutResponseBody(requestURI string, requestHeaders []stri
 
 // AssertPatchResponseBody PATCH to a URI and assert the response code and body
 func (tc *Tester) AssertPatchResponseBody(requestURI string, requestHeaders []string, requestBody *bytes.Buffer, expectedStatusCode int, expectedBody string) (*http.Response, string) {
-
 	req, err := http.NewRequest("PATCH", requestURI, requestBody)
 	if err != nil {
 		tc.t.Errorf("failed to create request %s", err)

--- a/caddytest/caddytest.go
+++ b/caddytest/caddytest.go
@@ -64,6 +64,7 @@ type Tester struct {
 
 // NewTester will create a new testing client with an attached cookie jar
 func NewTester(t *testing.T) *Tester {
+	t.Helper()
 	jar, err := cookiejar.New(nil)
 	if err != nil {
 		t.Fatalf("failed to create cookiejar: %s", err)
@@ -230,6 +231,7 @@ const initConfig = `{
 // validateTestPrerequisites ensures the certificates are available in the
 // designated path and Caddy sub-process is running.
 func validateTestPrerequisites(t *testing.T) error {
+	t.Helper()
 	// check certificates are found
 	for _, certName := range Default.Certifcates {
 		if _, err := os.Stat(getIntegrationDir() + certName); os.IsNotExist(err) {
@@ -327,6 +329,7 @@ func CreateTestingTransport() *http.Transport {
 
 // AssertLoadError will load a config and expect an error
 func AssertLoadError(t *testing.T, rawConfig string, configType string, expectedError string) {
+	t.Helper()
 	tc := NewTester(t)
 
 	err := tc.initServer(rawConfig, configType)
@@ -374,6 +377,7 @@ func (tc *Tester) AssertRedirect(requestURI string, expectedToLocation string, e
 
 // CompareAdapt adapts a config and then compares it against an expected result
 func CompareAdapt(t *testing.T, filename, rawConfig string, adapterName string, expectedResponse string) bool {
+	t.Helper()
 	cfgAdapter := caddyconfig.GetAdapter(adapterName)
 	if cfgAdapter == nil {
 		t.Logf("unrecognized config adapter '%s'", adapterName)
@@ -433,6 +437,7 @@ func CompareAdapt(t *testing.T, filename, rawConfig string, adapterName string, 
 
 // AssertAdapt adapts a config and then tests it against an expected result
 func AssertAdapt(t *testing.T, rawConfig string, adapterName string, expectedResponse string) {
+	t.Helper()
 	ok := CompareAdapt(t, "Caddyfile", rawConfig, adapterName, expectedResponse)
 	if !ok {
 		t.Fail()
@@ -442,6 +447,7 @@ func AssertAdapt(t *testing.T, rawConfig string, adapterName string, expectedRes
 // Generic request functions
 
 func applyHeaders(t *testing.T, req *http.Request, requestHeaders []string) {
+	t.Helper()
 	requestContentType := ""
 	for _, requestHeader := range requestHeaders {
 		arr := strings.SplitAfterN(requestHeader, ":", 2)

--- a/caddytest/caddytest.go
+++ b/caddytest/caddytest.go
@@ -1,6 +1,8 @@
 package caddytest
 
 import (
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
+
 	"bytes"
 	"context"
 	"crypto/tls"
@@ -22,8 +24,8 @@ import (
 	"time"
 
 	"github.com/aryann/difflib"
+
 	"github.com/caddyserver/caddy/v2/caddyconfig"
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 	// plug in Caddy modules here
 	_ "github.com/caddyserver/caddy/v2/modules/standard"
 )

--- a/caddytest/caddytest.go
+++ b/caddytest/caddytest.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
-
 	"github.com/aryann/difflib"
+
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	// plug in Caddy modules here

--- a/caddytest/caddytest.go
+++ b/caddytest/caddytest.go
@@ -24,7 +24,6 @@ import (
 	"github.com/aryann/difflib"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	caddycmd "github.com/caddyserver/caddy/v2/cmd"
-
 	// plug in Caddy modules here
 	_ "github.com/caddyserver/caddy/v2/modules/standard"
 )

--- a/caddytest/caddytest.go
+++ b/caddytest/caddytest.go
@@ -1,8 +1,6 @@
 package caddytest
 
 import (
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
-
 	"bytes"
 	"context"
 	"crypto/tls"
@@ -22,6 +20,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 
 	"github.com/aryann/difflib"
 

--- a/cmd/caddy/main.go
+++ b/cmd/caddy/main.go
@@ -30,6 +30,7 @@ package main
 
 import (
 	caddycmd "github.com/caddyserver/caddy/v2/cmd"
+
 	// plug in Caddy modules here
 	_ "github.com/caddyserver/caddy/v2/modules/standard"
 )

--- a/cmd/caddy/main.go
+++ b/cmd/caddy/main.go
@@ -30,7 +30,6 @@ package main
 
 import (
 	caddycmd "github.com/caddyserver/caddy/v2/cmd"
-
 	// plug in Caddy modules here
 	_ "github.com/caddyserver/caddy/v2/modules/standard"
 )

--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -565,7 +565,7 @@ func cmdFmt(fl Flags) (int, error) {
 	output := caddyfile.Format(input)
 
 	if fl.Bool("overwrite") {
-		if err := os.WriteFile(formatCmdConfigFile, output, 0600); err != nil {
+		if err := os.WriteFile(formatCmdConfigFile, output, 0o600); err != nil {
 			return caddy.ExitCodeFailedStartup, fmt.Errorf("overwriting formatted file: %v", err)
 		}
 		return caddy.ExitCodeSuccess, nil

--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -630,7 +630,7 @@ func AdminAPIRequest(adminAddr, method, uri string, headers http.Header, body io
 	if err != nil {
 		return nil, fmt.Errorf("making request: %v", err)
 	}
-	if parsedAddr.IsUnixNetwork() {
+	if parsedAddr.IsUnixNetwork() { //nolint:revive
 		// We used to conform to RFC 2616 Section 14.26 which requires
 		// an empty host header when there is no host, as is the case
 		// with unix sockets. However, Go required a Host value so we

--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -32,11 +32,12 @@ import (
 	"strings"
 
 	"github.com/aryann/difflib"
+	"go.uber.org/zap"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/internal"
-	"go.uber.org/zap"
 )
 
 func cmdStart(fl Flags) (int, error) {

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -444,7 +444,7 @@ argument of --directory. If the directory does not exist, it will be created.
 				if dir == "" {
 					return caddy.ExitCodeFailedQuit, fmt.Errorf("designated output directory and specified section are required")
 				}
-				if err := os.MkdirAll(dir, 0755); err != nil {
+				if err := os.MkdirAll(dir, 0o755); err != nil {
 					return caddy.ExitCodeFailedQuit, err
 				}
 				if err := doc.GenManTree(rootCmd, &doc.GenManHeader{

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -21,9 +21,10 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/caddyserver/caddy/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 // Command represents a subcommand. Name, Func,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,11 +30,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/certmagic"
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig"
 )
 
 func init() {

--- a/cmd/packagesfuncs.go
+++ b/cmd/packagesfuncs.go
@@ -27,8 +27,9 @@ import (
 	"runtime/debug"
 	"strings"
 
-	"github.com/caddyserver/caddy/v2"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 func cmdUpgrade(fl Flags) (int, error) {

--- a/cmd/storagefuncs.go
+++ b/cmd/storagefuncs.go
@@ -23,8 +23,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/certmagic"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 type storVal struct {

--- a/cmd/storagefuncs.go
+++ b/cmd/storagefuncs.go
@@ -200,7 +200,7 @@ func cmdExportStorage(fl Flags) (int, error) {
 
 			hdr := &tar.Header{
 				Name: k,
-				Mode: 0600,
+				Mode: 0o600,
 				Size: int64(len(v)),
 			}
 

--- a/internal/sockets.go
+++ b/internal/sockets.go
@@ -52,5 +52,5 @@ func SplitUnixSocketPermissionsBits(addr string) (path string, fileMode fs.FileM
 
 	// default to 0200 (symbolic: `u=w,g=,o=`)
 	// if no permission bits are specified
-	return addr, 0200, nil
+	return addr, 0o200, nil
 }

--- a/listeners.go
+++ b/listeners.go
@@ -174,7 +174,6 @@ func (na NetworkAddress) listen(ctx context.Context, portOffset uint, config net
 			if err := os.Chmod(address, unixFileMode); err != nil {
 				return nil, fmt.Errorf("unable to set permissions (%s) on %s: %v", unixFileMode, address, err)
 			}
-
 		}
 		return socket, err
 	}

--- a/listeners.go
+++ b/listeners.go
@@ -31,10 +31,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/caddyserver/caddy/v2/internal"
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2/internal"
 )
 
 // NetworkAddress represents one or more network addresses.

--- a/logging.go
+++ b/logging.go
@@ -627,7 +627,7 @@ func (DiscardWriter) OpenWriter() (io.WriteCloser, error) {
 // notClosable is an io.WriteCloser that can't be closed.
 type notClosable struct{ io.Writer }
 
-func (fc notClosable) Close() error { return nil }
+func (notClosable) Close() error { return nil }
 
 type defaultCustomLog struct {
 	*CustomLog

--- a/metrics.go
+++ b/metrics.go
@@ -3,10 +3,11 @@ package caddy
 import (
 	"net/http"
 
-	"github.com/caddyserver/caddy/v2/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/caddyserver/caddy/v2/internal/metrics"
 )
 
 // define and register the metrics used in this package.

--- a/modules/caddyevents/app.go
+++ b/modules/caddyevents/app.go
@@ -22,9 +22,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 func init() {

--- a/modules/caddyevents/app.go
+++ b/modules/caddyevents/app.go
@@ -156,7 +156,7 @@ func (app *App) Start() error {
 }
 
 // Stop gracefully shuts down the app.
-func (app *App) Stop() error {
+func (*App) Stop() error {
 	return nil
 }
 

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -26,12 +26,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/modules/caddyevents"
-	"github.com/caddyserver/caddy/v2/modules/caddytls"
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyevents"
+	"github.com/caddyserver/caddy/v2/modules/caddytls"
 )
 
 func init() {

--- a/modules/caddyhttp/autohttps.go
+++ b/modules/caddyhttp/autohttps.go
@@ -20,10 +20,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/modules/caddytls"
 	"github.com/caddyserver/certmagic"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddytls"
 )
 
 // AutoHTTPSConfig is used to disable automatic HTTPS

--- a/modules/caddyhttp/autohttps.go
+++ b/modules/caddyhttp/autohttps.go
@@ -68,7 +68,7 @@ type AutoHTTPSConfig struct {
 
 // Skipped returns true if name is in skipSlice, which
 // should be either the Skip or SkipCerts field on ahc.
-func (ahc AutoHTTPSConfig) Skipped(name string, skipSlice []string) bool {
+func (AutoHTTPSConfig) Skipped(name string, skipSlice []string) bool {
 	for _, n := range skipSlice {
 		if name == n {
 			return true

--- a/modules/caddyhttp/caddyauth/basicauth.go
+++ b/modules/caddyhttp/caddyauth/basicauth.go
@@ -24,8 +24,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/caddyserver/caddy/v2"
 	"golang.org/x/sync/singleflight"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 func init() {

--- a/modules/caddyhttp/caddyauth/caddyauth.go
+++ b/modules/caddyhttp/caddyauth/caddyauth.go
@@ -18,9 +18,10 @@ import (
 	"fmt"
 	"net/http"
 
+	"go.uber.org/zap"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	"go.uber.org/zap"
 )
 
 func init() {

--- a/modules/caddyhttp/caddyauth/command.go
+++ b/modules/caddyhttp/caddyauth/command.go
@@ -22,10 +22,10 @@ import (
 	"os"
 	"os/signal"
 
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
-
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 
 	"github.com/caddyserver/caddy/v2"
 )

--- a/modules/caddyhttp/caddyauth/command.go
+++ b/modules/caddyhttp/caddyauth/command.go
@@ -15,6 +15,8 @@
 package caddyauth
 
 import (
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
+
 	"bufio"
 	"bytes"
 	"encoding/base64"
@@ -22,10 +24,10 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/caddyserver/caddy/v2"
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 func init() {

--- a/modules/caddyhttp/caddyauth/command.go
+++ b/modules/caddyhttp/caddyauth/command.go
@@ -15,14 +15,14 @@
 package caddyauth
 
 import (
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
-
 	"bufio"
 	"bytes"
 	"encoding/base64"
 	"fmt"
 	"os"
 	"os/signal"
+
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"

--- a/modules/caddyhttp/caddyauth/hashes.go
+++ b/modules/caddyhttp/caddyauth/hashes.go
@@ -18,9 +18,10 @@ import (
 	"crypto/subtle"
 	"encoding/base64"
 
-	"github.com/caddyserver/caddy/v2"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/crypto/scrypt"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 func init() {

--- a/modules/caddyhttp/caddyhttp.go
+++ b/modules/caddyhttp/caddyhttp.go
@@ -307,5 +307,7 @@ const (
 const separator = string(filepath.Separator)
 
 // Interface guard
-var _ caddy.ListenerWrapper = (*tlsPlaceholderWrapper)(nil)
-var _ caddyfile.Unmarshaler = (*tlsPlaceholderWrapper)(nil)
+var (
+	_ caddy.ListenerWrapper = (*tlsPlaceholderWrapper)(nil)
+	_ caddyfile.Unmarshaler = (*tlsPlaceholderWrapper)(nil)
+)

--- a/modules/caddyhttp/caddyhttp.go
+++ b/modules/caddyhttp/caddyhttp.go
@@ -294,7 +294,7 @@ func (tlsPlaceholderWrapper) CaddyModule() caddy.ModuleInfo {
 
 func (tlsPlaceholderWrapper) WrapListener(ln net.Listener) net.Listener { return ln }
 
-func (tlsPlaceholderWrapper) UnmarshalCaddyfile(d *caddyfile.Dispenser) error { return nil }
+func (tlsPlaceholderWrapper) UnmarshalCaddyfile(_ *caddyfile.Dispenser) error { return nil }
 
 const (
 	// DefaultHTTPPort is the default port for HTTP.

--- a/modules/caddyhttp/caddyhttp.go
+++ b/modules/caddyhttp/caddyhttp.go
@@ -294,7 +294,7 @@ func (tlsPlaceholderWrapper) CaddyModule() caddy.ModuleInfo {
 
 func (tlsPlaceholderWrapper) WrapListener(ln net.Listener) net.Listener { return ln }
 
-func (tlsPlaceholderWrapper) UnmarshalCaddyfile(_ *caddyfile.Dispenser) error { return nil }
+func (tlsPlaceholderWrapper) UnmarshalCaddyfile(d *caddyfile.Dispenser) error { return nil }
 
 const (
 	// DefaultHTTPPort is the default port for HTTP.

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -234,9 +234,11 @@ func (cr celHTTPRequest) Parent() interpreter.Activation {
 func (cr celHTTPRequest) ConvertToNative(typeDesc reflect.Type) (any, error) {
 	return cr.Request, nil
 }
+
 func (celHTTPRequest) ConvertToType(typeVal ref.Type) ref.Val {
 	panic("not implemented")
 }
+
 func (cr celHTTPRequest) Equal(other ref.Val) ref.Val {
 	if o, ok := other.Value().(celHTTPRequest); ok {
 		return types.Bool(o.Request == cr.Request)
@@ -255,12 +257,14 @@ type celPkixName struct{ *pkix.Name }
 func (pn celPkixName) ConvertToNative(typeDesc reflect.Type) (any, error) {
 	return pn.Name, nil
 }
+
 func (pn celPkixName) ConvertToType(typeVal ref.Type) ref.Val {
 	if typeVal.TypeName() == "string" {
 		return types.String(pn.Name.String())
 	}
 	panic("not implemented")
 }
+
 func (pn celPkixName) Equal(other ref.Val) ref.Val {
 	if o, ok := other.Value().(string); ok {
 		return types.Bool(pn.Name.String() == o)

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -25,8 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/operators"
@@ -39,6 +37,9 @@ import (
 	"github.com/google/cel-go/parser"
 	"go.uber.org/zap"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
 func init() {

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -232,11 +232,11 @@ func (cr celHTTPRequest) Parent() interpreter.Activation {
 	return nil
 }
 
-func (cr celHTTPRequest) ConvertToNative(typeDesc reflect.Type) (any, error) {
+func (cr celHTTPRequest) ConvertToNative(_ reflect.Type) (any, error) {
 	return cr.Request, nil
 }
 
-func (celHTTPRequest) ConvertToType(typeVal ref.Type) ref.Val {
+func (celHTTPRequest) ConvertToType(_ ref.Type) ref.Val {
 	panic("not implemented")
 }
 
@@ -255,7 +255,7 @@ var pkixNameCELType = types.NewTypeValue("pkix.Name", traits.ReceiverType)
 // methods to satisfy the ref.Val interface.
 type celPkixName struct{ *pkix.Name }
 
-func (pn celPkixName) ConvertToNative(typeDesc reflect.Type) (any, error) {
+func (pn celPkixName) ConvertToNative(_ reflect.Type) (any, error) {
 	return pn.Name, nil
 }
 
@@ -442,7 +442,7 @@ func CELMatcherDecorator(funcName string, fac CELMatcherFactory) interpreter.Int
 
 // CELMatcherRuntimeFunction creates a function binding for when the input to the matcher
 // is dynamically resolved rather than a set of static constant values.
-func CELMatcherRuntimeFunction(funcName string, fac CELMatcherFactory) functions.BinaryOp {
+func CELMatcherRuntimeFunction(_ string, fac CELMatcherFactory) functions.BinaryOp {
 	return func(celReq, matcherData ref.Val) ref.Val {
 		matcher, err := fac(matcherData)
 		if err != nil {

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -228,7 +228,7 @@ func (cr celHTTPRequest) ResolveName(name string) (any, bool) {
 	return nil, false
 }
 
-func (cr celHTTPRequest) Parent() interpreter.Activation {
+func (celHTTPRequest) Parent() interpreter.Activation {
 	return nil
 }
 

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -232,11 +232,11 @@ func (cr celHTTPRequest) Parent() interpreter.Activation {
 	return nil
 }
 
-func (cr celHTTPRequest) ConvertToNative(_ reflect.Type) (any, error) {
+func (cr celHTTPRequest) ConvertToNative(typeDesc reflect.Type) (any, error) {
 	return cr.Request, nil
 }
 
-func (celHTTPRequest) ConvertToType(_ ref.Type) ref.Val {
+func (celHTTPRequest) ConvertToType(typeVal ref.Type) ref.Val {
 	panic("not implemented")
 }
 
@@ -255,7 +255,7 @@ var pkixNameCELType = types.NewTypeValue("pkix.Name", traits.ReceiverType)
 // methods to satisfy the ref.Val interface.
 type celPkixName struct{ *pkix.Name }
 
-func (pn celPkixName) ConvertToNative(_ reflect.Type) (any, error) {
+func (pn celPkixName) ConvertToNative(typeDesc reflect.Type) (any, error) {
 	return pn.Name, nil
 }
 
@@ -442,7 +442,7 @@ func CELMatcherDecorator(funcName string, fac CELMatcherFactory) interpreter.Int
 
 // CELMatcherRuntimeFunction creates a function binding for when the input to the matcher
 // is dynamically resolved rather than a set of static constant values.
-func CELMatcherRuntimeFunction(_ string, fac CELMatcherFactory) functions.BinaryOp {
+func CELMatcherRuntimeFunction(funcName string, fac CELMatcherFactory) functions.BinaryOp {
 	return func(celReq, matcherData ref.Val) ref.Val {
 		matcher, err := fac(matcherData)
 		if err != nil {

--- a/modules/caddyhttp/duplex_go120.go
+++ b/modules/caddyhttp/duplex_go120.go
@@ -20,6 +20,6 @@ import (
 	"net/http"
 )
 
-func enableFullDuplex(w http.ResponseWriter) {
+func enableFullDuplex(_ http.ResponseWriter) {
 	// Do nothing, Go 1.20 and earlier do not support full duplex
 }

--- a/modules/caddyhttp/duplex_go120.go
+++ b/modules/caddyhttp/duplex_go120.go
@@ -20,6 +20,6 @@ import (
 	"net/http"
 )
 
-func enableFullDuplex(_ http.ResponseWriter) {
+func enableFullDuplex(w http.ResponseWriter) {
 	// Do nothing, Go 1.20 and earlier do not support full duplex
 }

--- a/modules/caddyhttp/encode/encode.go
+++ b/modules/caddyhttp/encode/encode.go
@@ -269,9 +269,8 @@ func (rw *responseWriter) Write(p []byte) (int, error) {
 
 	if rw.w != nil {
 		return rw.w.Write(p)
-	} else {
-		return rw.ResponseWriter.Write(p)
 	}
+	return rw.ResponseWriter.Write(p)
 }
 
 // Close writes any remaining buffered response and

--- a/modules/caddyhttp/encode/gzip/gzip.go
+++ b/modules/caddyhttp/encode/gzip/gzip.go
@@ -18,10 +18,11 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/klauspost/compress/gzip"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/encode"
-	"github.com/klauspost/compress/gzip"
 )
 
 func init() {

--- a/modules/caddyhttp/encode/gzip/gzip.go
+++ b/modules/caddyhttp/encode/gzip/gzip.go
@@ -59,7 +59,7 @@ func (g *Gzip) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 }
 
 // Provision provisions g's configuration.
-func (g *Gzip) Provision(_ caddy.Context) error {
+func (g *Gzip) Provision(ctx caddy.Context) error {
 	if g.Level == 0 {
 		g.Level = defaultGzipLevel
 	}

--- a/modules/caddyhttp/encode/gzip/gzip.go
+++ b/modules/caddyhttp/encode/gzip/gzip.go
@@ -59,7 +59,7 @@ func (g *Gzip) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 }
 
 // Provision provisions g's configuration.
-func (g *Gzip) Provision(ctx caddy.Context) error {
+func (g *Gzip) Provision(_ caddy.Context) error {
 	if g.Level == 0 {
 		g.Level = defaultGzipLevel
 	}

--- a/modules/caddyhttp/encode/zstd/zstd.go
+++ b/modules/caddyhttp/encode/zstd/zstd.go
@@ -15,10 +15,11 @@
 package caddyzstd
 
 import (
+	"github.com/klauspost/compress/zstd"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/encode"
-	"github.com/klauspost/compress/zstd"
 )
 
 func init() {

--- a/modules/caddyhttp/encode/zstd/zstd.go
+++ b/modules/caddyhttp/encode/zstd/zstd.go
@@ -38,7 +38,7 @@ func (Zstd) CaddyModule() caddy.ModuleInfo {
 }
 
 // UnmarshalCaddyfile sets up the handler from Caddyfile tokens.
-func (z *Zstd) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (*Zstd) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	return nil
 }
 
@@ -47,7 +47,7 @@ func (z *Zstd) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 func (Zstd) AcceptEncoding() string { return "zstd" }
 
 // NewEncoder returns a new Zstandard writer.
-func (z Zstd) NewEncoder() encode.Encoder {
+func (Zstd) NewEncoder() encode.Encoder {
 	// The default of 8MB for the window is
 	// too large for many clients, so we limit
 	// it to 128K to lighten their load.

--- a/modules/caddyhttp/encode/zstd/zstd.go
+++ b/modules/caddyhttp/encode/zstd/zstd.go
@@ -38,7 +38,7 @@ func (Zstd) CaddyModule() caddy.ModuleInfo {
 }
 
 // UnmarshalCaddyfile sets up the handler from Caddyfile tokens.
-func (z *Zstd) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (z *Zstd) UnmarshalCaddyfile(_ *caddyfile.Dispenser) error {
 	return nil
 }
 

--- a/modules/caddyhttp/encode/zstd/zstd.go
+++ b/modules/caddyhttp/encode/zstd/zstd.go
@@ -38,7 +38,7 @@ func (Zstd) CaddyModule() caddy.ModuleInfo {
 }
 
 // UnmarshalCaddyfile sets up the handler from Caddyfile tokens.
-func (z *Zstd) UnmarshalCaddyfile(_ *caddyfile.Dispenser) error {
+func (z *Zstd) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	return nil
 }
 

--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -29,10 +29,11 @@ import (
 	"sync"
 	"text/template"
 
+	"go.uber.org/zap"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/templates"
-	"go.uber.org/zap"
 )
 
 //go:embed browse.html

--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -113,7 +113,7 @@ func (fsrv *FileServer) serveBrowse(root, dirPath string, w http.ResponseWriter,
 			fs = http.Dir(repl.ReplaceAll(fsrv.Root, "."))
 		}
 
-		var tplCtx = &templateContext{
+		tplCtx := &templateContext{
 			TemplateContext: templates.TemplateContext{
 				Root:       fs,
 				Req:        r,

--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -152,7 +152,7 @@ func (fsrv *FileServer) loadDirectoryContents(ctx context.Context, dir fs.ReadDi
 
 // browseApplyQueryParams applies query parameters to the listing.
 // It mutates the listing and may set cookies.
-func (fsrv *FileServer) browseApplyQueryParams(w http.ResponseWriter, r *http.Request, listing *browseTemplateContext) {
+func (*FileServer) browseApplyQueryParams(w http.ResponseWriter, r *http.Request, listing *browseTemplateContext) {
 	layoutParam := r.URL.Query().Get("layout")
 	sortParam := r.URL.Query().Get("sort")
 	orderParam := r.URL.Query().Get("order")

--- a/modules/caddyhttp/fileserver/browsetplcontext.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext.go
@@ -25,10 +25,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/dustin/go-humanize"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 )
 
 func (fsrv *FileServer) directoryListing(ctx context.Context, entries []fs.DirEntry, canGoUp bool, root, urlPath string, repl *caddy.Replacer) *browseTemplateContext {

--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -15,6 +15,8 @@
 package fileserver
 
 import (
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
+
 	"encoding/json"
 	"io"
 	"log"
@@ -22,14 +24,14 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddyconfig"
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
-	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	caddytpl "github.com/caddyserver/caddy/v2/modules/caddyhttp/templates"
 	"github.com/caddyserver/certmagic"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	caddytpl "github.com/caddyserver/caddy/v2/modules/caddyhttp/templates"
 )
 
 func init() {

--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -131,12 +131,12 @@ func cmdFileServer(fs caddycmd.Flags) (int, error) {
 		Servers: map[string]*caddyhttp.Server{"static": server},
 	}
 
-	var falseBool bool
+	var false bool
 	cfg := &caddy.Config{
 		Admin: &caddy.AdminConfig{
 			Disabled: true,
 			Config: &caddy.ConfigSettings{
-				Persist: &falseBool,
+				Persist: &false,
 			},
 		},
 		AppsRaw: caddy.ModuleMap{

--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -15,14 +15,14 @@
 package fileserver
 
 import (
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
-
 	"encoding/json"
 	"io"
 	"log"
 	"os"
 	"strconv"
 	"time"
+
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 
 	"github.com/caddyserver/certmagic"
 	"github.com/spf13/cobra"

--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -22,11 +22,11 @@ import (
 	"strconv"
 	"time"
 
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
-
 	"github.com/caddyserver/certmagic"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"

--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -131,12 +131,12 @@ func cmdFileServer(fs caddycmd.Flags) (int, error) {
 		Servers: map[string]*caddyhttp.Server{"static": server},
 	}
 
-	var false bool
+	var falseBool bool
 	cfg := &caddy.Config{
 		Admin: &caddy.AdminConfig{
 			Disabled: true,
 			Config: &caddy.ConfigSettings{
-				Persist: &false,
+				Persist: &falseBool,
 			},
 		},
 		AppsRaw: caddy.ModuleMap{

--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -26,9 +26,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
-	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/operators"
@@ -36,6 +33,10 @@ import (
 	"github.com/google/cel-go/parser"
 	"go.uber.org/zap"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 )
 
 func init() {

--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -181,15 +181,15 @@ func (MatchFile) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 			root = values["root"][0]
 		}
 
-		var try_policy string
+		var tryPolicy string
 		if len(values["try_policy"]) > 0 {
-			root = values["try_policy"][0]
+			tryPolicy = values["try_policy"][0]
 		}
 
 		m := MatchFile{
 			Root:      root,
 			TryFiles:  values["try_files"],
-			TryPolicy: try_policy,
+			TryPolicy: tryPolicy,
 			SplitPath: values["split_path"],
 		}
 

--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -181,7 +181,7 @@ func (MatchFile) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 			root = values["root"][0]
 		}
 
-		var try_policy string
+		var tryPolicy string
 		if len(values["try_policy"]) > 0 {
 			root = values["try_policy"][0]
 		}
@@ -189,7 +189,7 @@ func (MatchFile) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		m := MatchFile{
 			Root:      root,
 			TryFiles:  values["try_files"],
-			TryPolicy: try_policy,
+			TryPolicy: tryPolicy,
 			SplitPath: values["split_path"],
 		}
 

--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -181,7 +181,7 @@ func (MatchFile) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 			root = values["root"][0]
 		}
 
-		var tryPolicy string
+		var try_policy string
 		if len(values["try_policy"]) > 0 {
 			root = values["try_policy"][0]
 		}
@@ -189,7 +189,7 @@ func (MatchFile) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		m := MatchFile{
 			Root:      root,
 			TryFiles:  values["try_files"],
-			TryPolicy: tryPolicy,
+			TryPolicy: try_policy,
 			SplitPath: values["split_path"],
 		}
 

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -30,10 +30,11 @@ import (
 	"strconv"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/encode"
-	"go.uber.org/zap"
 )
 
 func init() {

--- a/modules/caddyhttp/http2listener.go
+++ b/modules/caddyhttp/http2listener.go
@@ -40,7 +40,7 @@ func (h *http2Listener) Accept() (net.Conn, error) {
 		if csc, ok := conn.(connectionStateConn); ok {
 			// *tls.Conn will return empty string because it's only populated after handshake is complete
 			if csc.ConnectionState().NegotiatedProtocol == http2.NextProtoTLS {
-				go h.serveHttp2(csc)
+				go h.serveHTTP2(csc)
 				continue
 			}
 		}
@@ -49,7 +49,7 @@ func (h *http2Listener) Accept() (net.Conn, error) {
 	}
 }
 
-func (h *http2Listener) serveHttp2(csc connectionStateConn) {
+func (h *http2Listener) serveHTTP2(csc connectionStateConn) {
 	atomic.AddUint64(&h.cnt, 1)
 	h.runHook(csc, http.StateNew)
 	defer func() {

--- a/modules/caddyhttp/http2listener.go
+++ b/modules/caddyhttp/http2listener.go
@@ -40,7 +40,7 @@ func (h *http2Listener) Accept() (net.Conn, error) {
 		if csc, ok := conn.(connectionStateConn); ok {
 			// *tls.Conn will return empty string because it's only populated after handshake is complete
 			if csc.ConnectionState().NegotiatedProtocol == http2.NextProtoTLS {
-				go h.serveHTTP2(csc)
+				go h.serveHttp2(csc)
 				continue
 			}
 		}
@@ -49,7 +49,7 @@ func (h *http2Listener) Accept() (net.Conn, error) {
 	}
 }
 
-func (h *http2Listener) serveHTTP2(csc connectionStateConn) {
+func (h *http2Listener) serveHttp2(csc connectionStateConn) {
 	atomic.AddUint64(&h.cnt, 1)
 	h.runHook(csc, http.StateNew)
 	defer func() {

--- a/modules/caddyhttp/httpredirectlistener.go
+++ b/modules/caddyhttp/httpredirectlistener.go
@@ -51,11 +51,11 @@ func (HTTPRedirectListenerWrapper) CaddyModule() caddy.ModuleInfo {
 	}
 }
 
-func (h *HTTPRedirectListenerWrapper) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (*HTTPRedirectListenerWrapper) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	return nil
 }
 
-func (h *HTTPRedirectListenerWrapper) WrapListener(l net.Listener) net.Listener {
+func (*HTTPRedirectListenerWrapper) WrapListener(l net.Listener) net.Listener {
 	return &httpRedirectListener{l}
 }
 

--- a/modules/caddyhttp/httpredirectlistener.go
+++ b/modules/caddyhttp/httpredirectlistener.go
@@ -51,7 +51,7 @@ func (HTTPRedirectListenerWrapper) CaddyModule() caddy.ModuleInfo {
 	}
 }
 
-func (h *HTTPRedirectListenerWrapper) UnmarshalCaddyfile(_ *caddyfile.Dispenser) error {
+func (h *HTTPRedirectListenerWrapper) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	return nil
 }
 

--- a/modules/caddyhttp/httpredirectlistener.go
+++ b/modules/caddyhttp/httpredirectlistener.go
@@ -51,7 +51,7 @@ func (HTTPRedirectListenerWrapper) CaddyModule() caddy.ModuleInfo {
 	}
 }
 
-func (h *HTTPRedirectListenerWrapper) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (h *HTTPRedirectListenerWrapper) UnmarshalCaddyfile(_ *caddyfile.Dispenser) error {
 	return nil
 }
 

--- a/modules/caddyhttp/ip_matchers.go
+++ b/modules/caddyhttp/ip_matchers.go
@@ -23,11 +23,12 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types/ref"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
 // MatchRemoteIP matches requests by the remote IP address,

--- a/modules/caddyhttp/ip_range.go
+++ b/modules/caddyhttp/ip_range.go
@@ -69,7 +69,7 @@ func (StaticIPRange) CaddyModule() caddy.ModuleInfo {
 	}
 }
 
-func (s *StaticIPRange) Provision(ctx caddy.Context) error {
+func (s *StaticIPRange) Provision(_ caddy.Context) error {
 	for _, str := range s.Ranges {
 		prefix, err := CIDRExpressionToPrefix(str)
 		if err != nil {
@@ -86,16 +86,16 @@ func (s *StaticIPRange) GetIPRanges(_ *http.Request) []netip.Prefix {
 }
 
 // UnmarshalCaddyfile implements caddyfile.Unmarshaler.
-func (f *StaticIPRange) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (s *StaticIPRange) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	if !d.Next() {
 		return nil
 	}
 	for d.NextArg() {
 		if d.Val() == "private_ranges" {
-			f.Ranges = append(f.Ranges, PrivateRangesCIDR()...)
+			s.Ranges = append(s.Ranges, PrivateRangesCIDR()...)
 			continue
 		}
-		f.Ranges = append(f.Ranges, d.Val())
+		s.Ranges = append(s.Ranges, d.Val())
 	}
 	return nil
 }

--- a/modules/caddyhttp/ip_range.go
+++ b/modules/caddyhttp/ip_range.go
@@ -86,16 +86,16 @@ func (s *StaticIPRange) GetIPRanges(_ *http.Request) []netip.Prefix {
 }
 
 // UnmarshalCaddyfile implements caddyfile.Unmarshaler.
-func (m *StaticIPRange) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (f *StaticIPRange) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	if !d.Next() {
 		return nil
 	}
 	for d.NextArg() {
 		if d.Val() == "private_ranges" {
-			m.Ranges = append(m.Ranges, PrivateRangesCIDR()...)
+			f.Ranges = append(f.Ranges, PrivateRangesCIDR()...)
 			continue
 		}
-		m.Ranges = append(m.Ranges, d.Val())
+		f.Ranges = append(f.Ranges, d.Val())
 	}
 	return nil
 }

--- a/modules/caddyhttp/ip_range.go
+++ b/modules/caddyhttp/ip_range.go
@@ -86,16 +86,16 @@ func (s *StaticIPRange) GetIPRanges(_ *http.Request) []netip.Prefix {
 }
 
 // UnmarshalCaddyfile implements caddyfile.Unmarshaler.
-func (f *StaticIPRange) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (s *StaticIPRange) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	if !d.Next() {
 		return nil
 	}
 	for d.NextArg() {
 		if d.Val() == "private_ranges" {
-			f.Ranges = append(f.Ranges, PrivateRangesCIDR()...)
+			s.Ranges = append(s.Ranges, PrivateRangesCIDR()...)
 			continue
 		}
-		f.Ranges = append(f.Ranges, d.Val())
+		s.Ranges = append(s.Ranges, d.Val())
 	}
 	return nil
 }

--- a/modules/caddyhttp/ip_range.go
+++ b/modules/caddyhttp/ip_range.go
@@ -69,7 +69,7 @@ func (StaticIPRange) CaddyModule() caddy.ModuleInfo {
 	}
 }
 
-func (s *StaticIPRange) Provision(_ caddy.Context) error {
+func (s *StaticIPRange) Provision(ctx caddy.Context) error {
 	for _, str := range s.Ranges {
 		prefix, err := CIDRExpressionToPrefix(str)
 		if err != nil {
@@ -86,16 +86,16 @@ func (s *StaticIPRange) GetIPRanges(_ *http.Request) []netip.Prefix {
 }
 
 // UnmarshalCaddyfile implements caddyfile.Unmarshaler.
-func (s *StaticIPRange) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (f *StaticIPRange) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	if !d.Next() {
 		return nil
 	}
 	for d.NextArg() {
 		if d.Val() == "private_ranges" {
-			s.Ranges = append(s.Ranges, PrivateRangesCIDR()...)
+			f.Ranges = append(f.Ranges, PrivateRangesCIDR()...)
 			continue
 		}
-		s.Ranges = append(s.Ranges, d.Val())
+		f.Ranges = append(f.Ranges, d.Val())
 	}
 	return nil
 }

--- a/modules/caddyhttp/logging.go
+++ b/modules/caddyhttp/logging.go
@@ -20,9 +20,10 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/caddyserver/caddy/v2"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 // ServerLogConfig describes a server's logging configuration. If

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -1392,9 +1392,7 @@ func ParseCaddyfileNestedMatcherSet(d *caddyfile.Dispenser) (caddy.ModuleMap, er
 	return matcherSet, nil
 }
 
-var (
-	wordRE = regexp.MustCompile(`\w+`)
-)
+var wordRE = regexp.MustCompile(`\w+`)
 
 const regexpPlaceholderPrefix = "http.regexp"
 

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -30,11 +30,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
 type (

--- a/modules/caddyhttp/metrics.go
+++ b/modules/caddyhttp/metrics.go
@@ -6,9 +6,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/caddyserver/caddy/v2/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/caddyserver/caddy/v2/internal/metrics"
 )
 
 // Metrics configures metrics observations.

--- a/modules/caddyhttp/proxyprotocol/listenerwrapper.go
+++ b/modules/caddyhttp/proxyprotocol/listenerwrapper.go
@@ -19,8 +19,9 @@ import (
 	"net"
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
 	"github.com/mastercactapus/proxyprotocol"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 // ListenerWrapper provides PROXY protocol support to Caddy by implementing

--- a/modules/caddyhttp/proxyprotocol/listenerwrapper.go
+++ b/modules/caddyhttp/proxyprotocol/listenerwrapper.go
@@ -43,7 +43,7 @@ type ListenerWrapper struct {
 }
 
 // Provision sets up the listener wrapper.
-func (pp *ListenerWrapper) Provision(_ caddy.Context) error {
+func (pp *ListenerWrapper) Provision(ctx caddy.Context) error {
 	rules := make([]proxyprotocol.Rule, 0, len(pp.Allow))
 	for _, s := range pp.Allow {
 		_, n, err := net.ParseCIDR(s)

--- a/modules/caddyhttp/proxyprotocol/listenerwrapper.go
+++ b/modules/caddyhttp/proxyprotocol/listenerwrapper.go
@@ -43,7 +43,7 @@ type ListenerWrapper struct {
 }
 
 // Provision sets up the listener wrapper.
-func (pp *ListenerWrapper) Provision(ctx caddy.Context) error {
+func (pp *ListenerWrapper) Provision(_ caddy.Context) error {
 	rules := make([]proxyprotocol.Rule, 0, len(pp.Allow))
 	for _, s := range pp.Allow {
 		_, n, err := net.ParseCIDR(s)

--- a/modules/caddyhttp/push/handler.go
+++ b/modules/caddyhttp/push/handler.go
@@ -19,10 +19,11 @@ import (
 	"net/http"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/headers"
-	"go.uber.org/zap"
 )
 
 func init() {

--- a/modules/caddyhttp/push/handler.go
+++ b/modules/caddyhttp/push/handler.go
@@ -156,7 +156,7 @@ func (h Handler) initializePushHeaders(r *http.Request, repl *caddy.Replacer) ht
 // resources described by them. If a resource has the "nopush"
 // attribute or describes an external entity (meaning, the resource
 // URI includes a scheme), it will not be pushed.
-func (h Handler) servePreloadLinks(pusher http.Pusher, hdr http.Header, resources []string) {
+func (Handler) servePreloadLinks(pusher http.Pusher, hdr http.Header, resources []string) {
 	for _, resource := range resources {
 		for _, resource := range parseLinkHeader(resource) {
 			if _, ok := resource.params["nopush"]; ok {

--- a/modules/caddyhttp/push/handler.go
+++ b/modules/caddyhttp/push/handler.go
@@ -122,11 +122,8 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhtt
 	}
 
 	// serve only after pushing!
-	if err := next.ServeHTTP(lp, r); err != nil {
-		return err
-	}
-
-	return nil
+	err := next.ServeHTTP(lp, r)
+	return err
 }
 
 func (h Handler) initializePushHeaders(r *http.Request, repl *caddy.Replacer) http.Header {

--- a/modules/caddyhttp/replacer.go
+++ b/modules/caddyhttp/replacer.go
@@ -39,9 +39,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
-	"github.com/google/uuid"
 )
 
 // NewTestReplacer creates a replacer for an http.Request

--- a/modules/caddyhttp/requestbody/caddyfile.go
+++ b/modules/caddyhttp/requestbody/caddyfile.go
@@ -15,9 +15,10 @@
 package requestbody
 
 import (
+	"github.com/dustin/go-humanize"
+
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	"github.com/dustin/go-humanize"
 )
 
 func init() {

--- a/modules/caddyhttp/reverseproxy/addresses.go
+++ b/modules/caddyhttp/reverseproxy/addresses.go
@@ -45,12 +45,15 @@ func (p parsedAddr) dialAddr() string {
 	}
 	return net.JoinHostPort(p.host, p.port)
 }
+
 func (p parsedAddr) rangedPort() bool {
 	return strings.Contains(p.port, "-")
 }
+
 func (p parsedAddr) replaceablePort() bool {
 	return strings.Contains(p.port, "{") && strings.Contains(p.port, "}")
 }
+
 func (p parsedAddr) isUnix() bool {
 	return caddy.IsUnixNetwork(p.network)
 }

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -549,7 +549,6 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				h.RequestBuffers = int64(size)
 			} else if subdir == "response_buffers" {
 				h.ResponseBuffers = int64(size)
-
 			}
 
 		// TODO: These three properties are deprecated; remove them sometime after v2.6.4

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -21,6 +21,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/dustin/go-humanize"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -28,7 +30,6 @@ import (
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/headers"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/rewrite"
-	"github.com/dustin/go-humanize"
 )
 
 func init() {

--- a/modules/caddyhttp/reverseproxy/command.go
+++ b/modules/caddyhttp/reverseproxy/command.go
@@ -284,7 +284,8 @@ func cmdReverseProxy(fs caddycmd.Flags) (int, error) {
 
 	var false bool
 	cfg := &caddy.Config{
-		Admin: &caddy.AdminConfig{Disabled: true,
+		Admin: &caddy.AdminConfig{
+			Disabled: true,
 			Config: &caddy.ConfigSettings{
 				Persist: &false,
 			},

--- a/modules/caddyhttp/reverseproxy/command.go
+++ b/modules/caddyhttp/reverseproxy/command.go
@@ -15,21 +15,23 @@
 package reverseproxy
 
 import (
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
+
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
 
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/headers"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
-	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 )
 
 func init() {

--- a/modules/caddyhttp/reverseproxy/command.go
+++ b/modules/caddyhttp/reverseproxy/command.go
@@ -15,13 +15,13 @@
 package reverseproxy
 
 import (
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
-
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
+
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"

--- a/modules/caddyhttp/reverseproxy/command.go
+++ b/modules/caddyhttp/reverseproxy/command.go
@@ -21,10 +21,10 @@ import (
 	"strconv"
 	"strings"
 
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
-
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"

--- a/modules/caddyhttp/reverseproxy/command.go
+++ b/modules/caddyhttp/reverseproxy/command.go
@@ -284,12 +284,12 @@ func cmdReverseProxy(fs caddycmd.Flags) (int, error) {
 		appsRaw["tls"] = caddyconfig.JSON(tlsApp, nil)
 	}
 
-	var false bool
+	var falseBool bool
 	cfg := &caddy.Config{
 		Admin: &caddy.AdminConfig{
 			Disabled: true,
 			Config: &caddy.ConfigSettings{
-				Persist: &false,
+				Persist: &falseBool,
 			},
 		},
 		AppsRaw: appsRaw,

--- a/modules/caddyhttp/reverseproxy/fastcgi/client.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/client.go
@@ -251,7 +251,6 @@ func (c *client) Request(p map[string]string, req io.Reader) (resp *http.Respons
 
 // Get issues a GET request to the fcgi responder.
 func (c *client) Get(p map[string]string, body io.Reader, l int64) (resp *http.Response, err error) {
-
 	p["REQUEST_METHOD"] = "GET"
 	p["CONTENT_LENGTH"] = strconv.FormatInt(l, 10)
 
@@ -260,7 +259,6 @@ func (c *client) Get(p map[string]string, body io.Reader, l int64) (resp *http.R
 
 // Head issues a HEAD request to the fcgi responder.
 func (c *client) Head(p map[string]string) (resp *http.Response, err error) {
-
 	p["REQUEST_METHOD"] = "HEAD"
 	p["CONTENT_LENGTH"] = "0"
 
@@ -269,7 +267,6 @@ func (c *client) Head(p map[string]string) (resp *http.Response, err error) {
 
 // Options issues an OPTIONS request to the fcgi responder.
 func (c *client) Options(p map[string]string) (resp *http.Response, err error) {
-
 	p["REQUEST_METHOD"] = "OPTIONS"
 	p["CONTENT_LENGTH"] = "0"
 

--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -24,12 +24,13 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 var noopLogger = zap.NewNop()

--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -24,13 +24,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-
-	"github.com/caddyserver/caddy/v2"
 )
 
 var noopLogger = zap.NewNop()

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -26,9 +26,10 @@ import (
 	"strconv"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	"go.uber.org/zap"
 )
 
 // HealthChecks configures active and passive health checks.

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -107,7 +107,7 @@ type ActiveHealthChecks struct {
 }
 
 // Provision ensures that a is set up properly before use.
-func (a *ActiveHealthChecks) Provision(_ caddy.Context, h *Handler) error {
+func (a *ActiveHealthChecks) Provision(ctx caddy.Context, h *Handler) error {
 	if !a.IsEnabled() {
 		return nil
 	}

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -107,7 +107,7 @@ type ActiveHealthChecks struct {
 }
 
 // Provision ensures that a is set up properly before use.
-func (a *ActiveHealthChecks) Provision(ctx caddy.Context, h *Handler) error {
+func (a *ActiveHealthChecks) Provision(_ caddy.Context, h *Handler) error {
 	if !a.IsEnabled() {
 		return nil
 	}

--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -28,12 +28,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	"github.com/caddyserver/caddy/v2/modules/caddytls"
 	"github.com/mastercactapus/proxyprotocol"
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/caddyserver/caddy/v2/modules/caddytls"
 )
 
 func init() {

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -32,14 +32,15 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
+	"golang.org/x/net/http/httpguts"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyevents"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/headers"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/rewrite"
-	"go.uber.org/zap"
-	"golang.org/x/net/http/httpguts"
 )
 
 func init() {

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -450,7 +450,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 // It returns true when the loop is done and should break; false otherwise. The error value returned should
 // be assigned to the proxyErr value for the next iteration of the loop (or the error handled after break).
 func (h *Handler) proxyLoopIteration(r *http.Request, origReq *http.Request, w http.ResponseWriter, proxyErr error, start time.Time, retries int,
-	repl *caddy.Replacer, reqHeader http.Header, reqHost string, next caddyhttp.Handler) (bool, error) {
+	repl *caddy.Replacer, reqHeader http.Header, reqHost string, next caddyhttp.Handler,
+) (bool, error) {
 	// get the updated list of upstreams
 	upstreams := h.Upstreams
 	if h.DynamicUpstreams != nil {

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -629,7 +629,7 @@ func (h Handler) prepareRequest(req *http.Request, repl *caddy.Replacer) (*http.
 	if err != nil {
 		// OK; probably didn't have a port
 		addr, err := netip.ParseAddr(address)
-		if err != nil {
+		if err != nil { //nolint:revive
 			// Doesn't seem like a valid ip address at all
 		} else {
 			// Ok, only the port was missing

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -629,7 +629,7 @@ func (h Handler) prepareRequest(req *http.Request, repl *caddy.Replacer) (*http.
 	if err != nil {
 		// OK; probably didn't have a port
 		addr, err := netip.ParseAddr(address)
-		if err != nil { //nolint:revive
+		if err != nil {
 			// Doesn't seem like a valid ip address at all
 		} else {
 			// Ok, only the port was missing

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -1097,7 +1097,7 @@ func (h Handler) provisionUpstream(upstream *Upstream) {
 // then returns a reader for the buffer along with how many bytes were buffered. Always close
 // the return value when done with it, just like if it was the original body! If limit is 0
 // (which it shouldn't be), this function returns its input; i.e. is a no-op, for safety.
-func (h Handler) bufferedBody(originalBody io.ReadCloser, limit int64) (io.ReadCloser, int64) {
+func (Handler) bufferedBody(originalBody io.ReadCloser, limit int64) (io.ReadCloser, int64) {
 	if limit == 0 {
 		return originalBody, 0
 	}
@@ -1410,15 +1410,15 @@ type ignoreClientGoneContext struct {
 	context.Context
 }
 
-func (c ignoreClientGoneContext) Deadline() (deadline time.Time, ok bool) {
+func (ignoreClientGoneContext) Deadline() (deadline time.Time, ok bool) {
 	return
 }
 
-func (c ignoreClientGoneContext) Done() <-chan struct{} {
+func (ignoreClientGoneContext) Done() <-chan struct{} {
 	return nil
 }
 
-func (c ignoreClientGoneContext) Err() error {
+func (ignoreClientGoneContext) Err() error {
 	return nil
 }
 

--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -770,7 +770,7 @@ func leastRequests(upstreams []*Upstream) *Upstream {
 		return nil
 	}
 	var best []*Upstream
-	var bestReqs int = -1
+	bestReqs := -1
 	for _, upstream := range upstreams {
 		if upstream == nil {
 			continue

--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -62,7 +62,7 @@ func (RandomSelection) CaddyModule() caddy.ModuleInfo {
 }
 
 // Select returns an available host, if any.
-func (r RandomSelection) Select(pool UpstreamPool, request *http.Request, _ http.ResponseWriter) *Upstream {
+func (r RandomSelection) Select(pool UpstreamPool, _ *http.Request, _ http.ResponseWriter) *Upstream {
 	return selectRandomHost(pool)
 }
 
@@ -119,7 +119,7 @@ func (r *WeightedRoundRobinSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser)
 }
 
 // Provision sets up r.
-func (r *WeightedRoundRobinSelection) Provision(ctx caddy.Context) error {
+func (r *WeightedRoundRobinSelection) Provision(_ caddy.Context) error {
 	for _, weight := range r.Weights {
 		r.totalWeight += weight
 	}
@@ -194,7 +194,7 @@ func (r *RandomChoiceSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error
 }
 
 // Provision sets up r.
-func (r *RandomChoiceSelection) Provision(ctx caddy.Context) error {
+func (r *RandomChoiceSelection) Provision(_ caddy.Context) error {
 	if r.Choose == 0 {
 		r.Choose = 2
 	}

--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -415,7 +415,7 @@ func (ClientIPHashSelection) Select(pool UpstreamPool, req *http.Request, _ http
 }
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens.
-func (r *ClientIPHashSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (*ClientIPHashSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		if d.NextArg() {
 			return d.ArgErr()

--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -62,7 +62,7 @@ func (RandomSelection) CaddyModule() caddy.ModuleInfo {
 }
 
 // Select returns an available host, if any.
-func (r RandomSelection) Select(pool UpstreamPool, _ *http.Request, _ http.ResponseWriter) *Upstream {
+func (r RandomSelection) Select(pool UpstreamPool, request *http.Request, _ http.ResponseWriter) *Upstream {
 	return selectRandomHost(pool)
 }
 
@@ -119,7 +119,7 @@ func (r *WeightedRoundRobinSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser)
 }
 
 // Provision sets up r.
-func (r *WeightedRoundRobinSelection) Provision(_ caddy.Context) error {
+func (r *WeightedRoundRobinSelection) Provision(ctx caddy.Context) error {
 	for _, weight := range r.Weights {
 		r.totalWeight += weight
 	}
@@ -194,7 +194,7 @@ func (r *RandomChoiceSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error
 }
 
 // Provision sets up r.
-func (r *RandomChoiceSelection) Provision(_ caddy.Context) error {
+func (r *RandomChoiceSelection) Provision(ctx caddy.Context) error {
 	if r.Choose == 0 {
 		r.Choose = 2
 	}

--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -62,12 +62,12 @@ func (RandomSelection) CaddyModule() caddy.ModuleInfo {
 }
 
 // Select returns an available host, if any.
-func (r RandomSelection) Select(pool UpstreamPool, request *http.Request, _ http.ResponseWriter) *Upstream {
+func (RandomSelection) Select(pool UpstreamPool, request *http.Request, _ http.ResponseWriter) *Upstream {
 	return selectRandomHost(pool)
 }
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens.
-func (r *RandomSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (*RandomSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		if d.NextArg() {
 			return d.ArgErr()
@@ -279,7 +279,7 @@ func (LeastConnSelection) Select(pool UpstreamPool, _ *http.Request, _ http.Resp
 }
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens.
-func (r *LeastConnSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (*LeastConnSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		if d.NextArg() {
 			return d.ArgErr()
@@ -319,7 +319,7 @@ func (r *RoundRobinSelection) Select(pool UpstreamPool, _ *http.Request, _ http.
 }
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens.
-func (r *RoundRobinSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (*RoundRobinSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		if d.NextArg() {
 			return d.ArgErr()
@@ -351,7 +351,7 @@ func (FirstSelection) Select(pool UpstreamPool, _ *http.Request, _ http.Response
 }
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens.
-func (r *FirstSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (*FirstSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		if d.NextArg() {
 			return d.ArgErr()
@@ -382,7 +382,7 @@ func (IPHashSelection) Select(pool UpstreamPool, req *http.Request, _ http.Respo
 }
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens.
-func (r *IPHashSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (*IPHashSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		if d.NextArg() {
 			return d.ArgErr()
@@ -442,7 +442,7 @@ func (URIHashSelection) Select(pool UpstreamPool, req *http.Request, _ http.Resp
 }
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens.
-func (r *URIHashSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (*URIHashSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		if d.NextArg() {
 			return d.ArgErr()

--- a/modules/caddyhttp/reverseproxy/streaming.go
+++ b/modules/caddyhttp/reverseproxy/streaming.go
@@ -522,5 +522,7 @@ var streamingBufPool = sync.Pool{
 	},
 }
 
-const defaultBufferSize = 32 * 1024
-const wordSize = int(unsafe.Sizeof(uintptr(0)))
+const (
+	defaultBufferSize = 32 * 1024
+	wordSize          = int(unsafe.Sizeof(uintptr(0)))
+)

--- a/modules/caddyhttp/reverseproxy/streaming.go
+++ b/modules/caddyhttp/reverseproxy/streaming.go
@@ -170,7 +170,7 @@ func (h Handler) flushInterval(req *http.Request, res *http.Response) time.Durat
 // isBidirectionalStream returns whether we should work in bi-directional stream mode.
 //
 // See https://github.com/caddyserver/caddy/pull/3620 for discussion of nuances.
-func (h Handler) isBidirectionalStream(req *http.Request, res *http.Response) bool {
+func (Handler) isBidirectionalStream(req *http.Request, res *http.Response) bool {
 	// We have to check the encoding here; only flush headers with identity encoding.
 	// Non-identity encoding might combine with "encode" directive, and in that case,
 	// if body size larger than enc.MinLength, upper level encode handle might have

--- a/modules/caddyhttp/reverseproxy/upstreams.go
+++ b/modules/caddyhttp/reverseproxy/upstreams.go
@@ -11,8 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 func init() {

--- a/modules/caddyhttp/rewrite/rewrite.go
+++ b/modules/caddyhttp/rewrite/rewrite.go
@@ -22,9 +22,10 @@ import (
 	"strconv"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	"go.uber.org/zap"
 )
 
 func init() {

--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -311,7 +311,7 @@ func wrapRoute(route Route) Middleware {
 // we need to pull this particular MiddlewareHandler
 // pointer into its own stack frame to preserve it so it
 // won't be overwritten in future loop iterations.
-func wrapMiddleware(ctx caddy.Context, mh MiddlewareHandler, metrics *Metrics) Middleware {
+func wrapMiddleware(_ caddy.Context, mh MiddlewareHandler, metrics *Metrics) Middleware {
 	handlerToUse := mh
 	if metrics != nil {
 		// wrap the middleware with metrics instrumentation

--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -311,7 +311,7 @@ func wrapRoute(route Route) Middleware {
 // we need to pull this particular MiddlewareHandler
 // pointer into its own stack frame to preserve it so it
 // won't be overwritten in future loop iterations.
-func wrapMiddleware(_ caddy.Context, mh MiddlewareHandler, metrics *Metrics) Middleware {
+func wrapMiddleware(ctx caddy.Context, mh MiddlewareHandler, metrics *Metrics) Middleware {
 	handlerToUse := mh
 	if metrics != nil {
 		// wrap the middleware with metrics instrumentation

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -30,14 +30,15 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/modules/caddyevents"
-	"github.com/caddyserver/caddy/v2/modules/caddytls"
 	"github.com/caddyserver/certmagic"
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyevents"
+	"github.com/caddyserver/caddy/v2/modules/caddytls"
 )
 
 // Server describes an HTTP server.

--- a/modules/caddyhttp/staticerror.go
+++ b/modules/caddyhttp/staticerror.go
@@ -95,7 +95,7 @@ func (e *StaticError) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	return nil
 }
 
-func (e StaticError) ServeHTTP(w http.ResponseWriter, r *http.Request, _ Handler) error {
+func (e StaticError) ServeHTTP(_ http.ResponseWriter, r *http.Request, _ Handler) error {
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 
 	statusCode := http.StatusInternalServerError

--- a/modules/caddyhttp/staticerror.go
+++ b/modules/caddyhttp/staticerror.go
@@ -95,7 +95,7 @@ func (e *StaticError) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	return nil
 }
 
-func (e StaticError) ServeHTTP(_ http.ResponseWriter, r *http.Request, _ Handler) error {
+func (e StaticError) ServeHTTP(w http.ResponseWriter, r *http.Request, _ Handler) error {
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 
 	statusCode := http.StatusInternalServerError

--- a/modules/caddyhttp/staticresp.go
+++ b/modules/caddyhttp/staticresp.go
@@ -15,8 +15,6 @@
 package caddyhttp
 
 import (
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
-
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -28,6 +26,8 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"

--- a/modules/caddyhttp/staticresp.go
+++ b/modules/caddyhttp/staticresp.go
@@ -394,12 +394,12 @@ func cmdRespond(fl caddycmd.Flags) (int, error) {
 	}
 
 	// finish building the config
-	var false bool
+	var falseBool bool
 	cfg := &caddy.Config{
 		Admin: &caddy.AdminConfig{
 			Disabled: true,
 			Config: &caddy.ConfigSettings{
-				Persist: &false,
+				Persist: &falseBool,
 			},
 		},
 		AppsRaw: caddy.ModuleMap{

--- a/modules/caddyhttp/staticresp.go
+++ b/modules/caddyhttp/staticresp.go
@@ -27,10 +27,10 @@ import (
 	"text/template"
 	"time"
 
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
-
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"

--- a/modules/caddyhttp/staticresp.go
+++ b/modules/caddyhttp/staticresp.go
@@ -15,6 +15,8 @@
 package caddyhttp
 
 import (
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
+
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -27,12 +29,12 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
-	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 )
 
 func init() {

--- a/modules/caddyhttp/templates/templates.go
+++ b/modules/caddyhttp/templates/templates.go
@@ -324,7 +324,7 @@ func (Templates) CaddyModule() caddy.ModuleInfo {
 }
 
 // Provision provisions t.
-func (t *Templates) Provision(ctx caddy.Context) error {
+func (t *Templates) Provision(_ caddy.Context) error {
 	fnModInfos := caddy.GetModules("http.handlers.templates.functions")
 	customFuncs := make([]template.FuncMap, 0, len(fnModInfos))
 	for _, modInfo := range fnModInfos {

--- a/modules/caddyhttp/templates/templates.go
+++ b/modules/caddyhttp/templates/templates.go
@@ -324,7 +324,7 @@ func (Templates) CaddyModule() caddy.ModuleInfo {
 }
 
 // Provision provisions t.
-func (t *Templates) Provision(_ caddy.Context) error {
+func (t *Templates) Provision(ctx caddy.Context) error {
 	fnModInfos := caddy.GetModules("http.handlers.templates.functions")
 	customFuncs := make([]template.FuncMap, 0, len(fnModInfos))
 	for _, modInfo := range fnModInfos {

--- a/modules/caddyhttp/templates/tplcontext.go
+++ b/modules/caddyhttp/templates/tplcontext.go
@@ -31,14 +31,15 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	chromahtml "github.com/alecthomas/chroma/v2/formatters/html"
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/dustin/go-humanize"
 	"github.com/yuin/goldmark"
 	highlighting "github.com/yuin/goldmark-highlighting/v2"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
 	gmhtml "github.com/yuin/goldmark/renderer/html"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 )
 
 // TemplateContext is the TemplateContext with which HTTP templates are executed.

--- a/modules/caddyhttp/templates/tplcontext.go
+++ b/modules/caddyhttp/templates/tplcontext.go
@@ -103,13 +103,11 @@ func (c TemplateContext) OriginalReq() http.Request {
 // trusted files. If it is not trusted, be sure to use escaping functions
 // in your template.
 func (c TemplateContext) funcInclude(filename string, args ...any) (string, error) {
-
 	bodyBuf := bufPool.Get().(*bytes.Buffer)
 	bodyBuf.Reset()
 	defer bufPool.Put(bodyBuf)
 
 	err := c.readFileToBuffer(filename, bodyBuf)
-
 	if err != nil {
 		return "", err
 	}
@@ -215,7 +213,6 @@ func (c TemplateContext) funcHTTPInclude(uri string) (string, error) {
 // {{ template }} from the standard template library. If the imported file has
 // no {{ define }} blocks, the name of the import will be the path
 func (c *TemplateContext) funcImport(filename string) (string, error) {
-
 	bodyBuf := bufPool.Get().(*bytes.Buffer)
 	bodyBuf.Reset()
 	defer bufPool.Put(bodyBuf)

--- a/modules/caddyhttp/templates/tplcontext.go
+++ b/modules/caddyhttp/templates/tplcontext.go
@@ -430,7 +430,7 @@ func (c TemplateContext) funcFileStat(filename string) (fs.FileInfo, error) {
 
 // funcHTTPError returns a structured HTTP handler error. EXPERIMENTAL; SUBJECT TO CHANGE.
 // Example usage: `{{if not (fileExists $includeFile)}}{{httpError 404}}{{end}}`
-func (c TemplateContext) funcHTTPError(statusCode int) (bool, error) {
+func (TemplateContext) funcHTTPError(statusCode int) (bool, error) {
 	return false, caddyhttp.Error(statusCode, nil)
 }
 
@@ -442,7 +442,7 @@ func (c TemplateContext) funcHTTPError(statusCode int) (bool, error) {
 // Time inputs are parsed using the given layout (default layout is RFC1123Z)
 // and are formatted as a relative time, such as "2 weeks ago".
 // See https://pkg.go.dev/time#pkg-constants for time layout docs.
-func (c TemplateContext) funcHumanize(formatType, data string) (string, error) {
+func (TemplateContext) funcHumanize(formatType, data string) (string, error) {
 	// The format type can optionally be followed
 	// by a colon to provide arguments for the format
 	parts := strings.Split(formatType, ":")

--- a/modules/caddyhttp/tracing/module.go
+++ b/modules/caddyhttp/tracing/module.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"net/http"
 
+	"go.uber.org/zap"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	"go.uber.org/zap"
 )
 
 func init() {

--- a/modules/caddyhttp/tracing/tracer.go
+++ b/modules/caddyhttp/tracing/tracer.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/contrib/propagators/autoprop"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -16,6 +14,9 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 )
 
 const (

--- a/modules/caddyhttp/tracing/tracer.go
+++ b/modules/caddyhttp/tracing/tracer.go
@@ -107,12 +107,12 @@ func (ot *openTelemetryWrapper) ServeHTTP(w http.ResponseWriter, r *http.Request
 }
 
 // cleanup flush all remaining data and shutdown a tracerProvider
-func (ot *openTelemetryWrapper) cleanup(logger *zap.Logger) error {
+func (*openTelemetryWrapper) cleanup(logger *zap.Logger) error {
 	return globalTracerProvider.cleanupTracerProvider(logger)
 }
 
 // newResource creates a resource that describe current handler instance and merge it with a default attributes value.
-func (ot *openTelemetryWrapper) newResource(
+func (*openTelemetryWrapper) newResource(
 	webEngineName,
 	webEngineVersion string,
 ) (*resource.Resource, error) {
@@ -123,6 +123,6 @@ func (ot *openTelemetryWrapper) newResource(
 }
 
 // spanNameFormatter performs the replacement of placeholders in the span name
-func (ot *openTelemetryWrapper) spanNameFormatter(operation string, r *http.Request) string {
+func (*openTelemetryWrapper) spanNameFormatter(operation string, r *http.Request) string {
 	return r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer).ReplaceAll(operation, "")
 }

--- a/modules/caddypki/acmeserver/acmeserver.go
+++ b/modules/caddypki/acmeserver/acmeserver.go
@@ -26,9 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	"github.com/caddyserver/caddy/v2/modules/caddypki"
 	"github.com/go-chi/chi"
 	"github.com/smallstep/certificates/acme"
 	"github.com/smallstep/certificates/acme/api"
@@ -38,6 +35,10 @@ import (
 	"github.com/smallstep/certificates/db"
 	"github.com/smallstep/nosql"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/caddyserver/caddy/v2/modules/caddypki"
 )
 
 func init() {

--- a/modules/caddypki/acmeserver/acmeserver.go
+++ b/modules/caddypki/acmeserver/acmeserver.go
@@ -239,7 +239,7 @@ func (ash Handler) openDatabase() (*db.AuthDB, error) {
 		dbFolder := filepath.Join(caddy.AppDataDir(), "acme_server", key)
 		dbPath := filepath.Join(dbFolder, "db")
 
-		err := os.MkdirAll(dbFolder, 0755)
+		err := os.MkdirAll(dbFolder, 0o755)
 		if err != nil {
 			return nil, fmt.Errorf("making folder for CA database: %v", err)
 		}
@@ -310,8 +310,10 @@ func (c resolverClient) LookupTxt(name string) ([]string, error) {
 
 const defaultPathPrefix = "/acme/"
 
-var keyCleaner = regexp.MustCompile(`[^\w.-_]`)
-var databasePool = caddy.NewUsagePool()
+var (
+	keyCleaner   = regexp.MustCompile(`[^\w.-_]`)
+	databasePool = caddy.NewUsagePool()
+)
 
 type databaseCloser struct {
 	DB *db.AuthDB

--- a/modules/caddypki/adminapi.go
+++ b/modules/caddypki/adminapi.go
@@ -20,8 +20,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/caddyserver/caddy/v2"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 func init() {

--- a/modules/caddypki/ca.go
+++ b/modules/caddypki/ca.go
@@ -376,15 +376,19 @@ func (ca CA) genIntermediate(rootCert *x509.Certificate, rootKey crypto.Signer) 
 func (ca CA) storageKeyCAPrefix() string {
 	return path.Join("pki", "authorities", certmagic.StorageKeys.Safe(ca.ID))
 }
+
 func (ca CA) storageKeyRootCert() string {
 	return path.Join(ca.storageKeyCAPrefix(), "root.crt")
 }
+
 func (ca CA) storageKeyRootKey() string {
 	return path.Join(ca.storageKeyCAPrefix(), "root.key")
 }
+
 func (ca CA) storageKeyIntermediateCert() string {
 	return path.Join(ca.storageKeyCAPrefix(), "intermediate.crt")
 }
+
 func (ca CA) storageKeyIntermediateKey() string {
 	return path.Join(ca.storageKeyCAPrefix(), "intermediate.key")
 }

--- a/modules/caddypki/ca.go
+++ b/modules/caddypki/ca.go
@@ -25,12 +25,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/certmagic"
 	"github.com/smallstep/certificates/authority"
 	"github.com/smallstep/certificates/db"
 	"github.com/smallstep/truststore"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 // CA describes a certificate authority, which consists of

--- a/modules/caddypki/command.go
+++ b/modules/caddypki/command.go
@@ -23,10 +23,10 @@ import (
 	"os"
 	"path"
 
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
-
 	"github.com/smallstep/truststore"
 	"github.com/spf13/cobra"
+
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 
 	"github.com/caddyserver/caddy/v2"
 )

--- a/modules/caddypki/command.go
+++ b/modules/caddypki/command.go
@@ -15,8 +15,6 @@
 package caddypki
 
 import (
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
-
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -24,6 +22,8 @@ import (
 	"net/http"
 	"os"
 	"path"
+
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 
 	"github.com/smallstep/truststore"
 	"github.com/spf13/cobra"

--- a/modules/caddypki/command.go
+++ b/modules/caddypki/command.go
@@ -15,6 +15,8 @@
 package caddypki
 
 import (
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
+
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -23,10 +25,10 @@ import (
 	"os"
 	"path"
 
-	"github.com/caddyserver/caddy/v2"
-	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 	"github.com/smallstep/truststore"
 	"github.com/spf13/cobra"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 func init() {

--- a/modules/caddypki/pki.go
+++ b/modules/caddypki/pki.go
@@ -17,8 +17,9 @@ package caddypki
 import (
 	"fmt"
 
-	"github.com/caddyserver/caddy/v2"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 func init() {

--- a/modules/caddypki/pki.go
+++ b/modules/caddypki/pki.go
@@ -116,7 +116,7 @@ func (p *PKI) Start() error {
 }
 
 // Stop stops the PKI app.
-func (p *PKI) Stop() error {
+func (*PKI) Stop() error {
 	return nil
 }
 

--- a/modules/caddytls/acmeissuer.go
+++ b/modules/caddytls/acmeissuer.go
@@ -24,13 +24,14 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddyconfig"
-	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/certmagic"
 	"github.com/mholt/acmez"
 	"github.com/mholt/acmez/acme"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
 func init() {

--- a/modules/caddytls/automation.go
+++ b/modules/caddytls/automation.go
@@ -22,10 +22,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/certmagic"
 	"github.com/mholt/acmez"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 // AutomationConfig governs the automated management of TLS certificates.

--- a/modules/caddytls/certmanagers.go
+++ b/modules/caddytls/certmanagers.go
@@ -9,11 +9,12 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/certmagic"
 	"github.com/tailscale/tscert"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
 func init() {

--- a/modules/caddytls/certmanagers.go
+++ b/modules/caddytls/certmanagers.go
@@ -118,7 +118,7 @@ func (hcg *HTTPCertGetter) Provision(ctx caddy.Context) error {
 	return nil
 }
 
-func (hcg HTTPCertGetter) GetCertificate(ctx context.Context, hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+func (hcg HTTPCertGetter) GetCertificate(_ context.Context, hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	sigs := make([]string, len(hello.SignatureSchemes))
 	for i, sig := range hello.SignatureSchemes {
 		sigs[i] = fmt.Sprintf("%x", uint16(sig)) // you won't believe what %x uses if the val is a Stringer

--- a/modules/caddytls/certmanagers.go
+++ b/modules/caddytls/certmanagers.go
@@ -118,7 +118,7 @@ func (hcg *HTTPCertGetter) Provision(ctx caddy.Context) error {
 	return nil
 }
 
-func (hcg HTTPCertGetter) GetCertificate(_ context.Context, hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+func (hcg HTTPCertGetter) GetCertificate(ctx context.Context, hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	sigs := make([]string, len(hello.SignatureSchemes))
 	for i, sig := range hello.SignatureSchemes {
 		sigs[i] = fmt.Sprintf("%x", uint16(sig)) // you won't believe what %x uses if the val is a Stringer

--- a/modules/caddytls/certmanagers.go
+++ b/modules/caddytls/certmanagers.go
@@ -52,7 +52,7 @@ func (ts Tailscale) GetCertificate(ctx context.Context, hello *tls.ClientHelloIn
 }
 
 // canHazCertificate returns true if Tailscale reports it can get a certificate for the given ClientHello.
-func (ts Tailscale) canHazCertificate(ctx context.Context, hello *tls.ClientHelloInfo) (bool, error) {
+func (Tailscale) canHazCertificate(ctx context.Context, hello *tls.ClientHelloInfo) (bool, error) {
 	if !strings.HasSuffix(strings.ToLower(hello.ServerName), tailscaleDomainAliasEnding) {
 		return false, nil
 	}
@@ -103,7 +103,7 @@ type HTTPCertGetter struct {
 }
 
 // CaddyModule returns the Caddy module information.
-func (hcg HTTPCertGetter) CaddyModule() caddy.ModuleInfo {
+func (HTTPCertGetter) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID:  "tls.get_certificate.http",
 		New: func() caddy.Module { return new(HTTPCertGetter) },

--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -25,9 +25,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/caddyserver/caddy/v2"
 	"github.com/mholt/acmez"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 func init() {

--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -316,7 +316,7 @@ func (p *ConnectionPolicy) buildStandardTLSConfig(ctx caddy.Context) error {
 			return err
 		}
 		logFile, _, err := secretsLogPool.LoadOrNew(filename, func() (caddy.Destructor, error) {
-			w, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+			w, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
 			return destructableWriter{w}, err
 		})
 		if err != nil {

--- a/modules/caddytls/distributedstek/distributedstek.go
+++ b/modules/caddytls/distributedstek/distributedstek.go
@@ -33,9 +33,10 @@ import (
 	"runtime/debug"
 	"time"
 
+	"github.com/caddyserver/certmagic"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
-	"github.com/caddyserver/certmagic"
 )
 
 func init() {

--- a/modules/caddytls/internalissuer.go
+++ b/modules/caddytls/internalissuer.go
@@ -21,12 +21,13 @@ import (
 	"encoding/pem"
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
-	"github.com/caddyserver/caddy/v2/modules/caddypki"
 	"github.com/caddyserver/certmagic"
 	"github.com/smallstep/certificates/authority/provisioner"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/modules/caddypki"
 )
 
 func init() {

--- a/modules/caddytls/internalissuer.go
+++ b/modules/caddytls/internalissuer.go
@@ -100,7 +100,7 @@ func (iss InternalIssuer) IssuerKey() string {
 }
 
 // Issue issues a certificate to satisfy the CSR.
-func (iss InternalIssuer) Issue(ctx context.Context, csr *x509.CertificateRequest) (*certmagic.IssuedCertificate, error) {
+func (iss InternalIssuer) Issue(_ context.Context, csr *x509.CertificateRequest) (*certmagic.IssuedCertificate, error) {
 	// prepare the signing authority
 	authCfg := caddypki.AuthorityConfig{
 		SignWithRoot: iss.SignWithRoot,

--- a/modules/caddytls/internalissuer.go
+++ b/modules/caddytls/internalissuer.go
@@ -100,7 +100,7 @@ func (iss InternalIssuer) IssuerKey() string {
 }
 
 // Issue issues a certificate to satisfy the CSR.
-func (iss InternalIssuer) Issue(_ context.Context, csr *x509.CertificateRequest) (*certmagic.IssuedCertificate, error) {
+func (iss InternalIssuer) Issue(ctx context.Context, csr *x509.CertificateRequest) (*certmagic.IssuedCertificate, error) {
 	// prepare the signing authority
 	authCfg := caddypki.AuthorityConfig{
 		SignWithRoot: iss.SignWithRoot,

--- a/modules/caddytls/matchers.go
+++ b/modules/caddytls/matchers.go
@@ -21,9 +21,10 @@ import (
 	"net/netip"
 	"strings"
 
-	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/certmagic"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 func init() {

--- a/modules/caddytls/sessiontickets.go
+++ b/modules/caddytls/sessiontickets.go
@@ -216,7 +216,7 @@ func (s SessionTicketService) RotateSTEKs(keys [][32]byte) ([][32]byte, error) {
 
 // generateSTEK generates key material suitable for use as a
 // session ticket ephemeral key.
-func (s *SessionTicketService) generateSTEK() ([32]byte, error) {
+func (*SessionTicketService) generateSTEK() ([32]byte, error) {
 	var newTicketKey [32]byte
 	_, err := io.ReadFull(rand.Reader, newTicketKey[:])
 	return newTicketKey, err

--- a/modules/caddytls/storageloader.go
+++ b/modules/caddytls/storageloader.go
@@ -18,8 +18,9 @@ import (
 	"crypto/tls"
 	"fmt"
 
-	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/certmagic"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 func init() {

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -25,10 +25,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/modules/caddyevents"
 	"github.com/caddyserver/certmagic"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyevents"
 )
 
 func init() {

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -609,7 +609,7 @@ func (t *TLS) storageCleanInterval() time.Duration {
 }
 
 // onEvent translates CertMagic events into Caddy events then dispatches them.
-func (t *TLS) onEvent(ctx context.Context, eventName string, data map[string]any) error {
+func (t *TLS) onEvent(_ context.Context, eventName string, data map[string]any) error {
 	evt := t.events.Emit(t.ctx, eventName, data)
 	return evt.Aborted
 }

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -609,7 +609,7 @@ func (t *TLS) storageCleanInterval() time.Duration {
 }
 
 // onEvent translates CertMagic events into Caddy events then dispatches them.
-func (t *TLS) onEvent(_ context.Context, eventName string, data map[string]any) error {
+func (t *TLS) onEvent(ctx context.Context, eventName string, data map[string]any) error {
 	evt := t.events.Emit(t.ctx, eventName, data)
 	return evt.Aborted
 }

--- a/modules/caddytls/zerosslissuer.go
+++ b/modules/caddytls/zerosslissuer.go
@@ -25,11 +25,12 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/certmagic"
 	"github.com/mholt/acmez/acme"
 	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
 func init() {

--- a/modules/filestorage/filestorage.go
+++ b/modules/filestorage/filestorage.go
@@ -15,9 +15,10 @@
 package filestorage
 
 import (
+	"github.com/caddyserver/certmagic"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
-	"github.com/caddyserver/certmagic"
 )
 
 func init() {

--- a/modules/logging/encoders.go
+++ b/modules/logging/encoders.go
@@ -17,11 +17,12 @@ package logging
 import (
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"go.uber.org/zap"
 	"go.uber.org/zap/buffer"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
 func init() {

--- a/modules/logging/filewriter.go
+++ b/modules/logging/filewriter.go
@@ -126,7 +126,7 @@ func (fw FileWriter) OpenWriter() (io.WriteCloser, error) {
 	}
 
 	// otherwise just open a regular file
-	return os.OpenFile(fw.Filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
+	return os.OpenFile(fw.Filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o666)
 }
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens. Syntax:

--- a/modules/logging/filewriter.go
+++ b/modules/logging/filewriter.go
@@ -22,10 +22,11 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/dustin/go-humanize"
 	"gopkg.in/natefinch/lumberjack.v2"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
 func init() {

--- a/modules/logging/filewriter.go
+++ b/modules/logging/filewriter.go
@@ -73,7 +73,7 @@ func (FileWriter) CaddyModule() caddy.ModuleInfo {
 }
 
 // Provision sets up the module
-func (fw *FileWriter) Provision(ctx caddy.Context) error {
+func (fw *FileWriter) Provision(caddy.Context) error {
 	// Replace placeholder in filename
 	repl := caddy.NewReplacer()
 	filename, err := repl.ReplaceOrErr(fw.Filename, true, true)

--- a/modules/logging/filewriter.go
+++ b/modules/logging/filewriter.go
@@ -73,7 +73,7 @@ func (FileWriter) CaddyModule() caddy.ModuleInfo {
 }
 
 // Provision sets up the module
-func (fw *FileWriter) Provision(caddy.Context) error {
+func (fw *FileWriter) Provision(ctx caddy.Context) error {
 	// Replace placeholder in filename
 	repl := caddy.NewReplacer()
 	filename, err := repl.ReplaceOrErr(fw.Filename, true, true)

--- a/modules/logging/filterencoder.go
+++ b/modules/logging/filterencoder.go
@@ -19,12 +19,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddyconfig"
-	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"go.uber.org/zap"
 	"go.uber.org/zap/buffer"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
 func init() {

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -25,10 +25,11 @@ import (
 	"strconv"
 	"strings"
 
+	"go.uber.org/zap/zapcore"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	"go.uber.org/zap/zapcore"
 )
 
 func init() {

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -81,8 +81,7 @@ func hash(s string) string {
 // of the SHA-256 hash of the content. Operates
 // on string fields, or on arrays of strings
 // where each string is hashed.
-type HashFilter struct {
-}
+type HashFilter struct{}
 
 // CaddyModule returns the Caddy module information.
 func (HashFilter) CaddyModule() caddy.ModuleInfo {

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -62,7 +62,7 @@ func (DeleteFilter) CaddyModule() caddy.ModuleInfo {
 }
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens.
-func (DeleteFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (DeleteFilter) UnmarshalCaddyfile(_ *caddyfile.Dispenser) error {
 	return nil
 }
 
@@ -93,7 +93,7 @@ func (HashFilter) CaddyModule() caddy.ModuleInfo {
 }
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens.
-func (f *HashFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (f *HashFilter) UnmarshalCaddyfile(_ *caddyfile.Dispenser) error {
 	return nil
 }
 
@@ -198,7 +198,7 @@ func (m *IPMaskFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 }
 
 // Provision parses m's IP masks, from integers.
-func (m *IPMaskFilter) Provision(ctx caddy.Context) error {
+func (m *IPMaskFilter) Provision(_ caddy.Context) error {
 	parseRawToMask := func(rawField int, bitLen int) net.IPMask {
 		if rawField == 0 {
 			return nil
@@ -566,7 +566,7 @@ func (f *RegexpFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 }
 
 // Provision compiles m's regexp.
-func (f *RegexpFilter) Provision(ctx caddy.Context) error {
+func (f *RegexpFilter) Provision(_ caddy.Context) error {
 	r, err := regexp.Compile(f.RawRegexp)
 	if err != nil {
 		return err

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -93,12 +93,12 @@ func (HashFilter) CaddyModule() caddy.ModuleInfo {
 }
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens.
-func (f *HashFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (*HashFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	return nil
 }
 
 // Filter filters the input field with the replacement value.
-func (f *HashFilter) Filter(in zapcore.Field) zapcore.Field {
+func (*HashFilter) Filter(in zapcore.Field) zapcore.Field {
 	if array, ok := in.Interface.(caddyhttp.LoggableStringArray); ok {
 		for i, s := range array {
 			array[i] = hash(s)

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -62,7 +62,7 @@ func (DeleteFilter) CaddyModule() caddy.ModuleInfo {
 }
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens.
-func (DeleteFilter) UnmarshalCaddyfile(_ *caddyfile.Dispenser) error {
+func (DeleteFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	return nil
 }
 
@@ -93,7 +93,7 @@ func (HashFilter) CaddyModule() caddy.ModuleInfo {
 }
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens.
-func (f *HashFilter) UnmarshalCaddyfile(_ *caddyfile.Dispenser) error {
+func (f *HashFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	return nil
 }
 
@@ -198,7 +198,7 @@ func (m *IPMaskFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 }
 
 // Provision parses m's IP masks, from integers.
-func (m *IPMaskFilter) Provision(_ caddy.Context) error {
+func (m *IPMaskFilter) Provision(ctx caddy.Context) error {
 	parseRawToMask := func(rawField int, bitLen int) net.IPMask {
 		if rawField == 0 {
 			return nil
@@ -566,7 +566,7 @@ func (f *RegexpFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 }
 
 // Provision compiles m's regexp.
-func (f *RegexpFilter) Provision(_ caddy.Context) error {
+func (f *RegexpFilter) Provision(ctx caddy.Context) error {
 	r, err := regexp.Compile(f.RawRegexp)
 	if err != nil {
 		return err

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -322,7 +322,7 @@ func (QueryFilter) CaddyModule() caddy.ModuleInfo {
 }
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens.
-func (m *QueryFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (f *QueryFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		for d.NextBlock(0) {
 			qfa := queryFilterAction{}
@@ -360,21 +360,21 @@ func (m *QueryFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				return d.Errf("unrecognized subdirective %s", d.Val())
 			}
 
-			m.Actions = append(m.Actions, qfa)
+			f.Actions = append(f.Actions, qfa)
 		}
 	}
 	return nil
 }
 
 // Filter filters the input field.
-func (m QueryFilter) Filter(in zapcore.Field) zapcore.Field {
+func (f QueryFilter) Filter(in zapcore.Field) zapcore.Field {
 	u, err := url.Parse(in.String)
 	if err != nil {
 		return in
 	}
 
 	q := u.Query()
-	for _, a := range m.Actions {
+	for _, a := range f.Actions {
 		switch a.Type {
 		case replaceAction:
 			for i := range q[a.Parameter] {
@@ -442,7 +442,7 @@ func (CookieFilter) CaddyModule() caddy.ModuleInfo {
 }
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens.
-func (m *CookieFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (f *CookieFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		for d.NextBlock(0) {
 			cfa := cookieFilterAction{}
@@ -480,14 +480,14 @@ func (m *CookieFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				return d.Errf("unrecognized subdirective %s", d.Val())
 			}
 
-			m.Actions = append(m.Actions, cfa)
+			f.Actions = append(f.Actions, cfa)
 		}
 	}
 	return nil
 }
 
 // Filter filters the input field.
-func (m CookieFilter) Filter(in zapcore.Field) zapcore.Field {
+func (f CookieFilter) Filter(in zapcore.Field) zapcore.Field {
 	cookiesSlice, ok := in.Interface.(caddyhttp.LoggableStringArray)
 	if !ok {
 		return in
@@ -500,7 +500,7 @@ func (m CookieFilter) Filter(in zapcore.Field) zapcore.Field {
 
 OUTER:
 	for _, c := range cookies {
-		for _, a := range m.Actions {
+		for _, a := range f.Actions {
 			if c.Name != a.Name {
 				continue
 			}
@@ -566,13 +566,13 @@ func (f *RegexpFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 }
 
 // Provision compiles m's regexp.
-func (m *RegexpFilter) Provision(ctx caddy.Context) error {
-	r, err := regexp.Compile(m.RawRegexp)
+func (f *RegexpFilter) Provision(ctx caddy.Context) error {
+	r, err := regexp.Compile(f.RawRegexp)
 	if err != nil {
 		return err
 	}
 
-	m.regexp = r
+	f.regexp = r
 
 	return nil
 }

--- a/modules/logging/netwriter.go
+++ b/modules/logging/netwriter.go
@@ -57,7 +57,7 @@ func (NetWriter) CaddyModule() caddy.ModuleInfo {
 }
 
 // Provision sets up the module.
-func (nw *NetWriter) Provision(_ caddy.Context) error {
+func (nw *NetWriter) Provision(ctx caddy.Context) error {
 	repl := caddy.NewReplacer()
 	address, err := repl.ReplaceOrErr(nw.Address, true, true)
 	if err != nil {

--- a/modules/logging/netwriter.go
+++ b/modules/logging/netwriter.go
@@ -57,7 +57,7 @@ func (NetWriter) CaddyModule() caddy.ModuleInfo {
 }
 
 // Provision sets up the module.
-func (nw *NetWriter) Provision(ctx caddy.Context) error {
+func (nw *NetWriter) Provision(_ caddy.Context) error {
 	repl := caddy.NewReplacer()
 	address, err := repl.ReplaceOrErr(nw.Address, true, true)
 	if err != nil {

--- a/modules/logging/nopencoder.go
+++ b/modules/logging/nopencoder.go
@@ -26,79 +26,79 @@ type nopEncoder struct{}
 
 // AddArray is part of the zapcore.ObjectEncoder interface.
 // Array elements do not get filtered.
-func (nopEncoder) AddArray(_ string, _ zapcore.ArrayMarshaler) error { return nil }
+func (nopEncoder) AddArray(key string, marshaler zapcore.ArrayMarshaler) error { return nil }
 
 // AddObject is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddObject(_ string, _ zapcore.ObjectMarshaler) error { return nil }
+func (nopEncoder) AddObject(key string, marshaler zapcore.ObjectMarshaler) error { return nil }
 
 // AddBinary is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddBinary(_ string, _ []byte) {}
+func (nopEncoder) AddBinary(key string, value []byte) {}
 
 // AddByteString is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddByteString(_ string, _ []byte) {}
+func (nopEncoder) AddByteString(key string, value []byte) {}
 
 // AddBool is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddBool(_ string, _ bool) {}
+func (nopEncoder) AddBool(key string, value bool) {}
 
 // AddComplex128 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddComplex128(_ string, _ complex128) {}
+func (nopEncoder) AddComplex128(key string, value complex128) {}
 
 // AddComplex64 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddComplex64(_ string, _ complex64) {}
+func (nopEncoder) AddComplex64(key string, value complex64) {}
 
 // AddDuration is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddDuration(_ string, _ time.Duration) {}
+func (nopEncoder) AddDuration(key string, value time.Duration) {}
 
 // AddFloat64 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddFloat64(_ string, _ float64) {}
+func (nopEncoder) AddFloat64(key string, value float64) {}
 
 // AddFloat32 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddFloat32(_ string, _ float32) {}
+func (nopEncoder) AddFloat32(key string, value float32) {}
 
 // AddInt is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddInt(_ string, _ int) {}
+func (nopEncoder) AddInt(key string, value int) {}
 
 // AddInt64 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddInt64(_ string, _ int64) {}
+func (nopEncoder) AddInt64(key string, value int64) {}
 
 // AddInt32 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddInt32(_ string, _ int32) {}
+func (nopEncoder) AddInt32(key string, value int32) {}
 
 // AddInt16 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddInt16(_ string, _ int16) {}
+func (nopEncoder) AddInt16(key string, value int16) {}
 
 // AddInt8 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddInt8(_ string, _ int8) {}
+func (nopEncoder) AddInt8(key string, value int8) {}
 
 // AddString is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddString(_, _ string) {}
+func (nopEncoder) AddString(key, value string) {}
 
 // AddTime is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddTime(_ string, _ time.Time) {}
+func (nopEncoder) AddTime(key string, value time.Time) {}
 
 // AddUint is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddUint(_ string, _ uint) {}
+func (nopEncoder) AddUint(key string, value uint) {}
 
 // AddUint64 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddUint64(_ string, _ uint64) {}
+func (nopEncoder) AddUint64(key string, value uint64) {}
 
 // AddUint32 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddUint32(_ string, _ uint32) {}
+func (nopEncoder) AddUint32(key string, value uint32) {}
 
 // AddUint16 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddUint16(_ string, _ uint16) {}
+func (nopEncoder) AddUint16(key string, value uint16) {}
 
 // AddUint8 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddUint8(_ string, _ uint8) {}
+func (nopEncoder) AddUint8(key string, value uint8) {}
 
 // AddUintptr is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddUintptr(_ string, _ uintptr) {}
+func (nopEncoder) AddUintptr(key string, value uintptr) {}
 
 // AddReflected is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddReflected(_ string, _ any) error { return nil }
+func (nopEncoder) AddReflected(key string, value any) error { return nil }
 
 // OpenNamespace is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) OpenNamespace(_ string) {}
+func (nopEncoder) OpenNamespace(key string) {}
 
 // Clone is part of the zapcore.ObjectEncoder interface.
 // We don't use it as of Oct 2019 (v2 beta 7), I'm not
@@ -106,7 +106,7 @@ func (nopEncoder) OpenNamespace(_ string) {}
 func (ne nopEncoder) Clone() zapcore.Encoder { return ne }
 
 // EncodeEntry partially implements the zapcore.Encoder interface.
-func (nopEncoder) EncodeEntry(_ zapcore.Entry, _ []zapcore.Field) (*buffer.Buffer, error) {
+func (nopEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field) (*buffer.Buffer, error) {
 	return bufferpool.Get(), nil
 }
 

--- a/modules/logging/nopencoder.go
+++ b/modules/logging/nopencoder.go
@@ -26,79 +26,79 @@ type nopEncoder struct{}
 
 // AddArray is part of the zapcore.ObjectEncoder interface.
 // Array elements do not get filtered.
-func (nopEncoder) AddArray(key string, marshaler zapcore.ArrayMarshaler) error { return nil }
+func (nopEncoder) AddArray(_ string, _ zapcore.ArrayMarshaler) error { return nil }
 
 // AddObject is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddObject(key string, marshaler zapcore.ObjectMarshaler) error { return nil }
+func (nopEncoder) AddObject(_ string, _ zapcore.ObjectMarshaler) error { return nil }
 
 // AddBinary is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddBinary(key string, value []byte) {}
+func (nopEncoder) AddBinary(_ string, _ []byte) {}
 
 // AddByteString is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddByteString(key string, value []byte) {}
+func (nopEncoder) AddByteString(_ string, _ []byte) {}
 
 // AddBool is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddBool(key string, value bool) {}
+func (nopEncoder) AddBool(_ string, _ bool) {}
 
 // AddComplex128 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddComplex128(key string, value complex128) {}
+func (nopEncoder) AddComplex128(_ string, _ complex128) {}
 
 // AddComplex64 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddComplex64(key string, value complex64) {}
+func (nopEncoder) AddComplex64(_ string, _ complex64) {}
 
 // AddDuration is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddDuration(key string, value time.Duration) {}
+func (nopEncoder) AddDuration(_ string, _ time.Duration) {}
 
 // AddFloat64 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddFloat64(key string, value float64) {}
+func (nopEncoder) AddFloat64(_ string, _ float64) {}
 
 // AddFloat32 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddFloat32(key string, value float32) {}
+func (nopEncoder) AddFloat32(_ string, _ float32) {}
 
 // AddInt is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddInt(key string, value int) {}
+func (nopEncoder) AddInt(_ string, _ int) {}
 
 // AddInt64 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddInt64(key string, value int64) {}
+func (nopEncoder) AddInt64(_ string, _ int64) {}
 
 // AddInt32 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddInt32(key string, value int32) {}
+func (nopEncoder) AddInt32(_ string, _ int32) {}
 
 // AddInt16 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddInt16(key string, value int16) {}
+func (nopEncoder) AddInt16(_ string, _ int16) {}
 
 // AddInt8 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddInt8(key string, value int8) {}
+func (nopEncoder) AddInt8(_ string, _ int8) {}
 
 // AddString is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddString(key, value string) {}
+func (nopEncoder) AddString(_, _ string) {}
 
 // AddTime is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddTime(key string, value time.Time) {}
+func (nopEncoder) AddTime(_ string, _ time.Time) {}
 
 // AddUint is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddUint(key string, value uint) {}
+func (nopEncoder) AddUint(_ string, _ uint) {}
 
 // AddUint64 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddUint64(key string, value uint64) {}
+func (nopEncoder) AddUint64(_ string, _ uint64) {}
 
 // AddUint32 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddUint32(key string, value uint32) {}
+func (nopEncoder) AddUint32(_ string, _ uint32) {}
 
 // AddUint16 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddUint16(key string, value uint16) {}
+func (nopEncoder) AddUint16(_ string, _ uint16) {}
 
 // AddUint8 is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddUint8(key string, value uint8) {}
+func (nopEncoder) AddUint8(_ string, _ uint8) {}
 
 // AddUintptr is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddUintptr(key string, value uintptr) {}
+func (nopEncoder) AddUintptr(_ string, _ uintptr) {}
 
 // AddReflected is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) AddReflected(key string, value any) error { return nil }
+func (nopEncoder) AddReflected(_ string, _ any) error { return nil }
 
 // OpenNamespace is part of the zapcore.ObjectEncoder interface.
-func (nopEncoder) OpenNamespace(key string) {}
+func (nopEncoder) OpenNamespace(_ string) {}
 
 // Clone is part of the zapcore.ObjectEncoder interface.
 // We don't use it as of Oct 2019 (v2 beta 7), I'm not
@@ -106,7 +106,7 @@ func (nopEncoder) OpenNamespace(key string) {}
 func (ne nopEncoder) Clone() zapcore.Encoder { return ne }
 
 // EncodeEntry partially implements the zapcore.Encoder interface.
-func (nopEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field) (*buffer.Buffer, error) {
+func (nopEncoder) EncodeEntry(_ zapcore.Entry, _ []zapcore.Field) (*buffer.Buffer, error) {
 	return bufferpool.Get(), nil
 }
 

--- a/modules/metrics/adminmetrics.go
+++ b/modules/metrics/adminmetrics.go
@@ -40,7 +40,7 @@ func (AdminMetrics) CaddyModule() caddy.ModuleInfo {
 }
 
 // Routes returns a route for the /metrics endpoint.
-func (m *AdminMetrics) Routes() []caddy.AdminRoute {
+func (*AdminMetrics) Routes() []caddy.AdminRoute {
 	metricsHandler := createMetricsHandler(nil, false)
 	h := caddy.AdminHandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		metricsHandler.ServeHTTP(w, r)

--- a/modules/metrics/metrics.go
+++ b/modules/metrics/metrics.go
@@ -17,13 +17,14 @@ package metrics
 import (
 	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.uber.org/zap"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"go.uber.org/zap"
 )
 
 func init() {

--- a/modules/metrics/metrics.go
+++ b/modules/metrics/metrics.go
@@ -96,7 +96,7 @@ func (m *Metrics) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	return nil
 }
 
-func (m Metrics) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
+func (m Metrics) ServeHTTP(w http.ResponseWriter, r *http.Request, _ caddyhttp.Handler) error {
 	m.metricsHandler.ServeHTTP(w, r)
 	return nil
 }

--- a/modules/metrics/metrics.go
+++ b/modules/metrics/metrics.go
@@ -96,7 +96,7 @@ func (m *Metrics) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	return nil
 }
 
-func (m Metrics) ServeHTTP(w http.ResponseWriter, r *http.Request, _ caddyhttp.Handler) error {
+func (m Metrics) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	m.metricsHandler.ServeHTTP(w, r)
 	return nil
 }

--- a/modules/metrics/metrics.go
+++ b/modules/metrics/metrics.go
@@ -21,11 +21,9 @@ import (
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-
-	"go.uber.org/zap"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.uber.org/zap"
 )
 
 func init() {

--- a/replacer.go
+++ b/replacer.go
@@ -131,7 +131,8 @@ func (r *Replacer) ReplaceFunc(input string, f ReplacementFunc) (string, error) 
 
 func (r *Replacer) replace(input, empty string,
 	treatUnknownAsEmpty, errOnEmpty, errOnUnknown bool,
-	f ReplacementFunc) (string, error) {
+	f ReplacementFunc,
+) (string, error) {
 	if !strings.Contains(input, string(phOpen)) {
 		return input, nil
 	}

--- a/usagepool.go
+++ b/usagepool.go
@@ -106,7 +106,7 @@ func (up *UsagePool) LoadOrNew(key any, construct Constructor) (value any, loade
 		}
 		upv.Unlock()
 	}
-	return
+	return value, loaded, err
 }
 
 // LoadOrStore loads the value associated with key from the pool if it
@@ -134,7 +134,7 @@ func (up *UsagePool) LoadOrStore(key, val any) (value any, loaded bool) {
 		up.Unlock()
 		value = val
 	}
-	return
+	return value, loaded
 }
 
 // Range iterates the pool similarly to how sync.Map.Range() does:
@@ -191,7 +191,7 @@ func (up *UsagePool) Delete(key any) (deleted bool, err error) {
 				upv.value, upv.refs))
 		}
 	}
-	return
+	return deleted, err
 }
 
 // References returns the number of references (count of usages) to a


### PR DESCRIPTION
This PR enables the revive linter, and should be merged after gci and gofumpt, since it contains them. 



- use gofmput to format code
- use gci to format imports
- reconfigure gci
- linter autofixes
- rearrange imports a little
- all changes other than unused-parameter
- use revive linter


## Contains

* #5707 
* #5708 
