### PR TITLE
Appease gosec linter

### DIFF
--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -529,7 +529,8 @@ func (t TLSConfig) MakeTLSClientConfig(ctx caddy.Context) (*tls.Config, error) {
 			certs := caddytls.AllMatchingCertificates(t.ClientCertificateAutomate)
 			var err error
 			for _, cert := range certs {
-				err = cri.SupportsCertificate(&cert.Certificate)
+				certCertificate := cert.Certificate // avoid taking address of iteration variable (gosec warning)
+				err = cri.SupportsCertificate(&certCertificate)
 				if err == nil {
 					return &cert.Certificate, nil
 				}

--- a/modules/caddytls/certselection.go
+++ b/modules/caddytls/certselection.go
@@ -58,7 +58,8 @@ nextChoice:
 		if len(p.SerialNumber) > 0 {
 			var found bool
 			for _, sn := range p.SerialNumber {
-				if cert.Leaf.SerialNumber.Cmp(&sn.Int) == 0 {
+				snInt := sn.Int // avoid taking address of iteration variable (gosec warning)
+				if cert.Leaf.SerialNumber.Cmp(&snInt) == 0 {
 					found = true
 					break
 				}


### PR DESCRIPTION
These happen to be harmless memory aliasing
but I guess the linter can't know that and we
can't really prove it in general.