### PR TITLE
cmd: remove zealous check of Caddyfile auto-detection

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -119,7 +119,6 @@ func isCaddyfile(configFile, adapterName string) (bool, error) {
 	baseConfig := strings.ToLower(filepath.Base(configFile))
 	baseConfigExt := filepath.Ext(baseConfig)
 	startsOrEndsInCaddyfile := strings.HasPrefix(baseConfig, "caddyfile") || strings.HasSuffix(baseConfig, ".caddyfile")
-	extNotCaddyfileOrJSON := (baseConfigExt != "" && baseConfigExt != ".caddyfile" && baseConfigExt != ".json")
 
 	if baseConfigExt == ".json" {
 		return false, nil
@@ -130,8 +129,8 @@ func isCaddyfile(configFile, adapterName string) (bool, error) {
 	// the config file has an extension,
 	// and isn't a JSON file (e.g. Caddyfile.yaml),
 	// then we don't know what the config format is.
-	if adapterName == "" && startsOrEndsInCaddyfile && extNotCaddyfileOrJSON {
-		return false, fmt.Errorf("ambiguous config file format; please specify adapter (use --adapter)")
+	if adapterName == "" && startsOrEndsInCaddyfile {
+		return true, nil
 	}
 
 	// If the config file starts or ends with "caddyfile",

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -133,14 +133,11 @@ func isCaddyfile(configFile, adapterName string) (bool, error) {
 		return true, nil
 	}
 
-	// If the config file starts or ends with "caddyfile",
-	// the extension of the config file is not ".json", AND
-	// the user did not specify an adapter, then we assume it's Caddyfile.
-	if startsOrEndsInCaddyfile &&
-		baseConfigExt != ".json" &&
-		adapterName == "" {
-		return true, nil
-	}
+	// adapter is not empty,
+	// adapter is not "caddyfile",
+	// extension is not ".json",
+	// extension is not ".caddyfile"
+	// file does not start with "Caddyfile"
 	return false, nil
 }
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -226,13 +226,13 @@ func Test_isCaddyfile(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "config is Caddyfile.yaml without adapter",
+			name: "config is Caddyfile.yaml with adapter",
 			args: args{
 				configFile:  "./Caddyfile.yaml",
-				adapterName: "",
+				adapterName: "yaml",
 			},
 			want:    false,
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "json is not caddyfile but not error",

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -246,9 +246,19 @@ func Test_isCaddyfile(t *testing.T) {
 		},
 		{
 			
-			name: "prefix of Caddyfile with any extension is Caddyfile",
+			name: "prefix of Caddyfile and ./ with any extension is Caddyfile",
 			args: args{
 				configFile:  "./Caddyfile.prd",
+				adapterName: "",
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			
+			name: "prefix of Caddyfile without ./ with any extension is Caddyfile",
+			args: args{
+				configFile:  "Caddyfile.prd",
 				adapterName: "",
 			},
 			want:    true,

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -235,12 +235,23 @@ func Test_isCaddyfile(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			
 			name: "json is not caddyfile but not error",
 			args: args{
 				configFile:  "./Caddyfile.json",
 				adapterName: "",
 			},
 			want:    false,
+			wantErr: false,
+		},
+		{
+			
+			name: "prefix of Caddyfile with any extension is Caddyfile",
+			args: args{
+				configFile:  "./Caddyfile.prd",
+				adapterName: "",
+			},
+			want:    true,
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
Turns out, it isn't uncommon to have `Caddyfile.prod` and such (https://github.com/caddyserver/caddy/pull/6362#discussion_r1623414880). This is mentioned on the website as:

> This flag is not necessary if the --config filename starts with "Caddyfile" which assumes the caddyfile adapter

[Source](https://caddyserver.com/docs/command-line#caddy-run)

Fixes https://github.com/caddyserver/caddy/issues/6373