### PR TITLE
ci: ensure short-sha is exported correctly on all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
 
     - name: Print Go version and environment
       id: vars
+      shell: bash
       run: |
         printf "Using go at: $(which go)\n"
         printf "Go version: $(go version)\n"


### PR DESCRIPTION
At some point, the export of the short SHA failed to on Windows and turned into empty string. Specifying the `shell` ensures we're working with the same conventions across all platforms. Without it, Windows defaults to PowerShell.