### PR TITLE
httpcaddyfile: fix placeholder shorthands in named routes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,3 +56,5 @@ jobs:
     steps:
       - name: govulncheck
         uses: golang/govulncheck-action@v1
+        with:
+          check-latest: true

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -451,7 +451,7 @@ func (ServerType) extractNamedRoutes(
 
 		wholeSegment := caddyfile.Segment{}
 		for _, segment := range sb.block.Segments {
-			// Replace user-defined placeholder shorthands in extracted named routes
+			// replace user-defined placeholder shorthands in extracted named routes
 			replacer.ReplaceSegmentsWithFullPlaceholder(&segment)
 
 			// zip up all the segments since ParseSegmentAsSubroute

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -92,14 +92,7 @@ func (st ServerType) Setup(
 
 	for _, sb := range originalServerBlocks {
 		for _, segment := range sb.block.Segments {
-			for i := 0; i < len(segment); i++ {
-				// simple string replacements
-				segment[i].Text = replacer.simple.Replace(segment[i].Text)
-				// complex regexp replacements
-				for _, r := range replacer.complex {
-					segment[i].Text = r.search.ReplaceAllString(segment[i].Text, r.replace)
-				}
-			}
+			replacer.ReplaceSegmentsWithFullPlaceholder(&segment)
 		}
 
 		if len(sb.block.Keys) == 0 {
@@ -459,14 +452,7 @@ func (ServerType) extractNamedRoutes(
 		wholeSegment := caddyfile.Segment{}
 		for _, segment := range sb.block.Segments {
 			// Replace user-defined placeholder shorthands in extracted named routes
-			for i := 0; i < len(segment); i++ {
-				// simple string replacements
-				segment[i].Text = replacer.simple.Replace(segment[i].Text)
-				// complex regexp replacements
-				for _, r := range replacer.complex {
-					segment[i].Text = r.search.ReplaceAllString(segment[i].Text, r.replace)
-				}
-			}
+			replacer.ReplaceSegmentsWithFullPlaceholder(&segment)
 
 			// zip up all the segments since ParseSegmentAsSubroute
 			// was designed to take a directive+

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -91,8 +91,8 @@ func (st ServerType) Setup(
 	}
 
 	for _, sb := range originalServerBlocks {
-		for _, segment := range sb.block.Segments {
-			replacer.ReplaceSegmentsWithFullPlaceholder(&segment)
+		for i := range sb.block.Segments {
+			replacer.ApplyToSegment(&sb.block.Segments[i])
 		}
 
 		if len(sb.block.Keys) == 0 {
@@ -450,13 +450,13 @@ func (ServerType) extractNamedRoutes(
 		}
 
 		wholeSegment := caddyfile.Segment{}
-		for _, segment := range sb.block.Segments {
+		for i := range sb.block.Segments {
 			// replace user-defined placeholder shorthands in extracted named routes
-			replacer.ReplaceSegmentsWithFullPlaceholder(&segment)
+			replacer.ApplyToSegment(&sb.block.Segments[i])
 
 			// zip up all the segments since ParseSegmentAsSubroute
 			// was designed to take a directive+
-			wholeSegment = append(wholeSegment, segment...)
+			wholeSegment = append(wholeSegment, sb.block.Segments[i]...)
 		}
 
 		h := Helper{

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -112,6 +112,18 @@ func (st ServerType) Setup(
 		{regexp.MustCompile(`{file_match\.([\w-]*)}`), "{http.matchers.file.$1}"},
 	}
 
+	// Replace placeholder shorthands in extracted named routes
+	for _, namedRoutes := range options["named_routes"].(map[string]*caddyhttp.Route) {
+		for i := 0; i < len(namedRoutes.HandlersRaw); i++ {
+			// simple string replacements
+			namedRoutes.HandlersRaw[i] = []byte(replacer.Replace(string(namedRoutes.HandlersRaw[i])))
+			// complex regexp replacements
+			for _, r := range regexpReplacements {
+				namedRoutes.HandlersRaw[i] = []byte(r.search.ReplaceAllString(string(namedRoutes.HandlersRaw[i]), r.replace))
+			}
+		}
+	}
+
 	for _, sb := range originalServerBlocks {
 		for _, segment := range sb.block.Segments {
 			for i := 0; i < len(segment); i++ {

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -82,55 +81,22 @@ func (st ServerType) Setup(
 		return nil, warnings, err
 	}
 
-	originalServerBlocks, err = st.extractNamedRoutes(originalServerBlocks, options, &warnings)
+	// this will replace both static and user-defined placeholder shorthands
+	// with actual identifiers used by Caddy
+	replacer := NewShorthandReplacer()
+
+	originalServerBlocks, err = st.extractNamedRoutes(originalServerBlocks, options, &warnings, replacer)
 	if err != nil {
 		return nil, warnings, err
-	}
-
-	// replace shorthand placeholders (which are convenient
-	// when writing a Caddyfile) with their actual placeholder
-	// identifiers or variable names
-	replacer := strings.NewReplacer(placeholderShorthands()...)
-
-	// these are placeholders that allow a user-defined final
-	// parameters, but we still want to provide a shorthand
-	// for those, so we use a regexp to replace
-	regexpReplacements := []struct {
-		search  *regexp.Regexp
-		replace string
-	}{
-		{regexp.MustCompile(`{header\.([\w-]*)}`), "{http.request.header.$1}"},
-		{regexp.MustCompile(`{cookie\.([\w-]*)}`), "{http.request.cookie.$1}"},
-		{regexp.MustCompile(`{labels\.([\w-]*)}`), "{http.request.host.labels.$1}"},
-		{regexp.MustCompile(`{path\.([\w-]*)}`), "{http.request.uri.path.$1}"},
-		{regexp.MustCompile(`{file\.([\w-]*)}`), "{http.request.uri.path.file.$1}"},
-		{regexp.MustCompile(`{query\.([\w-]*)}`), "{http.request.uri.query.$1}"},
-		{regexp.MustCompile(`{re\.([\w-]*)\.([\w-]*)}`), "{http.regexp.$1.$2}"},
-		{regexp.MustCompile(`{vars\.([\w-]*)}`), "{http.vars.$1}"},
-		{regexp.MustCompile(`{rp\.([\w-\.]*)}`), "{http.reverse_proxy.$1}"},
-		{regexp.MustCompile(`{err\.([\w-\.]*)}`), "{http.error.$1}"},
-		{regexp.MustCompile(`{file_match\.([\w-]*)}`), "{http.matchers.file.$1}"},
-	}
-
-	// Replace placeholder shorthands in extracted named routes
-	for _, namedRoutes := range options["named_routes"].(map[string]*caddyhttp.Route) {
-		for i := 0; i < len(namedRoutes.HandlersRaw); i++ {
-			// simple string replacements
-			namedRoutes.HandlersRaw[i] = []byte(replacer.Replace(string(namedRoutes.HandlersRaw[i])))
-			// complex regexp replacements
-			for _, r := range regexpReplacements {
-				namedRoutes.HandlersRaw[i] = []byte(r.search.ReplaceAllString(string(namedRoutes.HandlersRaw[i]), r.replace))
-			}
-		}
 	}
 
 	for _, sb := range originalServerBlocks {
 		for _, segment := range sb.block.Segments {
 			for i := 0; i < len(segment); i++ {
 				// simple string replacements
-				segment[i].Text = replacer.Replace(segment[i].Text)
+				segment[i].Text = replacer.simple.Replace(segment[i].Text)
 				// complex regexp replacements
-				for _, r := range regexpReplacements {
+				for _, r := range replacer.complex {
 					segment[i].Text = r.search.ReplaceAllString(segment[i].Text, r.replace)
 				}
 			}
@@ -464,6 +430,7 @@ func (ServerType) extractNamedRoutes(
 	serverBlocks []serverBlock,
 	options map[string]any,
 	warnings *[]caddyconfig.Warning,
+	replacer ShorthandReplacer,
 ) ([]serverBlock, error) {
 	namedRoutes := map[string]*caddyhttp.Route{}
 
@@ -489,10 +456,20 @@ func (ServerType) extractNamedRoutes(
 			continue
 		}
 
-		// zip up all the segments since ParseSegmentAsSubroute
-		// was designed to take a directive+
 		wholeSegment := caddyfile.Segment{}
 		for _, segment := range sb.block.Segments {
+			// Replace user-defined placeholder shorthands in extracted named routes
+			for i := 0; i < len(segment); i++ {
+				// simple string replacements
+				segment[i].Text = replacer.simple.Replace(segment[i].Text)
+				// complex regexp replacements
+				for _, r := range replacer.complex {
+					segment[i].Text = r.search.ReplaceAllString(segment[i].Text, r.replace)
+				}
+			}
+
+			// zip up all the segments since ParseSegmentAsSubroute
+			// was designed to take a directive+
 			wholeSegment = append(wholeSegment, segment...)
 		}
 
@@ -1459,37 +1436,6 @@ func encodeMatcherSet(matchers map[string]caddyhttp.RequestMatcher) (caddy.Modul
 		msEncoded[matcherName] = jsonBytes
 	}
 	return msEncoded, nil
-}
-
-// placeholderShorthands returns a slice of old-new string pairs,
-// where the left of the pair is a placeholder shorthand that may
-// be used in the Caddyfile, and the right is the replacement.
-func placeholderShorthands() []string {
-	return []string{
-		"{dir}", "{http.request.uri.path.dir}",
-		"{file}", "{http.request.uri.path.file}",
-		"{host}", "{http.request.host}",
-		"{hostport}", "{http.request.hostport}",
-		"{port}", "{http.request.port}",
-		"{method}", "{http.request.method}",
-		"{path}", "{http.request.uri.path}",
-		"{query}", "{http.request.uri.query}",
-		"{remote}", "{http.request.remote}",
-		"{remote_host}", "{http.request.remote.host}",
-		"{remote_port}", "{http.request.remote.port}",
-		"{scheme}", "{http.request.scheme}",
-		"{uri}", "{http.request.uri}",
-		"{tls_cipher}", "{http.request.tls.cipher_suite}",
-		"{tls_version}", "{http.request.tls.version}",
-		"{tls_client_fingerprint}", "{http.request.tls.client.fingerprint}",
-		"{tls_client_issuer}", "{http.request.tls.client.issuer}",
-		"{tls_client_serial}", "{http.request.tls.client.serial}",
-		"{tls_client_subject}", "{http.request.tls.client.subject}",
-		"{tls_client_certificate_pem}", "{http.request.tls.client.certificate_pem}",
-		"{tls_client_certificate_der_base64}", "{http.request.tls.client.certificate_der_base64}",
-		"{upstream_hostport}", "{http.reverse_proxy.upstream.hostport}",
-		"{client_ip}", "{http.vars.client_ip}",
-	}
 }
 
 // WasReplacedPlaceholderShorthand checks if a token string was

--- a/caddyconfig/httpcaddyfile/replace.go
+++ b/caddyconfig/httpcaddyfile/replace.go
@@ -1,0 +1,76 @@
+package httpcaddyfile
+
+import (
+	"regexp"
+	"strings"
+)
+
+type ComplexShorthandReplacer struct {
+	search  *regexp.Regexp
+	replace string
+}
+
+type ShorthandReplacer struct {
+	complex []ComplexShorthandReplacer
+	simple  *strings.Replacer
+}
+
+func NewShorthandReplacer() ShorthandReplacer {
+	// replace shorthand placeholders (which are convenient
+	// when writing a Caddyfile) with their actual placeholder
+	// identifiers or variable names
+	replacer := strings.NewReplacer(placeholderShorthands()...)
+
+	// these are placeholders that allow a user-defined final
+	// parameters, but we still want to provide a shorthand
+	// for those, so we use a regexp to replace
+	regexpReplacements := []ComplexShorthandReplacer{
+		{regexp.MustCompile(`{header\.([\w-]*)}`), "{http.request.header.$1}"},
+		{regexp.MustCompile(`{cookie\.([\w-]*)}`), "{http.request.cookie.$1}"},
+		{regexp.MustCompile(`{labels\.([\w-]*)}`), "{http.request.host.labels.$1}"},
+		{regexp.MustCompile(`{path\.([\w-]*)}`), "{http.request.uri.path.$1}"},
+		{regexp.MustCompile(`{file\.([\w-]*)}`), "{http.request.uri.path.file.$1}"},
+		{regexp.MustCompile(`{query\.([\w-]*)}`), "{http.request.uri.query.$1}"},
+		{regexp.MustCompile(`{re\.([\w-]*)\.([\w-]*)}`), "{http.regexp.$1.$2}"},
+		{regexp.MustCompile(`{vars\.([\w-]*)}`), "{http.vars.$1}"},
+		{regexp.MustCompile(`{rp\.([\w-\.]*)}`), "{http.reverse_proxy.$1}"},
+		{regexp.MustCompile(`{err\.([\w-\.]*)}`), "{http.error.$1}"},
+		{regexp.MustCompile(`{file_match\.([\w-]*)}`), "{http.matchers.file.$1}"},
+	}
+
+	return ShorthandReplacer{
+		complex: regexpReplacements,
+		simple:  replacer,
+	}
+}
+
+// placeholderShorthands returns a slice of old-new string pairs,
+// where the left of the pair is a placeholder shorthand that may
+// be used in the Caddyfile, and the right is the replacement.
+func placeholderShorthands() []string {
+	return []string{
+		"{dir}", "{http.request.uri.path.dir}",
+		"{file}", "{http.request.uri.path.file}",
+		"{host}", "{http.request.host}",
+		"{hostport}", "{http.request.hostport}",
+		"{port}", "{http.request.port}",
+		"{method}", "{http.request.method}",
+		"{path}", "{http.request.uri.path}",
+		"{query}", "{http.request.uri.query}",
+		"{remote}", "{http.request.remote}",
+		"{remote_host}", "{http.request.remote.host}",
+		"{remote_port}", "{http.request.remote.port}",
+		"{scheme}", "{http.request.scheme}",
+		"{uri}", "{http.request.uri}",
+		"{tls_cipher}", "{http.request.tls.cipher_suite}",
+		"{tls_version}", "{http.request.tls.version}",
+		"{tls_client_fingerprint}", "{http.request.tls.client.fingerprint}",
+		"{tls_client_issuer}", "{http.request.tls.client.issuer}",
+		"{tls_client_serial}", "{http.request.tls.client.serial}",
+		"{tls_client_subject}", "{http.request.tls.client.subject}",
+		"{tls_client_certificate_pem}", "{http.request.tls.client.certificate_pem}",
+		"{tls_client_certificate_der_base64}", "{http.request.tls.client.certificate_der_base64}",
+		"{upstream_hostport}", "{http.reverse_proxy.upstream.hostport}",
+		"{client_ip}", "{http.vars.client_ip}",
+	}
+}

--- a/caddyconfig/httpcaddyfile/shorthands.go
+++ b/caddyconfig/httpcaddyfile/shorthands.go
@@ -3,6 +3,8 @@ package httpcaddyfile
 import (
 	"regexp"
 	"strings"
+
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
 type ComplexShorthandReplacer struct {
@@ -72,5 +74,20 @@ func placeholderShorthands() []string {
 		"{tls_client_certificate_der_base64}", "{http.request.tls.client.certificate_der_base64}",
 		"{upstream_hostport}", "{http.reverse_proxy.upstream.hostport}",
 		"{client_ip}", "{http.vars.client_ip}",
+	}
+}
+
+// ReplaceSegmentsWithFullPlaceholder replaces shorthand placeholder to its full placeholder, understandable by Caddy.
+func (s ShorthandReplacer) ReplaceSegmentsWithFullPlaceholder(segment *caddyfile.Segment) {
+	if segment != nil {
+		for i := 0; i < len(*segment); i++ {
+			// simple string replacements
+			// (*segment)[i].Text
+			(*segment)[i].Text = s.simple.Replace((*segment)[i].Text)
+			// complex regexp replacements
+			for _, r := range s.complex {
+				(*segment)[i].Text = r.search.ReplaceAllString((*segment)[i].Text, r.replace)
+			}
+		}
 	}
 }

--- a/caddyconfig/httpcaddyfile/shorthands.go
+++ b/caddyconfig/httpcaddyfile/shorthands.go
@@ -77,8 +77,8 @@ func placeholderShorthands() []string {
 	}
 }
 
-// ReplaceSegmentsWithFullPlaceholder replaces shorthand placeholder to its full placeholder, understandable by Caddy.
-func (s ShorthandReplacer) ReplaceSegmentsWithFullPlaceholder(segment *caddyfile.Segment) {
+// ApplyToSegment replaces shorthand placeholder to its full placeholder, understandable by Caddy.
+func (s ShorthandReplacer) ApplyToSegment(segment *caddyfile.Segment) {
 	if segment != nil {
 		for i := 0; i < len(*segment); i++ {
 			// simple string replacements

--- a/caddyconfig/httpcaddyfile/shorthands.go
+++ b/caddyconfig/httpcaddyfile/shorthands.go
@@ -82,7 +82,6 @@ func (s ShorthandReplacer) ReplaceSegmentsWithFullPlaceholder(segment *caddyfile
 	if segment != nil {
 		for i := 0; i < len(*segment); i++ {
 			// simple string replacements
-			// (*segment)[i].Text
 			(*segment)[i].Text = s.simple.Replace((*segment)[i].Text)
 			// complex regexp replacements
 			for _, r := range s.complex {


### PR DESCRIPTION
Fixes #5788

Add a section to replace placeholder shorthands for extracted named routes.