### PR TITLE
fileserver: Exclude symlink target size from total, show arrow on size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
 
           # The environment is fresh, so there's no point in keeping accepting and adding the key.
           rsync -arz -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --progress --delete --exclude '.git' . "$CI_USER"@ci-s390x.caddyserver.com:/var/tmp/"$short_sha"
-          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -t "$CI_USER"@ci-s390x.caddyserver.com "cd /var/tmp/$short_sha; go version; go env; printf "\n\n";CGO_ENABLED=0 go test -tags nobadger -v ./..."
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -t "$CI_USER"@ci-s390x.caddyserver.com "cd /var/tmp/$short_sha; go version; go env; printf "\n\n";CGO_ENABLED=0 go test -p 1 -tags nobadger -v ./..."
           test_result=$?
 
           # There's no need leaving the files around

--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -980,7 +980,7 @@ footer {
 							<div class="sizebar">
 								<div class="sizebar-bar"></div>
 								<div class="sizebar-text">
-									{{if .IsSymlink}}↱ {{end}}{{.HumanSize}}
+									{{if .IsSymlink}}↱&nbsp;{{end}}{{.HumanSize}}
 								</div>
 							</div>
 						</td>

--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -980,7 +980,7 @@ footer {
 							<div class="sizebar">
 								<div class="sizebar-bar"></div>
 								<div class="sizebar-text">
-									{{.HumanSize}}
+									{{if .IsSymlink}}↱ {{end}}{{.HumanSize}}
 								</div>
 							</div>
 						</td>

--- a/modules/caddyhttp/fileserver/browsetplcontext.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext.go
@@ -111,7 +111,7 @@ func (fsrv *FileServer) directoryListing(ctx context.Context, fileSystem fs.FS, 
 
 		if !isDir {
 			// increase the total including the symlink target's size
-			tplCtx.TotalFileSizeWithSymlinks += size
+			tplCtx.TotalFileSizeFollowingSymlinks += size
 		}
 
 		u := url.URL{Path: "./" + name} // prepend with "./" to fix paths with ':' in the name
@@ -159,12 +159,13 @@ type browseTemplateContext struct {
 	NumFiles int `json:"num_files"`
 
 	// The total size of all files in the listing. Only includes the
-	// size of the files themselves, not the size of the symlinks.
+	// size of the files themselves, not the size of symlink targets
+	// (i.e. the calculation of this value does not follow symlinks).
 	TotalFileSize int64 `json:"total_file_size"`
 
 	// The total size of all files in the listing, including the
 	// size of the files targeted by symlinks.
-	TotalFileSizeWithSymlinks int64 `json:"total_file_size_with_symlinks"`
+	TotalFileSizeFollowingSymlinks int64 `json:"total_file_size_following_symlinks"`
 
 	// Sort column used
 	Sort string `json:"sort,omitempty"`
@@ -301,11 +302,10 @@ func (btc browseTemplateContext) HumanTotalFileSize() string {
 	return humanize.IBytes(uint64(btc.TotalFileSize))
 }
 
-// HumanTotalFileSizeWithSymlinks returns the total size of
-// all files in the listing (including symlinks) as a human-readable
-// string in IEC format (i.e. power of 2 or base 1024).
-func (btc browseTemplateContext) HumanTotalFileSizeWithSymlinks() string {
-	return humanize.IBytes(uint64(btc.TotalFileSizeWithSymlinks))
+// HumanTotalFileSizeFollowingSymlinks is the same as HumanTotalFileSize
+// except the returned value reflects the size of symlink targets.
+func (btc browseTemplateContext) HumanTotalFileSizeFollowingSymlinks() string {
+	return humanize.IBytes(uint64(btc.TotalFileSizeFollowingSymlinks))
 }
 
 // HumanModTime returns the modified time of the file

--- a/modules/caddyhttp/fileserver/browsetplcontext.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext.go
@@ -80,6 +80,12 @@ func (fsrv *FileServer) directoryListing(ctx context.Context, fileSystem fs.FS, 
 		}
 
 		size := info.Size()
+
+		// increase the total by the symlink's size, not the target's size.
+		if !isDir {
+			tplCtx.TotalFileSize += size
+		}
+
 		fileIsSymlink := isSymlink(info)
 		symlinkPath := ""
 		if fileIsSymlink {
@@ -100,10 +106,6 @@ func (fsrv *FileServer) directoryListing(ctx context.Context, fileSystem fs.FS, 
 			// which isn't entirely unusual and shouldn't fail the listing.
 			// In this case, just use the size of the symlink itself, which
 			// was already set above.
-		}
-
-		if !isDir {
-			tplCtx.TotalFileSize += size
 		}
 
 		u := url.URL{Path: "./" + name} // prepend with "./" to fix paths with ':' in the name

--- a/modules/caddyhttp/fileserver/browsetplcontext.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext.go
@@ -163,7 +163,7 @@ type browseTemplateContext struct {
 	TotalFileSize int64 `json:"total_file_size"`
 
 	// The total size of all files in the listing, including the
-	// size of the files targetted by symlinks.
+	// size of the files targeted by symlinks.
 	TotalFileSizeWithSymlinks int64 `json:"total_file_size_with_symlinks"`
 
 	// Sort column used


### PR DESCRIPTION
Closes https://github.com/caddyserver/caddy/issues/6409

![image](https://github.com/caddyserver/caddy/assets/2111701/c0a13d00-1a7c-45c7-b088-938da9e62424)