### PR TITLE
caddyauth: Rename `basicauth` to `basic_auth`

### DIFF
--- a/caddyconfig/caddyfile/parse_test.go
+++ b/caddyconfig/caddyfile/parse_test.go
@@ -801,7 +801,7 @@ func TestImportedFilesIgnoreNonDirectiveImportTokens(t *testing.T) {
 	fileName := writeStringToTempFileOrDie(t, `
 		http://example.com {
 			# This isn't an import directive, it's just an arg with value 'import'
-			basicauth / import password
+			basic_auth / import password
 		}
 	`)
 	// Parse the root file that imports the other one.
@@ -812,12 +812,12 @@ func TestImportedFilesIgnoreNonDirectiveImportTokens(t *testing.T) {
 	}
 	auth := blocks[0].Segments[0]
 	line := auth[0].Text + " " + auth[1].Text + " " + auth[2].Text + " " + auth[3].Text
-	if line != "basicauth / import password" {
+	if line != "basic_auth / import password" {
 		// Previously, it would be changed to:
-		//   basicauth / import /path/to/test/dir/password
+		//   basic_auth / import /path/to/test/dir/password
 		// referencing a file that (probably) doesn't exist and changing the
 		// password!
-		t.Errorf("Expected basicauth tokens to be 'basicauth / import password' but got %#q", line)
+		t.Errorf("Expected basic_auth tokens to be 'basic_auth / import password' but got %#q", line)
 	}
 }
 

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -58,7 +58,8 @@ var directiveOrder = []string{
 	"try_files",
 
 	// middleware handlers; some wrap responses
-	"basicauth",
+	"basicauth", // TODO: deprecated, renamed to basic_auth
+	"basic_auth",
 	"forward_auth",
 	"request_header",
 	"encode",

--- a/modules/caddyhttp/caddyauth/caddyfile.go
+++ b/modules/caddyhttp/caddyauth/caddyfile.go
@@ -22,12 +22,13 @@ import (
 )
 
 func init() {
-	httpcaddyfile.RegisterHandlerDirective("basicauth", parseCaddyfile)
+	httpcaddyfile.RegisterHandlerDirective("basicauth", parseCaddyfile) // deprecated
+	httpcaddyfile.RegisterHandlerDirective("basic_auth", parseCaddyfile)
 }
 
 // parseCaddyfile sets up the handler from Caddyfile tokens. Syntax:
 //
-//	basicauth [<matcher>] [<hash_algorithm> [<realm>]] {
+//	basic_auth [<matcher>] [<hash_algorithm> [<realm>]] {
 //	    <username> <hashed_password_base64> [<salt_base64>]
 //	    ...
 //	}
@@ -35,6 +36,11 @@ func init() {
 // If no hash algorithm is supplied, bcrypt will be assumed.
 func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
 	h.Next() // consume directive name
+
+	// "basicauth" is deprecated, replaced by "basic_auth"
+	if h.Val() == "basicauth" {
+		caddy.Log().Named("config.adapter.caddyfile").Warn("the 'basicauth' directive is deprecated, please use 'basic_auth' instead!")
+	}
 
 	var ba HTTPBasicAuth
 	ba.HashCache = new(Cache)


### PR DESCRIPTION
This allows `basic_auth` to work as well in the Caddyfile, and emits a deprecation warning when `basicauth` is used.

This was essentially a mistake in v2.0, we made the decision to use underscores for directives that are multiple words like `file_server` etc, but we left `basicauth`. Since then, we've added `forward_auth`, so `basicauth` feels incongruent with that.

I think now's as good a time as any to realign this.