### PR TITLE
core: MkdirAll appDataDir in InstanceID with 0o700

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -869,7 +869,7 @@ func InstanceID() (uuid.UUID, error) {
 		if err != nil {
 			return uuid, err
 		}
-		err = os.MkdirAll(appDataDir, 0o600)
+		err = os.MkdirAll(appDataDir, 0o700)
 		if err != nil {
 			return uuid, err
 		}


### PR DESCRIPTION
appDataDir components should be searchable (u+x) when they are created, or else Caddy is unable to start with an empty HOME.