### PR TITLE
httpcaddyfile: Add `RegisterDirectiveOrder` function for plugin authors

### DIFF
--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -154,15 +154,15 @@ func RegisterHandlerDirective(dir string, setupFunc UnmarshalHandlerFunc) {
 // to ('before' or 'after') a directive included in Caddy's
 // standard distribution. It cannot be relative to another
 // plugin's directive.
-func RegisterDirectiveOrder(dir string, position string, standardDir string) {
+func RegisterDirectiveOrder(dir string, position Positional, standardDir string) {
 	// check if directive was already ordered
 	if directiveIsOrdered(dir) {
 		panic("directive '" + dir + "' already ordered")
 	}
 
 	switch position {
-	case "before":
-	case "after":
+	case Before:
+	case After:
 	default:
 		panic("the 2nd argument must be either 'before' or 'after', got '" + position + "'")
 	}
@@ -186,9 +186,9 @@ func RegisterDirectiveOrder(dir string, position string, standardDir string) {
 		if d != standardDir {
 			continue
 		}
-		if position == "before" {
+		if position == Before {
 			newOrder = append(newOrder[:i], append([]string{dir}, newOrder[i:]...)...)
-		} else if position == "after" {
+		} else if position == After {
 			newOrder = append(newOrder[:i+1], append([]string{dir}, newOrder[i+1:]...)...)
 		}
 		break
@@ -619,6 +619,16 @@ func (sb serverBlock) isAllHTTP() bool {
 	}
 	return true
 }
+
+// Positional are the supported modes for ordering directives.
+type Positional string
+
+const (
+	Before Positional = "before"
+	After  Positional = "after"
+	First  Positional = "first"
+	Last   Positional = "last"
+)
 
 type (
 	// UnmarshalFunc is a function which can unmarshal Caddyfile

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -160,10 +160,7 @@ func RegisterDirectiveOrder(dir string, position Positional, standardDir string)
 		panic("directive '" + dir + "' already ordered")
 	}
 
-	switch position {
-	case Before:
-	case After:
-	default:
+	if position != Before && position != After {
 		panic("the 2nd argument must be either 'before' or 'after', got '" + position + "'")
 	}
 

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -154,6 +154,8 @@ func RegisterHandlerDirective(dir string, setupFunc UnmarshalHandlerFunc) {
 // to ('before' or 'after') a directive included in Caddy's
 // standard distribution. It cannot be relative to another
 // plugin's directive.
+//
+// EXPERIMENTAL: This API may change or be removed.
 func RegisterDirectiveOrder(dir string, position Positional, standardDir string) {
 	// check if directive was already ordered
 	if directiveIsOrdered(dir) {

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -27,18 +27,25 @@ import (
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 )
 
-// directiveOrder specifies the order
-// to apply directives in HTTP routes.
+// defaultDirectiveOrder specifies the default order
+// to apply directives in HTTP routes. This must only
+// consist of directives that are included in Caddy's
+// standard distribution.
 //
-// The root directive goes first in case rewrites or
-// redirects depend on existence of files, i.e. the
-// file matcher, which must know the root first.
+// e.g. The 'root' directive goes near the start in
+// case rewrites or redirects depend on existence of
+// files, i.e. the file matcher, which must know the
+// root first.
 //
-// The header directive goes second so that headers
-// can be manipulated before doing redirects.
-var directiveOrder = []string{
+// e.g. The 'header' directive goes before 'redir' so
+// that headers can be manipulated before doing redirects.
+//
+// e.g. The 'respond' directive is near the end because it
+// writes a response and terminates the middleware chain.
+var defaultDirectiveOrder = []string{
 	"tracing",
 
+	// set variables that may be used by other directives
 	"map",
 	"vars",
 	"fs",
@@ -85,6 +92,11 @@ var directiveOrder = []string{
 	"acme_server",
 }
 
+// directiveOrder specifies the order to apply directives
+// in HTTP routes, after being modified by either the
+// plugins or by the user via the "order" global option.
+var directiveOrder = defaultDirectiveOrder
+
 // directiveIsOrdered returns true if dir is
 // a known, ordered (sorted) directive.
 func directiveIsOrdered(dir string) bool {
@@ -129,6 +141,59 @@ func RegisterHandlerDirective(dir string, setupFunc UnmarshalHandlerFunc) {
 
 		return h.NewRoute(matcherSet, val), nil
 	})
+}
+
+// RegisterDirectiveOrder registers the default order for a
+// directive from a plugin.
+//
+// This is useful when a plugin has a well-understood place
+// it should run in the middleware pipeline, and it allows
+// users to avoid having to define the order themselves.
+//
+// The directive dir may be placed in the position relative
+// to ('before' or 'after') a directive included in Caddy's
+// standard distribution. It cannot be relative to another
+// plugin's directive.
+func RegisterDirectiveOrder(dir string, position string, standardDir string) {
+	// check if directive was already ordered
+	if directiveIsOrdered(dir) {
+		panic("directive '" + dir + "' already ordered")
+	}
+
+	switch position {
+	case "before":
+	case "after":
+	default:
+		panic("the 2nd argument must be either 'before' or 'after', got '" + position + "'")
+	}
+
+	// check if directive exists in standard distribution, since
+	// we can't allow plugins to depend on one another; we can't
+	// guarantee the order that plugins are loaded in.
+	foundStandardDir := false
+	for _, d := range defaultDirectiveOrder {
+		if d == standardDir {
+			foundStandardDir = true
+		}
+	}
+	if !foundStandardDir {
+		panic("the 3rd argument '" + standardDir + "' must be a directive that exists in the standard distribution of Caddy")
+	}
+
+	// insert directive into proper position
+	newOrder := directiveOrder
+	for i, d := range newOrder {
+		if d != standardDir {
+			continue
+		}
+		if position == "before" {
+			newOrder = append(newOrder[:i], append([]string{dir}, newOrder[i:]...)...)
+		} else if position == "after" {
+			newOrder = append(newOrder[:i+1], append([]string{dir}, newOrder[i+1:]...)...)
+		}
+		break
+	}
+	directiveOrder = newOrder
 }
 
 // RegisterGlobalOption registers a unique global option opt with

--- a/caddyconfig/httpcaddyfile/options.go
+++ b/caddyconfig/httpcaddyfile/options.go
@@ -107,7 +107,7 @@ func parseOptOrder(d *caddyfile.Dispenser, _ any) (any, error) {
 	if !d.Next() {
 		return nil, d.ArgErr()
 	}
-	pos := d.Val()
+	pos := Positional(d.Val())
 
 	newOrder := directiveOrder
 
@@ -121,22 +121,22 @@ func parseOptOrder(d *caddyfile.Dispenser, _ any) (any, error) {
 
 	// act on the positional
 	switch pos {
-	case "first":
+	case First:
 		newOrder = append([]string{dirName}, newOrder...)
 		if d.NextArg() {
 			return nil, d.ArgErr()
 		}
 		directiveOrder = newOrder
 		return newOrder, nil
-	case "last":
+	case Last:
 		newOrder = append(newOrder, dirName)
 		if d.NextArg() {
 			return nil, d.ArgErr()
 		}
 		directiveOrder = newOrder
 		return newOrder, nil
-	case "before":
-	case "after":
+	case Before:
+	case After:
 	default:
 		return nil, d.Errf("unknown positional '%s'", pos)
 	}
@@ -153,9 +153,9 @@ func parseOptOrder(d *caddyfile.Dispenser, _ any) (any, error) {
 	// insert directive into proper position
 	for i, d := range newOrder {
 		if d == otherDir {
-			if pos == "before" {
+			if pos == Before {
 				newOrder = append(newOrder[:i], append([]string{dirName}, newOrder[i:]...)...)
-			} else if pos == "after" {
+			} else if pos == After {
 				newOrder = append(newOrder[:i+1], append([]string{dirName}, newOrder[i+1:]...)...)
 			}
 			break


### PR DESCRIPTION
We (@mholt @dunglas and I) were talking in Slack about the ergonomics of using the Caddyfile for end-users of custom builds of Caddy which may include many handler plugins. Forcing users to specify `order` or wrap things in `route` causes some friction that would be nice to smooth out.

The reason we never did this in the past is because we didn't want to allow plugins to depend upon eachother, because we can't guarantee the order in which plugins are loaded. We also didn't want the ordering to become unreliable when the order of directives in the standard distribution changes.

We can mitigate those factors by doing two things:
- Only allow plugins to register an order for their directive in relation to a directive in Caddy's standard distribution (we keep a `defaultDirectiveOrder` which doesn't change, to ensure this, and modify `directiveOrder` accordingly)
- Only allow plugins to order "before" and "after" another directive (and no "first" or "last" like the `order` global option allows) to reduce the chance of ordering that doesn't make sense.

The API looks like this:

```go
httpcaddyfile.RegisterHandlerDirective("my_directive", parseDirective)
httpcaddyfile.RegisterDirectiveOrder("my_directive", "after", "redir") // new
```

Or course, there's still a slight problem if two plugins try to both order the same way in relation to a standard directive (e.g. both are "before headers") because their order will not be guaranteed. There are some complicated ways we could mitigate this though, for example we could invalidate the ordering for both directives since they're in conflict, forcing the user to specify their own order for both. But ultimately I think this it probably not an immediate need, and we can expand upon that later.