### PR TITLE
httpcaddyfile: Fix TLS automation policy merging with get_certificate

### DIFF
--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -582,6 +582,7 @@ outer:
 			// eaten up by the one with subjects; and if both have subjects, we
 			// need to combine their lists
 			if reflect.DeepEqual(aps[i].IssuersRaw, aps[j].IssuersRaw) &&
+				reflect.DeepEqual(aps[i].ManagersRaw, aps[j].ManagersRaw) &&
 				bytes.Equal(aps[i].StorageRaw, aps[j].StorageRaw) &&
 				aps[i].MustStaple == aps[j].MustStaple &&
 				aps[i].KeyType == aps[j].KeyType &&

--- a/caddytest/integration/caddyfile_adapt/tls_automation_policies_11.txt
+++ b/caddytest/integration/caddyfile_adapt/tls_automation_policies_11.txt
@@ -1,0 +1,67 @@
+# example from https://caddy.community/t/21415
+a.com {
+	tls {
+		get_certificate http http://foo.com/get
+	}
+}
+
+b.com {
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"a.com"
+									]
+								}
+							],
+							"terminal": true
+						},
+						{
+							"match": [
+								{
+									"host": [
+										"b.com"
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		},
+		"tls": {
+			"automation": {
+				"policies": [
+					{
+						"subjects": [
+							"a.com"
+						],
+						"get_certificate": [
+							{
+								"url": "http://foo.com/get",
+								"via": "http"
+							}
+						]
+					},
+					{
+						"subjects": [
+							"b.com"
+						]
+					}
+				]
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes an issue reported in https://caddy.community/t/21415

We need to check that the `ManagerRaw` (i.e. `get_certificate` usually) is also the same, otherwise automation policies get merged when they shouldn't.