### PR TITLE
httpcaddyfile: Enable TLS for catch-all site if `tls` directive is specified

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -716,10 +716,16 @@ func (st *ServerType) serversFromPairings(
 					}
 				}
 
+				// If TLS is specified as directive, it will also result in 1 or more connection policy being created
+				// Thus, catch-all address with non-standard port, e.g. :8443, can have TLS enabled without
+				// specifying prefix "https://"
+				createdTLSConnPolicies, ok := sblock.pile["tls.connection_policy"]
+				hasTLSDirectiveSpecified := ok && len(createdTLSConnPolicies) > 0
+
 				// we'll need to remember if the address qualifies for auto-HTTPS, so we
 				// can add a TLS conn policy if necessary
 				if addr.Scheme == "https" ||
-					(addr.Scheme != "http" && addr.Host != "" && addr.Port != httpPort) {
+					(addr.Scheme != "http" && addr.Port != httpPort && hasTLSDirectiveSpecified) {
 					addressQualifiesForTLS = true
 				}
 				// predict whether auto-HTTPS will add the conn policy for us; if so, we

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -723,13 +723,13 @@ func (st *ServerType) serversFromPairings(
 				// ensuring compatibility with behavior described in below link
 				// https://caddy.community/t/making-sense-of-auto-https-and-why-disabling-it-still-serves-https-instead-of-http/9761
 				createdTLSConnPolicies, ok := sblock.pile["tls.connection_policy"]
-				hasTLSDirectiveSpecified := (ok && len(createdTLSConnPolicies) > 0) ||
+				hasTLSEnabled := (ok && len(createdTLSConnPolicies) > 0) ||
 					(addr.Host != "" && srv.AutoHTTPS != nil && !sliceContains(srv.AutoHTTPS.Skip, addr.Host))
 
 				// we'll need to remember if the address qualifies for auto-HTTPS, so we
 				// can add a TLS conn policy if necessary
 				if addr.Scheme == "https" ||
-					(addr.Scheme != "http" && addr.Port != httpPort && hasTLSDirectiveSpecified) {
+					(addr.Scheme != "http" && addr.Port != httpPort && hasTLSEnabled) {
 					addressQualifiesForTLS = true
 				}
 				// predict whether auto-HTTPS will add the conn policy for us; if so, we

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -719,8 +719,12 @@ func (st *ServerType) serversFromPairings(
 				// If TLS is specified as directive, it will also result in 1 or more connection policy being created
 				// Thus, catch-all address with non-standard port, e.g. :8443, can have TLS enabled without
 				// specifying prefix "https://"
+				// Second part of the condition is to allow creating TLS conn policy even though `auto_https` has been disabled
+				// ensuring compability with behavior described in below link
+				// https://caddy.community/t/making-sense-of-auto-https-and-why-disabling-it-still-serves-https-instead-of-http/9761
 				createdTLSConnPolicies, ok := sblock.pile["tls.connection_policy"]
-				hasTLSDirectiveSpecified := ok && len(createdTLSConnPolicies) > 0
+				hasTLSDirectiveSpecified := (ok && len(createdTLSConnPolicies) > 0) ||
+					(addr.Host != "" && srv.AutoHTTPS != nil && !sliceContains(srv.AutoHTTPS.Skip, addr.Host))
 
 				// we'll need to remember if the address qualifies for auto-HTTPS, so we
 				// can add a TLS conn policy if necessary

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -720,7 +720,7 @@ func (st *ServerType) serversFromPairings(
 				// Thus, catch-all address with non-standard port, e.g. :8443, can have TLS enabled without
 				// specifying prefix "https://"
 				// Second part of the condition is to allow creating TLS conn policy even though `auto_https` has been disabled
-				// ensuring compability with behavior described in below link
+				// ensuring compatibility with behavior described in below link
 				// https://caddy.community/t/making-sense-of-auto-https-and-why-disabling-it-still-serves-https-instead-of-http/9761
 				createdTLSConnPolicies, ok := sblock.pile["tls.connection_policy"]
 				hasTLSDirectiveSpecified := (ok && len(createdTLSConnPolicies) > 0) ||

--- a/caddytest/integration/caddyfile_adapt/enable_tls_for_catch_all_site.txt
+++ b/caddytest/integration/caddyfile_adapt/enable_tls_for_catch_all_site.txt
@@ -1,0 +1,37 @@
+:8443 {
+	tls internal {
+		on_demand
+	}
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8443"
+					],
+					"tls_connection_policies": [
+						{}
+					]
+				}
+			}
+		},
+		"tls": {
+			"automation": {
+				"policies": [
+					{
+						"issuers": [
+							{
+								"module": "internal"
+							}
+						],
+						"on_demand": true
+					}
+				]
+			}
+		}
+	}
+}
+


### PR DESCRIPTION
## PR description
Enable TLS for catch-all site if `tls` directive is specified, even with non-standard port

## What does this PR fix/implement?
Fixes #5747 

## Tests
### Acceptance test
The input Caddyfile

```
:8443 {
    tls internal {
        on_demand
    }
}
```

is `adapt --pretty` to

```
{
	"apps": {
		"http": {
			"servers": {
				"srv0": {
					"listen": [
						":8443"
					],
					"tls_connection_policies": [
						{}
					]
				}
			}
		},
		"tls": {
			"automation": {
				"policies": [
					{
						"issuers": [
							{
								"module": "internal"
							}
						],
						"on_demand": true
					}
				]
			}
		}
	}
}
```

Regression test
The input Caddyfile
```
:8443 {

}
```

is `adapt --pretty` to

```
{
	"apps": {
		"http": {
			"servers": {
				"srv0": {
					"listen": [
						":8443"
					]
				}
			}
		}
	}
}
```