### PR TITLE
httpcaddyfile: Rewrite `root` and `rewrite` parsing to allow omitting matcher

### DIFF
--- a/caddytest/integration/caddyfile_adapt/rewrite_directive_permutations.txt
+++ b/caddytest/integration/caddyfile_adapt/rewrite_directive_permutations.txt
@@ -1,0 +1,112 @@
+:8080
+
+# With explicit wildcard matcher
+route {
+	rewrite * /a
+}
+
+# With path matcher
+route {
+	rewrite /path /b
+}
+
+# With named matcher
+route {
+	@named method GET
+	rewrite @named /c
+}
+
+# With no matcher, assumed to be wildcard
+route {
+	rewrite /d
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8080"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"group": "group0",
+											"handle": [
+												{
+													"handler": "rewrite",
+													"uri": "/a"
+												}
+											]
+										}
+									]
+								},
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"group": "group1",
+											"handle": [
+												{
+													"handler": "rewrite",
+													"uri": "/b"
+												}
+											],
+											"match": [
+												{
+													"path": [
+														"/path"
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"group": "group2",
+											"handle": [
+												{
+													"handler": "rewrite",
+													"uri": "/c"
+												}
+											],
+											"match": [
+												{
+													"method": [
+														"GET"
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"group": "group3",
+											"handle": [
+												{
+													"handler": "rewrite",
+													"uri": "/d"
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/caddytest/integration/caddyfile_adapt/root_directive_permutations.txt
+++ b/caddytest/integration/caddyfile_adapt/root_directive_permutations.txt
@@ -1,0 +1,108 @@
+:8080
+
+# With explicit wildcard matcher
+route {
+	root * /a
+}
+
+# With path matcher
+route {
+	root /path /b
+}
+
+# With named matcher
+route {
+	@named method GET
+	root @named /c
+}
+
+# With no matcher, assumed to be wildcard
+route {
+	root /d
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8080"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"handler": "vars",
+													"root": "/a"
+												}
+											]
+										}
+									]
+								},
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"handler": "vars",
+													"root": "/b"
+												}
+											],
+											"match": [
+												{
+													"path": [
+														"/path"
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"handler": "vars",
+													"root": "/c"
+												}
+											],
+											"match": [
+												{
+													"method": [
+														"GET"
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"handler": "vars",
+													"root": "/d"
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
I had this idea from reviewing @dunglas's code recently (where he copy-pasted some code from the Caddy codebase itself). The `php_fastcgi` directive uses `RegisterDirective` to get full control of parsing, instead of the `RegisterHandlerDirective` shortcut which does automatic request matcher parsing.

That made me realize we can do the same for `root`, and that we could actually make `root /srv` work, instead of the awkward `root * /srv` with an explicit `*` matcher) that we've been stuck with since v2.0.

Nice and simple, just a small rewrite of the parsing to count the number of arguments first, and if we have only one argument then we can assume it's the actual root path and that there's no matcher, because it never makes sense to ever only pass a matcher to `root` and no root path.

Added a test to cover the happy path, and tested the 0 and 3+ argument cases by hand quickly.

Before:
```
root * /srv
```
After:
```
root /srv
```
:tada: 