### PR TITLE
caddyhttp: Add `uuid` to access logs when used

### DIFF
--- a/caddyconfig/httpcaddyfile/shorthands.go
+++ b/caddyconfig/httpcaddyfile/shorthands.go
@@ -64,6 +64,7 @@ func placeholderShorthands() []string {
 		"{remote_port}", "{http.request.remote.port}",
 		"{scheme}", "{http.request.scheme}",
 		"{uri}", "{http.request.uri}",
+		"{uuid}", "{http.request.uuid}",
 		"{tls_cipher}", "{http.request.tls.cipher_suite}",
 		"{tls_version}", "{http.request.tls.version}",
 		"{tls_client_fingerprint}", "{http.request.tls.client.fingerprint}",

--- a/modules/caddyhttp/logging.go
+++ b/modules/caddyhttp/logging.go
@@ -151,6 +151,18 @@ func (e *ExtraLogFields) Add(field zap.Field) {
 	e.fields = append(e.fields, field)
 }
 
+// Set sets a field in the list of extra fields to log.
+// If the field already exists, it is replaced.
+func (e *ExtraLogFields) Set(field zap.Field) {
+	for i := range e.fields {
+		if e.fields[i].Key == field.Key {
+			e.fields[i] = field
+			return
+		}
+	}
+	e.fields = append(e.fields, field)
+}
+
 const (
 	// Variable name used to indicate that this request
 	// should be omitted from the access logs


### PR DESCRIPTION
Closes #5820

Whenever the `{http.request.uuid}` placeholder is processed, the UUID is also added to the access logs via `ExtraLogFields`.

Added a new Caddyfile shortcut `{uuid}` because why not.

I had to make a new `Set(field)` method for `ExtraLogFields` because otherwise when using `Add(field)`, using the placeholder multiple times in a request would add the log field each time.