### PR TITLE
test: highlight a deadlock when reloading Caddy

### DIFF
--- a/caddytest/integration/admin_test.go
+++ b/caddytest/integration/admin_test.go
@@ -1,0 +1,66 @@
+package integration
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/caddytest"
+)
+
+// TestReloadConcurrent exercises reload under concurrent conditions
+// and is most useful under test with `-race` enabled.
+func TestReloadConcurrent(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		skip_install_trust
+		admin localhost:2999
+		http_port 9080
+		https_port 9443
+	}
+
+	localhost:9080 {
+		root * testdata/
+	}
+	`, "caddyfile")
+
+	const configURL = "http://localhost:2999/config/apps/http"
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		go func() {
+			wg.Add(1)
+			resp1, err := tester.Client.Get(configURL)
+			if err != nil {
+				t.Errorf("cannot get app config %s", err)
+
+				return
+			}
+
+			r, err := http.NewRequest("POST", configURL, resp1.Body)
+			if err != nil {
+				t.Errorf("cannot create request %s", err)
+
+				return
+			}
+			r.Header.Add("Content-Type", "application/json")
+			r.Header.Add("Cache-Control", "must-revalidate")
+
+			resp, err := tester.Client.Do(r)
+			if err != nil {
+				t.Errorf("cannot reload app config %s", err)
+
+				return
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("expected status 200; got %d", resp.StatusCode)
+
+				return
+			}
+
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}

--- a/caddytest/integration/admin_test.go
+++ b/caddytest/integration/admin_test.go
@@ -29,8 +29,11 @@ func TestReloadConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
+		wg.Add(1)
+
 		go func() {
-			wg.Add(1)
+			defer wg.Done()
+
 			resp1, err := tester.Client.Get(configURL)
 			if err != nil {
 				t.Errorf("cannot get app config %s", err)
@@ -58,8 +61,6 @@ func TestReloadConcurrent(t *testing.T) {
 
 				return
 			}
-
-			wg.Done()
 		}()
 	}
 	wg.Wait()


### PR DESCRIPTION
When sending many concurrent requests to reload Caddy, a deadlock sometimes occurs. This test highlights it:

```
<snip>
{"level":"info","ts":1702636483.968044,"logger":"admin","msg":"stopped previous server","address":"localhost:2999"}
{"level":"info","ts":1702636483.974002,"logger":"admin","msg":"stopped previous server","address":"localhost:2999"}
{"level":"info","ts":1702636483.976449,"logger":"admin","msg":"stopped previous server","address":"localhost:2999"}
panic: test timed out after 15s
running tests:
	TestReloadConcurrent (15s)
<snip>
```

Problem found with @francislavoie, @mholt thanks to a reproducer provided by @nunomaduro while working on https://github.com/laravel/octane/pull/764.

(I'm using a Mac).