### PR TITLE
replacer: change timezone to UTC for "time.now.http" placeholders

### DIFF
--- a/replacer.go
+++ b/replacer.go
@@ -319,6 +319,9 @@ func globalDefaultReplacements(key string) (any, bool) {
 	case "time.now":
 		return nowFunc(), true
 	case "time.now.http":
+		// According to the comment for http.TimeFormat, the timezone must be in UTC
+		// to generate the correct format.
+		// https://github.com/caddyserver/caddy/issues/5773
 		return nowFunc().UTC().Format(http.TimeFormat), true
 	case "time.now.common_log":
 		return nowFunc().Format("02/Jan/2006:15:04:05 -0700"), true

--- a/replacer.go
+++ b/replacer.go
@@ -319,7 +319,7 @@ func globalDefaultReplacements(key string) (any, bool) {
 	case "time.now":
 		return nowFunc(), true
 	case "time.now.http":
-		return nowFunc().Format(http.TimeFormat), true
+		return nowFunc().UTC().Format(http.TimeFormat), true
 	case "time.now.common_log":
 		return nowFunc().Format("02/Jan/2006:15:04:05 -0700"), true
 	case "time.now.year":


### PR DESCRIPTION
Fix [5773](https://github.com/caddyserver/caddy/issues/5773)

The comment for `http.TimeFormat` says the time being formatted must be in the UTC timezone to get the correct value and it's indeed used by stdlib.