### PR TITLE
respond "100 Continue" continue the handler chain as "103 Early Hints"

### DIFF
--- a/modules/caddyhttp/staticresp.go
+++ b/modules/caddyhttp/staticresp.go
@@ -245,12 +245,12 @@ func (s StaticResponse) ServeHTTP(w http.ResponseWriter, r *http.Request, next H
 	w.WriteHeader(statusCode)
 
 	// write response body
-	if statusCode != http.StatusEarlyHints && body != "" {
+	if statusCode != http.StatusContinue && statusCode != http.StatusEarlyHints && body != "" {
 		fmt.Fprint(w, body)
 	}
 
 	// continue handling after Early Hints as they are not the final response
-	if statusCode == http.StatusEarlyHints {
+	if statusCode == http.StatusContinue || statusCode == http.StatusEarlyHints {
 		return next.ServeHTTP(w, r)
 	}
 


### PR DESCRIPTION
Some clients, such as curl, may sometimes send the Expect: 100-continue header, but many upstream HTTP listening libraries in various languages cannot handle it. With this pr, Caddy can handle it, and for the upstream, it is as if there is no Expect header.

```
{
	auto_https off
	admin off
	skip_install_trust
}

:8888 {
	@continue header Expect "100-*"
	route {
		header Server nginx
		handle @continue {
			respond 100
			reverse_proxy 127.0.0.1:9999 {
				header_up -Expect
				header_down -Server
			}
		}
		reverse_proxy 127.0.0.1:9999 {
			header_down -Server
		}
	}
}

:9999 {
	respond "OK {header.Expect}" 200
}
```