### PR TITLE
cmd: Only validate config is proper JSON if config slice has data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,12 @@ jobs:
       run: |
         go build -tags nobdger -trimpath -ldflags="-w -s" -v
 
+    - name: Smoke test Caddy
+      working-directory: ./cmd/caddy
+      run: |
+        ./caddy start
+        ./caddy stop
+
     - name: Publish Build Artifact
       uses: actions/upload-artifact@v4
       with:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -199,7 +199,7 @@ func loadConfigWithLogger(logger *zap.Logger, configFile, adapterName string) ([
 				zap.Int("line", warn.Line))
 		}
 		config = adaptedConfig
-	} else {
+	} else if len(config) != 0 {
 		// validate that the config is at least valid JSON
 		err = json.Unmarshal(config, new(any))
 		if err != nil {


### PR DESCRIPTION
Follow up for #6032. Only validate config is proper JSON if config slice has data.

Without this fix, running `caddy run` or `caddy start` without any config (not even Caddyfile around) results in the error:
```
Error: config is not valid JSON: unexpected end of JSON input; did you mean to use a config adapter (the --adapter flag)?
Error: caddy process exited with error: exit status 1
```