### PR TITLE
fileserver: Support `precompressed` files without base files

### DIFF
--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -147,6 +147,12 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 				}
 				fsrv.PassThru = true
 
+			case "prefer_precompressed":
+				if h.NextArg() {
+					return nil, h.ArgErr()
+				}
+				fsrv.PreferPrecompressed = true
+
 			default:
 				return nil, h.Errf("unknown subdirective '%s'", h.Val())
 			}

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -132,6 +132,8 @@ type FileServer struct {
 	// clobbering the explicit rewrite with implicit behavior.
 	CanonicalURIs *bool `json:"canonical_uris,omitempty"`
 
+	PreferPrecompressed bool `json:"prefer_precompressed,omitempty"`
+
 	// Override the status code written when successfully serving a file.
 	// Particularly useful when explicitly serving a file as display for
 	// an error, like a 404 page. A placeholder may be used. By default,


### PR DESCRIPTION
Closes https://github.com/caddyserver/caddy/issues/5116

Changes done so far:

1. Added a new bool value to the FileServer Struct called PreferPrecompressed
2. Start accepting prefer_precompressed subdirective under the fileserver directive
3. If PreCompressed is enabed on fileserver, ignore checking the existence of the original file and serve encoded file as per the accepted encoding if available, else return 404.
 
To Do:
    
If the file is not available as per accepted encoding, try to decompress the encoded file to original file and serve, if not able to, return 404. (Not handling this in current PR, will be opening a new PR for this.)

@francislavoie 