### PR TITLE
ci: correct `-tags nobadger` on binary build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       env:
         CGO_ENABLED: 0
       run: |
-        go build -tags nobdger -trimpath -ldflags="-w -s" -v
+        go build -tags nobadger -trimpath -ldflags="-w -s" -v
 
     - name: Smoke test Caddy
       working-directory: ./cmd/caddy


### PR DESCRIPTION
s/nobdger/nobadger

Seems like an oversight from https://github.com/caddyserver/caddy/pull/6031