### PR TITLE
#5871  Added "-v" flag as well along with "version"

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -221,6 +221,25 @@ documentation: https://go.dev/doc/modules/version-numbers
 	})
 
 	RegisterCommand(Command{
+		Name:  "-v",
+		Short: "Prints the version",
+		Long: `
+Prints the version of this Caddy binary.
+
+Version information must be embedded into the binary at compile-time in
+order for Caddy to display anything useful with this command. If Caddy
+is built from within a version control repository, the Go command will
+embed the revision hash if available. However, if Caddy is built in the
+way specified by our online documentation (or by using xcaddy), more
+detailed version information is printed as given by Go modules.
+
+For more details about the full version string, see the Go module
+documentation: https://go.dev/doc/modules/version-numbers
+`,
+		Func: cmdVersion,
+	})
+
+	RegisterCommand(Command{
 		Name:  "list-modules",
 		Usage: "[--packages] [--versions] [--skip-standard]",
 		Short: "Lists the installed Caddy modules",


### PR DESCRIPTION

**Fixed #5871**  
Added **-v** RegisterCommond component  in /cmd/commonds.go file which will work as "**caddy -v**" in cli to show the current version . Not removed existing version RegisterCommond component which means both "**caddy version**" and "caddy -v" works same .