### PR TITLE
Add option to set which HTTP method to use for active health checks

### DIFF
--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -136,6 +136,11 @@ func (a *ActiveHealthChecks) Provision(ctx caddy.Context, h *Handler) error {
 	}
 	a.Headers = cleaned
 
+	// If Method is not set, default to GET
+	if a.Method == "" {
+		a.Method = http.MethodGet
+	}
+
 	h.HealthChecks.Active.logger = h.logger.Named("health_checker.active")
 
 	timeout := time.Duration(a.Timeout)

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -82,6 +82,9 @@ type ActiveHealthChecks struct {
 	// HTTP headers to set on health check requests.
 	Headers http.Header `json:"headers,omitempty"`
 
+	// The HTTP method to use for health checks (default "GET").
+	Method string `json:"method,omitempty"`
+
 	// Whether to follow HTTP redirects in response to active health checks (default off).
 	FollowRedirects bool `json:"follow_redirects,omitempty"`
 
@@ -377,7 +380,7 @@ func (h *Handler) doActiveHealthCheck(dialInfo DialInfo, hostAddr string, networ
 	ctx = context.WithValue(ctx, caddyhttp.VarsCtxKey, map[string]any{
 		dialInfoVarKey: dialInfo,
 	})
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, h.HealthChecks.Active.Method, u.String(), nil)
 	if err != nil {
 		return fmt.Errorf("making request: %v", err)
 	}


### PR DESCRIPTION
## Changes

Added the option `Method` to the `ActiveHealthChecks` struct, which optionally sets the HTTP method used for the health check requests.

## Rational

It would be good to be able to use the `HEAD` HTTP method to limit transfers on upstreams that respond with a large body, or other methods for upstreams that only respond sensibly on eg. `POST`.

I specifically have a JSON RPC upstream that I would like to test and see if it is working. It has a well defined response body to a `POST` request, that lets the active health check determine if the underlying service is actually up and ready to serve requests.  