### PR TITLE
caddyfile: Add heredoc support to `fmt` command

### DIFF
--- a/caddyconfig/caddyfile/formatter.go
+++ b/caddyconfig/caddyfile/formatter.go
@@ -99,7 +99,7 @@ func Format(input []byte) []byte {
 
 		if heredoc == heredocOpening {
 			if ch == '\n' {
-				if heredocMarkerRegexp.Match([]byte(string(heredocMarker))) {
+				if len(heredocMarker) > 0 && heredocMarkerRegexp.MatchString(string(heredocMarker)) {
 					heredoc = heredocOpened
 				} else {
 					heredocMarker = nil

--- a/caddyconfig/caddyfile/formatter.go
+++ b/caddyconfig/caddyfile/formatter.go
@@ -31,6 +31,14 @@ func Format(input []byte) []byte {
 	out := new(bytes.Buffer)
 	rdr := bytes.NewReader(input)
 
+	type heredocState int
+
+	const (
+		heredocClosed  heredocState = 0
+		heredocOpening heredocState = 1
+		heredocOpened  heredocState = 2
+	)
+
 	var (
 		last rune // the last character that was written to the result
 
@@ -46,6 +54,11 @@ func Format(input []byte) []byte {
 		comment bool // whether we're in a comment
 		quoted  bool // whether we're in a quoted segment
 		escaped bool // whether current char is escaped
+
+		heredoc              heredocState // whether we're in a heredoc
+		heredocEscaped       bool         // whether heredoc is escaped
+		heredocMarker        []rune
+		heredocClosingMarker []rune
 
 		nesting int // indentation level
 	)
@@ -75,6 +88,58 @@ func Format(input []byte) []byte {
 			panic(err)
 		}
 
+		// detect whether we have the start of a heredoc
+		if !quoted && !(heredoc != heredocClosed || heredocEscaped) &&
+			space && last == '<' && ch == '<' {
+			write(ch)
+			heredoc = heredocOpening
+			space = false
+			continue
+		}
+
+		if heredoc == heredocOpening {
+			if ch == '\n' {
+				if heredocMarkerRegexp.Match([]byte(string(heredocMarker))) {
+					heredoc = heredocOpened
+				} else {
+					heredocMarker = nil
+					heredoc = heredocClosed
+					nextLine()
+					continue
+				}
+				write(ch)
+				continue
+			}
+			if unicode.IsSpace(ch) {
+				// a space means it's just a regular token and not a heredoc
+				heredocMarker = nil
+				heredoc = heredocClosed
+			} else {
+				heredocMarker = append(heredocMarker, ch)
+				write(ch)
+				continue
+			}
+		}
+		// if we're in a heredoc, all characters are read&write as-is
+		if heredoc == heredocOpened {
+			write(ch)
+			heredocClosingMarker = append(heredocClosingMarker, ch)
+			if len(heredocClosingMarker) > len(heredocMarker) {
+				heredocClosingMarker = heredocClosingMarker[1:]
+			}
+			// check if we're done
+			if string(heredocClosingMarker) == string(heredocMarker) {
+				heredocMarker = nil
+				heredocClosingMarker = nil
+				heredoc = heredocClosed
+			}
+			continue
+		}
+
+		if last == '<' && space {
+			space = false
+		}
+
 		if comment {
 			if ch == '\n' {
 				comment = false
@@ -98,6 +163,9 @@ func Format(input []byte) []byte {
 		}
 
 		if escaped {
+			if ch == '<' {
+				heredocEscaped = true
+			}
 			write(ch)
 			escaped = false
 			continue
@@ -117,6 +185,7 @@ func Format(input []byte) []byte {
 
 		if unicode.IsSpace(ch) {
 			space = true
+			heredocEscaped = false
 			if ch == '\n' {
 				newLines++
 			}
@@ -205,6 +274,11 @@ func Format(input []byte) []byte {
 			write('{')
 			openBraceWritten = true
 		}
+
+		if spacePrior && ch == '<' {
+			space = true
+		}
+
 		write(ch)
 
 		beginningOfLine = false

--- a/caddyconfig/caddyfile/formatter_test.go
+++ b/caddyconfig/caddyfile/formatter_test.go
@@ -364,6 +364,76 @@ block {
 }
 `,
 		},
+		{
+			description: "keep heredoc as-is",
+			input: `block {
+	heredoc <<HEREDOC
+	Here's more than a space       Here's more than a space
+	HEREDOC
+}
+`,
+			expect: `block {
+	heredoc <<HEREDOC
+	Here's more than a space       Here's more than a space
+	HEREDOC
+}
+`,
+		},
+		{
+			description: "Mixing heredoc with regular part",
+			input: `block {
+	heredoc <<HEREDOC
+	Here's more than a space       Here's more than a space
+	HEREDOC
+	respond "More than one space will be eaten"     200
+}
+
+block2 {
+	heredoc <<HEREDOC
+	Here's more than a space       Here's more than a space
+	HEREDOC
+	respond "More than one space will be eaten" 200
+}
+`,
+			expect: `block {
+	heredoc <<HEREDOC
+	Here's more than a space       Here's more than a space
+	HEREDOC
+	respond "More than one space will be eaten" 200
+}
+
+block2 {
+	heredoc <<HEREDOC
+	Here's more than a space       Here's more than a space
+	HEREDOC
+	respond "More than one space will be eaten" 200
+}
+`,
+		},
+		{
+			description: "Heredoc as regular token",
+			input: `block {
+	heredoc <<HEREDOC                                 "More than one space will be eaten"
+}
+`,
+			expect: `block {
+	heredoc <<HEREDOC "More than one space will be eaten"
+}
+`,
+		},
+		{
+			description: "Escape heredoc",
+			input: `block {
+	heredoc \<<HEREDOC
+	respond "More than one space will be eaten"                           200
+}
+`,
+			expect: `block {
+	heredoc \<<HEREDOC
+	respond "More than one space will be eaten" 200
+}
+`,
+		},
 	} {
 		// the formatter should output a trailing newline,
 		// even if the tests aren't written to expect that

--- a/caddyconfig/caddyfile/formatter_test.go
+++ b/caddyconfig/caddyfile/formatter_test.go
@@ -368,13 +368,13 @@ block {
 			description: "keep heredoc as-is",
 			input: `block {
 	heredoc <<HEREDOC
-	Here's more than a space       Here's more than a space
+	Here's more than one space       Here's more than one space
 	HEREDOC
 }
 `,
 			expect: `block {
 	heredoc <<HEREDOC
-	Here's more than a space       Here's more than a space
+	Here's more than one space       Here's more than one space
 	HEREDOC
 }
 `,
@@ -383,28 +383,28 @@ block {
 			description: "Mixing heredoc with regular part",
 			input: `block {
 	heredoc <<HEREDOC
-	Here's more than a space       Here's more than a space
+	Here's more than one space       Here's more than one space
 	HEREDOC
 	respond "More than one space will be eaten"     200
 }
 
 block2 {
 	heredoc <<HEREDOC
-	Here's more than a space       Here's more than a space
+	Here's more than one space       Here's more than one space
 	HEREDOC
 	respond "More than one space will be eaten" 200
 }
 `,
 			expect: `block {
 	heredoc <<HEREDOC
-	Here's more than a space       Here's more than a space
+	Here's more than one space       Here's more than one space
 	HEREDOC
 	respond "More than one space will be eaten" 200
 }
 
 block2 {
 	heredoc <<HEREDOC
-	Here's more than a space       Here's more than a space
+	Here's more than one space       Here's more than one space
 	HEREDOC
 	respond "More than one space will be eaten" 200
 }

--- a/caddyconfig/caddyfile/lexer.go
+++ b/caddyconfig/caddyfile/lexer.go
@@ -313,7 +313,7 @@ func (l *lexer) finalizeHeredoc(val []rune, marker string) ([]rune, error) {
 	// iterate over each line and strip the whitespace from the front
 	var out string
 	for lineNum, lineText := range lines[:len(lines)-1] {
-		if lineText == "" {
+		if lineText == "" || lineText == "\r" {
 			out += "\n"
 			continue
 		}


### PR DESCRIPTION
Fixes https://github.com/caddyserver/caddy/issues/5930

Let the formatter keep heredoc as-is.
Besides, because I missed the review window for #6051, This PR also contains a fix for #6051.
Let me know if you need me to separate them.