### PR TITLE
gitignore: Add rule for caddyfile.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ _gitignore/
 Caddyfile
 Caddyfile.*
 !caddyfile/
+!caddyfile.go
 
 # artifacts from pprof tooling
 *.prof


### PR DESCRIPTION
fix main.go based builds importing caddy with that are using `go mod vendor`

Similar to https://github.com/caddyserver/caddy/issues/2237

This fixes the main.go based builds which use `go mod vendor`. The `caddyfile.go` files from every module were being ignored due to the `Caddyfile.*` rule and some git configs being case insensitive.

macOS git is case insensitive by default. Arguable that people should change this git setting but it is the default and having a project not work with the default is bad.

Also the error message you end up getting after cloning on ci servers or another computer if you don't run go mod vendor there(you don't on ci servers, that's the point) is very confusing:

```
vendor/github.com/caddyserver/caddy/v2/modules/standard/imports.go:7:2: cannot find module providing package github.com/caddyserver/caddy/v2/modules/caddyevents/eventsconfig: import lookup disabled by -mod=vendor
vendor/github.com/caddyserver/caddy/v2/modules/caddyhttp/standard/imports.go:20:2: cannot find module providing package github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy/forwardauth: import lookup disabled by -mod=vendor
```