### PR TITLE
ci: don't exit early on error in remote CI machine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Run Tests
         run: |
+          set +e
           mkdir -p ~/.ssh && echo -e "${SSH_KEY//_/\\n}" > ~/.ssh/id_ecdsa && chmod og-rwx ~/.ssh/id_ecdsa
 
           # short sha is enough?


### PR DESCRIPTION
GitHub Actions shell scripts are loaded with `set -e`, which tells the shell to exit at any error. The impact on our flow is missing the deletion step of the code for every failed CI run on the remote machine. This PR fixes it so No Files Left Behind.