### PR TITLE
reverseproxy: Allow fallthrough for response handlers without routes

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -848,12 +848,6 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, origRe
 			break
 		}
 
-		// otherwise, if there are any routes configured, execute those as the
-		// actual response instead of what we got from the proxy backend
-		if len(rh.Routes) == 0 {
-			continue
-		}
-
 		// set up the replacer so that parts of the original response can be
 		// used for routing decisions
 		for field, value := range res.Header {


### PR DESCRIPTION
Fixes https://github.com/caddyserver/caddy/issues/5776

AFAICT there's no reason for this condition to exist. If there are no routes, then the compiled handler will simply invoke the `next` handler, which is the desired behavior.