### PR TITLE
cmd: Prevent overwriting existing env vars with `--envfile`

### DIFF
--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -160,11 +160,18 @@ func cmdRun(fl Flags) (int, error) {
 	runCmdConfigFlag := fl.String("config")
 	runCmdConfigAdapterFlag := fl.String("adapter")
 	runCmdResumeFlag := fl.Bool("resume")
-	runCmdLoadEnvfileFlag, _ := fl.GetStringSlice("envfile")
 	runCmdPrintEnvFlag := fl.Bool("environ")
 	runCmdWatchFlag := fl.Bool("watch")
 	runCmdPidfileFlag := fl.String("pidfile")
 	runCmdPingbackFlag := fl.String("pingback")
+
+	var err error
+	var runCmdLoadEnvfileFlag []string
+	runCmdLoadEnvfileFlag, err = fl.GetStringSlice("envfile")
+	if err != nil {
+		return caddy.ExitCodeFailedStartup,
+			fmt.Errorf("reading envfile flag: %v", err)
+	}
 
 	// load all additional envs as soon as possible
 	for _, envFile := range runCmdLoadEnvfileFlag {
@@ -181,7 +188,6 @@ func cmdRun(fl Flags) (int, error) {
 
 	// load the config, depending on flags
 	var config []byte
-	var err error
 	if runCmdResumeFlag {
 		config, err = os.ReadFile(caddy.ConfigAutosavePath)
 		if os.IsNotExist(err) {
@@ -497,7 +503,14 @@ func cmdAdaptConfig(fl Flags) (int, error) {
 func cmdValidateConfig(fl Flags) (int, error) {
 	validateCmdConfigFlag := fl.String("config")
 	validateCmdAdapterFlag := fl.String("adapter")
-	runCmdLoadEnvfileFlag, _ := fl.GetStringSlice("envfile")
+
+	var err error
+	var runCmdLoadEnvfileFlag []string
+	runCmdLoadEnvfileFlag, err = fl.GetStringSlice("envfile")
+	if err != nil {
+		return caddy.ExitCodeFailedStartup,
+			fmt.Errorf("reading envfile flag: %v", err)
+	}
 
 	// load all additional envs as soon as possible
 	for _, envFile := range runCmdLoadEnvfileFlag {
@@ -508,7 +521,6 @@ func cmdValidateConfig(fl Flags) (int, error) {
 	}
 
 	// use default config and ensure a config file is specified
-	var err error
 	validateCmdConfigFlag, err = configFileWithRespectToDefault(caddy.Log(), validateCmdConfigFlag)
 	if err != nil {
 		return caddy.ExitCodeFailedStartup, err

--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -160,15 +160,15 @@ func cmdRun(fl Flags) (int, error) {
 	runCmdConfigFlag := fl.String("config")
 	runCmdConfigAdapterFlag := fl.String("adapter")
 	runCmdResumeFlag := fl.Bool("resume")
-	runCmdLoadEnvfileFlag := fl.String("envfile")
+	runCmdLoadEnvfileFlag, _ := fl.GetStringSlice("envfile")
 	runCmdPrintEnvFlag := fl.Bool("environ")
 	runCmdWatchFlag := fl.Bool("watch")
 	runCmdPidfileFlag := fl.String("pidfile")
 	runCmdPingbackFlag := fl.String("pingback")
 
 	// load all additional envs as soon as possible
-	if runCmdLoadEnvfileFlag != "" {
-		if err := loadEnvFromFile(runCmdLoadEnvfileFlag); err != nil {
+	for _, envFile := range runCmdLoadEnvfileFlag {
+		if err := loadEnvFromFile(envFile); err != nil {
 			return caddy.ExitCodeFailedStartup,
 				fmt.Errorf("loading additional environment variables: %v", err)
 		}
@@ -497,11 +497,11 @@ func cmdAdaptConfig(fl Flags) (int, error) {
 func cmdValidateConfig(fl Flags) (int, error) {
 	validateCmdConfigFlag := fl.String("config")
 	validateCmdAdapterFlag := fl.String("adapter")
-	runCmdLoadEnvfileFlag := fl.String("envfile")
+	runCmdLoadEnvfileFlag, _ := fl.GetStringSlice("envfile")
 
 	// load all additional envs as soon as possible
-	if runCmdLoadEnvfileFlag != "" {
-		if err := loadEnvFromFile(runCmdLoadEnvfileFlag); err != nil {
+	for _, envFile := range runCmdLoadEnvfileFlag {
+		if err := loadEnvFromFile(envFile); err != nil {
 			return caddy.ExitCodeFailedStartup,
 				fmt.Errorf("loading additional environment variables: %v", err)
 		}

--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -46,7 +46,14 @@ func cmdStart(fl Flags) (int, error) {
 	startCmdConfigAdapterFlag := fl.String("adapter")
 	startCmdPidfileFlag := fl.String("pidfile")
 	startCmdWatchFlag := fl.Bool("watch")
-	startCmdEnvfileFlag := fl.String("envfile")
+
+	var err error
+	var startCmdEnvfileFlag []string
+	startCmdEnvfileFlag, err = fl.GetStringSlice("envfile")
+	if err != nil {
+		return caddy.ExitCodeFailedStartup,
+			fmt.Errorf("reading envfile flag: %v", err)
+	}
 
 	// open a listener to which the child process will connect when
 	// it is ready to confirm that it has successfully started
@@ -70,8 +77,9 @@ func cmdStart(fl Flags) (int, error) {
 	if startCmdConfigFlag != "" {
 		cmd.Args = append(cmd.Args, "--config", startCmdConfigFlag)
 	}
-	if startCmdEnvfileFlag != "" {
-		cmd.Args = append(cmd.Args, "--envfile", startCmdEnvfileFlag)
+
+	for _, envFile := range startCmdEnvfileFlag {
+		cmd.Args = append(cmd.Args, "--envfile", envFile)
 	}
 	if startCmdConfigAdapterFlag != "" {
 		cmd.Args = append(cmd.Args, "--adapter", startCmdConfigAdapterFlag)

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -104,7 +104,7 @@ using 'caddy run' instead to keep it in the foreground.
 		CobraFunc: func(cmd *cobra.Command) {
 			cmd.Flags().StringP("config", "c", "", "Configuration file")
 			cmd.Flags().StringP("adapter", "a", "", "Name of config adapter to apply")
-			cmd.Flags().StringP("envfile", "", "", "Environment file to load")
+			cmd.Flags().StringSliceP("envfile", "", []string{}, "Environment file to load")
 			cmd.Flags().BoolP("watch", "w", false, "Reload changed config file automatically")
 			cmd.Flags().StringP("pidfile", "", "", "Path of file to which to write process ID")
 			cmd.RunE = WrapCommandFuncForCobra(cmdStart)
@@ -150,7 +150,7 @@ option in a local development environment.
 		CobraFunc: func(cmd *cobra.Command) {
 			cmd.Flags().StringP("config", "c", "", "Configuration file")
 			cmd.Flags().StringP("adapter", "a", "", "Name of config adapter to apply")
-			cmd.Flags().StringP("envfile", "", "", "Environment file to load")
+			cmd.Flags().StringSliceP("envfile", "", []string{}, "Environment file to load")
 			cmd.Flags().BoolP("environ", "e", false, "Print environment")
 			cmd.Flags().BoolP("resume", "r", false, "Use saved config, if any (and prefer over --config file)")
 			cmd.Flags().BoolP("watch", "w", false, "Watch config file for changes and reload it automatically")
@@ -301,7 +301,7 @@ the KEY=VALUE format will be loaded into the Caddy process.
 		CobraFunc: func(cmd *cobra.Command) {
 			cmd.Flags().StringP("config", "c", "", "Input configuration file")
 			cmd.Flags().StringP("adapter", "a", "", "Name of config adapter")
-			cmd.Flags().StringP("envfile", "", "", "Environment file to load")
+			cmd.Flags().StringSliceP("envfile", "", []string{}, "Environment file to load")
 			cmd.RunE = WrapCommandFuncForCobra(cmdValidateConfig)
 		},
 	})
@@ -402,7 +402,7 @@ latest versions. EXPERIMENTAL: May be changed or removed.
 		Short: "Adds Caddy packages (EXPERIMENTAL)",
 		Long: `
 Downloads an updated Caddy binary with the specified packages (module/plugin)
-added. Retains existing packages. Returns an error if the any of packages are 
+added. Retains existing packages. Returns an error if the any of packages are
 already included. EXPERIMENTAL: May be changed or removed.
 `,
 		CobraFunc: func(cmd *cobra.Command) {
@@ -417,8 +417,8 @@ already included. EXPERIMENTAL: May be changed or removed.
 		Usage: "<packages...>",
 		Short: "Removes Caddy packages (EXPERIMENTAL)",
 		Long: `
-Downloads an updated Caddy binaries without the specified packages (module/plugin). 
-Returns an error if any of the packages are not included. 
+Downloads an updated Caddy binaries without the specified packages (module/plugin).
+Returns an error if any of the packages are not included.
 EXPERIMENTAL: May be changed or removed.
 `,
 		CobraFunc: func(cmd *cobra.Command) {
@@ -464,40 +464,40 @@ argument of --directory. If the directory does not exist, it will be created.
 		Use:   "completion [bash|zsh|fish|powershell]",
 		Short: "Generate completion script",
 		Long: fmt.Sprintf(`To load completions:
-	
+
 	Bash:
-	
+
 	  $ source <(%[1]s completion bash)
-	
+
 	  # To load completions for each session, execute once:
 	  # Linux:
 	  $ %[1]s completion bash > /etc/bash_completion.d/%[1]s
 	  # macOS:
 	  $ %[1]s completion bash > $(brew --prefix)/etc/bash_completion.d/%[1]s
-	
+
 	Zsh:
-	
+
 	  # If shell completion is not already enabled in your environment,
 	  # you will need to enable it.  You can execute the following once:
-	
+
 	  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
-	
+
 	  # To load completions for each session, execute once:
 	  $ %[1]s completion zsh > "${fpath[1]}/_%[1]s"
-	
+
 	  # You will need to start a new shell for this setup to take effect.
-	
+
 	fish:
-	
+
 	  $ %[1]s completion fish | source
-	
+
 	  # To load completions for each session, execute once:
 	  $ %[1]s completion fish > ~/.config/fish/completions/%[1]s.fish
-	
+
 	PowerShell:
-	
+
 	  PS> %[1]s completion powershell | Out-String | Invoke-Expression
-	
+
 	  # To load completions for every new session, run:
 	  PS> %[1]s completion powershell > %[1]s.ps1
 	  # and source this file from your PowerShell profile.

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -104,7 +104,7 @@ using 'caddy run' instead to keep it in the foreground.
 		CobraFunc: func(cmd *cobra.Command) {
 			cmd.Flags().StringP("config", "c", "", "Configuration file")
 			cmd.Flags().StringP("adapter", "a", "", "Name of config adapter to apply")
-			cmd.Flags().StringSliceP("envfile", "", []string{}, "Environment file to load")
+			cmd.Flags().StringSliceP("envfile", "", []string{}, "Environment file(s) to load")
 			cmd.Flags().BoolP("watch", "w", false, "Reload changed config file automatically")
 			cmd.Flags().StringP("pidfile", "", "", "Path of file to which to write process ID")
 			cmd.RunE = WrapCommandFuncForCobra(cmdStart)
@@ -150,7 +150,7 @@ option in a local development environment.
 		CobraFunc: func(cmd *cobra.Command) {
 			cmd.Flags().StringP("config", "c", "", "Configuration file")
 			cmd.Flags().StringP("adapter", "a", "", "Name of config adapter to apply")
-			cmd.Flags().StringSliceP("envfile", "", []string{}, "Environment file to load")
+			cmd.Flags().StringSliceP("envfile", "", []string{}, "Environment file(s) to load")
 			cmd.Flags().BoolP("environ", "e", false, "Print environment")
 			cmd.Flags().BoolP("resume", "r", false, "Use saved config, if any (and prefer over --config file)")
 			cmd.Flags().BoolP("watch", "w", false, "Watch config file for changes and reload it automatically")
@@ -301,7 +301,7 @@ the KEY=VALUE format will be loaded into the Caddy process.
 		CobraFunc: func(cmd *cobra.Command) {
 			cmd.Flags().StringP("config", "c", "", "Input configuration file")
 			cmd.Flags().StringP("adapter", "a", "", "Name of config adapter")
-			cmd.Flags().StringSliceP("envfile", "", []string{}, "Environment file to load")
+			cmd.Flags().StringSliceP("envfile", "", []string{}, "Environment file(s) to load")
 			cmd.RunE = WrapCommandFuncForCobra(cmdValidateConfig)
 		},
 	})

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -373,7 +373,11 @@ func parseEnvFile(envInput io.Reader) (map[string]string, error) {
 			val = strings.TrimSuffix(val, quote)
 		}
 
-		envMap[key] = val
+		// do not overwrite existing environment variables
+		_, exists := os.LookupEnv(key)
+		if !exists {
+			envMap[key] = val
+		}
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -300,8 +300,12 @@ func loadEnvFromFile(envFile string) error {
 	}
 
 	for k, v := range envMap {
-		if err := os.Setenv(k, v); err != nil {
-			return fmt.Errorf("setting environment variables: %v", err)
+		// do not overwrite existing environment variables
+		_, exists := os.LookupEnv(k)
+		if !exists {
+			if err := os.Setenv(k, v); err != nil {
+				return fmt.Errorf("setting environment variables: %v", err)
+			}
 		}
 	}
 
@@ -373,11 +377,7 @@ func parseEnvFile(envInput io.Reader) (map[string]string, error) {
 			val = strings.TrimSuffix(val, quote)
 		}
 
-		// do not overwrite existing environment variables
-		_, exists := os.LookupEnv(key)
-		if !exists {
-			envMap[key] = val
-		}
+		envMap[key] = val
 	}
 
 	if err := scanner.Err(); err != nil {


### PR DESCRIPTION
Fix: https://github.com/caddyserver/caddy/issues/5802

Prevent `--envfile` from overwriting existing environment variables.

For example:

```bash
$ cat .env
FOO=.env
FOO_DOT_ENV="set in .env"

$ cat .env.prod
FOO=.env.prod
FOO_DOT_ENV_TEST="set in .env.test"

# NOTE: --envfile loads env vars that don't exist
$ go run cmd/caddy/main.go run --envfile .env --environ | grep FOO
FOO=.env
FOO_DOT_ENV=set in .env

# NOTE: multiple --envfile passed get loaded, in decreasing precedence
$ go run cmd/caddy/main.go run --envfile .env.prod --envfile .env --environ | grep FOO
FOO=.env.prod
FOO_DOT_ENV_TEST=set in .env.test
FOO_DOT_ENV=set in .env

# NOTE: Existing env vars are preserved if they're also found in --envfiles
$ FOO=system go run cmd/caddy/main.go run --envfile .env.prod --envfile .env --environ | grep FOO
FOO=system
FOO_DOT_ENV_TEST=set in .env.test
FOO_DOT_ENV=set in .env
```
