### PR TITLE
tls: add reuse_private_keys

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -90,6 +90,7 @@ func parseBind(h Helper) ([]ConfigValue, error) {
 //	    dns_ttl                       <duration>
 //	    dns_challenge_override_domain <domain>
 //	    on_demand
+//	    reuse_private_keys
 //	    eab                           <key_id> <mac_key>
 //	    issuer                        <module_name> [...]
 //	    get_certificate               <module_name> [...]
@@ -106,6 +107,7 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 	var issuers []certmagic.Issuer
 	var certManagers []certmagic.Manager
 	var onDemand bool
+	var reusePrivateKeys bool
 
 	for h.Next() {
 		// file certificate loader
@@ -483,6 +485,12 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 				}
 				onDemand = true
 
+			case "reuse_private_keys":
+				if h.NextArg() {
+					return nil, h.ArgErr()
+				}
+				reusePrivateKeys = true
+
 			case "insecure_secrets_log":
 				if !h.NextArg() {
 					return nil, h.ArgErr()
@@ -586,6 +594,14 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 		configVals = append(configVals, ConfigValue{
 			Class: "tls.cert_manager",
 			Value: certManager,
+		})
+	}
+
+	// reuse private keys TLS
+	if reusePrivateKeys {
+		configVals = append(configVals, ConfigValue{
+			Class: "tls.reuse_private_keys",
+			Value: true,
 		})
 	}
 

--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -118,6 +118,11 @@ func (st ServerType) buildTLSApp(
 				ap.OnDemand = true
 			}
 
+			// reuse private keys tls
+			if _, ok := sblock.pile["tls.reuse_private_keys"]; ok {
+				ap.ReusePrivateKeys = true
+			}
+
 			if keyTypeVals, ok := sblock.pile["tls.key_type"]; ok {
 				ap.KeyType = keyTypeVals[0].Value.(string)
 			}
@@ -587,6 +592,7 @@ outer:
 				aps[i].MustStaple == aps[j].MustStaple &&
 				aps[i].KeyType == aps[j].KeyType &&
 				aps[i].OnDemand == aps[j].OnDemand &&
+				aps[i].ReusePrivateKeys == aps[j].ReusePrivateKeys &&
 				aps[i].RenewalWindowRatio == aps[j].RenewalWindowRatio {
 				if len(aps[i].SubjectsRaw) > 0 && len(aps[j].SubjectsRaw) == 0 {
 					// later policy (at j) has no subjects ("catch-all"), so we can

--- a/modules/caddytls/automation.go
+++ b/modules/caddytls/automation.go
@@ -138,6 +138,15 @@ type AutomationPolicy struct {
 	// load. This enables On-Demand TLS for this policy.
 	OnDemand bool `json:"on_demand,omitempty"`
 
+	// If true, private keys already existing in storage
+	// will be reused. Otherwise, a new key will be
+	// created for every new certificate to mitigate
+	// pinning and reduce the scope of key compromise.
+	// TEMPORARY: Key pinning is against industry best practices.
+	// This property will likely be removed in the future.
+	// Do not rely on it forever; watch the release notes.
+	ReusePrivateKeys bool `json:"reuse_private_keys,omitempty"`
+
 	// Disables OCSP stapling. Disabling OCSP stapling puts clients at
 	// greater risk, reduces their privacy, and usually lowers client
 	// performance. It is NOT recommended to disable this unless you
@@ -288,6 +297,7 @@ func (ap *AutomationPolicy) Provision(tlsApp *TLS) error {
 		KeySource:          keySource,
 		OnEvent:            tlsApp.onEvent,
 		OnDemand:           ond,
+		ReusePrivateKeys:   ap.ReusePrivateKeys,
 		OCSP: certmagic.OCSPConfig{
 			DisableStapling:    ap.DisableOCSPStapling,
 			ResponderOverrides: ap.OCSPOverrides,


### PR DESCRIPTION
### Details

This PR exposes certmagic's `ReusePrivateKeys` config to caddy. When certificates renew, by default, new keys are generated. But with this config, the same private keys (if available) can be reused.

Related to #5892 (maybe closes it if a new issue will be opened for TLSA updates as per https://github.com/caddyserver/caddy/issues/5892#issuecomment-1854172687)

**Note:** I'm fairly new to golang so may have missed something, but it seems to work with my naive testing below.

### Testing

I have a CA that (temporarily) issues self-signed certs valid for 2 mins, making it easy to test renewals. With this sample Caddyfile:

```
# you can run this with any domain, since http challenges always pass, nothing's really verified by the "CA"

https://letsdane {
    respond "Body."
    tls me+noemail@foo {
        ca https://acme.htools.work/directory
    }
}
```

run caddy, it gets cert:
```
Issued On	Sunday, 7 January 2024 at 22:15:23
Expires On	Sunday, 7 January 2024 at 22:19:23
Certificate	cebe1a2ad8ce9103985f1fb27ddf294b94776f2156af79cd824545929f444c1d
Public key	229c41815f576b45f8e24e65ef72af5eb435d075385a4cc79323bddcd51f3d3f
```

re-run caddy, it gets a cert with a different public key:
```
Issued On	Sunday, 7 January 2024 at 22:18:09
Expires On	Sunday, 7 January 2024 at 22:22:09
Certificate	51060c5ee7c54f325fc1639b0a06bf090e497c531c10e407454a4fbfb63abe22
Public key	a984b604bc63591b5bdabfe490bc5e5e1301bfa815ba8d1ed486b5468d7d2a54
```

change the config to add `ReusePrivateKeys`:
```
https://letsdane {
    respond "Body."
    tls me+noemail@foo {
        reuse_private_keys
        ca https://acme.htools.work/directory
    }
}
```

re-run caddy, it gets a cert with the same public key (see the expiry changing):
```
Issued On	Sunday, 7 January 2024 at 22:21:29
Expires On	Sunday, 7 January 2024 at 22:25:29
Certificate	f7bdb4c0c857ea09418f2d9708f575358a742af4bc384b939c413753f0a40704
Public key	a984b604bc63591b5bdabfe490bc5e5e1301bfa815ba8d1ed486b5468d7d2a54
```