### PR TITLE
reverseproxy: Stop following redirects in health checks by default, add `health_follow_redirects`

### DIFF
--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -450,6 +450,12 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			}
 			h.HealthChecks.Active.ExpectBody = d.Val()
 
+		case "health_follow_redirects":
+			if d.NextArg() {
+				return d.ArgErr()
+			}
+            h.HealthChecks.Active.HealthFollowRedirects = true
+
 		case "health_passes":
 			if !d.NextArg() {
 				return d.ArgErr()
@@ -643,6 +649,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				}
 				h.TrustedProxies = append(h.TrustedProxies, d.Val())
 			}
+
 
 		case "header_up":
 			var err error

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -75,6 +75,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 //	    health_timeout  <duration>
 //	    health_status   <status>
 //	    health_body     <regexp>
+//         health_follow_redirects
 //	    health_headers {
 //	        <field> [<values...>]
 //	    }
@@ -454,7 +455,13 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			if d.NextArg() {
 				return d.ArgErr()
 			}
-			h.HealthChecks.Active.HealthFollowRedirects = true
+			if h.HealthChecks == nil {
+				h.HealthChecks = new(HealthChecks)
+			}
+			if h.HealthChecks.Active == nil {
+				h.HealthChecks.Active = new(ActiveHealthChecks)
+			}
+			h.HealthChecks.Active.FollowRedirects = true
 
 		case "health_passes":
 			if !d.NextArg() {

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -454,7 +454,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			if d.NextArg() {
 				return d.ArgErr()
 			}
-            h.HealthChecks.Active.HealthFollowRedirects = true
+			h.HealthChecks.Active.HealthFollowRedirects = true
 
 		case "health_passes":
 			if !d.NextArg() {
@@ -649,7 +649,6 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				}
 				h.TrustedProxies = append(h.TrustedProxies, d.Val())
 			}
-
 
 		case "header_up":
 			var err error

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -75,7 +75,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 //	    health_timeout  <duration>
 //	    health_status   <status>
 //	    health_body     <regexp>
-//         health_follow_redirects
+//	    health_follow_redirects
 //	    health_headers {
 //	        <field> [<values...>]
 //	    }

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -158,8 +158,7 @@ func (a *ActiveHealthChecks) Provision(ctx caddy.Context, h *Handler) error {
 		Transport: h.Transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if !a.FollowRedirects {
-				return fmt.Errorf(
-					"active health check encountered a redirect; enable 'health_follow_redirects' if redirects are intentional")
+			    return http.ErrUseLastResponse
 			}
 			return nil
 		},
@@ -463,7 +462,7 @@ func (h *Handler) doActiveHealthCheck(dialInfo DialInfo, hostAddr string, upstre
 			markUnhealthy()
 			return nil
 		}
-	} else if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+	} else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		h.HealthChecks.Active.logger.Info("status code out of tolerances",
 			zap.Int("status_code", resp.StatusCode),
 			zap.String("host", hostAddr),

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -16,6 +16,7 @@ package reverseproxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -25,7 +26,6 @@ import (
 	"runtime/debug"
 	"strconv"
 	"time"
-    "errors"
 
 	"go.uber.org/zap"
 
@@ -157,14 +157,14 @@ func (a *ActiveHealthChecks) Provision(ctx caddy.Context, h *Handler) error {
 	a.httpClient = &http.Client{
 		Timeout:   timeout,
 		Transport: h.Transport,
-        CheckRedirect: func(req *http.Request, via []*http.Request) error {
-            if !a.HealthFollowRedirects {
-                return errors.New(
-                    "Redirects are disabled in health check, set health_follow_redirects flag in config to avoid this error")
-            } else {
-                return nil
-            }
-        },
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if !a.HealthFollowRedirects {
+				return errors.New(
+					"Redirects are disabled in health check, set health_follow_redirects flag in config to avoid this error")
+			} else {
+				return nil
+			}
+		},
 	}
 
 	for _, upstream := range h.Upstreams {

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -158,7 +158,7 @@ func (a *ActiveHealthChecks) Provision(ctx caddy.Context, h *Handler) error {
 		Transport: h.Transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if !a.FollowRedirects {
-			    return http.ErrUseLastResponse
+				return http.ErrUseLastResponse
 			}
 			return nil
 		},


### PR DESCRIPTION
fix: #6291 