### PR TITLE
httpcaddyfile: Fix redir <to> html

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -711,6 +711,7 @@ func parseRedir(h Helper) (caddyhttp.MiddlewareHandler, error) {
 `
 		safeTo := html.EscapeString(to)
 		body = fmt.Sprintf(metaRedir, safeTo, safeTo, safeTo, safeTo)
+		hdr = http.Header{"Content-Type": []string{"text/html; charset=utf-8"}}
 		code = "200" // don't redirect non-browser clients
 	default:
 		// Allow placeholders for the code


### PR DESCRIPTION
Before this commit, the response's Content-Type header was set to text/plain, which causes some browsers to treat it as plaintext instead of html, and thereby just showing the html code instead of parsing it and redirecting as expected.

This commit fixes that issue by setting Content-Type to text/html Now the browser parses the response body as HTML, which leads to the redirect working as expected.