### PR TITLE
fileserver: Add canonical URL to browse template

### DIFF
--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -774,7 +774,6 @@ footer {
 <body onload="initPage()">
 	<header>
 		<div class="wrapper">
-			<a href="//{{.Host}}" alt="Home">&nbsp;{{.Host}}</a>
 			<div class="breadcrumbs">Folder Path</div>
 				<h1>
 					{{range $i, $crumb := .Breadcrumbs}}<a href="{{html $crumb.Link}}">{{html $crumb.Text}}</a>{{if ne $i 0}}/{{end}}{{end}}

--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -299,6 +299,7 @@
 <html>
 	<head>
 		<title>{{html .Name}}</title>
+		<link rel="canonical" href="{{.Path}}/"  />
 		<meta charset="utf-8">
 		<meta name="color-scheme" content="light dark">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -773,6 +774,7 @@ footer {
 <body onload="initPage()">
 	<header>
 		<div class="wrapper">
+			<a href="//{{.Host}}" alt="Home">&nbsp;{{.Host}}</a>
 			<div class="breadcrumbs">Folder Path</div>
 				<h1>
 					{{range $i, $crumb := .Breadcrumbs}}<a href="{{html $crumb.Link}}">{{html $crumb.Text}}</a>{{if ne $i 0}}/{{end}}{{end}}


### PR DESCRIPTION
When contents are equal, but maybe just a sort order is different, it is good to add `<link rel="canonical" href="{{.Path}}/" />`. This helps search engines propeely index the page.

I also added a link to the home page with the name of `{{.Host}}` just above the bread crumbs to make the page clearer.
![Screenshot_20231007_134435_Opera](https://github.com/caddyserver/caddy/assets/68693597/ae223a3c-37e8-4773-a32b-214af957bab5)

https://paste.tnonline.net/files/28Wun5CQZiqA_Screenshot_20231007_134435_Opera.png