### PR TITLE
fileserver: add `sort` options

### DIFF
--- a/caddytest/integration/caddyfile_adapt/file_server_sort.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/file_server_sort.caddyfiletest
@@ -1,8 +1,7 @@
-:8082 {
-	root * .
-	file_server browse {
-		sort size desc
-	}
+:80
+
+file_server browse {
+	sort size desc
 }
 ----------
 {
@@ -11,21 +10,18 @@
 			"servers": {
 				"srv0": {
 					"listen": [
-						":8082"
+						":80"
 					],
 					"routes": [
 						{
 							"handle": [
 								{
+									"browse": {},
 									"handler": "file_server",
 									"hide": [
 										"./Caddyfile"
 									],
-									"file_server": {
-										"size": {},
-										"desc": {}
-									},
-									"file_server_order": [
+									"sort": [
 										"size",
 										"desc"
 									]

--- a/caddytest/integration/caddyfile_adapt/file_server_sort.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/file_server_sort.caddyfiletest
@@ -1,0 +1,40 @@
+:8082 {
+	root * .
+	file_server browse {
+		sort size desc
+	}
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8082"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "file_server",
+									"hide": [
+										"./Caddyfile"
+									],
+									"file_server": {
+										"size": {},
+										"desc": {}
+									},
+									"file_server_order": [
+										"size",
+										"desc"
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -206,11 +206,35 @@ func (fsrv *FileServer) loadDirectoryContents(ctx context.Context, fileSystem fs
 // browseApplyQueryParams applies query parameters to the listing.
 // It mutates the listing and may set cookies.
 func (fsrv *FileServer) browseApplyQueryParams(w http.ResponseWriter, r *http.Request, listing *browseTemplateContext) {
+	orderParam := ""
+	sortParam := ""
+
+	// The configs in Caddyfile have lower priority than Query params,
+	// so put it at first.
+	for idx, item := range fsrv.SortOptions {
+		// Only `sort` & `order`, 2 params are allowed
+		if idx >= 2 {
+			break
+		}
+		switch item {
+		case sortByName, sortByNameDirFirst, sortBySize, sortByTime:
+			sortParam = item
+		case sortOrderAsc, sortOrderDesc:
+			orderParam = item
+		}
+	}
+
 	layoutParam := r.URL.Query().Get("layout")
-	sortParam := r.URL.Query().Get("sort")
-	orderParam := r.URL.Query().Get("order")
 	limitParam := r.URL.Query().Get("limit")
 	offsetParam := r.URL.Query().Get("offset")
+	sortParamTmp := r.URL.Query().Get("sort")
+	if sortParamTmp != "" {
+		sortParam = sortParamTmp
+	}
+	orderParamTmp := r.URL.Query().Get("order")
+	if orderParamTmp != "" {
+		orderParam = orderParamTmp
+	}
 
 	switch layoutParam {
 	case "list", "grid", "":
@@ -233,11 +257,11 @@ func (fsrv *FileServer) browseApplyQueryParams(w http.ResponseWriter, r *http.Re
 	// then figure out the order
 	switch orderParam {
 	case "":
-		orderParam = "asc"
+		orderParam = sortOrderAsc
 		if orderCookie, orderErr := r.Cookie("order"); orderErr == nil {
 			orderParam = orderCookie.Value
 		}
-	case "asc", "desc":
+	case sortOrderAsc, sortOrderDesc:
 		http.SetCookie(w, &http.Cookie{Name: "order", Value: orderParam, Secure: r.TLS != nil})
 	}
 

--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -206,8 +206,7 @@ func (fsrv *FileServer) loadDirectoryContents(ctx context.Context, fileSystem fs
 // browseApplyQueryParams applies query parameters to the listing.
 // It mutates the listing and may set cookies.
 func (fsrv *FileServer) browseApplyQueryParams(w http.ResponseWriter, r *http.Request, listing *browseTemplateContext) {
-	orderParam := ""
-	sortParam := ""
+	var orderParam, sortParam string
 
 	// The configs in Caddyfile have lower priority than Query params,
 	// so put it at first.

--- a/modules/caddyhttp/fileserver/browsetplcontext.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext.go
@@ -373,4 +373,7 @@ const (
 	sortByNameDirFirst = "namedirfirst"
 	sortBySize         = "size"
 	sortByTime         = "time"
+
+	sortOrderAsc  = "asc"
+	sortOrderDesc = "desc"
 )

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -171,6 +171,17 @@ func (fsrv *FileServer) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			}
 			fsrv.EtagFileExtensions = etagFileExtensions
 
+		case "sort":
+			for d.NextArg() {
+				dVal := d.Val()
+				switch dVal {
+				case sortByName, sortBySize, sortByTime, sortOrderAsc, sortOrderDesc:
+					fsrv.SortOptions = append(fsrv.SortOptions, dVal)
+				default:
+					return d.Errf("unknown sort option '%s'", dVal)
+				}
+			}
+
 		default:
 			return d.Errf("unknown subdirective '%s'", d.Val())
 		}

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -153,6 +153,16 @@ type FileServer struct {
 	// a 404 error. By default, this is false (disabled).
 	PassThru bool `json:"pass_thru,omitempty"`
 
+	// Override the default sort. It includes the following options:
+	// sort_by: name(default), size, time
+	// order: asc(default), desc
+	// eg.:
+	//   - `sort time desc` will sort by time in descending order
+	//   - `sort size` will sort by size in ascending order
+	//   - `sort` will sort by name in ascending order, which is the default
+	// The order of the sort options is not important.
+	SortOptions []string `json:"sort,omitempty"`
+
 	// Selection of encoders to use to check for precompressed files.
 	PrecompressedRaw caddy.ModuleMap `json:"precompressed,omitempty" caddy:"namespace=http.precompressed"`
 

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -153,14 +153,14 @@ type FileServer struct {
 	// a 404 error. By default, this is false (disabled).
 	PassThru bool `json:"pass_thru,omitempty"`
 
-	// Override the default sort. It includes the following options:
-	// sort_by: name(default), size, time
-	// order: asc(default), desc
+	// Override the default sort.
+	// It includes the following options:
+	//   - sort_by: name(default), namedirfirst, size, time
+	//   - order: asc(default), desc
 	// eg.:
 	//   - `sort time desc` will sort by time in descending order
 	//   - `sort size` will sort by size in ascending order
-	//   - `sort` will sort by name in ascending order, which is the default
-	// The order of the sort options is not important.
+	// The first option must be `sort_by` and the second option must be `order` (if exists).
 	SortOptions []string `json:"sort,omitempty"`
 
 	// Selection of encoders to use to check for precompressed files.
@@ -244,6 +244,20 @@ func (fsrv *FileServer) Provision(ctx caddy.Context) error {
 			fsrv.precompressors = make(map[string]encode.Precompressed)
 		}
 		fsrv.precompressors[ae] = p
+	}
+
+	// check sort options
+	for idx, sortOption := range fsrv.SortOptions {
+		switch idx {
+		case 0:
+			if sortOption != sortByName && sortOption != sortByNameDirFirst && sortOption != sortBySize && sortOption != sortByTime {
+				return fmt.Errorf("invalid sort option %s", sortOption)
+			}
+		case 1:
+			if sortOption != sortOrderAsc && sortOption != sortOrderDesc {
+				return fmt.Errorf("invalid sort option %s", sortOption)
+			}
+		}
 	}
 
 	return nil

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -251,12 +251,14 @@ func (fsrv *FileServer) Provision(ctx caddy.Context) error {
 		switch idx {
 		case 0:
 			if sortOption != sortByName && sortOption != sortByNameDirFirst && sortOption != sortBySize && sortOption != sortByTime {
-				return fmt.Errorf("invalid sort option %s", sortOption)
+				return fmt.Errorf("the first option must be one of the following: %s, %s, %s, %s, but got %s", sortByName, sortByNameDirFirst, sortBySize, sortByTime, sortOption)
 			}
 		case 1:
 			if sortOption != sortOrderAsc && sortOption != sortOrderDesc {
-				return fmt.Errorf("invalid sort option %s", sortOption)
+				return fmt.Errorf("the second option must be one of the following: %s, %s, but got %s", sortOrderAsc, sortOrderDesc, sortOption)
 			}
+		default:
+			return fmt.Errorf("only max 2 sort options are allowed, but got %d", idx+1)
 		}
 	}
 


### PR DESCRIPTION
I have tested the config:
```
:8082 {
	root * .
	file_server browse {
		sort size desc
	}
}
```

<img width="2032" alt="Screenshot 2024-07-22 at 20 32 31" src="https://github.com/user-attachments/assets/c8cb95f4-d663-49e9-a828-9f0391d1d577">

Additionally, a `.caddyfiletest` file were wrote, but I don't know how to run it.

The related doc PR can be found [here](https://github.com/caddyserver/website/pull/407).