### PR TITLE
reverse_proxy: add placeholder http.reverse_proxy.retries

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -67,6 +67,7 @@ func init() {
 // `{http.reverse_proxy.upstream.duration_ms}` | Same as 'upstream.duration', but in milliseconds.
 // `{http.reverse_proxy.duration}` | Total time spent proxying, including selecting an upstream, retries, and writing response.
 // `{http.reverse_proxy.duration_ms}` | Same as 'duration', but in milliseconds.
+// `{http.reverse_proxy.lb.retries}` | The number of retries actually performed by the load balancer to communicate with an upstream.
 type Handler struct {
 	// Configures the method of transport for the proxy. A transport
 	// is what performs the actual "round trip" to the backend.
@@ -442,6 +443,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 		}
 		retries++
 	}
+
+	// number of retries actually performed
+	repl.Set("http.reverse_proxy.lb.retries", retries)
 
 	if proxyErr != nil {
 		return statusError(proxyErr)

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -67,7 +67,7 @@ func init() {
 // `{http.reverse_proxy.upstream.duration_ms}` | Same as 'upstream.duration', but in milliseconds.
 // `{http.reverse_proxy.duration}` | Total time spent proxying, including selecting an upstream, retries, and writing response.
 // `{http.reverse_proxy.duration_ms}` | Same as 'duration', but in milliseconds.
-// `{http.reverse_proxy.lb.retries}` | The number of retries actually performed by the load balancer to communicate with an upstream.
+// `{http.reverse_proxy.retries}` | The number of retries actually performed to communicate with an upstream.
 type Handler struct {
 	// Configures the method of transport for the proxy. A transport
 	// is what performs the actual "round trip" to the backend.
@@ -445,7 +445,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 	}
 
 	// number of retries actually performed
-	repl.Set("http.reverse_proxy.lb.retries", retries)
+	repl.Set("http.reverse_proxy.retries", retries)
 
 	if proxyErr != nil {
 		return statusError(proxyErr)


### PR DESCRIPTION
The `reverse_proxy` directive in Caddy already supports a variety of useful placeholders, as documented [here](https://caddyserver.com/docs/json/apps/http/servers/routes/handle/reverse_proxy/#docs)

This pull request proposes the addition of a new placeholder: `{http.reverse_proxy.lb.retries}`. This placeholder tracks the number of retries actually performed by the load balancer to communicate with an upstream. I believe this would be a valuable enhancement, providing more detailed insights into load balancing behavior.

For example, in a Caddyfile, this placeholder might be used with `log_append` like this:

```Caddyfile
:8080 {
	log {
		output file /var/log/access.json
	}

	reverse_proxy {
		to localhost:7070
		to localhost:7071
		to localhost:7072

		health_uri /ping
		health_body pong
		health_interval 15s

		lb_policy random
		lb_try_duration 5s
		lb_try_interval 700ms
	}

	log_append * rp_upstream_host "{http.reverse_proxy.upstream.hostport}"
	log_append * rp_upstream_duration_ms "{http.reverse_proxy.upstream.duration_ms}"
	log_append * rp_upstream_latency_ms "{http.reverse_proxy.upstream.latency_ms}"

	log_append * rp_lb_retries "{http.reverse_proxy.lb.retries}"
}
```