### PR TITLE
OnExit hooks

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -715,6 +715,7 @@ func exitProcess(ctx context.Context, logger *zap.Logger) {
 	logger.Warn("exiting; byeee!! 👋")
 
 	exitCode := ExitCodeSuccess
+	lastContext := ActiveContext()
 
 	// stop all apps
 	if err := Stop(); err != nil {
@@ -734,6 +735,11 @@ func exitProcess(ctx context.Context, logger *zap.Logger) {
 				zap.Error(err))
 			exitCode = ExitCodeFailedQuit
 		}
+	}
+
+	// execute any process-exit callbacks
+	for _, exitFunc := range lastContext.exitFuncs {
+		exitFunc(ctx)
 	}
 
 	// shut down admin endpoint(s) in goroutines so that

--- a/context.go
+++ b/context.go
@@ -46,7 +46,7 @@ type Context struct {
 	cfg             *Config
 	ancestry        []Module
 	cleanupFuncs    []func()                // invoked at every config unload
-	exitFuncs       []func(context.Context) // invoked at config unload ONLY IF the process is exiting
+	exitFuncs       []func(context.Context) // invoked at config unload ONLY IF the process is exiting (EXPERIMENTAL)
 }
 
 // NewContext provides a new context derived from the given
@@ -100,6 +100,8 @@ func (ctx *Context) Filesystems() FileSystems {
 // OnExit executes f when the process exits gracefully.
 // The function is only executed if the process is gracefully
 // shut down while this context is active.
+//
+// EXPERIMENTAL API: subject to change or removal.
 func (ctx *Context) OnExit(f func(context.Context)) {
 	ctx.exitFuncs = append(ctx.exitFuncs, f)
 }

--- a/context.go
+++ b/context.go
@@ -44,8 +44,9 @@ type Context struct {
 
 	moduleInstances map[string][]Module
 	cfg             *Config
-	cleanupFuncs    []func()
 	ancestry        []Module
+	cleanupFuncs    []func()                // invoked at every config unload
+	exitFuncs       []func(context.Context) // invoked at config unload ONLY IF the process is exiting
 }
 
 // NewContext provides a new context derived from the given
@@ -86,13 +87,21 @@ func (ctx *Context) OnCancel(f func()) {
 	ctx.cleanupFuncs = append(ctx.cleanupFuncs, f)
 }
 
-// Filesystems returns a ref to the FilesystemMap
+// Filesystems returns a ref to the FilesystemMap.
+// EXPERIMENTAL: This API is subject to change.
 func (ctx *Context) Filesystems() FileSystems {
 	// if no config is loaded, we use a default filesystemmap, which includes the osfs
 	if ctx.cfg == nil {
 		return &filesystems.FilesystemMap{}
 	}
 	return ctx.cfg.filesystems
+}
+
+// OnExit executes f when the process exits gracefully.
+// The function is only executed if the process is gracefully
+// shut down while this context is active.
+func (ctx *Context) OnExit(f func(context.Context)) {
+	ctx.exitFuncs = append(ctx.exitFuncs, f)
 }
 
 // LoadModule loads the Caddy module(s) from the specified field of the parent struct


### PR DESCRIPTION
A sponsor found these useful; in particular, the process-global OnExit hooks.

There are also context-scoped OnExit hooks which are cleaned up automatically every config unload (and thus need to be registered every config load, which is part of the module lifecycle anyway).