### PR TITLE
reverseproxy: Active health checks request body option

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_health_reqbody.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_health_reqbody.caddyfiletest
@@ -1,0 +1,40 @@
+:8884
+
+reverse_proxy 127.0.0.1:65535 {
+	health_uri /health
+	health_request_body "test body"
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8884"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "reverse_proxy",
+									"health_checks": {
+										"active": {
+											"body": "test body",
+											"uri": "/health"
+										}
+									},
+									"upstreams": [
+										{
+											"dial": "127.0.0.1:65535"
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -69,19 +69,20 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 //	    lb_retry_match <request-matcher>
 //
 //	    # active health checking
-//	    health_uri      <uri>
-//	    health_port     <port>
-//	    health_interval <interval>
-//	    health_passes   <num>
-//	    health_fails    <num>
-//	    health_timeout  <duration>
-//	    health_status   <status>
-//	    health_body     <regexp>
+//	    health_uri          <uri>
+//	    health_port         <port>
+//	    health_interval     <interval>
+//	    health_passes       <num>
+//	    health_fails        <num>
+//	    health_timeout      <duration>
+//	    health_status       <status>
+//	    health_body         <regexp>
+//	    health_method       <value>
+//	    health_request_body <value>
 //	    health_follow_redirects
 //	    health_headers {
 //	        <field> [<values...>]
 //	    }
-//	    health_method   <value>
 //
 //	    # passive health checking
 //	    fail_duration     <duration>
@@ -424,6 +425,18 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				h.HealthChecks.Active = new(ActiveHealthChecks)
 			}
 			h.HealthChecks.Active.Method = d.Val()
+
+		case "health_request_body":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			if h.HealthChecks == nil {
+				h.HealthChecks = new(HealthChecks)
+			}
+			if h.HealthChecks.Active == nil {
+				h.HealthChecks.Active = new(ActiveHealthChecks)
+			}
+			h.HealthChecks.Active.Body = d.Val()
 
 		case "health_interval":
 			if !d.NextArg() {

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -400,10 +400,14 @@ func (h *Handler) doActiveHealthCheck(dialInfo DialInfo, hostAddr string, networ
 		u.Path = h.HealthChecks.Active.Path
 	}
 
+	// replacer used for both body and headers. Only globals (env vars, system info, etc.) are available
+	repl := caddy.NewReplacer()
+
 	// if body is provided, create a reader for it, otherwise nil
 	var requestBody io.Reader
 	if h.HealthChecks.Active.Body != "" {
-		requestBody = strings.NewReader(h.HealthChecks.Active.Body)
+		// set body, using replacer
+		requestBody = strings.NewReader(repl.ReplaceAll(h.HealthChecks.Active.Body, ""))
 	}
 
 	// attach dialing information to this request, as well as context values that
@@ -420,8 +424,7 @@ func (h *Handler) doActiveHealthCheck(dialInfo DialInfo, hostAddr string, networ
 	ctx = context.WithValue(ctx, caddyhttp.OriginalRequestCtxKey, *req)
 	req = req.WithContext(ctx)
 
-	// set headers, using a replacer with only globals (env vars, system info, etc.)
-	repl := caddy.NewReplacer()
+	// set headers, using replacer
 	repl.Set("http.reverse_proxy.active.target_upstream", networkAddr)
 	for key, vals := range h.HealthChecks.Active.Headers {
 		key = repl.ReplaceAll(key, "")


### PR DESCRIPTION
## Changes

Added the field `Body` to the `ActiveHealthChecks` struct, which optionally sets the body of the request used for the health check requests.

Also added `Caddyfile` support for the same option under the name `health_request_body`. 

## Rational

After adding the option to setting the HTTP method used for active health checks it turns out it's also helpful to set the body. Eg when using the POST method on a JSON RPC service with an empty body may return a `400 Bad Request`, instead of a `200 OK`. Being able to set the body to a valid NOOP RPC call enables a "deeper" health check, than just accepting the 400 status.