### PR TITLE
admin: respond with 4xx status code on non-existing config path

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -1196,15 +1196,27 @@ traverseLoop:
 					}
 				case http.MethodPut:
 					if _, ok := v[part]; ok {
-						return fmt.Errorf("[%s] key already exists: %s", path, part)
+						return APIError{
+							HTTPStatus: http.StatusConflict,
+							Err:        fmt.Errorf("[%s] key already exists: %s", path, part),
+						}
 					}
 					v[part] = val
 				case http.MethodPatch:
 					if _, ok := v[part]; !ok {
-						return fmt.Errorf("[%s] key does not exist: %s", path, part)
+						return APIError{
+							HTTPStatus: http.StatusNotFound,
+							Err:        fmt.Errorf("[%s] key does not exist: %s", path, part),
+						}
 					}
 					v[part] = val
 				case http.MethodDelete:
+					if _, ok := v[part]; !ok {
+						return APIError{
+							HTTPStatus: http.StatusNotFound,
+							Err:        fmt.Errorf("[%s] key does not exist: %s", path, part),
+						}
+					}
 					delete(v, part)
 				default:
 					return fmt.Errorf("unrecognized method %s", method)

--- a/admin_test.go
+++ b/admin_test.go
@@ -76,6 +76,12 @@ func TestUnsyncedConfigAccess(t *testing.T) {
 			expect: `{"foo": "jet", "bar": {"aa": "bb"}, "list": ["a", "b", "c"]}`,
 		},
 		{
+			method:    "DELETE",
+			path:      "/bar/qq",
+			expect:    `{"foo": "jet", "bar": {"aa": "bb"}, "list": ["a", "b", "c"]}`,
+			shouldErr: true,
+		},
+		{
 			method:  "POST",
 			path:    "/list",
 			payload: `"e"`,


### PR DESCRIPTION
Fixes #5836

Deleting a non-existing config key returned status `200`. Now it returns `404`.

I took the chance to also update the status codes for putting an already existing key (status `409`) and patching a non-existing key (status `404`), instead of failing with an internal error.