### PR TITLE
browse: fix Content-Security-Policy warnings in Firefox

### DIFF
--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -1,6 +1,6 @@
 {{ $nonce := uuidv4 -}}
 {{ $nonceAttribute := print "nonce=" (quote $nonce) -}}
-{{ $csp := printf "default-src 'none'; img-src 'self'; object-src 'none'; base-uri 'none'; script-src 'nonce-%s' 'unsafe-inline'; style-src 'nonce-%s'; frame-ancestors 'self'; form-action 'self';" $nonce $nonce -}}
+{{ $csp := printf "default-src 'none'; img-src 'self'; object-src 'none'; base-uri 'none'; script-src 'nonce-%s'; style-src 'nonce-%s'; frame-ancestors 'self'; form-action 'self';" $nonce $nonce -}}
 {{/* To disable the Content-Security-Policy, set this to false */}}{{ $enableCsp := true -}}
 {{ if $enableCsp -}}
   {{- .RespHeader.Set "Content-Security-Policy" $csp -}}

--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -1,6 +1,6 @@
 {{ $nonce := uuidv4 -}}
 {{ $nonceAttribute := print "nonce=" (quote $nonce) -}}
-{{ $csp := printf "default-src 'none'; img-src 'self'; object-src 'none'; base-uri 'none'; script-src 'strict-dynamic' 'nonce-%s' 'unsafe-inline' https: http:; style-src 'strict-dynamic' 'nonce-%s'; frame-ancestors 'self'; form-action 'self'; block-all-mixed-content;" $nonce $nonce -}}
+{{ $csp := printf "default-src 'none'; img-src 'self'; object-src 'none'; base-uri 'none'; script-src 'nonce-%s' 'unsafe-inline'; style-src 'nonce-%s'; frame-ancestors 'self'; form-action 'self';" $nonce $nonce -}}
 {{/* To disable the Content-Security-Policy, set this to false */}}{{ $enableCsp := true -}}
 {{ if $enableCsp -}}
   {{- .RespHeader.Set "Content-Security-Policy" $csp -}}


### PR DESCRIPTION
This PR addresses the Content-Security-Policy warnings in Firefox: https://github.com/caddyserver/caddy/pull/6425#issuecomment-2211816751

The following changes have been made:

1. **Remove `strict-dynamic` from `style-src`**:
   > Content-Security-Policy: Ignoring source “strict-dynamic” (Only supported within script-src).

2. **Remove `block-all-mixed-content`**:
   > Content-Security-Policy: Ignoring ‘block-all-mixed-content’ because mixed content display upgrading makes block-all-mixed-content obsolete.

See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/block-all-mixed-content

3. **Remove `strict-dynamic`, `https:`, and `http:` from `script-src`**:
   > Content-Security-Policy: Ignoring “'unsafe-inline'” within script-src: ‘strict-dynamic’ specified
   > Content-Security-Policy: Ignoring “https:” within script-src: ‘strict-dynamic’ specified
   > Content-Security-Policy: Ignoring “http:” within script-src: ‘strict-dynamic’ specified

~~After these changes, only the following warning will remain due to the presence of `'unsafe-inline'` within `script-src` for backward compatibility with browsers not supporting Content-Security-Policy Version 3 (such as Internet Explorer 11):~~

~~> Content-Security-Policy: Ignoring “'unsafe-inline'” within script-src: nonce-source or hash-source specified~~

~~Unfortunately, Firefox will log this directive being ignored. We must make a trade-off between this warning and maintaining backward compatibility.~~

See also: https://developer.chrome.com/docs/lighthouse/best-practices/csp-xss/#ensure_csp_is_backwards_compatible

UPDATE:
4. **Remove ` unsafe-inline` from `script-src`**:
   > Content-Security-Policy: Ignoring “'unsafe-inline'” within script-src: nonce-source or hash-source specified

No more Content-Security-Policy warnings in Firefox.

The adjusted `browse.html` is currently active on my playground:
https://alma.stbu.net/testing-something/