### PR TITLE
tls: Add support for X25519Kyber768Draft00 post-quantum "curve" when compiled with cfgo.

### DIFF
--- a/modules/caddytls/cf.go
+++ b/modules/caddytls/cf.go
@@ -1,0 +1,24 @@
+//go:build cfgo
+
+package caddytls
+
+// This file adds support for X25519Kyber768Draft00, a post-quantum
+// key agreement that is currently being rolled out by Chrome [1]
+// and Cloudflare [2,3]. For more context, see the PR [4].
+//
+// [1] https://blog.chromium.org/2023/08/protecting-chrome-traffic-with-hybrid.html
+// [2] https://blog.cloudflare.com/post-quantum-for-all/
+// [3] https://blog.cloudflare.com/post-quantum-to-origins/
+// [4] https://github.com/caddyserver/caddy/pull/5852
+
+import (
+	"crypto/tls"
+)
+
+func init() {
+	SupportedCurves["X25519Kyber768Draft00"] = tls.X25519Kyber768Draft00
+	defaultCurves = append(
+		[]tls.CurveID{tls.X25519Kyber768Draft00},
+		defaultCurves...,
+	)
+}


### PR DESCRIPTION
It's not ideal to have to compile with a different toolchain, and I'd understand if you'd rather wait for upstream Go.

With this patch, we can get PQ caddy:

```
git clone https://github.com/bwesterb/caddy
git clone https://github.com/cloudflare/go
cd go/src
./make.bash
cd ../../caddy/cmd/caddy
git checkout pq
../../../go/bin/go build
```
This enables PQ for browser -> Caddy by default. For PQ Caddy -> upstream we need [this patch](https://github.com/caddyserver/caddy/pull/5851), and then we can use:

```
localhost {
    reverse_proxy https://pq.cloudflareresearch.com {
        header_up Host {upstream_hostport}
        transport http {
            tls_curves X25519Kyber768Draft00 x25519 secp256r1
        }
    }
}
```

For Caddy -> upstream we're not enabling it by default, as not all upstreams might support it, and it would incur an extra roundtrip (HelloRetryRequest). One can check for PQ caddy -> upstream in this case by visiting `https://localhost/cdn-cgi/trace`:

```
$ curl https://localhost/cdn-cgi/trace | grep kex
kex=X25519Kyber768Draft00
```

