### PR TITLE
fileserver: Preserve query during canonicalization redirect

### DIFF
--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -644,6 +644,10 @@ func redirect(w http.ResponseWriter, r *http.Request, to string) error {
 		// prevent path-based open redirects
 		to = strings.TrimPrefix(to, "/")
 	}
+	// preserve the query string if present
+	if r.URL.RawQuery != "" {
+		to += "?" + r.URL.RawQuery
+	}
 	http.Redirect(w, r, to, http.StatusPermanentRedirect)
 	return nil
 }

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -639,16 +639,18 @@ func calculateEtag(d os.FileInfo) string {
 	return `"` + t + s + `"`
 }
 
-func redirect(w http.ResponseWriter, r *http.Request, to string) error {
-	for strings.HasPrefix(to, "//") {
+// redirect performs a redirect to a given path. The 'toPath' parameter
+// MUST be solely a path, and MUST NOT include a query.
+func redirect(w http.ResponseWriter, r *http.Request, toPath string) error {
+	for strings.HasPrefix(toPath, "//") {
 		// prevent path-based open redirects
-		to = strings.TrimPrefix(to, "/")
+		toPath = strings.TrimPrefix(toPath, "/")
 	}
 	// preserve the query string if present
 	if r.URL.RawQuery != "" {
-		to += "?" + r.URL.RawQuery
+		toPath += "?" + r.URL.RawQuery
 	}
-	http.Redirect(w, r, to, http.StatusPermanentRedirect)
+	http.Redirect(w, r, toPath, http.StatusPermanentRedirect)
 	return nil
 }
 


### PR DESCRIPTION
Replaces https://github.com/caddyserver/caddy/pull/5254

Context: https://caddy.community/t/caddy-stripping-querystring/22754

When a canonicalization redirect happens, it's only taking the path and adding a `/`, which loses the original query if there was one.

This preserves it safely, without making additional modifications to the URL.
