### PR TITLE
core: add `iface` as network type

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,51 @@
+package caddy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+)
+
+func init() {
+	RegisterNetwork("iface", getInterfaceListener)
+	RegisterNetwork("iface+tcp", getInterfaceListener)
+	RegisterNetwork("iface+udp", getInterfaceListener)
+}
+
+func getInterfaceListener(ctx context.Context, network, addr string, config net.ListenConfig) (any, error) {
+	// assuming addr = "interface+family:port"
+	// if family is missing, then assume tcp
+	family := "tcp"
+	parts := strings.Split(network, "+")
+	if len(parts) == 2 {
+		family = parts[1]
+	}
+	host, port, _ := net.SplitHostPort(addr)
+	iface, err := net.InterfaceByName(host)
+	if err != nil {
+		return nil, fmt.Errorf("interface %s not found", addr)
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil, fmt.Errorf("error on obtaining interface %s addresses: %s", iface.Name, err)
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("interface %s has no addresses", iface.Name)
+	}
+	for _, addr := range addrs {
+		if face, ok := addr.(*net.IPNet); ok {
+			if ip4 := face.IP.To4(); ip4 != nil {
+				switch family {
+				case "tcp":
+					return net.Listen(family, net.JoinHostPort(ip4.String(), port))
+				case "udp":
+					return net.ListenPacket(family, net.JoinHostPort(ip4.String(), port))
+				default:
+					return net.Listen(family, net.JoinHostPort(ip4.String(), port))
+				}
+			}
+		}
+	}
+	return nil, fmt.Errorf("interface %s has no IPv4 addresses", iface.Name)
+}

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -40,6 +40,10 @@ import (
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
 )
 
+func init() {
+	RegisterNetworkHTTP3("iface", "iface+udp")
+}
+
 // Server describes an HTTP server.
 type Server struct {
 	// Socket addresses to which to bind listeners. Accepts


### PR DESCRIPTION
This PR allows using the interface name as the network address host when using the `iface+?{udp,tcp}` network. In other words, user will be able to say:

```
example.com {
    bind iface/eth0
    respond "What's up, Doc?"
}
```

Because an interface may have multiple IPv6 addresses, and I can't come up with a clean up to communicate this using the host part without it being hairy, I limited this to picking up only the IPv4 address of the defined interface.

I tried at first using the format, e.g. `iface/en0+tcp`, for the protocol selection, but the HTTP3 listener is created by looking up a custom registered network, then using that network to lookup its listener constructor. This makes registering a custom network for UDP the only possible approach to hook our constructor, i.e. doing `iface+udp` et al.

I'd classify this highly experimental. It's extremely limited for only supporting IPv4 addresses. I don't foresee any possibility of adding IPv6 support without it being convolute and painful. Do we really want this?