### PR TITLE
chore: build and test with Go 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,12 @@ jobs:
           - mac
           - windows
         go: 
-          - '1.21'
           - '1.22'
           - '1.23'
 
         include:
         # Set the minimum Go patch version for the given Go minor
         # Usable via ${{ matrix.GO_SEMVER }}
-        - go: '1.21'
-          GO_SEMVER: '~1.21.0'
-
         - go: '1.22'
           GO_SEMVER: '~1.22.3'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         go: 
           - '1.21'
           - '1.22'
+          - '1.23'
 
         include:
         # Set the minimum Go patch version for the given Go minor
@@ -34,6 +35,9 @@ jobs:
 
         - go: '1.22'
           GO_SEMVER: '~1.22.3'
+
+        - go: '1.23'
+          GO_SEMVER: '~1.23.0'
 
         # Set some variables per OS, usable via ${{ matrix.VAR }}
         # OS_LABEL: the VM label from GitHub Actions (see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)

--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -28,12 +28,16 @@ jobs:
           - 'netbsd'
         go: 
           - '1.22'
+          - '1.23'
 
         include:
         # Set the minimum Go patch version for the given Go minor
         # Usable via ${{ matrix.GO_SEMVER }}
         - go: '1.22'
           GO_SEMVER: '~1.22.3'
+
+        - go: '1.23'
+          GO_SEMVER: '~1.23.0'
 
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.55
+          version: v1.60
 
           # Windows times out frequently after about 5m50s if we don't set a longer timeout.
           args: --timeout 10m

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.22.3'
+          go-version: '~1.23'
           check-latest: true
 
       - name: golangci-lint
@@ -63,5 +63,5 @@ jobs:
       - name: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: '~1.22.3'
+          go-version-input: '~1.23.0'
           check-latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,13 @@ jobs:
         os: 
           - ubuntu-latest
         go: 
-          - '1.22'
+          - '1.23'
 
         include:
         # Set the minimum Go patch version for the given Go minor
         # Usable via ${{ matrix.GO_SEMVER }}
-        - go: '1.22'
-          GO_SEMVER: '~1.22.3'
+        - go: '1.23'
+          GO_SEMVER: '~1.23.0'
 
     runs-on: ${{ matrix.os }}
     # https://github.com/sigstore/cosign/issues/1258#issuecomment-1002251233

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ See [our online documentation](https://caddyserver.com/docs/install) for other i
 
 Requirements:
 
-- [Go 1.21 or newer](https://golang.org/dl/)
+- [Go 1.22.3 or newer](https://golang.org/dl/)
 
 ### For development
 

--- a/caddyconfig/caddyfile/dispenser.go
+++ b/caddyconfig/caddyfile/dispenser.go
@@ -415,7 +415,7 @@ func (d *Dispenser) EOFErr() error {
 
 // Err generates a custom parse-time error with a message of msg.
 func (d *Dispenser) Err(msg string) error {
-	return d.Errf(msg)
+	return d.WrapErr(errors.New(msg))
 }
 
 // Errf is like Err, but for formatted error messages

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/caddyserver/caddy/v2
 
 go 1.21.0
 
-toolchain go1.22.2
+toolchain go1.23.0
 
 require (
 	github.com/BurntSushi/toml v1.3.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/caddyserver/caddy/v2
 
-go 1.21.0
+go 1.22.3
 
 toolchain go1.23.0
 

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -340,7 +340,7 @@ func (celTypeAdapter) NativeToValue(value any) ref.Val {
 	case time.Time:
 		return types.Timestamp{Time: v}
 	case error:
-		types.NewErr(v.Error())
+		return types.WrapErr(v)
 	}
 	return types.DefaultTypeAdapter.NativeToValue(value)
 }
@@ -499,7 +499,7 @@ func CELMatcherRuntimeFunction(funcName string, fac CELMatcherFactory) functions
 	return func(celReq, matcherData ref.Val) ref.Val {
 		matcher, err := fac(matcherData)
 		if err != nil {
-			return types.NewErr(err.Error())
+			return types.WrapErr(err)
 		}
 		httpReq := celReq.Value().(celHTTPRequest)
 		return types.Bool(matcher.Match(httpReq.Request))


### PR DESCRIPTION
Adds [Go 1.23](https://go.dev/doc/go1.23) to the CI/CD pipeline.
Removes support for Go 1.21, which isn't maintained anymore.
Bumps golangci-lint to v1.60 (needed for Go 1.23) and fixes newly discovered errors.