### PR TITLE
Switch Solaris-derivatives away from listen_unix

### DIFF
--- a/listen.go
+++ b/listen.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !unix
+//go:build !unix || solaris
 
 package caddy
 

--- a/listen_unix.go
+++ b/listen_unix.go
@@ -15,7 +15,7 @@
 // Even though the filename ends in _unix.go, we still have to specify the
 // build constraint here, because the filename convention only works for
 // literal GOOS values, and "unix" is a shortcut unique to build tags.
-//go:build unix
+//go:build unix && !solaris
 
 package caddy
 

--- a/listen_unix_setopt.go
+++ b/listen_unix_setopt.go
@@ -1,4 +1,4 @@
-//go:build unix && !freebsd
+//go:build unix && !freebsd && !solaris
 
 package caddy
 


### PR DESCRIPTION
Solaris 10 and Illumos are missing SO_REUSEPORT. This PR treats them more like Windows (i.e. use the listener pool).

Since https://github.com/caddyserver/caddy/pull/4705 merged, Solaris/Illumos builds of Caddy have been failing. This was reported (and closed) in https://github.com/caddyserver/caddy/issues/5213 and it looked like it was due to missing constants from `sys/unix`.

After more investigation; it's not just missing constants. I actually hardcoded those into a build of Caddy, and it builds and started, but it's not correct because even with `const unixSOREUSEPORT = 0x2004` the behavior from Linux (doubling binding to the same port) doesn't function. This is caught by the test suite as an admin server reload failure:

```
--- FAIL: TestETags (0.00s)
    admin_test.go:191: expected update to work; got loading new config: starting caddy administration endpoint: listen tcp 127.0.0.1:2999: bind: address already in use
FAIL
exit status 1
```

I created [a commit](https://github.com/insom/caddy/commit/e3080f38d85a7a54621d9d6710b9c5a1016d9f2b) which no-ops the `reusePort` functions, but this still causes failures when reloading the admin server.

The use of `defer` to close the listening socket in https://github.com/caddyserver/caddy/blob/master/admin.go#L393 is the root issue, there. That _only_ works because of `SO_REUSEPORT` -- which made me look at why isn't that failing on Windows (where `SO_REUSEPORT` isn't present).

It doesn't fail on Windows because the Windows listeners use a pool of listening sockets and the same socket appears to get re-used. Adopting _that_ approach is what I've gone for with this PR.

As opposed to [the commit on my other branch](https://github.com/insom/caddy/commit/e3080f38d85a7a54621d9d6710b9c5a1016d9f2b) which adds even more conditional compilation, for an already niche OS, this just selects the Windows / generic version of `listener.go` when Solaris or Illumos is in use.

> Using GOOS=illumos matches build tags and files as for GOOS=solaris in addition to illumos tags and files. 
-- [Build Constraints in the Go docs](https://pkg.go.dev/cmd/go#hdr-Build_constraints)

The downside of this commit is that Unix sockets will no longer work for Solaris, but given that Caddy just cannot be built for Solaris right now, I think this is a superior solution.

This is my first contribution here, and the background explanation is far far longer than the code changes. Please let me know if I've missed a process I should be following, and thanks for your review!