### PR TITLE
staticresp: Use the evaluated response body for sniffing JSON content-type

### DIFF
--- a/caddytest/integration/handler_test.go
+++ b/caddytest/integration/handler_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"bytes"
 	"net/http"
 	"testing"
 
@@ -28,4 +29,31 @@ func TestBrowse(t *testing.T) {
 		return
 	}
 	tester.AssertResponseCode(req, 200)
+}
+
+func TestRespondWithJSON(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		skip_install_trust
+		admin localhost:2999
+		http_port     9080
+		https_port    9443
+		grace_period  1ns
+	}
+	localhost {
+		respond {http.request.body}
+	}
+  `, "caddyfile")
+
+	res, _ := tester.AssertPostResponseBody("https://localhost:9443/",
+		nil,
+		bytes.NewBufferString(`{
+		"greeting": "Hello, world!"
+	}`), 200, `{
+		"greeting": "Hello, world!"
+	}`)
+	if res.Header.Get("Content-Type") != "application/json" {
+		t.Errorf("expected Content-Type to be application/json, but was %s", res.Header.Get("Content-Type"))
+	}
 }

--- a/modules/caddyhttp/staticresp.go
+++ b/modules/caddyhttp/staticresp.go
@@ -206,7 +206,7 @@ func (s StaticResponse) ServeHTTP(w http.ResponseWriter, r *http.Request, next H
 	// or for clients to render JSON properly which is very common)
 	body := repl.ReplaceKnown(s.Body, "")
 	if body != "" && w.Header().Get("Content-Type") == "" {
-		content := strings.TrimSpace(s.Body)
+		content := strings.TrimSpace(body)
 		if len(content) > 2 &&
 			(content[0] == '{' && content[len(content)-1] == '}' ||
 				(content[0] == '[' && content[len(content)-1] == ']')) &&


### PR DESCRIPTION
Sneaky bug where the automatic setting of `application/json` never took place