### PR TITLE
reverseproxy: fix nil pointer dereference in AUpstreams.GetUpstreams

### DIFF
--- a/modules/caddyhttp/reverseproxy/upstreams.go
+++ b/modules/caddyhttp/reverseproxy/upstreams.go
@@ -297,8 +297,8 @@ func (au *AUpstreams) Provision(_ caddy.Context) error {
 func (au AUpstreams) GetUpstreams(r *http.Request) ([]*Upstream, error) {
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 
-	resolveIpv4 := au.Versions.IPv4 == nil || *au.Versions.IPv4
-	resolveIpv6 := au.Versions.IPv6 == nil || *au.Versions.IPv6
+	resolveIpv4 := au.Versions == nil || au.Versions.IPv4 == nil || *au.Versions.IPv4
+	resolveIpv6 := au.Versions == nil || au.Versions.IPv6 == nil || *au.Versions.IPv6
 
 	// Map ipVersion early, so we can use it as part of the cache-key.
 	// This should be fairly inexpensive and comes and the upside of


### PR DESCRIPTION
Add a nil check for AUpstreams.Versions in AUpstreams.GetUpstreams to handle the case where versions is not set in the configuration file.

This fixes #5809.

I'm not completely sure this is the correct place to fix this - nil checks are probably never a bad idea - but it might also be good to ensure AUpstreams.Versions is actually initialized to include both IPv4 and IPv6 in the first place when it is not set in the configuration.