### PR TITLE
reverseproxy: Add `tls_curves` option to HTTP transport

### DIFF
--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -1072,6 +1072,16 @@ func (h *HTTPTransport) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				}
 				h.TLS.InsecureSkipVerify = true
 
+			case "tls_curves":
+				args := d.RemainingArgs()
+				if len(args) == 0 {
+					return d.ArgErr()
+				}
+				if h.TLS == nil {
+					h.TLS = new(TLSConfig)
+				}
+				h.TLS.Curves = args
+
 			case "tls_timeout":
 				if !d.NextArg() {
 					return d.ArgErr()


### PR DESCRIPTION
Example Caddyfile

    localhost {
        reverse_proxy https://example.com {
            transport http {
                tls_curves secp521r1
            }
        }
    }

Long term goal is to be able to configure post-quantum for Caddy -> upstream.