### PR TITLE
fix file mode configuration parsing

### DIFF
--- a/modules/logging/filewriter.go
+++ b/modules/logging/filewriter.go
@@ -59,6 +59,11 @@ func (m *fileMode) UnmarshalJSON(b []byte) error {
 	return err
 }
 
+// MarshalJSON satisfies json.Marshaler.
+func (m *fileMode) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"%04o\"", *m)), nil
+}
+
 // parseFileMode parses a file mode string,
 // adding support for `chmod` unix command like
 // 1 to 4 digital octal values.

--- a/modules/logging/filewriter_test.go
+++ b/modules/logging/filewriter_test.go
@@ -306,3 +306,42 @@ func TestFileModeJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestFileModeToJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    fileMode
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "none zero",
+			mode:    0644,
+			want:    `"0644"`,
+			wantErr: false,
+		},
+		{
+			name:    "zero mode",
+			mode:    0,
+			want:    `"0000"`,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b []byte
+			var err error
+
+			if b, err = json.Marshal(&tt.mode); (err != nil) != tt.wantErr {
+				t.Fatalf("MarshalJSON() error = %v, want %v", err, tt.wantErr)
+			}
+
+			got := string(b[:])
+
+			if got != tt.want {
+				t.Errorf("got mode %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Commit 101d3e7 introduced file mode setting,
but was missing a JSON Marshaller so that
CaddyFile can be converted to JSON safely.