### PR TITLE
reverseproxy: Caddyfile support for health_method

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_health_method.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_health_method.caddyfiletest
@@ -1,0 +1,40 @@
+:8884
+
+reverse_proxy 127.0.0.1:65535 {
+	health_uri /health
+	health_method HEAD
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8884"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "reverse_proxy",
+									"health_checks": {
+										"active": {
+											"method": "HEAD",
+											"uri": "/health"
+										}
+									},
+									"upstreams": [
+										{
+											"dial": "127.0.0.1:65535"
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -79,6 +79,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 //	    health_headers {
 //	        <field> [<values...>]
 //	    }
+//	    health_method   <value>
 //
 //	    # passive health checking
 //	    fail_duration     <duration>
@@ -386,6 +387,18 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				h.HealthChecks.Active = new(ActiveHealthChecks)
 			}
 			h.HealthChecks.Active.Headers = healthHeaders
+
+		case "health_method":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			if h.HealthChecks == nil {
+				h.HealthChecks = new(HealthChecks)
+			}
+			if h.HealthChecks.Active == nil {
+				h.HealthChecks.Active = new(ActiveHealthChecks)
+			}
+			h.HealthChecks.Active.Method = d.Val()
 
 		case "health_interval":
 			if !d.NextArg() {


### PR DESCRIPTION
Adds Caddyfile support for setting the request method used for reverse proxy active health checks. 
 
Follow up to https://github.com/caddyserver/caddy/pull/6453, spurred on by https://github.com/caddyserver/caddy/pull/6453#issuecomment-2223293904

Note: There is no check on which HTTP verb is accepted as apparently some people like to make up their own.