### PR TITLE
caddyhttp: Export `LengthReader`

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -329,9 +329,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		// wrap the request body in a LengthReader
 		// so we can track the number of bytes read from it
-		var bodyReader *lengthReader
+		var bodyReader *LengthReader
 		if r.Body != nil {
-			bodyReader = &lengthReader{Source: r.Body}
+			bodyReader = &LengthReader{Source: r.Body}
 			r.Body = bodyReader
 		}
 
@@ -705,7 +705,7 @@ func (s *Server) shouldLogRequest(r *http.Request) bool {
 // logRequest logs the request to access logs, unless skipped.
 func (s *Server) logRequest(
 	accLog *zap.Logger, r *http.Request, wrec ResponseRecorder, duration *time.Duration,
-	repl *caddy.Replacer, bodyReader *lengthReader, shouldLogCredentials bool,
+	repl *caddy.Replacer, bodyReader *LengthReader, shouldLogCredentials bool,
 ) {
 	// this request may be flagged as omitted from the logs
 	if skipLog, ok := GetVar(r.Context(), SkipLogVar).(bool); ok && skipLog {
@@ -942,20 +942,20 @@ func cloneURL(from, to *url.URL) {
 	}
 }
 
-// lengthReader is an io.ReadCloser that keeps track of the
+// LengthReader is an io.ReadCloser that keeps track of the
 // number of bytes read from the request body.
-type lengthReader struct {
+type LengthReader struct {
 	Source io.ReadCloser
 	Length int
 }
 
-func (r *lengthReader) Read(b []byte) (int, error) {
+func (r *LengthReader) Read(b []byte) (int, error) {
 	n, err := r.Source.Read(b)
 	r.Length += n
 	return n, err
 }
 
-func (r *lengthReader) Close() error {
+func (r *LengthReader) Close() error {
 	return r.Source.Close()
 }
 

--- a/modules/caddyhttp/server_test.go
+++ b/modules/caddyhttp/server_test.go
@@ -55,7 +55,7 @@ func TestServer_LogRequest(t *testing.T) {
 
 	duration := 50 * time.Millisecond
 	repl := NewTestReplacer(req)
-	bodyReader := &lengthReader{Source: req.Body}
+	bodyReader := &LengthReader{Source: req.Body}
 	shouldLogCredentials := false
 
 	buf := bytes.Buffer{}
@@ -82,7 +82,7 @@ func TestServer_LogRequest_WithTraceID(t *testing.T) {
 
 	duration := 50 * time.Millisecond
 	repl := NewTestReplacer(req)
-	bodyReader := &lengthReader{Source: req.Body}
+	bodyReader := &LengthReader{Source: req.Body}
 	shouldLogCredentials := false
 
 	buf := bytes.Buffer{}
@@ -109,7 +109,7 @@ func BenchmarkServer_LogRequest(b *testing.B) {
 
 	duration := 50 * time.Millisecond
 	repl := NewTestReplacer(req)
-	bodyReader := &lengthReader{Source: req.Body}
+	bodyReader := &LengthReader{Source: req.Body}
 
 	buf := io.Discard
 	accLog := testLogger(buf.Write)
@@ -134,7 +134,7 @@ func BenchmarkServer_LogRequest_WithTraceID(b *testing.B) {
 
 	duration := 50 * time.Millisecond
 	repl := NewTestReplacer(req)
-	bodyReader := &lengthReader{Source: req.Body}
+	bodyReader := &LengthReader{Source: req.Body}
 
 	buf := io.Discard
 	accLog := testLogger(buf.Write)


### PR DESCRIPTION
Closes #5728

Exporting it allows other modules to look at the length at any point in time, which may be useful if they hijack the connection.