### PR TITLE
Fix a regression in #6480: the context may have no replacer

### DIFF
--- a/modules/caddytls/matchers.go
+++ b/modules/caddytls/matchers.go
@@ -50,12 +50,13 @@ func (MatchServerName) CaddyModule() caddy.ModuleInfo {
 
 // Match matches hello based on SNI.
 func (m MatchServerName) Match(hello *tls.ClientHelloInfo) bool {
+	repl := caddy.NewReplacer()
 	// caddytls.TestServerNameMatcher calls this function without any context
-	var repl *caddy.Replacer
 	if ctx := hello.Context(); ctx != nil {
-		repl = ctx.Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
-	} else {
-		repl = caddy.NewReplacer()
+		// In some situations the existing context may have no replacer
+		if replAny := ctx.Value(caddy.ReplacerCtxKey); replAny != nil {
+			repl = replAny.(*caddy.Replacer)
+		}
 	}
 
 	for _, name := range m {


### PR DESCRIPTION
As found by @mohammed90, TestDefaultSNI fails after #6480. I've looked into the issue and found the context has no replacer in this test for some reason. This PR makes the test pass.