### PR TITLE
fix: caddytest.AssertResponseCode error message

### DIFF
--- a/caddytest/caddytest.go
+++ b/caddytest/caddytest.go
@@ -467,7 +467,7 @@ func (tc *Tester) AssertResponseCode(req *http.Request, expectedStatusCode int) 
 	}
 
 	if expectedStatusCode != resp.StatusCode {
-		tc.t.Errorf("requesting \"%s\" expected status code: %d but got %d", req.RequestURI, expectedStatusCode, resp.StatusCode)
+		tc.t.Errorf("requesting \"%s\" expected status code: %d but got %d", req.URL.RequestURI(), expectedStatusCode, resp.StatusCode)
 	}
 
 	return resp


### PR DESCRIPTION
This error message is always empty because this field isn't set on a client request. This patch fixes the issue.