### PR TITLE
browse: Add total file size to directory listing

### DIFF
--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -791,7 +791,7 @@ footer {
 							<b>{{.NumFiles}}</b> file{{if ne 1 .NumFiles}}s{{end}}
 						</span>
 						<span class="meta-item">
-							<b>{{.HumanTotalFileSize}}</b> in total 
+							<b>{{.HumanTotalFileSize}}</b> total 
 						</span>
 						{{- if ne 0 .Limit}}
 						<span class="meta-item">

--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -790,6 +790,9 @@ footer {
 						<span class="meta-item">
 							<b>{{.NumFiles}}</b> file{{if ne 1 .NumFiles}}s{{end}}
 						</span>
+						<span class="meta-item">
+							<b>{{.HumanTotalFileSize}}</b> in total 
+						</span>
 						{{- if ne 0 .Limit}}
 						<span class="meta-item">
 							(of which only <b>{{.Limit}}</b> are displayed)

--- a/modules/caddyhttp/fileserver/browsetplcontext.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext.go
@@ -86,6 +86,10 @@ func (fsrv *FileServer) directoryListing(ctx context.Context, entries []fs.DirEn
 			// was already set above.
 		}
 
+		if !isDir {
+			tplCtx.TotalFileSize += size
+		}
+
 		u := url.URL{Path: "./" + name} // prepend with "./" to fix paths with ':' in the name
 
 		tplCtx.Items = append(tplCtx.Items, fileInfo{
@@ -128,6 +132,9 @@ type browseTemplateContext struct {
 
 	// The number of files (items that aren't directories) in the listing.
 	NumFiles int `json:"num_files"`
+
+	// The total size of all files in the listing.
+	TotalFileSize int64 `json:"total_file_size"`
 
 	// Sort column used
 	Sort string `json:"sort,omitempty"`
@@ -250,6 +257,13 @@ func (fi fileInfo) HasExt(exts ...string) bool {
 // power of 2 or base 1024).
 func (fi fileInfo) HumanSize() string {
 	return humanize.IBytes(uint64(fi.Size))
+}
+
+// HumanTotalFileSize returns the total size of all files
+// in the listing as a human-readable string in IEC format
+// (i.e. power of 2 or base 1024).
+func (btc browseTemplateContext) HumanTotalFileSize() string {
+	return humanize.IBytes(uint64(btc.TotalFileSize))
 }
 
 // HumanModTime returns the modified time of the file


### PR DESCRIPTION
Closes #6002

This PR is adding the total file size, human-readable, of all files in a directory listing.
Full-disclosure: this is my first go contribution