### PR TITLE
reverseproxy: Replace health header placeholders

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_health_headers.txt
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_health_headers.txt
@@ -6,6 +6,9 @@ reverse_proxy 127.0.0.1:65535 {
 		X-Header-Key 95ca39e3cbe7
 		X-Header-Keys VbG4NZwWnipo 335Q9/MhqcNU3s2TO
 		X-Empty-Value
+		Same-Key 1
+		Same-Key 2
+		X-System-Hostname {system.hostname}
 	}
 	health_uri /health
 }
@@ -29,6 +32,10 @@ reverse_proxy 127.0.0.1:65535 {
 												"Host": [
 													"example.com"
 												],
+												"Same-Key": [
+													"1",
+													"2"
+												],
 												"X-Empty-Value": [
 													""
 												],
@@ -38,6 +45,9 @@ reverse_proxy 127.0.0.1:65535 {
 												"X-Header-Keys": [
 													"VbG4NZwWnipo",
 													"335Q9/MhqcNU3s2TO"
+												],
+												"X-System-Hostname": [
+													"{system.hostname}"
 												]
 											},
 											"uri": "/health"

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -372,7 +372,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if len(values) == 0 {
 					values = append(values, "")
 				}
-				healthHeaders[key] = values
+				healthHeaders[key] = append(healthHeaders[key], values...)
 			}
 			if h.HealthChecks == nil {
 				h.HealthChecks = new(HealthChecks)


### PR DESCRIPTION
Fixes #5686

Essentially, this only supports placeholders from this list https://caddyserver.com/docs/conventions#placeholders, i.e. none of the request placeholders.