### PR TITLE
chore: Rename CI jobs, run on M1 mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: 
           - ubuntu-latest
-          - macos-latest
+          - macos-14
           - windows-latest
         go: 
           - '1.21'
@@ -42,7 +42,7 @@ jobs:
           CADDY_BIN_PATH: ./cmd/caddy/caddy
           SUCCESS: 0
 
-        - os: macos-latest
+        - os: macos-14
           CADDY_BIN_PATH: ./cmd/caddy/caddy
           SUCCESS: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         os: 
-          - ubuntu-latest
-          - macos-14
-          - windows-latest
+          - linux
+          - mac
+          - windows
         go: 
           - '1.21'
           - '1.22'
@@ -36,21 +36,25 @@ jobs:
           GO_SEMVER: '~1.22.0'
 
         # Set some variables per OS, usable via ${{ matrix.VAR }}
+        # OS_LABEL: the VM label from GitHub Actions (see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
         # CADDY_BIN_PATH: the path to the compiled Caddy binary, for artifact publishing
         # SUCCESS: the typical value for $? per OS (Windows/pwsh returns 'True')
-        - os: ubuntu-latest
+        - os: linux
+          OS_LABEL: ubuntu-latest
           CADDY_BIN_PATH: ./cmd/caddy/caddy
           SUCCESS: 0
 
-        - os: macos-14
+        - os: mac
+          OS_LABEL: macos-14
           CADDY_BIN_PATH: ./cmd/caddy/caddy
           SUCCESS: 0
 
-        - os: windows-latest
+        - os: windows
+          OS_LABEL: windows-latest
           CADDY_BIN_PATH: ./cmd/caddy/caddy.exe
           SUCCESS: 'True'
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.OS_LABEL }}
 
     steps:
     - name: Checkout code
@@ -125,7 +129,7 @@ jobs:
 
     # To return the correct result even though we set 'continue-on-error: true'
     # - name: Coerce correct build result
-    #   if: matrix.os != 'windows-latest' && steps.step_test.outputs.status != ${{ matrix.SUCCESS }}
+    #   if: matrix.os != 'windows' && steps.step_test.outputs.status != ${{ matrix.SUCCESS }}
     #   run: |
     #     echo "step_test ${{ steps.step_test.outputs.status }}\n"
     #     exit 1

--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -11,7 +11,7 @@ on:
       - 2.*
 
 jobs:
-  cross-build-test:
+  build:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-14
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,10 +23,22 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
-          - macos-14
-          - windows-latest
-    runs-on: ${{ matrix.os }}
+          - linux
+          - mac
+          - windows
+
+        include:
+        - os: linux
+          OS_LABEL: ubuntu-latest
+
+        - os: mac
+          OS_LABEL: macos-14
+
+        - os: windows
+          OS_LABEL: windows-latest
+
+    runs-on: ${{ matrix.OS_LABEL }}
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
We can test on M1 mac now!

But to do so, we need to change `macos-latest` to `macos-14` for now, as per https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

So for that reason, I decided to reorganize our CI config a bit, and the result is that the job names are now simplified.

- `ubuntu-latest` -> `linux`
- `macos-latest` -> `mac`
- `windows-latest` -> `windows`

See the Actions. Looks cleaner I think.

Before merging @mholt we'll need to update the repo's required jobs config again.