### PR TITLE
caddyfile: Fix variadic placeholder false positive when token contains `:`

### DIFF
--- a/caddyconfig/caddyfile/importargs.go
+++ b/caddyconfig/caddyfile/importargs.go
@@ -52,6 +52,13 @@ func parseVariadic(token Token, argCount int) (bool, int, int) {
 		return false, 0, 0
 	}
 
+	// A valid token may contain several placeholders, and
+	// they may be separated by ":". It's not variadic.
+	// https://github.com/caddyserver/caddy/issues/5716
+	if strings.Contains(start, "}") || strings.Contains(end, "{") {
+		return false, 0, 0
+	}
+
 	var (
 		startIndex = 0
 		endIndex   = argCount

--- a/caddyconfig/caddyfile/parse_test.go
+++ b/caddyconfig/caddyfile/parse_test.go
@@ -91,6 +91,10 @@ func TestParseVariadic(t *testing.T) {
 			input:  "{args[0:10]}",
 			result: true,
 		},
+		{
+			input:  "{args[0]}:{args[1]}:{args[2]}",
+			result: false,
+		},
 	} {
 		token := Token{
 			File: "test",


### PR DESCRIPTION
fix [5716](https://github.com/caddyserver/caddy/issues/5716).
