### PR TITLE
logging: Inline Caddyfile syntax for `ip_mask` filter

### DIFF
--- a/caddytest/integration/caddyfile_adapt/log_filters.txt
+++ b/caddytest/integration/caddyfile_adapt/log_filters.txt
@@ -21,6 +21,7 @@ log {
 				ipv4 24
 				ipv6 32
 			}
+			request>client_ip ip_mask 16 32
 			request>headers>Regexp regexp secret REDACTED
 			request>headers>Hash hash
 		}
@@ -41,6 +42,11 @@ log {
 				},
 				"encoder": {
 					"fields": {
+						"request\u003eclient_ip": {
+							"filter": "ip_mask",
+							"ipv4_cidr": 16,
+							"ipv6_cidr": 32
+						},
 						"request\u003eheaders\u003eAuthorization": {
 							"filter": "replace",
 							"value": "REDACTED"

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -169,6 +169,27 @@ func (IPMaskFilter) CaddyModule() caddy.ModuleInfo {
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens.
 func (m *IPMaskFilter) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	d.Next() // consume filter name
+
+	args := d.RemainingArgs()
+	if len(args) > 2 {
+		return d.Errf("too many arguments")
+	}
+	if len(args) > 0 {
+		val, err := strconv.Atoi(args[0])
+		if err != nil {
+			return d.Errf("error parsing %s: %v", args[0], err)
+		}
+		m.IPv4MaskRaw = val
+
+		if len(args) > 1 {
+			val, err := strconv.Atoi(args[1])
+			if err != nil {
+				return d.Errf("error parsing %s: %v", args[1], err)
+			}
+			m.IPv6MaskRaw = val
+		}
+	}
+
 	for d.NextBlock(0) {
 		switch d.Val() {
 		case "ipv4":


### PR DESCRIPTION
Just a small change to allow inlining the IP mask bits.

The config for IP masks is too verbose right now, especially because we log the IP in multiple fields: `request>remote_ip`, `request>client_ip`, and possibly in request headers depending on the clients/proxies.

Before:

```
			request>remote_ip ip_mask {
				ipv4 16
				ipv6 32
			}
			request>client_ip ip_mask {
				ipv4 16
				ipv6 32
			}
```

After:

```
			request>remote_ip ip_mask 16 32
			request>client_ip ip_mask 16 32
```