### PR TITLE
caddyhttp: Export PrivateRangesCIDR() for plugins after #6480

### DIFF
--- a/modules/caddyhttp/ip_range.go
+++ b/modules/caddyhttp/ip_range.go
@@ -128,3 +128,10 @@ var (
 	_ caddyfile.Unmarshaler = (*StaticIPRange)(nil)
 	_ IPRangeSource         = (*StaticIPRange)(nil)
 )
+
+// PrivateRangesCIDR returns a list of private CIDR range
+// strings, which can be used as a configuration shortcut.
+// Note: this function is used at least by mholt/caddy-l4.
+func PrivateRangesCIDR() []string {
+	return internal.PrivateRangesCIDR()
+}


### PR DESCRIPTION
As discussed in https://github.com/mholt/caddy-l4/pull/224, let's move PrivateRangesCIDR() back to caddyhttp and caddytls after #6480.