### PR TITLE
reverseproxy: only change the content-length header when the full request was buffered

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -582,8 +582,12 @@ func (h Handler) prepareRequest(req *http.Request, repl *caddy.Replacer) (*http.
 	// feature if absolutely required, if read timeouts are
 	// set, and if body size is limited
 	if h.RequestBuffers != 0 && req.Body != nil {
-		req.Body, req.ContentLength = h.bufferedBody(req.Body, h.RequestBuffers)
-		req.Header.Set("Content-Length", strconv.FormatInt(req.ContentLength, 10))
+		var readBytes int64
+		req.Body, readBytes = h.bufferedBody(req.Body, h.RequestBuffers)
+		if h.RequestBuffers == -1 {
+			req.ContentLength = readBytes
+			req.Header.Set("Content-Length", strconv.FormatInt(req.ContentLength, 10))
+		}
 	}
 
 	if req.ContentLength == 0 {


### PR DESCRIPTION
fixes: https://github.com/caddyserver/caddy/issues/5829

currently if a request body was longer than `request_buffers` the `content-length` header sent to the upstream will be wrong, it will be the length of the buffer.

With this change, only in the case that the full request was read into the buffer, because it was set to unlimited length then the `content-length` is changed
