### PR TITLE
caddyhttp: http2 uses new round-robin scheduler

### DIFF
--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -378,11 +378,7 @@ func (app *App) Start() error {
 				return context.WithValue(ctx, ConnCtxKey, c)
 			},
 		}
-		h2server := &http2.Server{
-			NewWriteScheduler: func() http2.WriteScheduler {
-				return http2.NewPriorityWriteScheduler(nil)
-			},
-		}
+		h2server := new(http2.Server)
 
 		// disable HTTP/2, which we enabled by default during provisioning
 		if !srv.protocol("h2") {


### PR DESCRIPTION
Stdlib begins to use the new round-robin scheduler in [the commit](https://go-review.googlesource.com/c/net/+/478735). neild also [said this was intended](https://github.com/golang/go/discussions/60746).

Bundled http2 is still using the old scheduler because a change was not made. We are not using the bundled http2, so this change is easy to make.