### PR TITLE
tls: replace only known placeholders in sni matcher

### DIFF
--- a/modules/caddytls/matchers.go
+++ b/modules/caddytls/matchers.go
@@ -60,7 +60,7 @@ func (m MatchServerName) Match(hello *tls.ClientHelloInfo) bool {
 	}
 
 	for _, name := range m {
-		rs := repl.ReplaceAll(name, "")
+		rs := repl.ReplaceKnown(name, "")
 		if certmagic.MatchWildcard(hello.ServerName, rs) {
 			return true
 		}


### PR DESCRIPTION
The fix from #6510 revealed another bug in the application of replacer.