### PR TITLE
cmd: fix regression in auto-detect of Caddyfile

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -166,7 +166,7 @@ func loadConfigWithLogger(logger *zap.Logger, configFile, adapterName string) ([
 	startsOrEndsInCaddyfile := strings.HasPrefix(baseConfig, "caddyfile") || strings.HasSuffix(baseConfig, ".caddyfile")
 
 	// If the adapter is not specified,
-	// the config file is not starts with "caddyfile",
+	// the config file does not starts with "caddyfile",
 	// the config file has an extension,
 	// and isn't a JSON file (e.g. Caddyfile.yaml),
 	// then we don't know what the config format is.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -119,18 +119,18 @@ func isCaddyfile(configFile, adapterName string) (bool, error) {
 	baseConfig := strings.ToLower(filepath.Base(configFile))
 	baseConfigExt := filepath.Ext(baseConfig)
 	startsOrEndsInCaddyfile := strings.HasPrefix(baseConfig, "caddyfile") || strings.HasSuffix(baseConfig, ".caddyfile")
-	notCaddyfileNorJSON := (baseConfigExt != "" && baseConfigExt != ".caddyfile" && baseConfigExt != ".json")
+	extNotCaddyfileOrJSON := (baseConfigExt != "" && baseConfigExt != ".caddyfile" && baseConfigExt != ".json")
 
 	if baseConfigExt == ".json" {
 		return false, nil
 	}
 
 	// If the adapter is not specified,
-	// the config file does not starts with "caddyfile",
+	// the config file starts with "caddyfile",
 	// the config file has an extension,
 	// and isn't a JSON file (e.g. Caddyfile.yaml),
 	// then we don't know what the config format is.
-	if adapterName == "" && startsOrEndsInCaddyfile && notCaddyfileNorJSON {
+	if adapterName == "" && startsOrEndsInCaddyfile && extNotCaddyfileOrJSON {
 		return false, fmt.Errorf("ambiguous config file format; please specify adapter (use --adapter)")
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -165,9 +165,12 @@ func loadConfigWithLogger(logger *zap.Logger, configFile, adapterName string) ([
 	baseConfigExt := filepath.Ext(baseConfig)
 	startsOrEndsInCaddyfile := strings.HasPrefix(baseConfig, "caddyfile") || strings.HasSuffix(baseConfig, ".caddyfile")
 
-	// If the adapter is not specified, the config file is not starts with "caddyfile", and isn't a JSON file (e.g. Caddyfile.yaml),
+	// If the adapter is not specified,
+	// the config file is not starts with "caddyfile",
+	// the config file has an extension,
+	// and isn't a JSON file (e.g. Caddyfile.yaml),
 	// then we don't know what the config format is.
-	if adapterName == "" && startsOrEndsInCaddyfile && baseConfigExt != ".caddyfile" && baseConfigExt != ".json" {
+	if adapterName == "" && startsOrEndsInCaddyfile && (baseConfigExt != "" && baseConfigExt != ".caddyfile" && baseConfigExt != ".json") {
 		return nil, "", fmt.Errorf("ambiguous config file format; please specify adapter (use --adapter)")
 	}
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -181,6 +181,15 @@ func Test_isCaddyfile(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name: "bare Caddyfile without adapter",
+			args: args{
+				configFile:  "Caddyfile",
+				adapterName: "",
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
 			name: "local Caddyfile without adapter",
 			args: args{
 				configFile:  "./Caddyfile",

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -168,3 +168,83 @@ here"
 		}
 	}
 }
+
+func Test_isCaddyfile(t *testing.T) {
+	type args struct {
+		configFile  string
+		adapterName string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "local Caddyfile without adapter",
+			args: args{
+				configFile:  "./Caddyfile",
+				adapterName: "",
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "local caddyfile with adapter",
+			args: args{
+				configFile:  "./Caddyfile",
+				adapterName: "caddyfile",
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "ends with .caddyfile with adapter",
+			args: args{
+				configFile:  "./conf.caddyfile",
+				adapterName: "caddyfile",
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "ends with .caddyfile without adapter",
+			args: args{
+				configFile:  "./conf.caddyfile",
+				adapterName: "",
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "config is Caddyfile.yaml without adapter",
+			args: args{
+				configFile:  "./Caddyfile.yaml",
+				adapterName: "",
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "json is not caddyfile but not error",
+			args: args{
+				configFile:  "./Caddyfile.json",
+				adapterName: "",
+			},
+			want:    false,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := isCaddyfile(tt.args.configFile, tt.args.adapterName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("isCaddyfile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("isCaddyfile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Regression caused by #6356 
Reported here:
- https://caddy.community/t/error-in-logs-with-updating-ari-after-upgrading-to-caddy-v2-8-1/24320/12
- https://github.com/caddyserver/caddy/pull/6356#issuecomment-2143713053
- fixes https://github.com/caddyserver/caddy/issues/6363