### PR TITLE
Pull Request: Refactor FastCGI Client into Separate Package (#4378)

### DIFF
--- a/modules/caddyhttp/reverseproxy/fastcgi/client_test.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/client_test.go
@@ -38,6 +38,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy/fastcgi/fastcgiclient"
 )
 
 // test fcgi protocol includes:
@@ -123,7 +125,7 @@ func sendFcgi(reqType int, fcgiParams map[string]string, data []byte, posts map[
 		return
 	}
 
-	fcgi := client{rwc: conn, reqID: 1}
+	fcgi := fastcgiclient.Client{Rwc: conn, ReqID: 1}
 
 	length := 0
 

--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -30,10 +30,9 @@ import (
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy/fastcgi/fastcgiclient"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
 )
-
-var noopLogger = zap.NewNop()
 
 func init() {
 	caddy.RegisterModule(Transport{})
@@ -167,11 +166,11 @@ func (t Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 	}()
 
 	// create the client that will facilitate the protocol
-	client := client{
-		rwc:    conn,
-		reqID:  1,
-		logger: logger,
-		stderr: t.CaptureStderr,
+	client := fastcgiclient.Client{
+		Rwc:    conn,
+		ReqID:  1,
+		Logger: logger,
+		Stderr: t.CaptureStderr,
 	}
 
 	// read/write timeouts

--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgiclient/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgiclient/fastcgi.go
@@ -12,33 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fastcgi
+package fastcgiclient
 
-import (
-	"bytes"
-	"io"
-)
+import "go.uber.org/zap"
 
-type streamReader struct {
-	c      *client
-	rec    record
-	stderr bytes.Buffer
-}
-
-func (w *streamReader) Read(p []byte) (n int, err error) {
-	for !w.rec.hasMore() {
-		err = w.rec.fill(w.c.rwc)
-		if err != nil {
-			return 0, err
-		}
-
-		// standard error output
-		if w.rec.h.Type == Stderr {
-			if _, err = io.Copy(&w.stderr, &w.rec); err != nil {
-				return 0, err
-			}
-		}
-	}
-
-	return w.rec.Read(p)
-}
+var noopLogger = zap.NewNop()

--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgiclient/header.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgiclient/header.go
@@ -1,0 +1,32 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fastcgiclient
+
+type header struct {
+	Version       uint8
+	Type          uint8
+	ID            uint16
+	ContentLength uint16
+	PaddingLength uint8
+	Reserved      uint8
+}
+
+func (h *header) init(recType uint8, reqID uint16, contentLength int) {
+	h.Version = 1
+	h.Type = recType
+	h.ID = reqID
+	h.ContentLength = uint16(contentLength)
+	h.PaddingLength = uint8(-contentLength & 7)
+}

--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgiclient/pool.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgiclient/pool.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fastcgi
+package fastcgiclient
 
 import (
 	"bytes"

--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgiclient/record.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgiclient/record.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fastcgi
+package fastcgiclient
 
 import (
 	"encoding/binary"

--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgiclient/writer.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgiclient/writer.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fastcgi
+package fastcgiclient
 
 import (
 	"bytes"
@@ -22,19 +22,19 @@ import (
 // streamWriter abstracts out the separation of a stream into discrete records.
 // It only writes maxWrite bytes at a time.
 type streamWriter struct {
-	c       *client
+	c       *Client
 	h       header
 	buf     *bytes.Buffer
 	recType uint8
 }
 
 func (w *streamWriter) writeRecord(recType uint8, content []byte) (err error) {
-	w.h.init(recType, w.c.reqID, len(content))
+	w.h.init(recType, w.c.ReqID, len(content))
 	w.buf.Write(pad[:8])
 	w.writeHeader()
 	w.buf.Write(content)
 	w.buf.Write(pad[:w.h.PaddingLength])
-	_, err = w.buf.WriteTo(w.c.rwc)
+	_, err = w.buf.WriteTo(w.c.Rwc)
 	return err
 }
 
@@ -129,10 +129,10 @@ func (w *streamWriter) writeHeader() {
 
 // Flush write buffer data to the underlying connection, it assumes header data is the first 8 bytes of buf
 func (w *streamWriter) Flush() error {
-	w.h.init(w.recType, w.c.reqID, w.buf.Len()-8)
+	w.h.init(w.recType, w.c.ReqID, w.buf.Len()-8)
 	w.writeHeader()
 	w.buf.Write(pad[:w.h.PaddingLength])
-	_, err := w.buf.WriteTo(w.c.rwc)
+	_, err := w.buf.WriteTo(w.c.Rwc)
 	return err
 }
 


### PR DESCRIPTION
## Hi Caddy team,

Looking at the list of issues about FastCGI, I noticed a "help wanted SOS" issue #4378 requesting the FastCGI client be moved into its own package (pretty logic). And as I was already familiar with this codebase (because when I contributed in the [v2.7.3](https://github.com/caddyserver/caddy/releases/tag/v2.7.3) release, I read the whole package), I've prepared a pull request to address this issue. I hope to help you!

## The Problem

Currently, the FastCGI client code is intertwined with Caddy's FastCGI implementation, making it harder to maintain (and read!) and potentially reuse the client elsewhere. This refactor aims to improve the code's organization and clarity.

## The Solution

1. **Moved client files:** The files `writer.go`, `record.go`, `reader.go`, `pool.go`, and `header.go` are now in the fastcgiclient subpackage. They were non exportable auxiliar FastCGI client files.
2. **Created fastcgi.go:** It was created a `fastcgi.go` file in the subpackage just for clean handling the initialization of the noopLogger, previously a single line of the `fastcgi.go` in the previous implementation. (This is a noopLogger, so it can be safely initialized inside the client, because it just discard the output, but we can now easily refactor the logging in a future)
3. **Exported Client:** The Client type and its fields are now exportable, so they can be imported in the Caddy's FastCGI implementation package, without changing their behavior.
4. **Updated imports:** The main FastCGI package now just imports the client, simplifying its dependencies.
5. **Maintained compatibility:** The commented-out ´client_test.go´ file remains for reference, but it is continue been disabled due to performance concerns, as it was.

## Testing

The majority of changes are fast revisable code edits and movements, easily verifiable using Git (they're mainly rename trackings and single lines). It do not change any code logic (I was careful about that).

To thoroughly test the changes, I successfully ran a WordPress site using a Caddy server with this modification. All functionality, including file uploads, API access, and GET/POST requests, worked seamlessly.

## Closing Remarks

Well, I hope this solve the 3 years issue #4378 and makes the FastCGI codebase cleaner and more maintainable.

I'd hope to be included in the contributor list for the next release. This is my second contribution! :)

Best regards,