### PR TITLE
chore: check vuln Go mods in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,6 @@ jobs:
       with:
         go-version: ${{ matrix.GO_SEMVER }}
         check-latest: true
-    
-    - name: Run govulncheck   
-      uses: golang/govulncheck-action@v1
-      with:
-        go-version-input: ${{ matrix.GO_SEMVER }}
-        go-package: ./...
 
     # These tools would be useful if we later decide to reinvestigate
     # publishing test/coverage reports to some tool for easier consumption

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,12 @@ jobs:
       with:
         go-version: ${{ matrix.GO_SEMVER }}
         check-latest: true
+    
+    - name: Run govulncheck   
+      uses: golang/govulncheck-action@v1
+      with:
+        go-version-input: ${{ matrix.GO_SEMVER }}
+        go-packages: ./...
 
     # These tools would be useful if we later decide to reinvestigate
     # publishing test/coverage reports to some tool for easier consumption

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       uses: golang/govulncheck-action@v1
       with:
         go-version-input: ${{ matrix.GO_SEMVER }}
-        go-packages: ./...
+        go-package: ./...
 
     # These tools would be useful if we later decide to reinvestigate
     # publishing test/coverage reports to some tool for easier consumption

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,9 @@ jobs:
 
           # Workaround for https://github.com/golangci/golangci-lint-action/issues/135
           skip-pkg-cache: true
+      
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@v1
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,9 +36,6 @@ jobs:
 
           # Workaround for https://github.com/golangci/golangci-lint-action/issues/135
           skip-pkg-cache: true
-      
-      - name: Run govulncheck
-        uses: golang/govulncheck-action@v1
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -53,3 +50,9 @@ jobs:
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
+
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: govulncheck
+        uses: golang/govulncheck-action@v1


### PR DESCRIPTION
Implements #5768
Run `govulncheck` to scan for vulnerable Go packages/modules in CI