### PR TITLE
tracing: add `http.vars.trace_id` placeholder

### DIFF
--- a/modules/caddyhttp/tracing/tracer.go
+++ b/modules/caddyhttp/tracing/tracer.go
@@ -87,8 +87,12 @@ func (ot *openTelemetryWrapper) serveHTTP(w http.ResponseWriter, r *http.Request
 	ot.propagators.Inject(ctx, propagation.HeaderCarrier(r.Header))
 	spanCtx := trace.SpanContextFromContext(ctx)
 	if spanCtx.IsValid() {
+		traceID := spanCtx.TraceID().String()
+		// Add a trace_id placeholder, accessible via `{http.vars.trace_id}`.
+		caddyhttp.SetVar(ctx, "trace_id", traceID)
+		// Add the trace id to the log fields for the request.
 		if extra, ok := ctx.Value(caddyhttp.ExtraLogFieldsCtxKey).(*caddyhttp.ExtraLogFields); ok {
-			extra.Add(zap.String("traceID", spanCtx.TraceID().String()))
+			extra.Add(zap.String("traceID", traceID))
 		}
 	}
 	next := ctx.Value(nextCallCtxKey).(*nextCall)


### PR DESCRIPTION
Adds the ability to use `trace_id` as a placeholder so it can be used wherever it is needed.  Such as being returned in a header to the client.