### PR TITLE
caddyauth: Drop support for `scrypt`

### DIFF
--- a/modules/caddyhttp/caddyauth/caddyfile.go
+++ b/modules/caddyhttp/caddyauth/caddyfile.go
@@ -29,7 +29,7 @@ func init() {
 // parseCaddyfile sets up the handler from Caddyfile tokens. Syntax:
 //
 //	basic_auth [<matcher>] [<hash_algorithm> [<realm>]] {
-//	    <username> <hashed_password_base64>
+//	    <username> <hashed_password>
 //	    ...
 //	}
 //

--- a/modules/caddyhttp/caddyauth/caddyfile.go
+++ b/modules/caddyhttp/caddyauth/caddyfile.go
@@ -28,7 +28,7 @@ func init() {
 // parseCaddyfile sets up the handler from Caddyfile tokens. Syntax:
 //
 //	basicauth [<matcher>] [<hash_algorithm> [<realm>]] {
-//	    <username> <hashed_password_base64> [<salt_base64>]
+//	    <username> <hashed_password>
 //	    ...
 //	}
 //
@@ -58,8 +58,6 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 	switch hashName {
 	case "bcrypt":
 		cmp = BcryptHash{}
-	case "scrypt":
-		cmp = ScryptHash{}
 	default:
 		return nil, h.Errf("unrecognized hash algorithm: %s", hashName)
 	}
@@ -69,8 +67,8 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 	for h.NextBlock(0) {
 		username := h.Val()
 
-		var b64Pwd, b64Salt string
-		h.Args(&b64Pwd, &b64Salt)
+		var b64Pwd string
+		h.Args(&b64Pwd)
 		if h.NextArg() {
 			return nil, h.ArgErr()
 		}
@@ -82,7 +80,6 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 		ba.AccountList = append(ba.AccountList, Account{
 			Username: username,
 			Password: b64Pwd,
-			Salt:     b64Salt,
 		})
 	}
 

--- a/modules/caddyhttp/caddyauth/hashes.go
+++ b/modules/caddyhttp/caddyauth/hashes.go
@@ -15,18 +15,13 @@
 package caddyauth
 
 import (
-	"crypto/subtle"
-	"encoding/base64"
-
 	"golang.org/x/crypto/bcrypt"
-	"golang.org/x/crypto/scrypt"
 
 	"github.com/caddyserver/caddy/v2"
 )
 
 func init() {
 	caddy.RegisterModule(BcryptHash{})
-	caddy.RegisterModule(ScryptHash{})
 }
 
 // BcryptHash implements the bcrypt hash.
@@ -41,7 +36,7 @@ func (BcryptHash) CaddyModule() caddy.ModuleInfo {
 }
 
 // Compare compares passwords.
-func (BcryptHash) Compare(hashed, plaintext, _ []byte) (bool, error) {
+func (BcryptHash) Compare(hashed, plaintext []byte) (bool, error) {
 	err := bcrypt.CompareHashAndPassword(hashed, plaintext)
 	if err == bcrypt.ErrMismatchedHashAndPassword {
 		return false, nil
@@ -53,7 +48,7 @@ func (BcryptHash) Compare(hashed, plaintext, _ []byte) (bool, error) {
 }
 
 // Hash hashes plaintext using a random salt.
-func (BcryptHash) Hash(plaintext, _ []byte) ([]byte, error) {
+func (BcryptHash) Hash(plaintext []byte) ([]byte, error) {
 	return bcrypt.GenerateFromPassword(plaintext, 14)
 }
 
@@ -64,94 +59,8 @@ func (BcryptHash) FakeHash() []byte {
 	return []byte("$2a$14$X3ulqf/iGxnf1k6oMZ.RZeJUoqI9PX2PM4rS5lkIKJXduLGXGPrt6")
 }
 
-// ScryptHash implements the scrypt KDF as a hash.
-//
-// DEPRECATED, please use 'bcrypt' instead.
-type ScryptHash struct {
-	// scrypt's N parameter. If unset or 0, a safe default is used.
-	N int `json:"N,omitempty"`
-
-	// scrypt's r parameter. If unset or 0, a safe default is used.
-	R int `json:"r,omitempty"`
-
-	// scrypt's p parameter. If unset or 0, a safe default is used.
-	P int `json:"p,omitempty"`
-
-	// scrypt's key length parameter (in bytes). If unset or 0, a
-	// safe default is used.
-	KeyLength int `json:"key_length,omitempty"`
-}
-
-// CaddyModule returns the Caddy module information.
-func (ScryptHash) CaddyModule() caddy.ModuleInfo {
-	return caddy.ModuleInfo{
-		ID:  "http.authentication.hashes.scrypt",
-		New: func() caddy.Module { return new(ScryptHash) },
-	}
-}
-
-// Provision sets up s.
-func (s *ScryptHash) Provision(ctx caddy.Context) error {
-	s.SetDefaults()
-	ctx.Logger().Warn("use of 'scrypt' is deprecated, please use 'bcrypt' instead")
-	return nil
-}
-
-// SetDefaults sets safe default parameters, but does
-// not overwrite existing values. Each default parameter
-// is set independently; it does not check to ensure
-// that r*p < 2^30. The defaults chosen are those as
-// recommended in 2019 by
-// https://godoc.org/golang.org/x/crypto/scrypt.
-func (s *ScryptHash) SetDefaults() {
-	if s.N == 0 {
-		s.N = 32768
-	}
-	if s.R == 0 {
-		s.R = 8
-	}
-	if s.P == 0 {
-		s.P = 1
-	}
-	if s.KeyLength == 0 {
-		s.KeyLength = 32
-	}
-}
-
-// Compare compares passwords.
-func (s ScryptHash) Compare(hashed, plaintext, salt []byte) (bool, error) {
-	ourHash, err := scrypt.Key(plaintext, salt, s.N, s.R, s.P, s.KeyLength)
-	if err != nil {
-		return false, err
-	}
-	if hashesMatch(hashed, ourHash) {
-		return true, nil
-	}
-	return false, nil
-}
-
-// Hash hashes plaintext using the given salt.
-func (s ScryptHash) Hash(plaintext, salt []byte) ([]byte, error) {
-	return scrypt.Key(plaintext, salt, s.N, s.R, s.P, s.KeyLength)
-}
-
-// FakeHash returns a fake hash.
-func (ScryptHash) FakeHash() []byte {
-	// hashed with the following command:
-	// caddy hash-password --plaintext "antitiming" --salt "fakesalt" --algorithm "scrypt"
-	bytes, _ := base64.StdEncoding.DecodeString("kFbjiVemlwK/ZS0tS6/UQqEDeaNMigyCs48KEsGUse8=")
-	return bytes
-}
-
-func hashesMatch(pwdHash1, pwdHash2 []byte) bool {
-	return subtle.ConstantTimeCompare(pwdHash1, pwdHash2) == 1
-}
-
 // Interface guards
 var (
-	_ Comparer          = (*BcryptHash)(nil)
-	_ Comparer          = (*ScryptHash)(nil)
-	_ Hasher            = (*BcryptHash)(nil)
-	_ Hasher            = (*ScryptHash)(nil)
-	_ caddy.Provisioner = (*ScryptHash)(nil)
+	_ Comparer = (*BcryptHash)(nil)
+	_ Hasher   = (*BcryptHash)(nil)
 )


### PR DESCRIPTION
It's been deprecated for over a year, time to remove it.

See https://github.com/caddyserver/caddy/pull/4720 for context.

We are changing the interfaces here, so if anyone has a plugin using those interfaces, it'll need updating. But I'm pretty sure there aren't any plugins for additional algorithms right now.