### PR TITLE
http: record the number of bytes read when response writer is hijacked

### DIFF
--- a/modules/caddyhttp/responsewriter.go
+++ b/modules/caddyhttp/responsewriter.go
@@ -66,6 +66,8 @@ type responseRecorder struct {
 	size         int
 	wroteHeader  bool
 	stream       bool
+
+	readSize *int
 }
 
 // NewResponseRecorder returns a new ResponseRecorder that can be
@@ -240,6 +242,12 @@ func (rr *responseRecorder) FlushError() error {
 	return nil
 }
 
+// Private interface so it can only be used in this package
+// #TODO: maybe export it later
+func (rr *responseRecorder) setReadSize(size *int) {
+	rr.readSize = size
+}
+
 func (rr *responseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	//nolint:bodyclose
 	conn, brw, err := http.NewResponseController(rr.ResponseWriterWrapper).Hijack()
@@ -249,6 +257,15 @@ func (rr *responseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	// Per http documentation, returned bufio.Writer is empty, but bufio.Read maybe not
 	conn = &hijackedConn{conn, rr}
 	brw.Writer.Reset(conn)
+
+	buffered := brw.Reader.Buffered()
+	if buffered != 0 {
+		conn.(*hijackedConn).updateReadSize(buffered)
+		data, _ := brw.Peek(buffered)
+		brw.Reader.Reset(io.MultiReader(bytes.NewReader(data), conn))
+	} else {
+		brw.Reader.Reset(conn)
+	}
 	return conn, brw, nil
 }
 
@@ -256,6 +273,24 @@ func (rr *responseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 type hijackedConn struct {
 	net.Conn
 	rr *responseRecorder
+}
+
+func (hc *hijackedConn) updateReadSize(n int) {
+	if hc.rr.readSize != nil {
+		*hc.rr.readSize += n
+	}
+}
+
+func (hc *hijackedConn) Read(p []byte) (int, error) {
+	n, err := hc.Conn.Read(p)
+	hc.updateReadSize(n)
+	return n, err
+}
+
+func (hc *hijackedConn) WriteTo(w io.Writer) (int64, error) {
+	n, err := io.Copy(w, hc.Conn)
+	hc.updateReadSize(int(n))
+	return n, err
 }
 
 func (hc *hijackedConn) Write(p []byte) (int, error) {
@@ -298,4 +333,6 @@ var (
 	_ io.ReaderFrom = (*ResponseWriterWrapper)(nil)
 	_ io.ReaderFrom = (*responseRecorder)(nil)
 	_ io.ReaderFrom = (*hijackedConn)(nil)
+
+	_ io.WriterTo = (*hijackedConn)(nil)
 )

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -335,6 +335,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			r.Body = bodyReader
 		}
 
+		// should always be true, private interface can only be referenced in the same package
+		if setReadSizer, ok := wrec.(interface{ setReadSize(*int) }); ok {
+			setReadSizer.setReadSize(&bodyReader.Length)
+		}
+
 		// capture the original version of the request
 		accLog := s.accessLogger.With(loggableReq)
 


### PR DESCRIPTION
Closes [5728](https://github.com/caddyserver/caddy/issues/5728).