### PR TITLE
reverseproxy: fix parsing Caddyfile fails for unlimited request/response buffers

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_buffers.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_buffers.txt
@@ -1,0 +1,58 @@
+https://example.com {
+	reverse_proxy https://localhost:54321 {
+		request_buffers unlimited
+		response_buffers unlimited
+	}
+}
+
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"handler": "reverse_proxy",
+													"request_buffers": -1,
+													"response_buffers": -1,
+													"transport": {
+														"protocol": "http",
+														"tls": {}
+													},
+													"upstreams": [
+														{
+															"dial": "localhost:54321"
+														}
+													]
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -551,17 +551,24 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			if !d.NextArg() {
 				return d.ArgErr()
 			}
-			size, err := humanize.ParseBytes(d.Val())
-			if err != nil {
-				return d.Errf("invalid byte size '%s': %v", d.Val(), err)
+			val := d.Val()
+			var size int64
+			if val == "unlimited" {
+				size = -1
+			} else {
+				usize, err := humanize.ParseBytes(val)
+				if err != nil {
+					return d.Errf("invalid byte size '%s': %v", val, err)
+				}
+				size = int64(usize)
 			}
 			if d.NextArg() {
 				return d.ArgErr()
 			}
 			if subdir == "request_buffers" {
-				h.RequestBuffers = int64(size)
+				h.RequestBuffers = size
 			} else if subdir == "response_buffers" {
-				h.ResponseBuffers = int64(size)
+				h.ResponseBuffers = size
 			}
 
 		// TODO: These three properties are deprecated; remove them sometime after v2.6.4


### PR DESCRIPTION
When trying to set the `requst_buffers` or `response_buffers` to `-1` for unlimited, go-humanise fails to parse the value and crashes caddy

This allows the special value of `-1` to be set in the Caddyfile, this seemed like a good simple way to do this, as no other negative values would be valid.

It was always possible to set `-1` using JSON or the API.