### PR TITLE
error: run `error` (msg) through replacer

### DIFF
--- a/caddytest/caddytest_test.go
+++ b/caddytest/caddytest_test.go
@@ -84,7 +84,6 @@ func TestLoadUnorderedJSON(t *testing.T) {
 				"servers": {
 					"s_server": {
 						"listen": [
-							":9443",
 							":9080"
 						],
 						"routes": [

--- a/modules/caddyhttp/staticerror.go
+++ b/modules/caddyhttp/staticerror.go
@@ -105,8 +105,7 @@ func (e StaticError) ServeHTTP(w http.ResponseWriter, r *http.Request, _ Handler
 		}
 		statusCode = intVal
 	}
-
-	return Error(statusCode, fmt.Errorf("%s", e.Error))
+	return Error(statusCode, fmt.Errorf("%s", repl.ReplaceKnown(e.Error, "")))
 }
 
 // Interface guard


### PR DESCRIPTION
Updates #6527