### PR TITLE
changes healthcheck to block on provision until first success (and also block properly in general)

### DIFF
--- a/caddytest/integration/reverseproxy_test.go
+++ b/caddytest/integration/reverseproxy_test.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/caddyserver/caddy/v2/caddytest"
 )
@@ -199,7 +198,7 @@ func TestReverseProxyWithPlaceholderDialAddress(t *testing.T) {
 								],
 								"handle": [
 									{
-	
+
 										"handler": "reverse_proxy",
 										"upstreams": [
 											{
@@ -293,7 +292,7 @@ func TestReverseProxyWithPlaceholderTCPDialAddress(t *testing.T) {
 								],
 								"handle": [
 									{
-	
+
 										"handler": "reverse_proxy",
 										"upstreams": [
 											{
@@ -345,7 +344,7 @@ func TestReverseProxyHealthCheck(t *testing.T) {
 	http://localhost:9080 {
 		reverse_proxy {
 			to localhost:2020
-	
+
 			health_uri /health
 			health_port 2021
 			health_interval 10ms
@@ -356,7 +355,6 @@ func TestReverseProxyHealthCheck(t *testing.T) {
 	}
 	`, "caddyfile")
 
-	time.Sleep(100 * time.Millisecond) // TODO: for some reason this test seems particularly flaky, getting 503 when it should be 200, unless we wait
 	tester.AssertGetResponse("http://localhost:9080/", 200, "Hello, World!")
 }
 
@@ -406,7 +404,7 @@ func TestReverseProxyHealthCheckUnixSocket(t *testing.T) {
 	http://localhost:9080 {
 		reverse_proxy {
 			to unix/%s
-	
+
 			health_uri /health
 			health_port 2021
 			health_interval 2s
@@ -464,7 +462,7 @@ func TestReverseProxyHealthCheckUnixSocketWithoutPort(t *testing.T) {
 	http://localhost:9080 {
 		reverse_proxy {
 			to unix/%s
-	
+
 			health_uri /health
 			health_interval 2s
 			health_timeout 5s


### PR DESCRIPTION
https://github.com/caddyserver/caddy/blob/master/caddytest/integration/reverseproxy_test.go#L359 there is a todo here: `TODO: for some reason this test seems particularly flaky, getting 503 when it should be 200, unless we wait`

the reason is because health check hasn't succeeded, so there needs to be a wait to wait until the test starts.

the health checkers are started in goroutine, https://github.com/caddyserver/caddy/blob/master/modules/caddyhttp/reverseproxy/healthchecks.go#L254-L264

and the health checker start includes the initial request.
the issues are twofold.
1. the goroutine returns before the first round of h.doActiveHealthCheckForAllHosts
2. doActiveHealthCheckForAllHosts will return before any health checkers finish.

so the fixes are to
1. make sure provision doesn't return until activeHealthChecker has started, and make the goroutine start within activeHealthChecker
2. make sure that doActiveHealthCheckForAllHosts doesn't return until all checkers have finished. 

of course, this "fix" also makes it so that if a health check hangs - caddy will stay in provisioning state until it times out. i think this is the correct behavior (caddy should fail health check until it has health checked all reverse proxies at least once), but maybe others disagree?

this change has the additional advantage of making it more difficult for configuration errors to stampede a remote

maybe there though needs to be better timeout guarantees on the underlying healthchecks though before this can be pushed? perhaps some people are relying on this weird behavior as well, i am not sure. 