### PR TITLE
caddyhttp: Accept XFF header values with ports, when parsing client IP

### DIFF
--- a/modules/caddyhttp/server_test.go
+++ b/modules/caddyhttp/server_test.go
@@ -188,6 +188,15 @@ func TestServer_TrustedRealClientIP_OneTrustedHeaderValidArray(t *testing.T) {
 	assert.Equal(t, ip, "1.1.1.1")
 }
 
+func TestServer_TrustedRealClientIP_IncludesPort(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "192.0.2.1:12345"
+	req.Header.Set("X-Forwarded-For", "1.1.1.1:1234")
+	ip := trustedRealClientIP(req, []string{"X-Forwarded-For"}, "192.0.2.1")
+
+	assert.Equal(t, ip, "1.1.1.1")
+}
+
 func TestServer_TrustedRealClientIP_SkipsInvalidIps(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 	req.RemoteAddr = "192.0.2.1:12345"


### PR DESCRIPTION
Context: https://caddy.community/t/trusted-proxies-in-openshift/23205

As it turns out, some proxies like OpenShift (Red Hat Kubernetes platform) keep the port in the X-Forwarded-For header (or whatever configured client IP header). That's weird, but apparently not unheard of.

We weren't splitting up the value, so when we passed it to `netip.ParseAddr` it would fail, so the `client_ip` in logs didn't get populated. This fixes that, and add some clarifying comments in surrounding code.