### PR TITLE
httpcaddyfile: Remove port from logger names

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -17,6 +17,7 @@ package httpcaddyfile
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"reflect"
 	"sort"
 	"strconv"
@@ -797,7 +798,12 @@ func (st *ServerType) serversFromPairings(
 						if srv.Logs.LoggerNames == nil {
 							srv.Logs.LoggerNames = make(map[string]string)
 						}
-						srv.Logs.LoggerNames[h] = ncl.name
+						// strip the port from the host, if any
+						host, _, err := net.SplitHostPort(h)
+						if err != nil {
+							host = h
+						}
+						srv.Logs.LoggerNames[host] = ncl.name
 					}
 				}
 			}

--- a/caddytest/integration/caddyfile_adapt/log_except_catchall_blocks.txt
+++ b/caddytest/integration/caddyfile_adapt/log_except_catchall_blocks.txt
@@ -99,7 +99,7 @@ http://localhost:2020 {
 					},
 					"logs": {
 						"logger_names": {
-							"localhost:2020": ""
+							"localhost": ""
 						},
 						"skip_unmapped_hosts": true
 					}

--- a/caddytest/integration/caddyfile_adapt/log_override_hostname.txt
+++ b/caddytest/integration/caddyfile_adapt/log_override_hostname.txt
@@ -8,6 +8,12 @@
 		output file /baz.txt
 	}
 }
+
+example.com:8443 {
+	log {
+		output file /port.txt
+	}
+}
 ----------
 {
 	"logging": {
@@ -15,7 +21,8 @@
 			"default": {
 				"exclude": [
 					"http.log.access.log0",
-					"http.log.access.log1"
+					"http.log.access.log1",
+					"http.log.access.log2"
 				]
 			},
 			"log0": {
@@ -34,6 +41,15 @@
 				},
 				"include": [
 					"http.log.access.log1"
+				]
+			},
+			"log2": {
+				"writer": {
+					"filename": "/port.txt",
+					"output": "file"
+				},
+				"include": [
+					"http.log.access.log2"
 				]
 			}
 		}
@@ -62,6 +78,28 @@
 							"bar.example.com": "log0",
 							"baz.example.com": "log1",
 							"foo.example.com": "log0"
+						}
+					}
+				},
+				"srv1": {
+					"listen": [
+						":8443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"example.com"
+									]
+								}
+							],
+							"terminal": true
+						}
+					],
+					"logs": {
+						"logger_names": {
+							"example.com": "log2"
 						}
 					}
 				}

--- a/caddytest/integration/caddyfile_adapt/log_override_name_multiaccess.txt
+++ b/caddytest/integration/caddyfile_adapt/log_override_name_multiaccess.txt
@@ -76,7 +76,7 @@ http://localhost:8881 {
 					},
 					"logs": {
 						"logger_names": {
-							"localhost:8881": "foo"
+							"localhost": "foo"
 						}
 					}
 				}

--- a/caddytest/integration/caddyfile_adapt/log_override_name_multiaccess_debug.txt
+++ b/caddytest/integration/caddyfile_adapt/log_override_name_multiaccess_debug.txt
@@ -81,7 +81,7 @@ http://localhost:8881 {
 					},
 					"logs": {
 						"logger_names": {
-							"localhost:8881": "foo"
+							"localhost": "foo"
 						}
 					}
 				}


### PR DESCRIPTION
This took a long while to figure out. https://caddy.community/t/logging-per-subdomain-reverse-proxies/20586

When a site address has a port, the port number would be included as part of `logger_names` in the JSON output. This means that when the request is trying to match a logger, it would never match (therefore not write any access logs) because it would only use the `Host` to match it, which wouldn't have the port if some port forwarding happened.

This is safe because the Caddyfile adapter always makes separate servers even if the same domain with different ports are used in the same site block, so the hostname is unique to each server.