### PR TITLE
caddyhttp: Fix panic when request missing ClientIPVarKey

### DIFF
--- a/modules/caddyhttp/marshalers.go
+++ b/modules/caddyhttp/marshalers.go
@@ -40,7 +40,9 @@ func (r LoggableHTTPRequest) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 
 	enc.AddString("remote_ip", ip)
 	enc.AddString("remote_port", port)
-	enc.AddString("client_ip", GetVar(r.Context(), ClientIPVarKey).(string))
+	if ip, ok := GetVar(r.Context(), ClientIPVarKey).(string); ok {
+		enc.AddString("client_ip", ip)
+	}
 	enc.AddString("proto", r.Proto)
 	enc.AddString("method", r.Method)
 	enc.AddString("host", r.Host)


### PR DESCRIPTION
Reported in https://caddy.community/t/caddy-v2-health-check-with-php-fastcgi-not-working/22334

Health checks make a `Request` and try to log it with `LoggableHTTPRequest`. When trying to marshal it, we do `GetVar(r.Context(), ClientIPVarKey).(string)` which panics because we never set this var in context for health checks.

Fix is just to type assert in a guard instead of blindly using the value. Good enough.