### PR TITLE
usagepool: Adds generic `UsagePoolOf`, deprecates `UsagePool`

### DIFF
--- a/listen.go
+++ b/listen.go
@@ -167,7 +167,7 @@ func (sl *sharedListener) setDeadline() error {
 	return err
 }
 
-// Destruct is called by the UsagePool when the listener is
+// Destruct is called by UsagePoolOf when the listener is
 // finally not being used anymore. It closes the socket.
 func (sl *sharedListener) Destruct() error {
 	return sl.Listener.Close()

--- a/listen_unix.go
+++ b/listen_unix.go
@@ -105,7 +105,7 @@ func listenTCPOrUnix(ctx context.Context, lnKey string, network, address string,
 	// whether to enforce shutdown delays, for example (see #5393).
 	ln, err := config.Listen(ctx, network, address)
 	if err == nil {
-		listenerPool.LoadOrStore(lnKey, nil)
+		listenerPool.LoadOrStore(lnKey, deleteListener{})
 	}
 
 	// if new listener is a unix socket, make sure we can reuse it later
@@ -170,4 +170,8 @@ type deleteListener struct {
 func (dl deleteListener) Close() error {
 	_, _ = listenerPool.Delete(dl.lnKey)
 	return dl.Listener.Close()
+}
+
+func (dl deleteListener) Destruct() error {
+	return nil
 }

--- a/listeners.go
+++ b/listeners.go
@@ -787,7 +787,7 @@ type ListenerWrapper interface {
 }
 
 // listenerPool stores and allows reuse of active listeners.
-var listenerPool = NewUsagePool()
+var listenerPool = NewUsagePoolOf[string, Destructor]()
 
 const maxPortSpan = 65535
 

--- a/logging.go
+++ b/logging.go
@@ -690,7 +690,12 @@ var (
 	defaultLoggerMu  sync.RWMutex
 )
 
-var writers = NewUsagePool()
+type DestructableWriter interface {
+	Destructor
+	io.Writer
+}
+
+var writers = NewUsagePoolOf[string, DestructableWriter]()
 
 const DefaultLoggerName = "default"
 

--- a/modules/caddyhttp/ip_range.go
+++ b/modules/caddyhttp/ip_range.go
@@ -40,7 +40,7 @@ func init() {
 // so that it's ready to be used when requests start getting handled.
 // A read lock should probably be used to get the cached value if the
 // ranges can change at runtime (e.g. periodically refreshed).
-// Using a `caddy.UsagePool` may be a good idea to avoid having refetch
+// Using a `caddy.UsagePoolOf` may be a good idea to avoid having refetch
 // the values when a config reload occurs, which would waste time.
 //
 // If the list of IP ranges cannot be sourced, then provisioning SHOULD

--- a/modules/caddyhttp/reverseproxy/admin.go
+++ b/modules/caddyhttp/reverseproxy/admin.go
@@ -76,25 +76,7 @@ func (adminUpstreams) handleUpstreams(w http.ResponseWriter, r *http.Request) er
 
 	// Iterate over the upstream pool (needs to be fast)
 	var rangeErr error
-	hosts.Range(func(key, val any) bool {
-		address, ok := key.(string)
-		if !ok {
-			rangeErr = caddy.APIError{
-				HTTPStatus: http.StatusInternalServerError,
-				Err:        fmt.Errorf("could not type assert upstream address"),
-			}
-			return false
-		}
-
-		upstream, ok := val.(*Host)
-		if !ok {
-			rangeErr = caddy.APIError{
-				HTTPStatus: http.StatusInternalServerError,
-				Err:        fmt.Errorf("could not type assert upstream struct"),
-			}
-			return false
-		}
-
+	hosts.Range(func(address string, upstream *Host) bool {
 		results = append(results, upstreamStatus{
 			Address:     address,
 			NumRequests: upstream.NumRequests(),

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -128,7 +128,7 @@ func (u *Upstream) fillHost() {
 	host := new(Host)
 	existingHost, loaded := hosts.LoadOrStore(u.String(), host)
 	if loaded {
-		host = existingHost.(*Host)
+		host = existingHost
 	}
 	u.Host = host
 }
@@ -138,6 +138,10 @@ func (u *Upstream) fillHost() {
 type Host struct {
 	numRequests int64 // must be 64-bit aligned on 32-bit systems (see https://golang.org/pkg/sync/atomic/#pkg-note-BUG)
 	fails       int64
+}
+
+func (h *Host) Destruct() error {
+	return nil
 }
 
 // NumRequests returns the number of active requests to the upstream.
@@ -229,7 +233,7 @@ func GetDialInfo(ctx context.Context) (DialInfo, bool) {
 // currently in use by active configuration(s). This
 // allows the state of remote hosts to be preserved
 // through config reloads.
-var hosts = caddy.NewUsagePool()
+var hosts = caddy.NewUsagePoolOf[string, *Host]()
 
 // dialInfoVarKey is the key used for the variable that holds
 // the dial info for the upstream connection.

--- a/modules/caddypki/acmeserver/acmeserver.go
+++ b/modules/caddypki/acmeserver/acmeserver.go
@@ -241,7 +241,7 @@ func (ash Handler) openDatabase() (*db.AuthDB, error) {
 
 		err := os.MkdirAll(dbFolder, 0o755)
 		if err != nil {
-			return nil, fmt.Errorf("making folder for CA database: %v", err)
+			return databaseCloser{}, fmt.Errorf("making folder for CA database: %v", err)
 		}
 
 		dbConfig := &db.Config{
@@ -256,7 +256,7 @@ func (ash Handler) openDatabase() (*db.AuthDB, error) {
 		ash.logger.Debug("loaded preexisting CA database", zap.String("db_key", key))
 	}
 
-	return database.(databaseCloser).DB, err
+	return database.DB, err
 }
 
 // makeClient creates an ACME client which will use a custom
@@ -312,7 +312,7 @@ const defaultPathPrefix = "/acme/"
 
 var (
 	keyCleaner   = regexp.MustCompile(`[^\w.-_]`)
-	databasePool = caddy.NewUsagePool()
+	databasePool = caddy.NewUsagePoolOf[string, databaseCloser]()
 )
 
 type databaseCloser struct {

--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -20,7 +20,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -324,7 +323,7 @@ func (p *ConnectionPolicy) buildStandardTLSConfig(ctx caddy.Context) error {
 		}
 		ctx.OnCancel(func() { _, _ = secretsLogPool.Delete(filename) })
 
-		cfg.KeyLogWriter = logFile.(io.Writer)
+		cfg.KeyLogWriter = logFile
 
 		tlsApp.logger.Warn("TLS SECURITY COMPROMISED: secrets logging is enabled!",
 			zap.String("log_filename", filename))
@@ -598,4 +597,4 @@ type destructableWriter struct{ *os.File }
 
 func (d destructableWriter) Destruct() error { return d.Close() }
 
-var secretsLogPool = caddy.NewUsagePool()
+var secretsLogPool = caddy.NewUsagePoolOf[string, destructableWriter]()


### PR DESCRIPTION
Adds much-needed type safety for UsagePool with a new type, UsagePoolOf. 
UsagePool definition and public interfaces intact, with deprecation warning.
Updates usages within core modules, and adds specific value types to UsagePools, except for listenerPool, for which there is no interface common to quic.EarlyListener and the net package. 