### PR TITLE
Use sync.Pool to reduce lengthReader allocations

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -921,12 +921,12 @@ var lengthReaderPool = sync.Pool{
 func getLengthReader(source io.ReadCloser) *lengthReader {
 	reader := lengthReaderPool.Get().(*lengthReader)
 	reader.Source = source
-	reader.Length = 0
 	return reader
 }
 
 func putLengthReader(reader *lengthReader) {
 	reader.Source = nil
+	reader.Length = 0
 	lengthReaderPool.Put(reader)
 }
 

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -320,6 +320,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var bodyReader *lengthReader
 		if r.Body != nil {
 			bodyReader = getLengthReader(r.Body)
+			defer putLengthReader(bodyReader)
 			r.Body = bodyReader
 		}
 
@@ -728,7 +729,6 @@ func (s *Server) logRequest(
 	reqBodyLength := 0
 	if bodyReader != nil {
 		reqBodyLength = bodyReader.Length
-		putLengthReader(bodyReader)
 	}
 
 	extra := r.Context().Value(ExtraLogFieldsCtxKey).(*ExtraLogFields)


### PR DESCRIPTION
Should fix #5756.

Tested allocations with this benchmark:

```
func BenchmarkServer_LengthReader(b *testing.B) {
	req := httptest.NewRequest(http.MethodGet, "/", nil)

	for i := 0; i < b.N; i++ {
		var bodyReader *lengthReader
		for j := 0; j < 10000; j++ {
			if req.Body != nil {
				// For testing without sync.Pool
				// bodyReader = &lengthReader{Source: req.Body}
				bodyReader = GetLengthReader(req.Body)
				req.Body = bodyReader
			}
			PutLengthReader(bodyReader)
		}
	}
	b.ReportAllocs()
}
```
Without sync.Pool:
BenchmarkServer_LengthReader-12    	    1808	    700019 ns/op	  240003 B/op	   10000 allocs/op

With sync.Pool
BenchmarkServer_LengthReader-12    	    9516	    127160 ns/op	       0 B/op	       0 allocs/op

This is my first time writing Go code, tried my best to stick to the same style. Successfully passed unit tests locally.