### PR TITLE
dheerajsingh0-#5858-Revise-redir-status-code-shortcuts

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -650,8 +650,12 @@ func parseRedir(h Helper) (caddyhttp.MiddlewareHandler, error) {
 	switch code {
 	case "permanent":
 		code = "301"
+	case "permanent-strict":
+		code = "308"
 	case "temporary", "":
 		code = "302"
+	case "temporary-strict":
+		code = "307"
 	case "html":
 		// Script tag comes first since that will better imitate a redirect in the browser's
 		// history, but the meta tag is a fallback for most non-JS clients.


### PR DESCRIPTION
PR Update for redir Directive in Caddyfile
Reference: [Caddyserver's redir Directive](https://caddyserver.com/docs/caddyfile/directives/redir)

Changes Proposed:

Introduced new shortcuts for HTTP redirection codes:
temporary-strict maps to 307 Temporary Redirect.
permanent-strict maps to 308 Permanent Redirect.
Ensured existing redirection codes are retained:
temporary (or no code) maps to 302 Found.
permanent maps to 301 Moved Permanently.
Extended documentation to specify behavior of different HTTP methods during redirection and clarified client responsibilities for conformance.
Rationale:
Previously, only two shortcuts were available for redirections: temporary and permanent. While these cover the most common redirections, there are scenarios where a client needs to differentiate between a 302 Found and a 307 Temporary Redirect, or between a 301 Moved Permanently and a 308 Permanent Redirect.

The inclusion of the new shortcuts ensures that Caddy users have granular control over their redirection behaviors. Furthermore, enhanced documentation ensures clarity in client-server interactions during redirections, promoting conformance and predictability.

Feedback and further suggestions are welcome!