### PR TITLE
Add newline character to version string in CLI output

### DIFF
--- a/cmd/cobra.go
+++ b/cmd/cobra.go
@@ -106,7 +106,7 @@ const fullDocsFooter = `Full documentation is available at:
 https://caddyserver.com/docs/command-line`
 
 func init() {
-	rootCmd.SetVersionTemplate("{{.Version}}")
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
 	rootCmd.SetHelpTemplate(rootCmd.HelpTemplate() + "\n" + fullDocsFooter + "\n")
 }
 


### PR DESCRIPTION
This pull request addresses issue https://github.com/caddyserver/caddy/issues/5893, where the version string was reported inconsistently when using the `-v` or `--version` CLI flags. The issue was due to the absence of a newline character at the end of the version string when using these flags. This inconsistency could potentially disrupt update check automation and other tooling that relies on consistent version string formatting.

To fix this issue, I have added a newline character (`\n`) to the version template in the code. With this change, the version string output is now consistent whether you use `caddy version` or `caddy -v / caddy --version`. This ensures a smoother experience for users and more reliable tooling integration.

Please review and merge this pull request to ensure consistent and predictable behavior when retrieving Caddy's version information via the CLI.