### PR TITLE
reverseproxy: Support HTTP/3 transport to backend

### DIFF
--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/pires/go-proxyproto"
+	"github.com/quic-go/quic-go/http3"
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
 
@@ -124,12 +125,18 @@ type HTTPTransport struct {
 	// can be specified to use H2C (HTTP/2 over Cleartext) to the
 	// upstream (this feature is experimental and subject to
 	// change or removal). Default: ["1.1", "2"]
+	//
+	// EXPERIMENTAL: "3" enables HTTP/3, but it must be the only
+	// version specified if enabled. Additionally, HTTPS must be
+	// enabled to the upstream as HTTP/3 requires TLS. Subject
+	// to change or removal while experimental.
 	Versions []string `json:"versions,omitempty"`
 
 	// The pre-configured underlying HTTP transport.
 	Transport *http.Transport `json:"-"`
 
 	h2cTransport *http2.Transport
+	h3Transport  *http3.RoundTripper // TODO: EXPERIMENTAL (May 2024)
 }
 
 // CaddyModule returns the Caddy module information.
@@ -350,6 +357,16 @@ func (h *HTTPTransport) NewTransport(caddyCtx caddy.Context) (*http.Transport, e
 		}
 	}
 
+	// configure HTTP/3 transport if enabled; however, this does not
+	// automatically fall back to lower versions like most web browsers
+	// do (that'd add latency and complexity, besides, we expect that
+	// site owners  control the backends), so it must be exclusive
+	if len(h.Versions) == 1 && h.Versions[0] == "3" {
+		h.h3Transport = new(http3.RoundTripper)
+	} else if len(h.Versions) > 1 && sliceContains(h.Versions, "3") {
+		return nil, fmt.Errorf("if HTTP/3 is enabled to the upstream, no other HTTP versions are supported")
+	}
+
 	// if h2c is enabled, configure its transport (std lib http.Transport
 	// does not "HTTP/2 over cleartext TCP")
 	if sliceContains(h.Versions, "h2c") {
@@ -413,6 +430,11 @@ func (h *HTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	transport := h.replaceTLSServername(repl)
 
 	transport.SetScheme(req)
+
+	// use HTTP/3 if enabled (TODO: This is EXPERIMENTAL)
+	if h.h3Transport != nil {
+		return h.h3Transport.RoundTrip(req)
+	}
 
 	// if H2C ("HTTP/2 over cleartext") is enabled and the upstream request is
 	// HTTP without TLS, use the alternate H2C-capable transport instead


### PR DESCRIPTION
VERY EXPERIMENTAL. Enables HTTP/3 protocol from proxy to backend ("upstream").

I still don't fully understand why this would be needed/useful, but here is a quick stab attempt with the APIs available to us.

**Enabling HTTP/3 necessarily disables other HTTP versions. (If you specify version "3" in your config, you cannot have any other versions.) We do not support protocol downgrade or negotiation like web browsers do.** That would probably add considerable latency and complexity where you should already have control over the backends. Additionally, other HTTP transport options don't apply to the HTTP/3 round-tripper because it does not use the `http.Transport` type like the lower HTTP versions.

Example Caddyfile:

```
# for demonstration purposes, the backend will ONLY support HTTP/3,
# but of course it doesn't have to be this way
{
	servers :1235 {
		protocols h3
	}
}

# this runs the proxy on HTTP but you can use HTTPS in yours
:1234 {
	reverse_proxy localhost:1235 {
		transport http {
			tls
			versions 3
		}
	}
	log
}

# this is the HTTP/3 backend
localhost:1235 {
	log
	respond "Hello world!"
}
```

Then run `curl -v "http://localhost:1234/"` and you'll see the response on the front-end using HTTP/1.1, but the proxy used HTTP/3 to the backend.

In the backend (:1235) we log the request so you can verify that it shows `"proto": "HTTP/3.0"` for the proxied request. The frontend (:1234) will log `"proto": "HTTP/1.1"`.

Anyway, this seems to work, but with the limitations I mentioned above. We have similar, albeit slightly less tight, restrictions on the "h2c" transport as well.

(@marten-seemann You might like to know we're trying this.)

Closes #5086