### PR TITLE
caddyhttp: Only attempt to enable full duplex for HTTP/1.x

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -301,11 +301,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// enable full-duplex for HTTP/1, ensuring the entire
 	// request body gets consumed before writing the response
-	if s.EnableFullDuplex {
+	if s.EnableFullDuplex && r.ProtoMajor == 1 {
 		//nolint:bodyclose
 		err := http.NewResponseController(w).EnableFullDuplex()
 		if err != nil {
-			s.accessLogger.Warn("failed to enable full duplex", zap.Error(err))
+			s.logger.Warn("failed to enable full duplex", zap.Error(err))
 		}
 	}
 


### PR DESCRIPTION
When trying to enable full duplex for HTTP/2, the warning log was causing a panic because `accessLogger` references an expired pointer to the request, I think.

```
2024/02/13 09:49:06.567	DEBUG	http.stdlib	http2: panic serving 127.0.0.1:48350: runtime error: invalid memory address or nil pointer dereference
goroutine 78 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	/home/francis/go/pkg/mod/golang.org/x/net@v0.19.0/http2/server.go:2361 +0x145
panic({0x17c9de0?, 0x2bb1fe0?})
	/usr/local/go1.22.0.linux-amd64/src/runtime/panic.go:770 +0x132
go.uber.org/zap.(*Logger).check(0x0, 0x1, {0x1a543e7, 0x1c})
	/home/francis/go/pkg/mod/go.uber.org/zap@v1.26.0/logger.go:330 +0x5e
go.uber.org/zap.(*Logger).Warn(0x1ef3c20?, {0x1a543e7?, 0x1a67a88?}, {0xc0004c4080, 0x1, 0x1})
	/home/francis/go/pkg/mod/go.uber.org/zap@v1.26.0/logger.go:253 +0x38
github.com/caddyserver/caddy/v2/modules/caddyhttp.(*Server).ServeHTTP(0xc00026d8c8, {0x1f052a0, 0xc00068a008}, 0xc000428d80)
	/home/francis/repos/caddy/modules/caddyhttp/server.go:309 +0x6ea
net/http.serverHandler.ServeHTTP({0x0?}, {0x1f052a0?, 0xc00068a008?}, 0x0?)
	/usr/local/go1.22.0.linux-amd64/src/net/http/server.go:3137 +0x8e
net/http.initALPNRequest.ServeHTTP({{0x1f089c8?, 0xc000770a20?}, 0xc0001b9508?, {0xc0004d0000?}}, {0x1f052a0, 0xc00068a008}, 0xc000428d80)
	/usr/local/go1.22.0.linux-amd64/src/net/http/server.go:3745 +0x231
golang.org/x/net/http2.(*serverConn).runHandler(0x0?, 0x0?, 0x0?, 0x41baad?)
	/home/francis/go/pkg/mod/golang.org/x/net@v0.19.0/http2/server.go:2368 +0xbb
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 115
	/home/francis/go/pkg/mod/golang.org/x/net@v0.19.0/http2/server.go:2303 +0x21d
```

Simple fix, just need to only attempt it for HTTP/1.1, and using `s.logger` instead to avoid referencing the request.