### PR TITLE
rewrite: `uri query` replace operation

### DIFF
--- a/caddytest/integration/caddyfile_adapt/uri_query_operations.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/uri_query_operations.caddyfiletest
@@ -1,0 +1,106 @@
+:9080
+uri query +foo bar
+uri query -baz
+uri query taz test
+uri query key=value example
+uri query changethis>changed
+uri query {
+	findme value replacement
+	+foo1 baz
+}
+
+respond "{query}"
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":9080"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "rewrite",
+									"query": {
+										"add": [
+											{
+												"key": "foo",
+												"val": "bar"
+											}
+										]
+									}
+								},
+								{
+									"handler": "rewrite",
+									"query": {
+										"delete": [
+											"baz"
+										]
+									}
+								},
+								{
+									"handler": "rewrite",
+									"query": {
+										"set": [
+											{
+												"key": "taz",
+												"val": "test"
+											}
+										]
+									}
+								},
+								{
+									"handler": "rewrite",
+									"query": {
+										"set": [
+											{
+												"key": "key=value",
+												"val": "example"
+											}
+										]
+									}
+								},
+								{
+									"handler": "rewrite",
+									"query": {
+										"rename": [
+											{
+												"key": "changethis",
+												"val": "changed"
+											}
+										]
+									}
+								},
+								{
+									"handler": "rewrite",
+									"query": {
+										"add": [
+											{
+												"key": "foo1",
+												"val": "baz"
+											}
+										],
+										"replace": [
+											{
+												"key": "findme",
+												"replace": "replacement",
+												"search_regexp": "value"
+											}
+										]
+									}
+								},
+								{
+									"body": "{http.request.uri.query}",
+									"handler": "static_response"
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/caddytest/integration/caddyfile_test.go
+++ b/caddytest/integration/caddyfile_test.go
@@ -569,6 +569,36 @@ func TestRenameAndOtherOps(t *testing.T) {
 	tester.AssertGetResponse("http://localhost:9080/endpoint?foo=bar", 200, "bar=taz&bar=baz")
 }
 
+func TestReplaceOps(t *testing.T) {
+	tester := caddytest.NewTester(t)
+
+	tester.InitServer(`
+	{
+		admin localhost:2999
+		http_port     9080
+	}
+	:9080
+	uri query foo bar baz	
+	respond "{query}"`, "caddyfile")
+
+	tester.AssertGetResponse("http://localhost:9080/endpoint?foo=bar", 200, "foo=baz")
+}
+
+func TestReplaceAllOps(t *testing.T) {
+	tester := caddytest.NewTester(t)
+
+	tester.InitServer(`
+	{
+		admin localhost:2999
+		http_port     9080
+	}
+	:9080
+	uri query * bar baz	
+	respond "{query}"`, "caddyfile")
+
+	tester.AssertGetResponse("http://localhost:9080/endpoint?foo=bar&baz=bar", 200, "baz=baz&foo=baz")
+}
+
 func TestUriOpsBlock(t *testing.T) {
 	tester := caddytest.NewTester(t)
 

--- a/caddytest/integration/caddyfile_test.go
+++ b/caddytest/integration/caddyfile_test.go
@@ -584,6 +584,63 @@ func TestReplaceOps(t *testing.T) {
 	tester.AssertGetResponse("http://localhost:9080/endpoint?foo=bar", 200, "foo=baz")
 }
 
+func TestReplaceWithReplacementPlaceholder(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		admin localhost:2999
+		http_port     9080
+	}
+	:9080
+	uri query foo bar {query.placeholder}	
+	respond "{query}"`, "caddyfile")
+
+	tester.AssertGetResponse("http://localhost:9080/endpoint?placeholder=baz&foo=bar", 200, "foo=baz&placeholder=baz")
+
+}
+
+func TestReplaceWithKeyPlaceholder(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		admin localhost:2999
+		http_port     9080
+	}
+	:9080
+	uri query {query.placeholder} bar baz	
+	respond "{query}"`, "caddyfile")
+
+	tester.AssertGetResponse("http://localhost:9080/endpoint?placeholder=foo&foo=bar", 200, "foo=baz&placeholder=foo")
+}
+
+func TestPartialReplacement(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		admin localhost:2999
+		http_port     9080
+	}
+	:9080
+	uri query foo ar az	
+	respond "{query}"`, "caddyfile")
+
+	tester.AssertGetResponse("http://localhost:9080/endpoint?foo=bar", 200, "foo=baz")
+}
+
+func TestNonExistingSearch(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		admin localhost:2999
+		http_port     9080
+	}
+	:9080
+	uri query foo var baz	
+	respond "{query}"`, "caddyfile")
+
+	tester.AssertGetResponse("http://localhost:9080/endpoint?foo=bar", 200, "foo=bar")
+}
+
 func TestReplaceAllOps(t *testing.T) {
 	tester := caddytest.NewTester(t)
 

--- a/modules/caddyhttp/rewrite/caddyfile.go
+++ b/modules/caddyhttp/rewrite/caddyfile.go
@@ -213,6 +213,9 @@ func applyQueryOps(h httpcaddyfile.Helper, qo *queryOps, args []string) error {
 		renameValKey := strings.Split(key, ">")
 		qo.Rename = append(qo.Rename, queryOpsArguments{Key: renameValKey[0], Val: renameValKey[1]})
 
+	case len(args) == 3:
+		qo.Replace = append(qo.Replace, queryOpsReplacement{Key: key, Search: args[1], Replace: args[2]})
+
 	default:
 		if len(args) != 2 {
 			return h.ArgErr()

--- a/modules/caddyhttp/rewrite/caddyfile.go
+++ b/modules/caddyhttp/rewrite/caddyfile.go
@@ -214,7 +214,7 @@ func applyQueryOps(h httpcaddyfile.Helper, qo *queryOps, args []string) error {
 		qo.Rename = append(qo.Rename, queryOpsArguments{Key: renameValKey[0], Val: renameValKey[1]})
 
 	case len(args) == 3:
-		qo.Replace = append(qo.Replace, queryOpsReplacement{Key: key, Search: args[1], Replace: args[2]})
+		qo.Replace = append(qo.Replace, &queryOpsReplacement{Key: key, SearchRegexp: args[1], Replace: args[2]})
 
 	default:
 		if len(args) != 2 {

--- a/modules/caddyhttp/rewrite/rewrite.go
+++ b/modules/caddyhttp/rewrite/rewrite.go
@@ -497,7 +497,7 @@ type queryOps struct {
 	Add []queryOpsArguments `json:"add,omitempty"`
 
 	// Replaces query parameters.
-	Replace []*queryOpsReplacement
+	Replace []*queryOpsReplacement `json:"replace,omitempty"`
 
 	// Deletes a given query key by name.
 	Delete []string `json:"delete,omitempty"`


### PR DESCRIPTION
This PR is a followup to close #6096. It implements the replace operation for query strings. 