### PR TITLE
Revert "caddyhttp: Use sync.Pool to reduce lengthReader allocations (#5848)"

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -318,8 +318,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// so we can track the number of bytes read from it
 		var bodyReader *lengthReader
 		if r.Body != nil {
-			bodyReader = getLengthReader(r.Body)
-			defer putLengthReader(bodyReader)
+			bodyReader = &lengthReader{Source: r.Body}
 			r.Body = bodyReader
 		}
 
@@ -901,24 +900,6 @@ func cloneURL(from, to *url.URL) {
 type lengthReader struct {
 	Source io.ReadCloser
 	Length int
-}
-
-var lengthReaderPool = sync.Pool{
-	New: func() interface{} {
-		return &lengthReader{}
-	},
-}
-
-func getLengthReader(source io.ReadCloser) *lengthReader {
-	reader := lengthReaderPool.Get().(*lengthReader)
-	reader.Source = source
-	return reader
-}
-
-func putLengthReader(reader *lengthReader) {
-	reader.Source = nil
-	reader.Length = 0
-	lengthReaderPool.Put(reader)
 }
 
 func (r *lengthReader) Read(b []byte) (int, error) {


### PR DESCRIPTION
This reverts commit c8559c448537969376623be9d352949b59907b0e to resolve the following panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x122f9b5]

goroutine 222573 [running]:
github.com/caddyserver/caddy/v2/modules/caddyhttp.(*lengthReader).Close(0x0?)
	github.com/caddyserver/caddy/v2@v2.7.6-0.20231024195719-67e567b7ecec/modules/caddyhttp/server.go:931 +0x15
golang.org/x/net/http2.(*clientStream).cleanupWriteRequest(0xc000e49980, {0x0, 0x0})
	golang.org/x/net@v0.17.0/http2/transport.go:1550 +0x1a2
golang.org/x/net/http2.(*clientStream).doRequest(0xc000e58f00?, 0x0?)
	golang.org/x/net@v0.17.0/http2/transport.go:1327 +0x28
created by golang.org/x/net/http2.(*ClientConn).RoundTrip in goroutine 222537
	golang.org/x/net@v0.17.0/http2/transport.go:1232 +0x308
```

