### PR TITLE
cmd: upgrade: resolve symlink of the executable

### DIFF
--- a/cmd/packagesfuncs.go
+++ b/cmd/packagesfuncs.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"runtime/debug"
@@ -102,6 +103,15 @@ func upgradeBuild(pluginPkgs map[string]struct{}, fl Flags) (int, error) {
 	thisExecStat, err := os.Stat(thisExecPath)
 	if err != nil {
 		return caddy.ExitCodeFailedStartup, fmt.Errorf("retrieving current executable permission bits: %v", err)
+	}
+	if thisExecStat.Mode()&os.ModeSymlink == os.ModeSymlink {
+		symSource := thisExecPath
+		// we are a symlink; resolve it
+		thisExecPath, err = filepath.EvalSymlinks(thisExecPath)
+		if err != nil {
+			return caddy.ExitCodeFailedStartup, fmt.Errorf("resolving current executable symlink: %v", err)
+		}
+		l.Info("this executable is a symlink", zap.String("source", symSource), zap.String("target", thisExecPath))
 	}
 	l.Info("this executable will be replaced", zap.String("path", thisExecPath))
 


### PR DESCRIPTION
It occurred to me that users of `dpkg-divert` (per our instructions [here](https://caddyserver.com/docs/build#package-support-files-for-custom-builds-for-debianubunturaspbian)) may have their symlink `/usr/local/bin/caddy` be overwritten by the `upgrade`, `add-package`, or `remove-package` commands because we're replacing the symlink source, i.e. `/usr/local/bin/caddy`, and not its target. This may cause some system inconsistency or confusion. The fix is simply to resolve the symlink.