### PR TITLE
fix: http.intercept.header.* placeholders

### DIFF
--- a/caddytest/integration/intercept_test.go
+++ b/caddytest/integration/intercept_test.go
@@ -18,17 +18,23 @@ func TestIntercept(t *testing.T) {
 	
 		localhost:9080 {
 			respond /intercept "I'm a teapot" 408
+			header /intercept To-Intercept ok
 			respond /no-intercept "I'm not a teapot"
 
 			intercept {
 				@teapot status 408
 				handle_response @teapot {
+					header /intercept intercepted {resp.header.To-Intercept}
 					respond /intercept "I'm a combined coffee/tea pot that is temporarily out of coffee" 503
 				}
 			}	
 		}
 		`, "caddyfile")
 
-	tester.AssertGetResponse("http://localhost:9080/intercept", 503, "I'm a combined coffee/tea pot that is temporarily out of coffee")
+	r, _ := tester.AssertGetResponse("http://localhost:9080/intercept", 503, "I'm a combined coffee/tea pot that is temporarily out of coffee")
+	if r.Header.Get("intercepted") != "ok" {
+		t.Fatalf(`header "intercepted" value is not "ok": %s`, r.Header.Get("intercepted"))
+	}
+
 	tester.AssertGetResponse("http://localhost:9080/no-intercept", 200, "I'm not a teapot")
 }

--- a/modules/caddyhttp/intercept/intercept.go
+++ b/modules/caddyhttp/intercept/intercept.go
@@ -50,7 +50,6 @@ type Intercept struct {
 	//
 	// Three new placeholders are available in this handler chain:
 	// - `{http.intercept.status_code}` The status code from the response
-	// - `{http.intercept.status_text}` The status text from the response
 	// - `{http.intercept.header.*}` The headers from the response
 	HandleResponse []caddyhttp.ResponseHandler `json:"handle_response,omitempty"`
 
@@ -161,7 +160,7 @@ func (ir Intercept) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 
 	// set up the replacer so that parts of the original response can be
 	// used for routing decisions
-	for field, value := range r.Header {
+	for field, value := range rec.Header() {
 		repl.Set("http.intercept.header."+field, strings.Join(value, ","))
 	}
 	repl.Set("http.intercept.status_code", rec.Status())


### PR DESCRIPTION
I introduced a bug in #6232: `http.intercept.header.*` placeholders contain request headers instead of original response headers.

This patch fixes the issue.

Closes https://github.com/dunglas/frankenphp/issues/884.