### PR TITLE
caddyfile: Switch to slices.Equal for better performance

### DIFF
--- a/caddyconfig/caddyfile/formatter.go
+++ b/caddyconfig/caddyfile/formatter.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"io"
 	"unicode"
+
+	"golang.org/x/exp/slices"
 )
 
 // Format formats the input Caddyfile to a standard, nice-looking
@@ -128,7 +130,7 @@ func Format(input []byte) []byte {
 				heredocClosingMarker = heredocClosingMarker[1:]
 			}
 			// check if we're done
-			if string(heredocClosingMarker) == string(heredocMarker) {
+			if slices.Equal(heredocClosingMarker, heredocMarker) {
 				heredocMarker = nil
 				heredocClosingMarker = nil
 				heredoc = heredocClosed


### PR DESCRIPTION
Fixes #6058

Switch to strings.Builder for better performance.
Converting []rune to string seems to be inefficient.
Or we can simply use slices.Equal from "golang.org/x/exp/slices".

```
(pprof) top10
Showing nodes accounting for 17.37s, 94.30% of 18.42s total
Dropped 126 nodes (cum <= 0.09s)
Showing top 10 nodes out of 37
      flat  flat%   sum%        cum   cum%
    10.65s 57.82% 57.82%     15.62s 84.80%  runtime.slicerunetostring
     4.87s 26.44% 84.26%      4.87s 26.44%  runtime.encoderune
     0.56s  3.04% 87.30%      1.78s  9.66%  runtime.scanobject
     0.28s  1.52% 88.82%      0.29s  1.57%  runtime.spanOf (inline)
     0.23s  1.25% 90.07%      0.23s  1.25%  runtime.heapBits.nextFast (inline)
     0.22s  1.19% 91.26%      0.51s  2.77%  runtime.findObject
     0.17s  0.92% 92.18%      0.17s  0.92%  runtime.(*gcBits).bitp (inline)
     0.15s  0.81% 93.00%      0.15s  0.81%  runtime.heapBitsForAddr
     0.13s  0.71% 93.70%      2.45s 13.30%  runtime.gcDrain
     0.11s   0.6% 94.30%      0.11s   0.6%  runtime.futex
`
