### PR TITLE
random float64 maybe? 

### DIFF
--- a/replacer.go
+++ b/replacer.go
@@ -295,6 +295,9 @@ func ToString(val any) string {
 // returned.
 type ReplacerFunc func(key string) (any, bool)
 
+//nolint:gosec
+var weakrand = rand.New(rand.NewSource(time.Now().UnixMicro()))
+
 func globalDefaultReplacements(key string) (any, bool) {
 	// check environment variable
 	const envPrefix = "env."
@@ -320,7 +323,8 @@ func globalDefaultReplacements(key string) (any, bool) {
 	case "time.now":
 		return nowFunc(), true
 	case "math.rand.float64":
-		return rand.Float64(), true
+		// this is intentionally not crypto-secure. people should not rely on this value as a secure source of randomness.
+		return weakrand.Float64(), true
 	case "time.now.http":
 		// According to the comment for http.TimeFormat, the timezone must be in UTC
 		// to generate the correct format.

--- a/replacer.go
+++ b/replacer.go
@@ -320,11 +320,11 @@ func globalDefaultReplacements(key string) (any, bool) {
 		return wd, true
 	case "system.arch":
 		return runtime.GOARCH, true
-	case "time.now":
-		return nowFunc(), true
 	case "math.rand.float64":
 		// this is intentionally not crypto-secure. people should not rely on this value as a secure source of randomness.
 		return weakrand.Float64(), true
+	case "time.now":
+		return nowFunc(), true
 	case "time.now.http":
 		// According to the comment for http.TimeFormat, the timezone must be in UTC
 		// to generate the correct format.

--- a/replacer.go
+++ b/replacer.go
@@ -16,6 +16,7 @@ package caddy
 
 import (
 	"fmt"
+	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -318,6 +319,8 @@ func globalDefaultReplacements(key string) (any, bool) {
 		return runtime.GOARCH, true
 	case "time.now":
 		return nowFunc(), true
+	case "math.rand.float64":
+		return rand.Float64(), true
 	case "time.now.http":
 		// According to the comment for http.TimeFormat, the timezone must be in UTC
 		// to generate the correct format.


### PR DESCRIPTION
#6019 

instead of trying to parse a number or decide on some new default, i think it makes sense to recycle the existing default of [0,1) that go provides. this is also similar to js Math.random()


