### PR TITLE
caddyfile: Fix case where heredoc marker is empty after newline

### DIFF
--- a/caddyconfig/caddyfile/lexer.go
+++ b/caddyconfig/caddyfile/lexer.go
@@ -154,6 +154,10 @@ func (l *lexer) next() (bool, error) {
 			// we reset the val because the heredoc is syntax we don't
 			// want to keep.
 			if ch == '\n' {
+				if len(val) == 2 {
+					return false, fmt.Errorf("missing opening heredoc marker on line #%d; must contain only alpha-numeric characters, dashes and underscores; got empty string", l.line)
+				}
+
 				// check if there's too many <
 				if string(val[:3]) == "<<<" {
 					return false, fmt.Errorf("too many '<' for heredoc on line #%d; only use two, for example <<END", l.line)

--- a/caddyconfig/caddyfile/lexer_test.go
+++ b/caddyconfig/caddyfile/lexer_test.go
@@ -410,6 +410,11 @@ EOF same-line-arg
 			},
 		},
 		{
+			input:        []byte("not-a-heredoc <<\n"),
+			expectErr:    true,
+			errorMessage: "missing opening heredoc marker on line #1; must contain only alpha-numeric characters, dashes and underscores; got empty string",
+		},
+		{
 			input: []byte(`heredoc <<<EOF
 	content
 	EOF same-line-arg


### PR DESCRIPTION
Fixes `panic: runtime error: slice bounds out of range [:3] with capacity 2`

Followup to #5761, fixes #5770
