### PR TITLE
Set the `ServerName` field in the ClientHelloInfo when it was unset and a default SNI name is configured

### DIFF
--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -232,6 +232,9 @@ func (p *ConnectionPolicy) buildStandardTLSConfig(ctx caddy.Context) error {
 				cfg.CertSelection = p.CertSelection
 			}
 			cfg.DefaultServerName = p.DefaultSNI
+			if hello.ServerName == "" && p.DefaultSNI != "" {
+				hello.ServerName = p.DefaultSNI
+			}
 			cfg.FallbackServerName = p.FallbackSNI
 			return cfg.GetCertificate(hello)
 		},

--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -232,7 +232,9 @@ func (p *ConnectionPolicy) buildStandardTLSConfig(ctx caddy.Context) error {
 				cfg.CertSelection = p.CertSelection
 			}
 			cfg.DefaultServerName = p.DefaultSNI
+			tlsApp.logger.Info("Looking for ClientHello.ServerName", zap.String("default_sni", p.DefaultSNI))
 			if hello.ServerName == "" && p.DefaultSNI != "" {
+				tlsApp.logger.Info("ClientHello.ServerName is empty; using default SNI", zap.String("default_sni", p.DefaultSNI))
 				hello.ServerName = p.DefaultSNI
 			}
 			cfg.FallbackServerName = p.FallbackSNI


### PR DESCRIPTION
See discussion in slack: https://caddyserver.slack.com/archives/C4DMTEMGD/p1714689199952049