### PR TITLE
caddyhttp: Fix merging consecutive `client_ip` or `remote_ip` matchers

### DIFF
--- a/caddytest/integration/caddyfile_adapt/matcher_syntax.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/matcher_syntax.caddyfiletest
@@ -46,6 +46,18 @@
 
 	@matcher12 client_ip private_ranges
 	respond @matcher12 "client_ip matcher with private ranges"
+
+	@matcher13 {
+		remote_ip 1.1.1.1
+		remote_ip 2.2.2.2
+	}
+	respond @matcher13 "remote_ip merged"
+
+	@matcher14 {
+		client_ip 1.1.1.1
+		client_ip 2.2.2.2
+	}
+	respond @matcher14 "client_ip merged"
 }
 ----------
 {
@@ -276,6 +288,42 @@
 							"handle": [
 								{
 									"body": "client_ip matcher with private ranges",
+									"handler": "static_response"
+								}
+							]
+						},
+						{
+							"match": [
+								{
+									"remote_ip": {
+										"ranges": [
+											"1.1.1.1",
+											"2.2.2.2"
+										]
+									}
+								}
+							],
+							"handle": [
+								{
+									"body": "remote_ip merged",
+									"handler": "static_response"
+								}
+							]
+						},
+						{
+							"match": [
+								{
+									"client_ip": {
+										"ranges": [
+											"1.1.1.1",
+											"2.2.2.2"
+										]
+									}
+								}
+							],
+							"handle": [
+								{
+									"body": "client_ip merged",
 									"handler": "static_response"
 								}
 							]

--- a/modules/caddyhttp/ip_matchers.go
+++ b/modules/caddyhttp/ip_matchers.go
@@ -72,19 +72,21 @@ func (MatchRemoteIP) CaddyModule() caddy.ModuleInfo {
 
 // UnmarshalCaddyfile implements caddyfile.Unmarshaler.
 func (m *MatchRemoteIP) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
-	d.Next() // consume matcher name
-	for d.NextArg() {
-		if d.Val() == "forwarded" {
-			return d.Err("the 'forwarded' option is no longer supported; use the 'client_ip' matcher instead")
+	// iterate to merge multiple matchers into one
+	for d.Next() {
+		for d.NextArg() {
+			if d.Val() == "forwarded" {
+				return d.Err("the 'forwarded' option is no longer supported; use the 'client_ip' matcher instead")
+			}
+			if d.Val() == "private_ranges" {
+				m.Ranges = append(m.Ranges, PrivateRangesCIDR()...)
+				continue
+			}
+			m.Ranges = append(m.Ranges, d.Val())
 		}
-		if d.Val() == "private_ranges" {
-			m.Ranges = append(m.Ranges, PrivateRangesCIDR()...)
-			continue
+		if d.NextBlock(0) {
+			return d.Err("malformed remote_ip matcher: blocks are not supported")
 		}
-		m.Ranges = append(m.Ranges, d.Val())
-	}
-	if d.NextBlock(0) {
-		return d.Err("malformed remote_ip matcher: blocks are not supported")
 	}
 	return nil
 }
@@ -164,16 +166,18 @@ func (MatchClientIP) CaddyModule() caddy.ModuleInfo {
 
 // UnmarshalCaddyfile implements caddyfile.Unmarshaler.
 func (m *MatchClientIP) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
-	d.Next() // consume matcher name
-	for d.NextArg() {
-		if d.Val() == "private_ranges" {
-			m.Ranges = append(m.Ranges, PrivateRangesCIDR()...)
-			continue
+	// iterate to merge multiple matchers into one
+	for d.Next() {
+		for d.NextArg() {
+			if d.Val() == "private_ranges" {
+				m.Ranges = append(m.Ranges, PrivateRangesCIDR()...)
+				continue
+			}
+			m.Ranges = append(m.Ranges, d.Val())
 		}
-		m.Ranges = append(m.Ranges, d.Val())
-	}
-	if d.NextBlock(0) {
-		return d.Err("malformed client_ip matcher: blocks are not supported")
+		if d.NextBlock(0) {
+			return d.Err("malformed client_ip matcher: blocks are not supported")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/caddyserver/caddy/issues/6349