### PR TITLE
caddytls: remove ClientHelloSNICtxKey

### DIFF
--- a/modules/caddytls/certmanagers.go
+++ b/modules/caddytls/certmanagers.go
@@ -22,9 +22,6 @@ func init() {
 	caddy.RegisterModule(HTTPCertGetter{})
 }
 
-// For referencing the requested SNI server name.
-const ClientHelloSNICtxKey caddy.CtxKey = "client_hello_sni"
-
 // Tailscale is a module that can get certificates from the local Tailscale process.
 type Tailscale struct {
 	logger *zap.Logger
@@ -44,7 +41,6 @@ func (ts *Tailscale) Provision(ctx caddy.Context) error {
 }
 
 func (ts Tailscale) GetCertificate(ctx context.Context, hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	ctx = context.WithValue(ctx, ClientHelloSNICtxKey, hello.ServerName)
 	canGetCert, err := ts.canHazCertificate(ctx, hello)
 	if err == nil && !canGetCert {
 		return nil, nil // pass-thru: Tailscale can't offer a cert for this name


### PR DESCRIPTION
It turns out this is unnecessary due to certmagic setting the entire ClientHelloInfo on the context using `certmagic.ClientHelloInfoCtxKey`.