### PR TITLE
caddyhttp: Security enhancements for client IP parsing

### DIFF
--- a/caddyconfig/httpcaddyfile/serveroptions.go
+++ b/caddyconfig/httpcaddyfile/serveroptions.go
@@ -34,22 +34,22 @@ type serverOptions struct {
 	ListenerAddress string
 
 	// These will all map 1:1 to the caddyhttp.Server struct
-	Name                   string
-	ListenerWrappersRaw    []json.RawMessage
-	ReadTimeout            caddy.Duration
-	ReadHeaderTimeout      caddy.Duration
-	WriteTimeout           caddy.Duration
-	IdleTimeout            caddy.Duration
-	KeepAliveInterval      caddy.Duration
-	MaxHeaderBytes         int
-	EnableFullDuplex       bool
-	Protocols              []string
-	StrictSNIHost          *bool
-	TrustedProxiesRaw      json.RawMessage
-	EnableStrictXffParsing bool
-	ClientIPHeaders        []string
-	ShouldLogCredentials   bool
-	Metrics                *caddyhttp.Metrics
+	Name                 string
+	ListenerWrappersRaw  []json.RawMessage
+	ReadTimeout          caddy.Duration
+	ReadHeaderTimeout    caddy.Duration
+	WriteTimeout         caddy.Duration
+	IdleTimeout          caddy.Duration
+	KeepAliveInterval    caddy.Duration
+	MaxHeaderBytes       int
+	EnableFullDuplex     bool
+	Protocols            []string
+	StrictSNIHost        *bool
+	TrustedProxiesRaw    json.RawMessage
+	TrustedProxiesStrict bool
+	ClientIPHeaders      []string
+	ShouldLogCredentials bool
+	Metrics              *caddyhttp.Metrics
 }
 
 func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (any, error) {
@@ -218,11 +218,11 @@ func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (any, error) {
 				)
 				serverOpts.TrustedProxiesRaw = jsonSource
 
-			case "enable_strict_xff_parsing":
+			case "trusted_proxies_strict":
 				if d.NextArg() {
 					return nil, d.ArgErr()
 				}
-				serverOpts.EnableStrictXffParsing = true
+				serverOpts.TrustedProxiesStrict = true
 
 			case "client_ip_headers":
 				headers := d.RemainingArgs()
@@ -347,7 +347,7 @@ func applyServerOptions(
 		server.StrictSNIHost = opts.StrictSNIHost
 		server.TrustedProxiesRaw = opts.TrustedProxiesRaw
 		server.ClientIPHeaders = opts.ClientIPHeaders
-		server.EnableStrictXffParsing = opts.EnableStrictXffParsing
+		server.TrustedProxiesStrict = opts.TrustedProxiesStrict
 		server.Metrics = opts.Metrics
 		if opts.ShouldLogCredentials {
 			if server.Logs == nil {

--- a/caddyconfig/httpcaddyfile/serveroptions.go
+++ b/caddyconfig/httpcaddyfile/serveroptions.go
@@ -46,7 +46,7 @@ type serverOptions struct {
 	Protocols            []string
 	StrictSNIHost        *bool
 	TrustedProxiesRaw    json.RawMessage
-	TrustedProxiesStrict bool
+	TrustedProxiesStrict int
 	ClientIPHeaders      []string
 	ShouldLogCredentials bool
 	Metrics              *caddyhttp.Metrics
@@ -222,7 +222,7 @@ func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (any, error) {
 				if d.NextArg() {
 					return nil, d.ArgErr()
 				}
-				serverOpts.TrustedProxiesStrict = true
+				serverOpts.TrustedProxiesStrict = 1
 
 			case "client_ip_headers":
 				headers := d.RemainingArgs()

--- a/caddyconfig/httpcaddyfile/serveroptions.go
+++ b/caddyconfig/httpcaddyfile/serveroptions.go
@@ -34,21 +34,22 @@ type serverOptions struct {
 	ListenerAddress string
 
 	// These will all map 1:1 to the caddyhttp.Server struct
-	Name                 string
-	ListenerWrappersRaw  []json.RawMessage
-	ReadTimeout          caddy.Duration
-	ReadHeaderTimeout    caddy.Duration
-	WriteTimeout         caddy.Duration
-	IdleTimeout          caddy.Duration
-	KeepAliveInterval    caddy.Duration
-	MaxHeaderBytes       int
-	EnableFullDuplex     bool
-	Protocols            []string
-	StrictSNIHost        *bool
-	TrustedProxiesRaw    json.RawMessage
-	ClientIPHeaders      []string
-	ShouldLogCredentials bool
-	Metrics              *caddyhttp.Metrics
+	Name                   string
+	ListenerWrappersRaw    []json.RawMessage
+	ReadTimeout            caddy.Duration
+	ReadHeaderTimeout      caddy.Duration
+	WriteTimeout           caddy.Duration
+	IdleTimeout            caddy.Duration
+	KeepAliveInterval      caddy.Duration
+	MaxHeaderBytes         int
+	EnableFullDuplex       bool
+	Protocols              []string
+	StrictSNIHost          *bool
+	TrustedProxiesRaw      json.RawMessage
+	EnableStrictXffParsing bool
+	ClientIPHeaders        []string
+	ShouldLogCredentials   bool
+	Metrics                *caddyhttp.Metrics
 }
 
 func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (any, error) {
@@ -217,6 +218,12 @@ func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (any, error) {
 				)
 				serverOpts.TrustedProxiesRaw = jsonSource
 
+			case "enable_strict_xff_parsing":
+				if d.NextArg() {
+					return nil, d.ArgErr()
+				}
+				serverOpts.EnableStrictXffParsing = true
+
 			case "client_ip_headers":
 				headers := d.RemainingArgs()
 				for _, header := range headers {
@@ -340,6 +347,7 @@ func applyServerOptions(
 		server.StrictSNIHost = opts.StrictSNIHost
 		server.TrustedProxiesRaw = opts.TrustedProxiesRaw
 		server.ClientIPHeaders = opts.ClientIPHeaders
+		server.EnableStrictXffParsing = opts.EnableStrictXffParsing
 		server.Metrics = opts.Metrics
 		if opts.ShouldLogCredentials {
 			if server.Logs == nil {

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -173,6 +173,18 @@ type Server struct {
 	// remote IP address.
 	ClientIPHeaders []string `json:"client_ip_headers,omitempty"`
 
+	// Enables strict ClientIPHeaders (default X-Forwarded-For)
+	// parsing. If enabled, the ClientIPHeaders will be parsed
+	// from right to left, and the first value that is both valid
+	// and doesn't match the trusted proxy list will be used as
+	// client IP. If disabled, the ClientIPHeaders will be parsed
+	// from left to right, and the first value that is a valid IP
+	// address will be used as client IP.
+	//
+	// This depends on `trusted_proxies` being configured.
+	// This option is disabled by default.
+	EnableStrictXffParsing bool `json:"enable_strict_xff_parsing,omitempty"`
+
 	// Enables access logging and configures how access logs are handled
 	// in this server. To minimally enable access logs, simply set this
 	// to a non-null, empty struct.
@@ -839,15 +851,26 @@ func determineTrustedProxy(r *http.Request, s *Server) (bool, string) {
 	if s.trustedProxies == nil {
 		return false, ipAddr.String()
 	}
-	for _, ipRange := range s.trustedProxies.GetIPRanges(r) {
-		if ipRange.Contains(ipAddr) {
-			// We trust the proxy, so let's try to
-			// determine the real client IP
-			return true, trustedRealClientIP(r, s.ClientIPHeaders, ipAddr.String())
+
+	if isTrustedClientIP(ipAddr, s.trustedProxies.GetIPRanges(r)) {
+		if s.EnableStrictXffParsing {
+			return true, strictUntrustedClientIp(r, s.ClientIPHeaders, s.trustedProxies.GetIPRanges(r), ipAddr.String())
 		}
+		return true, trustedRealClientIP(r, s.ClientIPHeaders, ipAddr.String())
 	}
 
 	return false, ipAddr.String()
+}
+
+// isTrustedClientIP returns true if the given IP address is
+// in the list of trusted IP ranges.
+func isTrustedClientIP(ipAddr netip.Addr, trusted []netip.Prefix) bool {
+	for _, ipRange := range trusted {
+		if ipRange.Contains(ipAddr) {
+			return true
+		}
+	}
+	return false
 }
 
 // trustedRealClientIP finds the client IP from the request assuming it is
@@ -881,6 +904,29 @@ func trustedRealClientIP(r *http.Request, headers []string, clientIP string) str
 	}
 
 	// We didn't find a valid IP
+	return clientIP
+}
+
+// strictUntrustedClientIp iterates through the list of client IP headers,
+// parses them from right-to-left, and returns the first valid IP address
+// that is untrusted. If no valid IP address is found, then the direct
+// remote address is returned.
+func strictUntrustedClientIp(r *http.Request, headers []string, trusted []netip.Prefix, clientIP string) string {
+	for _, headerName := range headers {
+		ips := strings.Split(strings.Join(r.Header.Values(headerName), ","), ",")
+
+		for i := len(ips) - 1; i >= 0; i-- {
+			ip, _, _ := strings.Cut(strings.TrimSpace(ips[i]), "%")
+			ipAddr, err := netip.ParseAddr(ip)
+			if err != nil {
+				continue
+			}
+			if !isTrustedClientIP(ipAddr, trusted) {
+				return ipAddr.String()
+			}
+		}
+	}
+
 	return clientIP
 }
 

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -183,7 +183,7 @@ type Server struct {
 	//
 	// This depends on `trusted_proxies` being configured.
 	// This option is disabled by default.
-	EnableStrictXffParsing bool `json:"enable_strict_xff_parsing,omitempty"`
+	TrustedProxiesStrict bool `json:"trusted_proxies_strict,omitempty"`
 
 	// Enables access logging and configures how access logs are handled
 	// in this server. To minimally enable access logs, simply set this
@@ -853,7 +853,7 @@ func determineTrustedProxy(r *http.Request, s *Server) (bool, string) {
 	}
 
 	if isTrustedClientIP(ipAddr, s.trustedProxies.GetIPRanges(r)) {
-		if s.EnableStrictXffParsing {
+		if s.TrustedProxiesStrict {
 			return true, strictUntrustedClientIp(r, s.ClientIPHeaders, s.trustedProxies.GetIPRanges(r), ipAddr.String())
 		}
 		return true, trustedRealClientIP(r, s.ClientIPHeaders, ipAddr.String())

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -173,17 +173,18 @@ type Server struct {
 	// remote IP address.
 	ClientIPHeaders []string `json:"client_ip_headers,omitempty"`
 
-	// Enables strict ClientIPHeaders (default X-Forwarded-For)
-	// parsing. If enabled, the ClientIPHeaders will be parsed
-	// from right to left, and the first value that is both valid
-	// and doesn't match the trusted proxy list will be used as
-	// client IP. If disabled, the ClientIPHeaders will be parsed
-	// from left to right, and the first value that is a valid IP
-	// address will be used as client IP.
+	// If greater than zero, enables strict ClientIPHeaders
+	// (default X-Forwarded-For) parsing. If enabled, the
+	// ClientIPHeaders will be parsed from right to left, and
+	// the first value that is both valid and doesn't match the
+	// trusted proxy list will be used as client IP. If zero,
+	// the ClientIPHeaders will be parsed from left to right,
+	// and the first value that is a valid IP address will be
+	// used as client IP.
 	//
 	// This depends on `trusted_proxies` being configured.
 	// This option is disabled by default.
-	TrustedProxiesStrict bool `json:"trusted_proxies_strict,omitempty"`
+	TrustedProxiesStrict int `json:"trusted_proxies_strict,omitempty"`
 
 	// Enables access logging and configures how access logs are handled
 	// in this server. To minimally enable access logs, simply set this
@@ -853,7 +854,7 @@ func determineTrustedProxy(r *http.Request, s *Server) (bool, string) {
 	}
 
 	if isTrustedClientIP(ipAddr, s.trustedProxies.GetIPRanges(r)) {
-		if s.TrustedProxiesStrict {
+		if s.TrustedProxiesStrict > 0 {
 			return true, strictUntrustedClientIp(r, s.ClientIPHeaders, s.trustedProxies.GetIPRanges(r), ipAddr.String())
 		}
 		return true, trustedRealClientIP(r, s.ClientIPHeaders, ipAddr.String())

--- a/modules/caddyhttp/server_test.go
+++ b/modules/caddyhttp/server_test.go
@@ -357,8 +357,8 @@ func TestServer_DetermineTrustedProxy_MatchRightMostUntrusted(t *testing.T) {
 		trustedProxies: &StaticIPRange{
 			ranges: []netip.Prefix{localPrivatePrefix},
 		},
-		ClientIPHeaders:        []string{"X-Forwarded-For"},
-		EnableStrictXffParsing: true,
+		ClientIPHeaders:      []string{"X-Forwarded-For"},
+		TrustedProxiesStrict: true,
 	}
 
 	req := httptest.NewRequest("GET", "/", nil)
@@ -378,8 +378,8 @@ func TestServer_DetermineTrustedProxy_MatchRightMostUntrustedSkippingEmpty(t *te
 		trustedProxies: &StaticIPRange{
 			ranges: []netip.Prefix{localPrivatePrefix},
 		},
-		ClientIPHeaders:        []string{"Missing-Header", "CF-Connecting-IP", "X-Forwarded-For"},
-		EnableStrictXffParsing: true,
+		ClientIPHeaders:      []string{"Missing-Header", "CF-Connecting-IP", "X-Forwarded-For"},
+		TrustedProxiesStrict: true,
 	}
 
 	req := httptest.NewRequest("GET", "/", nil)
@@ -400,8 +400,8 @@ func TestServer_DetermineTrustedProxy_MatchRightMostUntrustedSkippingTrusted(t *
 		trustedProxies: &StaticIPRange{
 			ranges: []netip.Prefix{localPrivatePrefix},
 		},
-		ClientIPHeaders:        []string{"CF-Connecting-IP", "X-Forwarded-For"},
-		EnableStrictXffParsing: true,
+		ClientIPHeaders:      []string{"CF-Connecting-IP", "X-Forwarded-For"},
+		TrustedProxiesStrict: true,
 	}
 
 	req := httptest.NewRequest("GET", "/", nil)
@@ -422,8 +422,8 @@ func TestServer_DetermineTrustedProxy_MatchRightMostUntrustedFirst(t *testing.T)
 		trustedProxies: &StaticIPRange{
 			ranges: []netip.Prefix{localPrivatePrefix},
 		},
-		ClientIPHeaders:        []string{"CF-Connecting-IP", "X-Forwarded-For"},
-		EnableStrictXffParsing: true,
+		ClientIPHeaders:      []string{"CF-Connecting-IP", "X-Forwarded-For"},
+		TrustedProxiesStrict: true,
 	}
 
 	req := httptest.NewRequest("GET", "/", nil)

--- a/modules/caddyhttp/server_test.go
+++ b/modules/caddyhttp/server_test.go
@@ -358,7 +358,7 @@ func TestServer_DetermineTrustedProxy_MatchRightMostUntrusted(t *testing.T) {
 			ranges: []netip.Prefix{localPrivatePrefix},
 		},
 		ClientIPHeaders:      []string{"X-Forwarded-For"},
-		TrustedProxiesStrict: true,
+		TrustedProxiesStrict: 1,
 	}
 
 	req := httptest.NewRequest("GET", "/", nil)
@@ -379,7 +379,7 @@ func TestServer_DetermineTrustedProxy_MatchRightMostUntrustedSkippingEmpty(t *te
 			ranges: []netip.Prefix{localPrivatePrefix},
 		},
 		ClientIPHeaders:      []string{"Missing-Header", "CF-Connecting-IP", "X-Forwarded-For"},
-		TrustedProxiesStrict: true,
+		TrustedProxiesStrict: 1,
 	}
 
 	req := httptest.NewRequest("GET", "/", nil)
@@ -401,7 +401,7 @@ func TestServer_DetermineTrustedProxy_MatchRightMostUntrustedSkippingTrusted(t *
 			ranges: []netip.Prefix{localPrivatePrefix},
 		},
 		ClientIPHeaders:      []string{"CF-Connecting-IP", "X-Forwarded-For"},
-		TrustedProxiesStrict: true,
+		TrustedProxiesStrict: 1,
 	}
 
 	req := httptest.NewRequest("GET", "/", nil)
@@ -423,7 +423,7 @@ func TestServer_DetermineTrustedProxy_MatchRightMostUntrustedFirst(t *testing.T)
 			ranges: []netip.Prefix{localPrivatePrefix},
 		},
 		ClientIPHeaders:      []string{"CF-Connecting-IP", "X-Forwarded-For"},
-		TrustedProxiesStrict: true,
+		TrustedProxiesStrict: 1,
 	}
 
 	req := httptest.NewRequest("GET", "/", nil)


### PR DESCRIPTION
This is the first stab at addressing #5804 

Commits are readable in order. This review is easiest done by going through them one-by-one:
- cover existing `client_ip_headers` functionality
- cover existing `trusted_proxy` functionality with custom ranges
- write tests covering both scenarios above in combination
- introduce a failing test proving the potential security weakness of existing `trusted_proxy` + `client_ip_headers` configuration
- introduce a new configuration option (default: false) to opt-in to a safer method of parsing `client_ip_headers`

The first 3 commits provide confidence in maintaining backwards compatibility for those who rely on the existing, left-most parsing of XFF headers. The remaining commits introduce tests + config options (default off) to enable the new right-most, first untrusted IP XFF parsing.