### PR TITLE
caddyhttp: Trace individual middleware handlers

### DIFF
--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -198,6 +198,9 @@ func (app *App) Provision(ctx caddy.Context) error {
 		// only enable access logs if configured
 		if srv.Logs != nil {
 			srv.accessLogger = app.logger.Named("log.access")
+			if srv.Logs.Trace {
+				srv.traceLogger = app.logger.Named("log.trace")
+			}
 		}
 
 		// the Go standard library does not let us serve only HTTP/2 using

--- a/modules/caddyhttp/logging.go
+++ b/modules/caddyhttp/logging.go
@@ -65,6 +65,17 @@ type ServerLogConfig struct {
 	// and this includes some request and response headers, i.e `Cookie`,
 	// `Set-Cookie`, `Authorization`, and `Proxy-Authorization`.
 	ShouldLogCredentials bool `json:"should_log_credentials,omitempty"`
+
+	// Log each individual handler that is invoked.
+	// Requires that the log emit at DEBUG level.
+	//
+	// NOTE: This may log the configuration of your
+	// HTTP handler modules; do not enable this in
+	// insecure contexts when there is sensitive
+	// data in the configuration.
+	//
+	// EXPERIMENTAL: Subject to change or removal.
+	Trace bool `json:"trace,omitempty"`
 }
 
 // wrapLogger wraps logger in one or more logger named

--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -328,7 +328,7 @@ func wrapMiddleware(_ caddy.Context, mh MiddlewareHandler, metrics *Metrics) Mid
 		return HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 			// EXPERIMENTAL: Trace each module that gets invoked
 			if server, ok := r.Context().Value(ServerCtxKey).(*Server); ok && server != nil {
-				server.traceLog(handlerToUse)
+				server.logTrace(handlerToUse)
 			}
 			return handlerToUse.ServeHTTP(w, r, nextCopy)
 		})

--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -326,8 +326,10 @@ func wrapMiddleware(_ caddy.Context, mh MiddlewareHandler, metrics *Metrics) Mid
 		nextCopy := next
 
 		return HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-			// TODO: This is where request tracing could be implemented
-			// TODO: see what the std lib gives us in terms of stack tracing too
+			// EXPERIMENTAL: Trace each module that gets invoked
+			if server, ok := r.Context().Value(ServerCtxKey).(*Server); ok && server != nil {
+				server.traceLog(handlerToUse)
+			}
 			return handlerToUse.ServeHTTP(w, r, nextCopy)
 		})
 	}

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -234,6 +234,7 @@ type Server struct {
 	logger       *zap.Logger
 	accessLogger *zap.Logger
 	errorLogger  *zap.Logger
+	traceLogger  *zap.Logger
 	ctx          caddy.Context
 
 	server      *http.Server
@@ -736,6 +737,15 @@ func (s *Server) shouldLogRequest(r *http.Request) bool {
 	}
 	// if configured, this host is not mapped and thus must not be logged
 	return !s.Logs.SkipUnmappedHosts
+}
+
+// logTrace will log that this middleware handler is being invoked.
+// It emits at DEBUG level.
+func (s *Server) logTrace(mh MiddlewareHandler) {
+	if s.Logs == nil || !s.Logs.Trace {
+		return
+	}
+	s.traceLogger.Debug(caddy.GetModuleName(mh), zap.Any("module", mh))
 }
 
 // logRequest logs the request to access logs, unless skipped.


### PR DESCRIPTION
This has been on my mind for years. Just a simple way to see which middleware handlers are being invoked during a request.

Requires DEBUG level logging to be enabled, as well as explicitly opting-in to trace logs. Here is an example global option config along with a sample server in a Caddyfile:

```
{
	debug
	servers {
		trace
	}
}

:1234 {
	root /asdf
	file_server browse
	encode gzip zstd
	templates
	rewrite /foo /bar
	log
}
```

Making a simple request using `curl -v http://localhost:1234` I get:

```
2024/05/10 22:32:52.613 DEBUG   http.log.trace  vars    {"module": {"root":"/asdf"}}
2024/05/10 22:32:52.613 DEBUG   http.log.trace  encode  {"module": {"prefer":["gzip","zstd"],"minimum_length":512,"match":{"headers":{"Content-Type":["application/atom+xml*","application/eot*","application/font*","application/geo+json*","application/graphql+json*","application/javascript*","application/json*","application/ld+json*","application/manifest+json*","application/opentype*","application/otf*","application/rss+xml*","application/truetype*","application/ttf*","application/vnd.api+json*","application/vnd.ms-fontobject*","application/wasm*","application/x-httpd-cgi*","application/x-javascript*","application/x-opentype*","application/x-otf*","application/x-perl*","application/x-protobuf*","application/x-ttf*","application/xhtml+xml*","application/xml*","font/*","image/svg+xml*","image/vnd.microsoft.icon*","image/x-icon*","multipart/bag*","multipart/mixed*","text/*"]}}}}
2024/05/10 22:32:52.613 DEBUG   http.log.trace  templates       {"module": {"file_root":"{http.vars.root}","mime_types":["text/html","text/plain","text/markdown"]}}
2024/05/10 22:32:52.613 DEBUG   http.log.trace  file_server     {"module": {"fs":"{http.vars.fs}","root":"{http.vars.root}","hide":["/home/matt/Dev/caddyserver/caddy/cmd/caddy/Caddyfile"],"index_names":["index.html","index.txt"],"browse":{}}}
2024/05/10 22:32:52.613 DEBUG   http.handlers.file_server       sanitized path join     {"site_root": "/asdf", "fs": "", "request_path": "/", "result": "/asdf"}
2024/05/10 22:32:52.613 DEBUG   http.log.error  {id=h9n01tz5n} fileserver.(*FileServer).notFound (staticfiles.go:818): HTTP 404 {"request": {"remote_ip": "::1", "remote_port": "36704", "client_ip": "::1", "proto": "HTTP/1.1", "method": "GET", "host": "localhost:1234", "uri": "/", "headers": {"User-Agent": ["curl/8.7.1"], "Accept": ["*/*"]}}, "duration": 0.000174089, "status": 404, "err_id": "h9n01tz5n", "err_trace": "fileserver.(*FileServer).notFound (staticfiles.go:818)"}
2024/05/10 22:32:52.613 INFO    http.log.access handled request {"request": {"remote_ip": "::1", "remote_port": "36704", "client_ip": "::1", "proto": "HTTP/1.1", "method": "GET", "host": "localhost:1234", "uri": "/", "headers": {"Accept": ["*/*"], "User-Agent": ["curl/8.7.1"]}}, "bytes_read": 0, "user_id": "", "duration": 0.000174089, "size": 0, "status": 404, "resp_headers": {"Server": ["Caddy"]}}
```

So I can see every middleware it went through. (Notice it didn't go through `rewrite` because it didn't match.)

This would almost never be used in production, but I would be aware that this will log your middleware configurations which may be sensitive (?) so keep that in mind.