### PR TITLE
templates: Add dummy `RemoteAddr` to `httpInclude` request, proxy compatibility

### DIFF
--- a/modules/caddyhttp/templates/tplcontext.go
+++ b/modules/caddyhttp/templates/tplcontext.go
@@ -192,12 +192,10 @@ func (c TemplateContext) funcHTTPInclude(uri string) (string, error) {
 	// Set the Host header to the original request's Host
 	virtReq.Host = c.Req.Host
 
+	virtReq.RemoteAddr = "127.0.0.1"
+
 	// Clone the original request's headers and add X-Forwarded-For
 	virtReq.Header = c.Req.Header.Clone()
-	clientIP := c.RemoteIP() // Get the client's IP address
-	virtReq.Header.Add("X-Forwarded-For", clientIP)
-
-	// Set other headers as needed
 	virtReq.Header.Set("Accept-Encoding", "identity")
 	virtReq.Trailer = c.Req.Trailer.Clone()
 	virtReq.Header.Set(recursionPreventionHeader, strconv.Itoa(recursionCount))

--- a/modules/caddyhttp/templates/tplcontext.go
+++ b/modules/caddyhttp/templates/tplcontext.go
@@ -188,7 +188,7 @@ func (c TemplateContext) funcHTTPInclude(uri string) (string, error) {
 		return "", err
 	}
 	virtReq.Host = c.Req.Host
-	virtReq.RemoteAddr = "127.0.0.1"
+	virtReq.RemoteAddr = "127.0.0.1:10000" // https://github.com/caddyserver/caddy/issues/5835
 	virtReq.Header = c.Req.Header.Clone()
 	virtReq.Header.Set("Accept-Encoding", "identity") // https://github.com/caddyserver/caddy/issues/4352
 	virtReq.Trailer = c.Req.Trailer.Clone()

--- a/modules/caddyhttp/templates/tplcontext.go
+++ b/modules/caddyhttp/templates/tplcontext.go
@@ -183,28 +183,21 @@ func (c TemplateContext) funcHTTPInclude(uri string) (string, error) {
 	buf.Reset()
 	defer bufPool.Put(buf)
 
-	// Create a new virtual request
 	virtReq, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		return "", err
 	}
-
-	// Set the Host header to the original request's Host
 	virtReq.Host = c.Req.Host
-
 	virtReq.RemoteAddr = "127.0.0.1"
-
-	// Clone the original request's headers and add X-Forwarded-For
 	virtReq.Header = c.Req.Header.Clone()
-	virtReq.Header.Set("Accept-Encoding", "identity")
+	virtReq.Header.Set("Accept-Encoding", "identity") // https://github.com/caddyserver/caddy/issues/4352
 	virtReq.Trailer = c.Req.Trailer.Clone()
 	virtReq.Header.Set(recursionPreventionHeader, strconv.Itoa(recursionCount))
 
-	// Perform the virtual request
 	vrw := &virtualResponseWriter{body: buf, header: make(http.Header)}
 	server := c.Req.Context().Value(caddyhttp.ServerCtxKey).(http.Handler)
-	server.ServeHTTP(vrw, virtReq)
 
+	server.ServeHTTP(vrw, virtReq)
 	if vrw.status >= 400 {
 		return "", fmt.Errorf("http %d", vrw.status)
 	}


### PR DESCRIPTION
Issue:
This pull request addresses fixes #5835, which was created to track the progress of the discussion on the Caddy community forum: https://caddy.community/t/file-server-httpinclude-with-x-forwarded-for/21087. The issue discusses the need to allow the virtual request of `httpInclude` of a file_server to include the `X-Forwarded-For` header. Currently, the `X-Forwarded-For` header is not set in the virtual request, which poses a challenge for applications that rely on this header to determine the client's IP address and make decisions based on it.

Goal:
The goal of this enhancement is to modify the `funcHTTPInclude` function in the Caddy codebase to include the `X-Forwarded-For` header in the virtual request. This change will enable reverse proxies to set the `X-Forwarded-For` header, ensuring that the client's IP address is correctly provided to the target endpoint. This modification is essential for applications that depend on the `X-Forwarded-For` header for various functionalities, such as authentication, logging, or content customization.

Proposed Changes:

- In the funcHTTPInclude function, we will create a new virtual request (virtReq).
- We will set the Host header of the virtual request to match the original request's Host.
- The X-Forwarded-For header will be added to the virtual request, including the client's IP address obtained from the c.RemoteIP() function.
- Other headers, such as Accept-Encoding, will be set as needed.
- The virtual request will be performed as before, ensuring that the target endpoint receives the X-Forwarded-For header.