### PR TITLE
Runtime placeholders for selected TLS and HTTP matchers

### DIFF
--- a/internal/ranges.go
+++ b/internal/ranges.go
@@ -1,0 +1,14 @@
+package internal
+
+// PrivateRangesCIDR returns a list of private CIDR range
+// strings, which can be used as a configuration shortcut.
+func PrivateRangesCIDR() []string {
+	return []string{
+		"192.168.0.0/16",
+		"172.16.0.0/12",
+		"10.0.0.0/8",
+		"127.0.0.1/8",
+		"fd00::/8",
+		"::1",
+	}
+}

--- a/modules/caddyhttp/ip_matchers.go
+++ b/modules/caddyhttp/ip_matchers.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/internal"
 )
 
 // MatchRemoteIP matches requests by the remote IP address,
@@ -79,7 +80,7 @@ func (m *MatchRemoteIP) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				return d.Err("the 'forwarded' option is no longer supported; use the 'client_ip' matcher instead")
 			}
 			if d.Val() == "private_ranges" {
-				m.Ranges = append(m.Ranges, PrivateRangesCIDR()...)
+				m.Ranges = append(m.Ranges, internal.PrivateRangesCIDR()...)
 				continue
 			}
 			m.Ranges = append(m.Ranges, d.Val())
@@ -173,7 +174,7 @@ func (m *MatchClientIP) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		for d.NextArg() {
 			if d.Val() == "private_ranges" {
-				m.Ranges = append(m.Ranges, PrivateRangesCIDR()...)
+				m.Ranges = append(m.Ranges, internal.PrivateRangesCIDR()...)
 				continue
 			}
 			m.Ranges = append(m.Ranges, d.Val())

--- a/modules/caddyhttp/ip_matchers.go
+++ b/modules/caddyhttp/ip_matchers.go
@@ -250,7 +250,9 @@ func (m MatchClientIP) Match(r *http.Request) bool {
 func provisionCidrsZonesFromRanges(ranges []string) ([]*netip.Prefix, []string, error) {
 	cidrs := []*netip.Prefix{}
 	zones := []string{}
+	repl := caddy.NewReplacer()
 	for _, str := range ranges {
+		str = repl.ReplaceAll(str, "")
 		// Exclude the zone_id from the IP
 		if strings.Contains(str, "%") {
 			split := strings.Split(str, "%")

--- a/modules/caddyhttp/ip_range.go
+++ b/modules/caddyhttp/ip_range.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/internal"
 )
 
 func init() {
@@ -92,7 +93,7 @@ func (m *StaticIPRange) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	}
 	for d.NextArg() {
 		if d.Val() == "private_ranges" {
-			m.Ranges = append(m.Ranges, PrivateRangesCIDR()...)
+			m.Ranges = append(m.Ranges, internal.PrivateRangesCIDR()...)
 			continue
 		}
 		m.Ranges = append(m.Ranges, d.Val())
@@ -119,19 +120,6 @@ func CIDRExpressionToPrefix(expr string) (netip.Prefix, error) {
 	}
 	prefix := netip.PrefixFrom(parsed, parsed.BitLen())
 	return prefix, nil
-}
-
-// PrivateRangesCIDR returns a list of private CIDR range
-// strings, which can be used as a configuration shortcut.
-func PrivateRangesCIDR() []string {
-	return []string{
-		"192.168.0.0/16",
-		"172.16.0.0/12",
-		"10.0.0.0/8",
-		"127.0.0.1/8",
-		"fd00::/8",
-		"::1",
-	}
 }
 
 // Interface guards

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -28,6 +28,7 @@ import (
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
+	"github.com/caddyserver/caddy/v2/internal"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/headers"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/rewrite"
@@ -688,7 +689,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		case "trusted_proxies":
 			for d.NextArg() {
 				if d.Val() == "private_ranges" {
-					h.TrustedProxies = append(h.TrustedProxies, caddyhttp.PrivateRangesCIDR()...)
+					h.TrustedProxies = append(h.TrustedProxies, internal.PrivateRangesCIDR()...)
 					continue
 				}
 				h.TrustedProxies = append(h.TrustedProxies, d.Val())

--- a/modules/caddytls/matchers.go
+++ b/modules/caddytls/matchers.go
@@ -107,16 +107,19 @@ func (MatchRemoteIP) CaddyModule() caddy.ModuleInfo {
 
 // Provision parses m's IP ranges, either from IP or CIDR expressions.
 func (m *MatchRemoteIP) Provision(ctx caddy.Context) error {
+	repl := caddy.NewReplacer()
 	m.logger = ctx.Logger()
 	for _, str := range m.Ranges {
-		cidrs, err := m.parseIPRange(str)
+		rs := repl.ReplaceAll(str, "")
+		cidrs, err := m.parseIPRange(rs)
 		if err != nil {
 			return err
 		}
 		m.cidrs = append(m.cidrs, cidrs...)
 	}
 	for _, str := range m.NotRanges {
-		cidrs, err := m.parseIPRange(str)
+		rs := repl.ReplaceAll(str, "")
+		cidrs, err := m.parseIPRange(rs)
 		if err != nil {
 			return err
 		}
@@ -229,9 +232,11 @@ func (MatchLocalIP) CaddyModule() caddy.ModuleInfo {
 
 // Provision parses m's IP ranges, either from IP or CIDR expressions.
 func (m *MatchLocalIP) Provision(ctx caddy.Context) error {
+	repl := caddy.NewReplacer()
 	m.logger = ctx.Logger()
 	for _, str := range m.Ranges {
-		cidrs, err := m.parseIPRange(str)
+		rs := repl.ReplaceAll(str, "")
+		cidrs, err := m.parseIPRange(rs)
 		if err != nil {
 			return err
 		}

--- a/modules/caddytls/matchers.go
+++ b/modules/caddytls/matchers.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/internal"
 )
 
 func init() {
@@ -203,7 +204,7 @@ func (m *MatchRemoteIP) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			}
 			ranges := []string{val}
 			if val == "private_ranges" {
-				ranges = PrivateRangesCIDR()
+				ranges = internal.PrivateRangesCIDR()
 			}
 			if exclamation {
 				m.NotRanges = append(m.NotRanges, ranges...)
@@ -312,7 +313,7 @@ func (m *MatchLocalIP) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		for d.NextArg() {
 			val := d.Val()
 			if val == "private_ranges" {
-				m.Ranges = append(m.Ranges, PrivateRangesCIDR()...)
+				m.Ranges = append(m.Ranges, internal.PrivateRangesCIDR()...)
 				continue
 			}
 			m.Ranges = append(m.Ranges, val)
@@ -339,17 +340,3 @@ var (
 	_ caddyfile.Unmarshaler = (*MatchRemoteIP)(nil)
 	_ caddyfile.Unmarshaler = (*MatchServerName)(nil)
 )
-
-// PrivateRangesCIDR returns a list of private CIDR range
-// strings, which can be used as a configuration shortcut.
-// Copied from caddyhttp/ip_range.go due to an import cycle.
-func PrivateRangesCIDR() []string {
-	return []string{
-		"192.168.0.0/16",
-		"172.16.0.0/12",
-		"10.0.0.0/8",
-		"127.0.0.1/8",
-		"fd00::/8",
-		"::1",
-	}
-}


### PR DESCRIPTION
This PR follows https://github.com/mholt/caddy-l4/pull/224 and deals with the following mainline matchers only:
- caddytls.MatchLocalIP
- caddytls.MatchRemoteIP
- caddytls.MatchServerName
- caddyhttp.MatchClientIP
- caddyhttp.MatchRemoteIP

These changes allow to use runtime placeholders with TLS and HTTP IP matchers, e.g. `remote_ip {env.VAR}`. Such placeholders, if present, are evaluated **once at provision** due to the existing optimisations.

In addition, this PR adds runtime placeholders support for TLS SNI matcher, e.g. `sni {env.VAR}`. Contrary to the above, such placeholders are evaluated **each time at match**.