### PR TITLE
logging: Automatic `wrap` default for `filter` encoder

### DIFF
--- a/caddytest/integration/caddyfile_adapt/log_filter_no_wrap.txt
+++ b/caddytest/integration/caddyfile_adapt/log_filter_no_wrap.txt
@@ -1,0 +1,52 @@
+:80
+
+log {
+	output stdout
+	format filter {
+		fields {
+			request>headers>Server delete
+		}
+	}
+}
+----------
+{
+	"logging": {
+		"logs": {
+			"default": {
+				"exclude": [
+					"http.log.access.log0"
+				]
+			},
+			"log0": {
+				"writer": {
+					"output": "stdout"
+				},
+				"encoder": {
+					"fields": {
+						"request\u003eheaders\u003eServer": {
+							"filter": "delete"
+						}
+					},
+					"format": "filter"
+				},
+				"include": [
+					"http.log.access.log0"
+				]
+			}
+		}
+	},
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"logs": {
+						"default_logger_name": "log0"
+					}
+				}
+			}
+		}
+	}
+}

--- a/logging.go
+++ b/logging.go
@@ -265,6 +265,17 @@ type WriterOpener interface {
 	OpenWriter() (io.WriteCloser, error)
 }
 
+// IsWriterStandardStream returns true if the input is a
+// writer-opener to a standard stream (stdout, stderr).
+func IsWriterStandardStream(wo WriterOpener) bool {
+	switch wo.(type) {
+	case StdoutWriter, StderrWriter,
+		*StdoutWriter, *StderrWriter:
+		return true
+	}
+	return false
+}
+
 type writerDestructor struct {
 	io.WriteCloser
 }
@@ -341,16 +352,19 @@ func (cl *BaseLog) provisionCommon(ctx Context, logging *Logging) error {
 			return fmt.Errorf("loading log encoder module: %v", err)
 		}
 		cl.encoder = mod.(zapcore.Encoder)
+
+		// if the encoder module needs the writer to determine
+		// the correct default to use for a nested encoder, we
+		// pass it down as a secondary provisioning step
+		if cfd, ok := mod.(ConfiguresFormatterDefault); ok {
+			err := cfd.ConfigureDefaultFormat(cl.writerOpener)
+			if err != nil {
+				return fmt.Errorf("configuring default format for encoder module: %v", err)
+			}
+		}
 	}
 	if cl.encoder == nil {
-		// only allow colorized output if this log is going to stdout or stderr
-		var colorize bool
-		switch cl.writerOpener.(type) {
-		case StdoutWriter, StderrWriter,
-			*StdoutWriter, *StderrWriter:
-			colorize = true
-		}
-		cl.encoder = newDefaultProductionLogEncoder(colorize)
+		cl.encoder = newDefaultProductionLogEncoder(cl.writerOpener)
 	}
 	cl.buildCore()
 	return nil
@@ -680,7 +694,7 @@ func newDefaultProductionLog() (*defaultCustomLog, error) {
 	if err != nil {
 		return nil, err
 	}
-	cl.encoder = newDefaultProductionLogEncoder(true)
+	cl.encoder = newDefaultProductionLogEncoder(cl.writerOpener)
 	cl.levelEnabler = zapcore.InfoLevel
 
 	cl.buildCore()
@@ -697,16 +711,14 @@ func newDefaultProductionLog() (*defaultCustomLog, error) {
 	}, nil
 }
 
-func newDefaultProductionLogEncoder(colorize bool) zapcore.Encoder {
+func newDefaultProductionLogEncoder(wo WriterOpener) zapcore.Encoder {
 	encCfg := zap.NewProductionEncoderConfig()
-	if term.IsTerminal(int(os.Stdout.Fd())) {
+	if IsWriterStandardStream(wo) && term.IsTerminal(int(os.Stderr.Fd())) {
 		// if interactive terminal, make output more human-readable by default
 		encCfg.EncodeTime = func(ts time.Time, encoder zapcore.PrimitiveArrayEncoder) {
 			encoder.AppendString(ts.UTC().Format("2006/01/02 15:04:05.000"))
 		}
-		if colorize {
-			encCfg.EncodeLevel = zapcore.CapitalColorLevelEncoder
-		}
+		encCfg.EncodeLevel = zapcore.CapitalColorLevelEncoder
 		return zapcore.NewConsoleEncoder(encCfg)
 	}
 	return zapcore.NewJSONEncoder(encCfg)
@@ -752,6 +764,15 @@ var (
 )
 
 var writers = NewUsagePool()
+
+// ConfiguresFormatterDefault is an optional interface that
+// encoder modules can implement to configure the default
+// format of their encoder. This is useful for encoders
+// which nest an encoder, that needs to know the writer
+// in order to determine the correct default.
+type ConfiguresFormatterDefault interface {
+	ConfigureDefaultFormat(WriterOpener) error
+}
 
 const DefaultLoggerName = "default"
 

--- a/logging.go
+++ b/logging.go
@@ -357,8 +357,7 @@ func (cl *BaseLog) provisionCommon(ctx Context, logging *Logging) error {
 		// the correct default to use for a nested encoder, we
 		// pass it down as a secondary provisioning step
 		if cfd, ok := mod.(ConfiguresFormatterDefault); ok {
-			err := cfd.ConfigureDefaultFormat(cl.writerOpener)
-			if err != nil {
+			if err := cfd.ConfigureDefaultFormat(cl.writerOpener); err != nil {
 				return fmt.Errorf("configuring default format for encoder module: %v", err)
 			}
 		}

--- a/modules/logging/filterencoder.go
+++ b/modules/logging/filterencoder.go
@@ -128,8 +128,7 @@ func (fe *FilterEncoder) ConfigureDefaultFormat(wo caddy.WriterOpener) error {
 	if caddy.IsWriterStandardStream(wo) && term.IsTerminal(int(os.Stderr.Fd())) {
 		fe.wrapped = &ConsoleEncoder{}
 		if p, ok := fe.wrapped.(caddy.Provisioner); ok {
-			err := p.Provision(fe.ctx)
-			if err != nil {
+			if err := p.Provision(fe.ctx) ; err != nil {
 				return fmt.Errorf("provisioning fallback encoder module: %v", err)
 			}
 		}

--- a/modules/logging/filterencoder.go
+++ b/modules/logging/filterencoder.go
@@ -84,8 +84,7 @@ func (fe *FilterEncoder) Provision(ctx caddy.Context) error {
 		// if wrap is not specified, default to JSON
 		fe.wrapped = &JSONEncoder{}
 		if p, ok := fe.wrapped.(caddy.Provisioner); ok {
-			err := p.Provision(ctx)
-			if err != nil {
+			if err := p.Provision(ctx); err != nil {
 				return fmt.Errorf("provisioning fallback encoder module: %v", err)
 			}
 		}

--- a/modules/logging/filterencoder.go
+++ b/modules/logging/filterencoder.go
@@ -128,7 +128,7 @@ func (fe *FilterEncoder) ConfigureDefaultFormat(wo caddy.WriterOpener) error {
 	if caddy.IsWriterStandardStream(wo) && term.IsTerminal(int(os.Stderr.Fd())) {
 		fe.wrapped = &ConsoleEncoder{}
 		if p, ok := fe.wrapped.(caddy.Provisioner); ok {
-			if err := p.Provision(fe.ctx) ; err != nil {
+			if err := p.Provision(fe.ctx); err != nil {
 				return fmt.Errorf("provisioning fallback encoder module: %v", err)
 			}
 		}

--- a/modules/logging/filterencoder.go
+++ b/modules/logging/filterencoder.go
@@ -17,11 +17,13 @@ package logging
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/buffer"
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/term"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
@@ -36,8 +38,10 @@ func init() {
 // log entries before they are actually encoded by
 // an underlying encoder.
 type FilterEncoder struct {
-	// The underlying encoder that actually
-	// encodes the log entries. Required.
+	// The underlying encoder that actually encodes the
+	// log entries. If not specified, defaults to "json",
+	// unless the output is a terminal, in which case
+	// it defaults to "console".
 	WrappedRaw json.RawMessage `json:"wrap,omitempty" caddy:"namespace=caddy.logging.encoders inline_key=format"`
 
 	// A map of field names to their filters. Note that this
@@ -59,6 +63,9 @@ type FilterEncoder struct {
 
 	// used to keep keys unique across nested objects
 	keyPrefix string
+
+	wrappedIsDefault bool
+	ctx              caddy.Context
 }
 
 // CaddyModule returns the Caddy module information.
@@ -71,16 +78,26 @@ func (FilterEncoder) CaddyModule() caddy.ModuleInfo {
 
 // Provision sets up the encoder.
 func (fe *FilterEncoder) Provision(ctx caddy.Context) error {
-	if fe.WrappedRaw == nil {
-		return fmt.Errorf("missing \"wrap\" (must specify an underlying encoder)")
-	}
+	fe.ctx = ctx
 
-	// set up wrapped encoder (required)
-	val, err := ctx.LoadModule(fe, "WrappedRaw")
-	if err != nil {
-		return fmt.Errorf("loading fallback encoder module: %v", err)
+	if fe.WrappedRaw == nil {
+		// if wrap is not specified, default to JSON
+		fe.wrapped = &JSONEncoder{}
+		if p, ok := fe.wrapped.(caddy.Provisioner); ok {
+			err := p.Provision(ctx)
+			if err != nil {
+				return fmt.Errorf("provisioning fallback encoder module: %v", err)
+			}
+		}
+		fe.wrappedIsDefault = true
+	} else {
+		// set up wrapped encoder
+		val, err := ctx.LoadModule(fe, "WrappedRaw")
+		if err != nil {
+			return fmt.Errorf("loading fallback encoder module: %v", err)
+		}
+		fe.wrapped = val.(zapcore.Encoder)
 	}
-	fe.wrapped = val.(zapcore.Encoder)
 
 	// set up each field filter
 	if fe.Fields == nil {
@@ -94,6 +111,30 @@ func (fe *FilterEncoder) Provision(ctx caddy.Context) error {
 		fe.Fields[fieldName] = modIface.(LogFieldFilter)
 	}
 
+	return nil
+}
+
+// ConfigureDefaultFormat will set the default format to "console"
+// if the writer is a terminal. If already configured as a filter
+// encoder, it passes through the writer so a deeply nested filter
+// encoder can configure its own default format.
+func (fe *FilterEncoder) ConfigureDefaultFormat(wo caddy.WriterOpener) error {
+	if !fe.wrappedIsDefault {
+		if cfd, ok := fe.wrapped.(caddy.ConfiguresFormatterDefault); ok {
+			return cfd.ConfigureDefaultFormat(wo)
+		}
+		return nil
+	}
+
+	if caddy.IsWriterStandardStream(wo) && term.IsTerminal(int(os.Stderr.Fd())) {
+		fe.wrapped = &ConsoleEncoder{}
+		if p, ok := fe.wrapped.(caddy.Provisioner); ok {
+			err := p.Provision(fe.ctx)
+			if err != nil {
+				return fmt.Errorf("provisioning fallback encoder module: %v", err)
+			}
+		}
+	}
 	return nil
 }
 
@@ -390,7 +431,8 @@ func (mom logObjectMarshalerWrapper) MarshalLogObject(_ zapcore.ObjectEncoder) e
 
 // Interface guards
 var (
-	_ zapcore.Encoder         = (*FilterEncoder)(nil)
-	_ zapcore.ObjectMarshaler = (*logObjectMarshalerWrapper)(nil)
-	_ caddyfile.Unmarshaler   = (*FilterEncoder)(nil)
+	_ zapcore.Encoder                  = (*FilterEncoder)(nil)
+	_ zapcore.ObjectMarshaler          = (*logObjectMarshalerWrapper)(nil)
+	_ caddyfile.Unmarshaler            = (*FilterEncoder)(nil)
+	_ caddy.ConfiguresFormatterDefault = (*FilterEncoder)(nil)
 )


### PR DESCRIPTION
I was talking with @dunglas and he pointed out how awkward it is to have to configure `wrap` on the [`filter` encoder](https://caddyserver.com/docs/caddyfile/directives/log#filter) because it loses the nice-to-have default behaviour of checking if `stderr` is a terminal to choose a default of `console` vs `json`.

Getting this to work just right was quite messy, but I think I got it working well now. I also made some adjustments that may or may not be considered breaking changes for some people, since we're changing some default behaviour for the `filter` encoder, and I slightly changed the logic for detecting the terminal.

- we're now checking if `stderr` is a terminal instead of `stdout` because our default writer is `stderr` anyway, it was kinda incorrect to be checking `stdout` I think
- fixed a bug where the `writer` wasn't considered when determining the default encoder; this meant that if a `output file foo.log` was configured and it was run at a terminal, it would write `console` logs to the file by default (but with color turned off). That's a bad default, it should be writing `json` to the file even when run as a terminal unless otherwise stated.
- now we're never removing color by default from the log output. What we would need to do is detect whether the terminal supports color or not, but we weren't doing that before so this is certainly not a regression, if anything it's just a gap, but it's not the end of the world. I do know some Windows users have complained when they used the legacy command prompt which didn't support unix style colors, but the new windows terminal does support it now so 🤷 I don't really care to deal with that detail right now, not a big deal
- `wrap` is no longer required for `filter` encoder, it now defaults to `json` when `stderr` is not a terminal, and `console` when it is a terminal
- to make this work, we now pass down the logger's `writer` module to the configured `encoder` if it has the `ConfiguresFormatterDefault` interface, which is called immediately after provisioning as a 2nd phase in provisioning
- the `filter` encoder implements that interface, and uses it to check if the writer is a terminal, switching the nested encoder to `console`; it also passes down the writer if the explicitly configured encoder if itself wants the writer (e.g. filter inside filter, or whatever).