### PR TITLE
caddyfile: Assert having a space after heredoc marker to simply check

### DIFF
--- a/caddyconfig/caddyfile/formatter.go
+++ b/caddyconfig/caddyfile/formatter.go
@@ -124,18 +124,22 @@ func Format(input []byte) []byte {
 		}
 		// if we're in a heredoc, all characters are read&write as-is
 		if heredoc == heredocOpened {
-			write(ch)
 			heredocClosingMarker = append(heredocClosingMarker, ch)
-			if len(heredocClosingMarker) > len(heredocMarker) {
+			if len(heredocClosingMarker) > len(heredocMarker)+1 { // We assert that the heredocClosingMarker is followed by a unicode.Space
 				heredocClosingMarker = heredocClosingMarker[1:]
 			}
 			// check if we're done
-			if slices.Equal(heredocClosingMarker, heredocMarker) {
+			if unicode.IsSpace(ch) && slices.Equal(heredocClosingMarker[:len(heredocClosingMarker)-1], heredocMarker) {
 				heredocMarker = nil
 				heredocClosingMarker = nil
 				heredoc = heredocClosed
+			} else {
+				write(ch)
+				if ch == '\n' {
+					heredocClosingMarker = heredocClosingMarker[:0]
+				}
+				continue
 			}
-			continue
 		}
 
 		if last == '<' && space {


### PR DESCRIPTION
Fixes: #6099

We assert that heredocClosingMarker is followed by a unicode.Space to simplify the check of heredoc closing

That's about a 10x speed increase in [clusterfuzz-testcase-minimized-fuzz-format-5806400649363456.txt](https://github.com/caddyserver/caddy/files/14233558/clusterfuzz-testcase-minimized-fuzz-format-5806400649363456.txt). 

**Before** 
```
$ time ./caddy fmt clusterfuzz-testcase-minimized-fuzz-format-5806400649363456.txt > /dev/null
Executed in  609.03 millis    fish           external
   usr time  721.92 millis  127.15 millis  594.77 millis
   sys time   64.97 millis   26.36 millis   38.60 millis
```

**After**
```
$ time ./caddy fmt clusterfuzz-testcase-minimized-fuzz-format-5806400649363456.txt > /dev/null
Executed in   51.12 millis    fish           external
   usr time   40.00 millis    0.00 micros   40.00 millis
   sys time   31.47 millis  636.00 micros   30.83 millis
```
