### PR TITLE
fileserver: Add command shortcuts `-l` and `-a`

### DIFF
--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -58,7 +58,7 @@ respond with a file listing.`,
 			cmd.Flags().StringP("listen", "l", "", "The address to which to bind the listener")
 			cmd.Flags().BoolP("browse", "b", false, "Enable directory browsing")
 			cmd.Flags().BoolP("templates", "t", false, "Enable template rendering")
-			cmd.Flags().BoolP("access-log", "", false, "Enable the access log")
+			cmd.Flags().BoolP("access-log", "a", false, "Enable the access log")
 			cmd.Flags().BoolP("debug", "v", false, "Enable verbose debug logs")
 			cmd.RunE = caddycmd.WrapCommandFuncForCobra(cmdFileServer)
 			cmd.AddCommand(&cobra.Command{

--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -55,7 +55,7 @@ respond with a file listing.`,
 		CobraFunc: func(cmd *cobra.Command) {
 			cmd.Flags().StringP("domain", "d", "", "Domain name at which to serve the files")
 			cmd.Flags().StringP("root", "r", "", "The path to the root of the site")
-			cmd.Flags().StringP("listen", "", "", "The address to which to bind the listener")
+			cmd.Flags().StringP("listen", "l", "", "The address to which to bind the listener")
 			cmd.Flags().BoolP("browse", "b", false, "Enable directory browsing")
 			cmd.Flags().BoolP("templates", "t", false, "Enable template rendering")
 			cmd.Flags().BoolP("access-log", "", false, "Enable the access log")


### PR DESCRIPTION
Original idea from @francislavoie: https://github.com/dunglas/frankenphp/pull/238#discussion_r1344667798

Maybe could we also add a `-a` shortcut for `--access-log`?