### PR TITLE
Make it possible to configure the `DisableStorageCheck` setting for certmagic

### DIFF
--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -81,6 +81,16 @@ type TLS struct {
 	// EXPERIMENTAL. Subject to change.
 	DisableOCSPStapling bool `json:"disable_ocsp_stapling,omitempty"`
 
+	// Disables checks in certmagic that the configured storage is ready
+	// and able to handle writing new content to it. These checks are
+	// intended to prevent information loss (newly issued certificates), but
+	// can be expensive on the storage.
+	//
+	// Disabling these checks should only be done when the storage
+	// can be trusted to have enough capacity and no other problems.
+	// EXPERIMENTAL. Subject to change.
+	DisableStorageCheck bool `json:"disable_storage_check,omitempty"`
+
 	certificateLoaders []CertificateLoader
 	automateNames      []string
 	ctx                caddy.Context
@@ -255,6 +265,7 @@ func (t *TLS) Provision(ctx caddy.Context) error {
 		OCSP: certmagic.OCSPConfig{
 			DisableStapling: t.DisableOCSPStapling,
 		},
+		DisableStorageCheck: t.DisableStorageCheck,
 	})
 	certCacheMu.RUnlock()
 	for _, loader := range t.certificateLoaders {


### PR DESCRIPTION
See discussion about this setting in https://github.com/caddyserver/certmagic/issues/201

Note that this doesn't expose the setting through the caddyfile, I guess that would have to happen just-about-here: https://github.com/framer/caddy/blob/5b13f9272454ea13105689fbe24a14b00421f901/caddyconfig/httpcaddyfile/tlsapp.go#L331-L334

Not sure whether that's wanted/needed, and if it is, how to best name it?

I did consider another idea of injecting some sort of "configuration adapter" here, which would take a certmagic config, do whatever it needs to do, and then return the adapted config. This could over the long term be nicer, especially for these kind of special options -- but it would also open the world to a lot more mischief. WDYT?