### PR TITLE
reverseproxy: Change logs for write errors to warn level

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -979,7 +979,7 @@ func (h *Handler) finalizeResponse(
 		// we'll just log the error and abort the stream here and panic just as
 		// the standard lib's proxy to propagate the stream error.
 		// see issue https://github.com/caddyserver/caddy/issues/5951
-		logger.Error("aborting with incomplete response", zap.Error(err))
+		logger.Warn("aborting with incomplete response", zap.Error(err))
 		// no extra logging from stdlib
 		panic(http.ErrAbortHandler)
 	}


### PR DESCRIPTION
Most of the errors that can be seen here are write errors due to clients aborting the request from their side. Often seen ones include:

	* writing: ... write: broken pipe
	* writing: ... connection timed out
	* writing: http2: stream closed
	* writing: timeout...
	* writing: h3 error...

Most of these errors are beyond of the control of caddy on the client side, probably nothing can be done on the server side. It still warrants researching when these errors occur very often, so a change in level from error to warn is better here to not polute the logs with errors in the normal case.