### PR TITLE
Avoid skipping a storage due to identical string representations

### DIFF
--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -570,14 +570,13 @@ func (t *TLS) cleanStorageUnits() {
 	}
 
 	// avoid cleaning same storage more than once per cleaning cycle
-	storagesCleaned := make(map[string]struct{})
+	storagesCleaned := make(map[interface{}]struct{})
 
 	// start with the default/global storage
 	storage := t.ctx.Storage()
-	storageStr := fmt.Sprintf("%v", storage)
-	t.logger.Info("cleaning storage unit", zap.String("description", storageStr))
+	t.logger.Info("cleaning storage unit", zap.Any("description", storage))
 	certmagic.CleanStorage(t.ctx, storage, options)
-	storagesCleaned[storageStr] = struct{}{}
+	storagesCleaned[storage] = struct{}{}
 
 	// then clean each storage defined in ACME automation policies
 	if t.Automation != nil {
@@ -585,13 +584,12 @@ func (t *TLS) cleanStorageUnits() {
 			if ap.storage == nil {
 				continue
 			}
-			storageStr := fmt.Sprintf("%v", ap.storage)
-			if _, ok := storagesCleaned[storageStr]; ok {
+			if _, ok := storagesCleaned[storage]; ok {
 				continue
 			}
-			t.logger.Info("cleaning storage unit", zap.String("description", storageStr))
+			t.logger.Info("cleaning storage unit", zap.Any("description", storage))
 			certmagic.CleanStorage(t.ctx, ap.storage, options)
-			storagesCleaned[storageStr] = struct{}{}
+			storagesCleaned[storage] = struct{}{}
 		}
 	}
 

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -570,7 +570,7 @@ func (t *TLS) cleanStorageUnits() {
 	}
 
 	// avoid cleaning same storage more than once per cleaning cycle
-	storagesCleaned := make(map[interface{}]struct{})
+	storagesCleaned := make(map[certmagic.Storage]struct{})
 
 	// start with the default/global storage
 	storage := t.ctx.Storage()


### PR DESCRIPTION
fmt.Sprintf("%v", thing) will use a fmt.Stringer implementation in thing, which means that we cannot easily assume that this value is going to be unique here and can be used to deduplicate the storages.

Instead: Use a `map[interface{}]struct{}` as we anyways have an interface, and interfaces are perfectly fine map keys.

As a side-effect: Implementors of storage can now implement fmt.Stringer safely, and get the expected output here.