### PR TITLE
reverseproxy: Allow `0` as weights for `weighted_round_robin`

### DIFF
--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -110,8 +110,8 @@ func (r *WeightedRoundRobinSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser)
 		if err != nil {
 			return d.Errf("invalid weight value '%s': %v", weight, err)
 		}
-		if weightInt < 1 {
-			return d.Errf("invalid weight value '%s': weight should be non-zero and positive", weight)
+		if weightInt < 0 {
+			return d.Errf("invalid weight value '%s': weight should be non-negative", weight)
 		}
 		r.Weights = append(r.Weights, weightInt)
 	}


### PR DESCRIPTION
Enable 0 weights to be allowed when using weighted_round_robin policy with cookie. Discussed in https://caddy.community/t/invalid-weight-value/24440