### PR TITLE
encode: Add `application/wasm*` to the default content types

### DIFF
--- a/caddytest/integration/caddyfile_adapt/encode_options.txt
+++ b/caddytest/integration/caddyfile_adapt/encode_options.txt
@@ -11,6 +11,7 @@ encode gzip zstd {
 		header Content-Type application/xhtml+xml*
 		header Content-Type application/atom+xml*
 		header Content-Type application/rss+xml*
+		header Content-Type application/wasm*
 		header Content-Type image/svg+xml*
 	}
 }
@@ -47,6 +48,7 @@ encode {
 												"application/xhtml+xml*",
 												"application/atom+xml*",
 												"application/rss+xml*",
+												"application/wasm*",
 												"image/svg+xml*"
 											]
 										},

--- a/modules/caddyhttp/encode/encode.go
+++ b/modules/caddyhttp/encode/encode.go
@@ -93,6 +93,7 @@ func (enc *Encode) Provision(ctx caddy.Context) error {
 					"application/xhtml+xml*",
 					"application/atom+xml*",
 					"application/rss+xml*",
+					"application/wasm*",
 					"image/svg+xml*",
 				},
 			},


### PR DESCRIPTION
After this change, WebAssembly files will be encoded (compressed). This is useful because WebAssembly files are uncompressed.

Pull request #2624 did the same thing 4 years ago but it seems that the change got lost.