### PR TITLE
admin: Allow origins header value to not have a scheme

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -924,6 +924,10 @@ func (h adminHandler) getOrigin(r *http.Request) (string, *url.URL) {
 	if err != nil {
 		return origin, nil
 	}
+	if originURL.Path != "" && !strings.HasPrefix("/", originURL.Path) {
+		// if it doesn't look like a path, use it as the host instead
+		originURL.Host = originURL.Path
+	}
 	originURL.Path = ""
 	originURL.RawPath = ""
 	originURL.Fragment = ""


### PR DESCRIPTION
Currently when `enforce_origin` is set, the request header must have `http://` otherwise the header value gets stuffed in the URL's `Path` field. Our code only looks at Host and not Path, so this is at minimum a less confusing result if a configured origin is passed without a scheme.