### PR TITLE
fastcgi: use client IP for REMOTE_ADDR

### DIFF
--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -211,18 +211,11 @@ func (t Transport) buildEnv(r *http.Request) (envVars, error) {
 
 	var env envVars
 
-	// Separate remote IP and port; more lenient than net.SplitHostPort
-	var ip, port string
-	if idx := strings.LastIndex(r.RemoteAddr, ":"); idx > -1 {
-		ip = r.RemoteAddr[:idx]
-		port = r.RemoteAddr[idx+1:]
-	} else {
-		ip = r.RemoteAddr
+	ip := caddyhttp.GetVar(r.Context(), caddyhttp.ClientIPVarKey).(string)
+	_, port, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		port = ""
 	}
-
-	// Remove [] from IPv6 addresses
-	ip = strings.Replace(ip, "[", "", 1)
-	ip = strings.Replace(ip, "]", "", 1)
 
 	// make sure file root is absolute
 	root, err := filepath.Abs(repl.ReplaceAll(t.Root, "."))


### PR DESCRIPTION
The remote port is still used for REMOTE_PORT. I believe this matches the normal/desired behavior when using PHP with nginx realip / apache remoteip (which is provided by caddy client_ip_headers/trusted_proxies). It allows better compatibility with most PHP applications that expect the client IP in REMOTE_ADDR. Tested working with php fastcgi.