### PR TITLE
caddyhttp: Test cases for %2F and %252F

### DIFF
--- a/modules/caddyhttp/caddyhttp_test.go
+++ b/modules/caddyhttp/caddyhttp_test.go
@@ -66,6 +66,16 @@ func TestSanitizedPathJoin(t *testing.T) {
 			expect:    filepath.Join("/", "a", "b") + separator,
 		},
 		{
+			inputRoot: "/a/b",
+			inputPath: "/foo%2fbar",
+			expect:    filepath.Join("/", "a", "b", "foo", "bar"),
+		},
+		{
+			inputRoot: "/a/b",
+			inputPath: "/foo%252fbar",
+			expect:    filepath.Join("/", "a", "b", "foo%2fbar"),
+		},
+		{
 			inputRoot: "C:\\www",
 			inputPath: "/foo/bar",
 			expect:    filepath.Join("C:\\www", "foo", "bar"),


### PR DESCRIPTION
As per the discussion in https://caddy.community/t/serving-static-files-with-encoding/22382, I just wanted to add a test case as a sanity check that `%252F` behaves correctly, i.e. it would result in `%2F` after being joined.