### PR TITLE
httpcaddyfile: Sort skip_hosts for deterministic JSON

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -820,6 +820,9 @@ func (st *ServerType) serversFromPairings(
 			}
 		}
 
+		// sort for deterministic JSON output
+		slices.Sort(srv.Logs.SkipHosts)
+
 		// a server cannot (natively) serve both HTTP and HTTPS at the
 		// same time, so make sure the configuration isn't in conflict
 		err := detectConflictingSchemes(srv, p.serverBlocks, options)


### PR DESCRIPTION
Fix #5989