### PR TITLE
reverse_proxy: handle buffered data during hijack

### DIFF
--- a/modules/caddyhttp/responsewriter.go
+++ b/modules/caddyhttp/responsewriter.go
@@ -263,6 +263,8 @@ func (rr *responseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 		conn.(*hijackedConn).updateReadSize(buffered)
 		data, _ := brw.Peek(buffered)
 		brw.Reader.Reset(io.MultiReader(bytes.NewReader(data), conn))
+		// peek to make buffered data appear, as Reset will make it 0
+		_, _ = brw.Peek(buffered)
 	} else {
 		brw.Reader.Reset(conn)
 	}


### PR DESCRIPTION
Fix [6273](https://github.com/caddyserver/caddy/issues/6273).

The cause of the problem can be found in the [comment](https://github.com/caddyserver/caddy/issues/6273#issuecomment-2078415617).