### PR TITLE
logging: query filter for array of strings

### DIFF
--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"go.uber.org/zap/zapcore"
-	"golang.org/x/exp/slices"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -375,11 +374,12 @@ func (m *QueryFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 // Filter filters the input field.
 func (m QueryFilter) Filter(in zapcore.Field) zapcore.Field {
 	if array, ok := in.Interface.(caddyhttp.LoggableStringArray); ok {
-	newArray := slices.Clone(array)
-		for i, s := range newArray {
+		newArray := make(caddyhttp.LoggableStringArray, len(array))
+		for i, s := range array {
 			newArray[i] = m.processQueryString(s)
 		}
-		in.Interface = newArray	} else {
+		in.Interface = newArray
+	} else {
 		in.String = m.processQueryString(in.String)
 	}
 

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/exp/slices"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -369,10 +370,11 @@ func (m *QueryFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 // Filter filters the input field.
 func (m QueryFilter) Filter(in zapcore.Field) zapcore.Field {
 	if array, ok := in.Interface.(caddyhttp.LoggableStringArray); ok {
-		for i, s := range array {
-			array[i] = m.processQueryString(s)
+	newArray := slices.Clone(array)
+		for i, s := range newArray {
+			newArray[i] = m.processQueryString(s)
 		}
-	} else {
+		in.Interface = newArray	} else {
 		in.String = m.processQueryString(in.String)
 	}
 


### PR DESCRIPTION
As discussed in this [previous PR](https://github.com/caddyserver/caddy/pull/5101), here is the improvement to make the query filter handle array of strings.

This is needed so that the query filter can be used on headers, especially useful for the `Referer`.

**Disclaimer:** my first lines of code in Go, tried my best using the same logic and style that were used already. Successfully tested locally (and unit tests passed).