### PR TITLE
caddyhttp: Support multiple logger names per host

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -804,10 +804,10 @@ func (st *ServerType) serversFromPairings(
 				} else if len(ncl.hostnames) > 0 {
 					// if the logger overrides the hostnames, map that to the logger name
 					for _, h := range ncl.hostnames {
-						if srv.Logs.LoggerMapping == nil {
-							srv.Logs.LoggerMapping = make(map[string][]string)
+						if srv.Logs.LoggerNames == nil {
+							srv.Logs.LoggerNames = make(map[string]caddyhttp.StringArray)
 						}
-						srv.Logs.LoggerMapping[h] = append(srv.Logs.LoggerMapping[h], ncl.name)
+						srv.Logs.LoggerNames[h] = append(srv.Logs.LoggerNames[h], ncl.name)
 					}
 				} else {
 					// otherwise, map each host to the logger name
@@ -817,10 +817,10 @@ func (st *ServerType) serversFromPairings(
 						if err != nil {
 							host = h
 						}
-						if srv.Logs.LoggerMapping == nil {
-							srv.Logs.LoggerMapping = make(map[string][]string)
+						if srv.Logs.LoggerNames == nil {
+							srv.Logs.LoggerNames = make(map[string]caddyhttp.StringArray)
 						}
-						srv.Logs.LoggerMapping[host] = append(srv.Logs.LoggerMapping[host], ncl.name)
+						srv.Logs.LoggerNames[host] = append(srv.Logs.LoggerNames[host], ncl.name)
 					}
 				}
 			}

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -804,23 +804,23 @@ func (st *ServerType) serversFromPairings(
 				} else if len(ncl.hostnames) > 0 {
 					// if the logger overrides the hostnames, map that to the logger name
 					for _, h := range ncl.hostnames {
-						if srv.Logs.LoggerNames == nil {
-							srv.Logs.LoggerNames = make(map[string]string)
+						if srv.Logs.LoggerMapping == nil {
+							srv.Logs.LoggerMapping = make(map[string][]string)
 						}
-						srv.Logs.LoggerNames[h] = ncl.name
+						srv.Logs.LoggerMapping[h] = append(srv.Logs.LoggerMapping[h], ncl.name)
 					}
 				} else {
 					// otherwise, map each host to the logger name
 					for _, h := range sblockLogHosts {
-						if srv.Logs.LoggerNames == nil {
-							srv.Logs.LoggerNames = make(map[string]string)
-						}
 						// strip the port from the host, if any
 						host, _, err := net.SplitHostPort(h)
 						if err != nil {
 							host = h
 						}
-						srv.Logs.LoggerNames[host] = ncl.name
+						if srv.Logs.LoggerMapping == nil {
+							srv.Logs.LoggerMapping = make(map[string][]string)
+						}
+						srv.Logs.LoggerMapping[host] = append(srv.Logs.LoggerMapping[host], ncl.name)
 					}
 				}
 			}

--- a/caddytest/integration/caddyfile_adapt/import_args_snippet.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/import_args_snippet.caddyfiletest
@@ -71,7 +71,7 @@ b.example.com {
 						}
 					],
 					"logs": {
-						"logger_mapping": {
+						"logger_names": {
 							"a.example.com": [
 								"log0"
 							],

--- a/caddytest/integration/caddyfile_adapt/import_args_snippet.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/import_args_snippet.caddyfiletest
@@ -71,9 +71,13 @@ b.example.com {
 						}
 					],
 					"logs": {
-						"logger_names": {
-							"a.example.com": "log0",
-							"b.example.com": "log1"
+						"logger_mapping": {
+							"a.example.com": [
+								"log0"
+							],
+							"b.example.com": [
+								"log1"
+							]
 						}
 					}
 				}

--- a/caddytest/integration/caddyfile_adapt/log_except_catchall_blocks.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/log_except_catchall_blocks.caddyfiletest
@@ -98,7 +98,7 @@ http://localhost:2020 {
 						]
 					},
 					"logs": {
-						"logger_mapping": {
+						"logger_names": {
 							"localhost": [
 								""
 							]

--- a/caddytest/integration/caddyfile_adapt/log_except_catchall_blocks.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/log_except_catchall_blocks.caddyfiletest
@@ -98,8 +98,10 @@ http://localhost:2020 {
 						]
 					},
 					"logs": {
-						"logger_names": {
-							"localhost": ""
+						"logger_mapping": {
+							"localhost": [
+								""
+							]
 						},
 						"skip_unmapped_hosts": true
 					}

--- a/caddytest/integration/caddyfile_adapt/log_multi_logger_name.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/log_multi_logger_name.caddyfiletest
@@ -60,7 +60,7 @@
 						}
 					],
 					"logs": {
-						"logger_mapping": {
+						"logger_names": {
 							"bar.example.com": [
 								"json"
 							],

--- a/caddytest/integration/caddyfile_adapt/log_multi_logger_name.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/log_multi_logger_name.caddyfiletest
@@ -1,42 +1,81 @@
-{
-	log json {
-		output file /var/log/caddy-json.log
+(log-both) {
+	log {args[0]}-json {
+		hostnames {args[0]}
+		output file /var/log/{args[0]}.log
 		format json
 	}
-	log console {
-		output stdout
+	log {args[0]}-console {
+		hostnames {args[0]}
+		output file /var/log/{args[0]}.json
 		format console
 	}
 }
 
 *.example.com {
-	log json {
-		hostnames foo.example.com bar.example.com
-	}
-	log console {
-		hostnames foo.example.com
-	}
+	# Subdomains log to multiple files at once, with
+	# different output files and formats.
+	import log-both foo.example.com
+	import log-both bar.example.com
 }
 ----------
 {
 	"logging": {
 		"logs": {
-			"console": {
+			"bar.example.com-console": {
 				"writer": {
-					"output": "stdout"
+					"filename": "/var/log/bar.example.com.json",
+					"output": "file"
 				},
 				"encoder": {
 					"format": "console"
-				}
+				},
+				"include": [
+					"http.log.access.bar.example.com-console"
+				]
 			},
-			"json": {
+			"bar.example.com-json": {
 				"writer": {
-					"filename": "/var/log/caddy-json.log",
+					"filename": "/var/log/bar.example.com.log",
 					"output": "file"
 				},
 				"encoder": {
 					"format": "json"
-				}
+				},
+				"include": [
+					"http.log.access.bar.example.com-json"
+				]
+			},
+			"default": {
+				"exclude": [
+					"http.log.access.bar.example.com-console",
+					"http.log.access.bar.example.com-json",
+					"http.log.access.foo.example.com-console",
+					"http.log.access.foo.example.com-json"
+				]
+			},
+			"foo.example.com-console": {
+				"writer": {
+					"filename": "/var/log/foo.example.com.json",
+					"output": "file"
+				},
+				"encoder": {
+					"format": "console"
+				},
+				"include": [
+					"http.log.access.foo.example.com-console"
+				]
+			},
+			"foo.example.com-json": {
+				"writer": {
+					"filename": "/var/log/foo.example.com.log",
+					"output": "file"
+				},
+				"encoder": {
+					"format": "json"
+				},
+				"include": [
+					"http.log.access.foo.example.com-json"
+				]
 			}
 		}
 	},
@@ -62,11 +101,12 @@
 					"logs": {
 						"logger_names": {
 							"bar.example.com": [
-								"json"
+								"bar.example.com-json",
+								"bar.example.com-console"
 							],
 							"foo.example.com": [
-								"json",
-								"console"
+								"foo.example.com-json",
+								"foo.example.com-console"
 							]
 						}
 					}

--- a/caddytest/integration/caddyfile_adapt/log_multi_logger_name.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/log_multi_logger_name.caddyfiletest
@@ -1,0 +1,77 @@
+{
+	log json {
+		output file /var/log/caddy-json.log
+		format json
+	}
+	log console {
+		output stdout
+		format console
+	}
+}
+
+*.example.com {
+	log json {
+		hostnames foo.example.com bar.example.com
+	}
+	log console {
+		hostnames foo.example.com
+	}
+}
+----------
+{
+	"logging": {
+		"logs": {
+			"console": {
+				"writer": {
+					"output": "stdout"
+				},
+				"encoder": {
+					"format": "console"
+				}
+			},
+			"json": {
+				"writer": {
+					"filename": "/var/log/caddy-json.log",
+					"output": "file"
+				},
+				"encoder": {
+					"format": "json"
+				}
+			}
+		}
+	},
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"*.example.com"
+									]
+								}
+							],
+							"terminal": true
+						}
+					],
+					"logs": {
+						"logger_mapping": {
+							"bar.example.com": [
+								"json"
+							],
+							"foo.example.com": [
+								"json",
+								"console"
+							]
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/caddytest/integration/caddyfile_adapt/log_override_hostname.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/log_override_hostname.caddyfiletest
@@ -74,7 +74,7 @@ example.com:8443 {
 						}
 					],
 					"logs": {
-						"logger_mapping": {
+						"logger_names": {
 							"bar.example.com": [
 								"log0"
 							],
@@ -104,7 +104,7 @@ example.com:8443 {
 						}
 					],
 					"logs": {
-						"logger_mapping": {
+						"logger_names": {
 							"example.com": [
 								"log2"
 							]

--- a/caddytest/integration/caddyfile_adapt/log_override_hostname.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/log_override_hostname.caddyfiletest
@@ -74,10 +74,16 @@ example.com:8443 {
 						}
 					],
 					"logs": {
-						"logger_names": {
-							"bar.example.com": "log0",
-							"baz.example.com": "log1",
-							"foo.example.com": "log0"
+						"logger_mapping": {
+							"bar.example.com": [
+								"log0"
+							],
+							"baz.example.com": [
+								"log1"
+							],
+							"foo.example.com": [
+								"log0"
+							]
 						}
 					}
 				},
@@ -98,8 +104,10 @@ example.com:8443 {
 						}
 					],
 					"logs": {
-						"logger_names": {
-							"example.com": "log2"
+						"logger_mapping": {
+							"example.com": [
+								"log2"
+							]
 						}
 					}
 				}

--- a/caddytest/integration/caddyfile_adapt/log_override_name_multiaccess.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/log_override_name_multiaccess.caddyfiletest
@@ -75,8 +75,10 @@ http://localhost:8881 {
 						]
 					},
 					"logs": {
-						"logger_names": {
-							"localhost": "foo"
+						"logger_mapping": {
+							"localhost": [
+								"foo"
+							]
 						}
 					}
 				}

--- a/caddytest/integration/caddyfile_adapt/log_override_name_multiaccess.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/log_override_name_multiaccess.caddyfiletest
@@ -75,7 +75,7 @@ http://localhost:8881 {
 						]
 					},
 					"logs": {
-						"logger_mapping": {
+						"logger_names": {
 							"localhost": [
 								"foo"
 							]

--- a/caddytest/integration/caddyfile_adapt/log_override_name_multiaccess_debug.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/log_override_name_multiaccess_debug.caddyfiletest
@@ -80,7 +80,7 @@ http://localhost:8881 {
 						]
 					},
 					"logs": {
-						"logger_mapping": {
+						"logger_names": {
 							"localhost": [
 								"foo"
 							]

--- a/caddytest/integration/caddyfile_adapt/log_override_name_multiaccess_debug.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/log_override_name_multiaccess_debug.caddyfiletest
@@ -80,8 +80,10 @@ http://localhost:8881 {
 						]
 					},
 					"logs": {
-						"logger_names": {
-							"localhost": "foo"
+						"logger_mapping": {
+							"localhost": [
+								"foo"
+							]
 						}
 					}
 				}

--- a/caddytest/integration/caddyfile_adapt/log_skip_hosts.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/log_skip_hosts.caddyfiletest
@@ -62,8 +62,10 @@ example.com {
 						}
 					],
 					"logs": {
-						"logger_names": {
-							"one.example.com": ""
+						"logger_mapping": {
+							"one.example.com": [
+								""
+							]
 						},
 						"skip_hosts": [
 							"example.com",

--- a/caddytest/integration/caddyfile_adapt/log_skip_hosts.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/log_skip_hosts.caddyfiletest
@@ -62,7 +62,7 @@ example.com {
 						}
 					],
 					"logs": {
-						"logger_mapping": {
+						"logger_names": {
 							"one.example.com": [
 								""
 							]

--- a/modules/caddyhttp/logging.go
+++ b/modules/caddyhttp/logging.go
@@ -69,8 +69,9 @@ type ServerLogConfig struct {
 // wrapLogger wraps logger in one or more logger named
 // according to user preferences for the given host.
 func (slc ServerLogConfig) wrapLogger(logger *zap.Logger, host string) []*zap.Logger {
-	var loggers []*zap.Logger
-	for _, loggerName := range slc.getLoggerHosts(host) {
+	hosts := slc.getLoggerHosts(host)
+	loggers := make([]*zap.Logger, 0, len(hosts))
+	for _, loggerName := range hosts {
 		if loggerName == "" {
 			continue
 		}
@@ -89,7 +90,7 @@ func (slc ServerLogConfig) getLoggerHosts(host string) []string {
 		// match "example.com" if there is no "example.com:1234" in the map)
 		hostOnly, _, err := net.SplitHostPort(key)
 		if err != nil {
-			return []string{""}, false
+			return []string{}, false
 		}
 		if hosts, ok := slc.LoggerMapping[hostOnly]; ok {
 			return hosts, ok
@@ -105,7 +106,7 @@ func (slc ServerLogConfig) getLoggerHosts(host string) []string {
 		// match "example.com" if there is no "example.com:1234" in the map)
 		hostOnly, _, err = net.SplitHostPort(key)
 		if err != nil {
-			return []string{""}, false
+			return []string{}, false
 		}
 		host, ok := slc.LoggerNames[hostOnly]
 		return []string{host}, ok

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -712,10 +712,6 @@ func (s *Server) shouldLogRequest(r *http.Request) bool {
 		// logging is disabled
 		return false
 	}
-	if _, ok := s.Logs.LoggerMapping[r.Host]; ok {
-		// this host is mapped to a particular logger name
-		return true
-	}
 	if _, ok := s.Logs.LoggerNames[r.Host]; ok {
 		// this host is mapped to a particular logger name
 		return true

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -361,11 +361,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cloneURL(origReq.URL, r.URL)
 
 	// prepare the error log
-	logger := errLog
+	errLog = errLog.With(zap.Duration("duration", duration))
+	errLoggers := []*zap.Logger{errLog}
 	if s.Logs != nil {
-		logger = s.Logs.wrapLogger(logger, r.Host)
+		errLoggers = s.Logs.wrapLogger(errLog, r.Host)
 	}
-	logger = logger.With(zap.Duration("duration", duration))
 
 	// get the values that will be used to log the error
 	errStatus, errMsg, errFields := errLogValues(err)
@@ -379,7 +379,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if err2 == nil {
 			// user's error route handled the error response
 			// successfully, so now just log the error
-			logger.Debug(errMsg, errFields...)
+			for _, logger := range errLoggers {
+				logger.Debug(errMsg, errFields...)
+			}
 		} else {
 			// well... this is awkward
 			errFields = append([]zapcore.Field{
@@ -387,7 +389,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				zap.Namespace("first_error"),
 				zap.String("msg", errMsg),
 			}, errFields...)
-			logger.Error("error handling handler error", errFields...)
+			for _, logger := range errLoggers {
+				logger.Error("error handling handler error", errFields...)
+			}
 			if handlerErr, ok := err.(HandlerError); ok {
 				w.WriteHeader(handlerErr.StatusCode)
 			} else {
@@ -395,10 +399,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	} else {
-		if errStatus >= 500 {
-			logger.Error(errMsg, errFields...)
-		} else {
-			logger.Debug(errMsg, errFields...)
+		for _, logger := range errLoggers {
+			if errStatus >= 500 {
+				logger.Error(errMsg, errFields...)
+			} else {
+				logger.Debug(errMsg, errFields...)
+			}
 		}
 		w.WriteHeader(errStatus)
 	}
@@ -706,6 +712,10 @@ func (s *Server) shouldLogRequest(r *http.Request) bool {
 		// logging is disabled
 		return false
 	}
+	if _, ok := s.Logs.LoggerMapping[r.Host]; ok {
+		// this host is mapped to a particular logger name
+		return true
+	}
 	if _, ok := s.Logs.LoggerNames[r.Host]; ok {
 		// this host is mapped to a particular logger name
 		return true
@@ -735,16 +745,6 @@ func (s *Server) logRequest(
 	repl.Set("http.response.duration", duration)
 	repl.Set("http.response.duration_ms", duration.Seconds()*1e3) // multiply seconds to preserve decimal (see #4666)
 
-	logger := accLog
-	if s.Logs != nil {
-		logger = s.Logs.wrapLogger(logger, r.Host)
-	}
-
-	log := logger.Info
-	if wrec.Status() >= 400 {
-		log = logger.Error
-	}
-
 	userID, _ := repl.GetString("http.auth.user.id")
 
 	reqBodyLength := 0
@@ -768,7 +768,20 @@ func (s *Server) logRequest(
 		}))
 	fields = append(fields, extra.fields...)
 
-	log("handled request", fields...)
+	loggers := []*zap.Logger{accLog}
+	if s.Logs != nil {
+		loggers = s.Logs.wrapLogger(accLog, r.Host)
+	}
+
+	// wrapping may return multiple loggers, so we log to all of them
+	for _, logger := range loggers {
+		logAtLevel := logger.Info
+		if wrec.Status() >= 400 {
+			logAtLevel = logger.Error
+		}
+
+		logAtLevel("handled request", fields...)
+	}
 }
 
 // protocol returns true if the protocol proto is configured/enabled.


### PR DESCRIPTION
Context: https://caddy.community/t/config-cleanup-for-logging-blocking-and-a-signalr-issue/22643

I realized that there's currently no good way to point a specific hostname to write to more than one logger at once, because `logger_names` is a simple `map[string]string` (so only one value per key).

To solve this, ~~I'm deprecating `logger_names` and adding a new `logger_mapping` (which Caddyfile immediately uses)~~ I'm changing `logger_names` to be a `map[string]StringArray` which is a type which accepts either a JSON string or array (where a string gets turned into a one-element string slice). Then, I reworked the logging code in the server to loop over the list of wrapped loggers.

~~I'm not 100% convinced about the `logger_mapping` name... I'd rather reuse `logger_names`, but obviously we can't do that, it would be a breaking change. Any better naming ideas?~~ Resolved by doing custom JSON unmarshaling.