### PR TITLE
caddytls: verifier: caddyfile: re-add Caddyfile support

### DIFF
--- a/caddytest/integration/caddyfile_adapt/tls_client_auth_cert_file-legacy-with-verifier.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/tls_client_auth_cert_file-legacy-with-verifier.caddyfiletest
@@ -1,0 +1,75 @@
+localhost
+
+respond "hello from localhost"
+tls {
+	client_auth {
+		mode request
+		trusted_ca_cert_file ../caddy.ca.cer
+		verifier dummy
+	}
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"localhost"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "hello from localhost",
+													"handler": "static_response"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					],
+					"tls_connection_policies": [
+						{
+							"match": {
+								"sni": [
+									"localhost"
+								]
+							},
+							"client_authentication": {
+								"ca": {
+									"provider": "inline",
+									"trusted_ca_certs": [
+										"MIIDSzCCAjOgAwIBAgIUfIRObjWNUA4jxQ/0x8BOCvE2Vw4wDQYJKoZIhvcNAQELBQAwFjEUMBIGA1UEAwwLRWFzeS1SU0EgQ0EwHhcNMTkwODI4MTYyNTU5WhcNMjkwODI1MTYyNTU5WjAWMRQwEgYDVQQDDAtFYXN5LVJTQSBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK5m5elxhQfMp/3aVJ4JnpN9PUSz6LlP6LePAPFU7gqohVVFVtDkChJAG3FNkNQNlieVTja/bgH9IcC6oKbROwdY1h0MvNV8AHHigvl03WuJD8g2ReVFXXwsnrPmKXCFzQyMI6TYk3m2gYrXsZOU1GLnfMRC3KAMRgE2F45twOs9hqG169YJ6mM2eQjzjCHWI6S2/iUYvYxRkCOlYUbLsMD/AhgAf1plzg6LPqNxtdlwxZnA0ytgkmhK67HtzJu0+ovUCsMv0RwcMhsEo9T8nyFAGt9XLZ63X5WpBCTUApaAUhnG0XnerjmUWb6eUWw4zev54sEfY5F3x002iQaW6cECAwEAAaOBkDCBjTAdBgNVHQ4EFgQU4CBUbZsS2GaNIkGRz/cBsD5ivjswUQYDVR0jBEowSIAU4CBUbZsS2GaNIkGRz/cBsD5ivjuhGqQYMBYxFDASBgNVBAMMC0Vhc3ktUlNBIENBghR8hE5uNY1QDiPFD/THwE4K8TZXDjAMBgNVHRMEBTADAQH/MAsGA1UdDwQEAwIBBjANBgkqhkiG9w0BAQsFAAOCAQEAKB3V4HIzoiO/Ch6WMj9bLJ2FGbpkMrcb/Eq01hT5zcfKD66lVS1MlK+cRL446Z2b2KDP1oFyVs+qmrmtdwrWgD+nfe2sBmmIHo9m9KygMkEOfG3MghGTEcS+0cTKEcoHYWYyOqQh6jnedXY8Cdm4GM1hAc9MiL3/sqV8YCVSLNnkoNysmr06/rZ0MCUZPGUtRmfd0heWhrfzAKw2HLgX+RAmpOE2MZqWcjvqKGyaRiaZks4nJkP6521aC2Lgp0HhCz1j8/uQ5ldoDszCnu/iro0NAsNtudTMD+YoLQxLqdleIh6CW+illc2VdXwj7mn6J04yns9jfE2jRjW/yTLFuQ=="
+									]
+								},
+								"verifiers": [
+									{
+										"verifier": "dummy"
+									}
+								],
+								"mode": "request"
+							}
+						},
+						{}
+					]
+				}
+			}
+		}
+	}
+}

--- a/caddytest/integration/caddyfile_adapt_test.go
+++ b/caddytest/integration/caddyfile_adapt_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/caddyserver/caddy/v2/caddytest"
+
+	_ "github.com/caddyserver/caddy/v2/internal/testmocks"
 )
 
 func TestCaddyfileAdaptToJSON(t *testing.T) {

--- a/internal/testmocks/dummyverifier.go
+++ b/internal/testmocks/dummyverifier.go
@@ -1,0 +1,39 @@
+package testmocks
+
+import (
+	"crypto/x509"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/modules/caddytls"
+)
+
+func init() {
+	caddy.RegisterModule(new(dummyVerifier))
+}
+
+type dummyVerifier struct{}
+
+// UnmarshalCaddyfile implements caddyfile.Unmarshaler.
+func (dummyVerifier) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	return nil
+}
+
+// CaddyModule implements caddy.Module.
+func (dummyVerifier) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID: "tls.client_auth.dummy",
+		New: func() caddy.Module {
+			return new(dummyVerifier)
+		},
+	}
+}
+
+// VerifyClientCertificate implements ClientCertificateVerifier.
+func (dummyVerifier) VerifyClientCertificate(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+	return nil
+}
+
+var _ caddy.Module = dummyVerifier{}
+var _ caddytls.ClientCertificateVerifier = dummyVerifier{}
+var _ caddyfile.Unmarshaler = dummyVerifier{}

--- a/internal/testmocks/dummyverifier.go
+++ b/internal/testmocks/dummyverifier.go
@@ -34,6 +34,8 @@ func (dummyVerifier) VerifyClientCertificate(rawCerts [][]byte, verifiedChains [
 	return nil
 }
 
-var _ caddy.Module = dummyVerifier{}
-var _ caddytls.ClientCertificateVerifier = dummyVerifier{}
-var _ caddyfile.Unmarshaler = dummyVerifier{}
+var (
+	_ caddy.Module                       = dummyVerifier{}
+	_ caddytls.ClientCertificateVerifier = dummyVerifier{}
+	_ caddyfile.Unmarshaler              = dummyVerifier{}
+)

--- a/internal/testmocks/dummyverifier.go
+++ b/internal/testmocks/dummyverifier.go
@@ -22,7 +22,7 @@ func (dummyVerifier) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 // CaddyModule implements caddy.Module.
 func (dummyVerifier) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		ID: "tls.client_auth.dummy",
+		ID: "tls.client_auth.verifier.dummy",
 		New: func() caddy.Module {
 			return new(dummyVerifier)
 		},

--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -379,7 +379,7 @@ type ClientAuthentication struct {
 
 	// DEPRECATED: This field is deprecated and will be removed in
 	// a future version. Please use the `validators` field instead
-	// with the tls.client_auth.leaf module instead.
+	// with the tls.client_auth.verifier.leaf module instead.
 	//
 	// A list of base64 DER-encoded client leaf certs
 	// to accept. If this list is not empty, client certs
@@ -389,7 +389,7 @@ type ClientAuthentication struct {
 	// Client certificate verification modules. These can perform
 	// custom client authentication checks, such as ensuring the
 	// certificate is not revoked.
-	VerifiersRaw []json.RawMessage `json:"verifiers,omitempty" caddy:"namespace=tls.client_auth inline_key=verifier"`
+	VerifiersRaw []json.RawMessage `json:"verifiers,omitempty" caddy:"namespace=tls.client_auth.verifier inline_key=verifier"`
 
 	verifiers []ClientCertificateVerifier
 
@@ -500,7 +500,7 @@ func (ca *ClientAuthentication) UnmarshalCaddyfile(d *caddyfile.Dispenser) error
 			}
 
 			vType := d.Val()
-			modID := "tls.client_auth." + vType
+			modID := "tls.client_auth.verifier." + vType
 			unm, err := caddyfile.UnmarshalModule(d, modID)
 			if err != nil {
 				return err
@@ -721,7 +721,7 @@ type LeafCertClientAuth struct {
 // CaddyModule returns the Caddy module information.
 func (LeafCertClientAuth) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		ID:  "tls.client_auth.leaf",
+		ID:  "tls.client_auth.verifier.leaf",
 		New: func() caddy.Module { return new(LeafCertClientAuth) },
 	}
 }


### PR DESCRIPTION
This was inadvertently missed during #5784. Re-adding Caddyfile support with a test of a dummy verifier to ensure it isn't broken in the future. I know `LeafCertClientAuth` is there, but it doesn't have Caddyfile support. This PR is faster to fix the gap until the `LeafCertClientAuth` module supports Caddyfile.

CC/ @Gr33nbl00d 