### PR TITLE
linter: gocritic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
   enable:
     - bodyclose
     - errcheck
+    - gocritic
     - gci
     - gofumpt
     - gosec

--- a/caddyconfig/caddyfile/adapter.go
+++ b/caddyconfig/caddyfile/adapter.go
@@ -68,7 +68,7 @@ func (a Adapter) Adapt(body []byte, options map[string]any) ([]byte, []caddyconf
 // TODO: also perform this check on imported files
 func FormattingDifference(filename string, body []byte) (caddyconfig.Warning, bool) {
 	// replace windows-style newlines to normalize comparison
-	normalizedBody := bytes.Replace(body, []byte("\r\n"), []byte("\n"), -1)
+	normalizedBody := bytes.ReplaceAll(body, []byte("\r\n"), []byte("\n"))
 
 	formatted := Format(normalizedBody)
 	if bytes.Equal(formatted, normalizedBody) {

--- a/caddyconfig/caddyfile/lexer.go
+++ b/caddyconfig/caddyfile/lexer.go
@@ -204,10 +204,9 @@ func (l *lexer) next() (bool, error) {
 					val = append(val, '\\')
 				}
 				escaped = false
-			} else {
-				if (quoted && ch == '"') || (btQuoted && ch == '`') {
-					return makeToken(ch), nil
-				}
+			} else if (quoted && ch == '"') || (btQuoted && ch == '`') {
+				return makeToken(ch), nil
+
 			}
 			// allow quoted text to wrap continue on multiple lines
 			if ch == '\n' {

--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -837,16 +837,14 @@ func parseLogHelper(h Helper, globalLogNames map[string]struct{}) ([]ConfigValue
 				return nil, h.Err("duplicate global log option for: " + logName)
 			}
 			globalLogNames[logName] = struct{}{}
-		} else {
 			// An optional override of the logger name can be provided;
 			// otherwise a default will be used, like "log0", "log1", etc.
-			if h.NextArg() {
-				logName = h.Val()
+		} else if h.NextArg() {
+			logName = h.Val()
 
-				// Only a single argument is supported.
-				if h.NextArg() {
-					return nil, h.ArgErr()
-				}
+			// Only a single argument is supported.
+			if h.NextArg() {
+				return nil, h.ArgErr()
 			}
 		}
 

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -599,13 +599,8 @@ func isCELStringExpr(e *exprpb.Expr) bool {
 
 // isCELStringLiteral returns whether the expression is a CEL string literal.
 func isCELStringLiteral(e *exprpb.Expr) bool {
-	switch e.GetExprKind().(type) {
-	case *exprpb.Expr_ConstExpr:
-		constant := e.GetConstExpr()
-		switch constant.GetConstantKind().(type) {
-		case *exprpb.Constant_StringValue:
-			return true
-		}
+	if _, ok := e.GetConstExpr().GetConstantKind().(*exprpb.Constant_StringValue); ok {
+		return true
 	}
 	return false
 }

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -866,7 +866,11 @@ func (h *Handler) FinalizeUnmarshalCaddyfile(helper httpcaddyfile.Helper) error 
 			withMatchers = append(withMatchers, hr)
 		}
 	}
-	h.HandleResponse = append(withMatchers, withoutMatchers...)
+	h.HandleResponse = make([]caddyhttp.ResponseHandler, 0, len(h.HandleResponse))
+	h.HandleResponse = append(h.HandleResponse, withMatchers...)
+	h.HandleResponse = append(h.HandleResponse, withoutMatchers...)
+	h.HandleResponse = append(h.HandleResponse, withMatchers...)
+	h.HandleResponse = append(h.HandleResponse, withoutMatchers...)
 
 	// clean up the bits we only needed for adapting
 	h.handleResponseSegments = nil

--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -366,7 +366,7 @@ type ClientAuthentication struct {
 	// these CA certificates will be rejected.
 	TrustedCACertPEMFiles []string `json:"trusted_ca_certs_pem_files,omitempty"`
 
-	// DEPRECATED: This field is deprecated and will be removed in
+	// Deprecated: This field is deprecated and will be removed in
 	// a future version. Please use the `validators` field instead
 	// with the tls.client_auth.leaf module instead.
 	//


### PR DESCRIPTION
- use gofmput to format code
- use gci to format imports
- reconfigure gci
- linter autofixes
- rearrange imports a little
- gocritic
