### PR TITLE
httpcaddyfile: Keep deprecated `skip_log` in directive order

### DIFF
--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -51,6 +51,7 @@ var defaultDirectiveOrder = []string{
 	"fs",
 	"root",
 	"log_append",
+	"skip_log", // TODO: deprecated, renamed to log_skip
 	"log_skip",
 
 	"header",


### PR DESCRIPTION
This small PR will add the deprecated `skip_log` directive back to the directive order to avoid this error:
`Error: adapting config using caddyfile: directive 'skip_log' is not an ordered HTTP handler, so it cannot be used here - try placing 

See also: 
https://github.com/caddyserver/caddy/pull/6066#issuecomment-1984176170