### PR TITLE
vars: Make nil values act as empty string instead of `"<nil>"`

### DIFF
--- a/modules/caddyhttp/vars.go
+++ b/modules/caddyhttp/vars.go
@@ -190,6 +190,8 @@ func (m VarsMatcher) Match(r *http.Request) bool {
 				varStr = vv.String()
 			case error:
 				varStr = vv.Error()
+			case nil:
+				varStr = ""
 			default:
 				varStr = fmt.Sprintf("%v", vv)
 			}
@@ -281,6 +283,8 @@ func (m MatchVarsRE) Match(r *http.Request) bool {
 			varStr = vv.String()
 		case error:
 			varStr = vv.Error()
+		case nil:
+			varStr = ""
 		default:
 			varStr = fmt.Sprintf("%v", vv)
 		}


### PR DESCRIPTION
This is a silly little bug.

I was looking into a possible config to fix an issue for Authelia, and while testing I noticed that `vars` and `vars_regexp` matchers were turning placeholders that return no value (`nil`) into literally the string `"<nil>"` because of the `default:` case doing `fmt.Sprintf("%v", vv)`.

This means that it was impossible to match against nil placeholders by checking for empty string, because the value would always be non-empty. So this fixes a matchers like this:

```
@foo not vars {rp.header.Foo} ""
@bar vars_regexp bar {rp.header.Bar} ^(.+)$
```

These matchers when inside a proxy `handle_response` _should not_ match when the response had a non-empty header value (first one because of `not` negating empty string, and the regexp requiring at least one character), but instead it _did match_ because the actual string was `<nil>`.