### PR TITLE
rewrite: Avoid panic on bad arg count for `uri`

### DIFF
--- a/modules/caddyhttp/rewrite/caddyfile.go
+++ b/modules/caddyhttp/rewrite/caddyfile.go
@@ -98,7 +98,7 @@ func parseCaddyfileURI(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, err
 	h.Next() // consume directive name
 
 	args := h.RemainingArgs()
-	if len(args) < 1 {
+	if len(args) <= 1 {
 		return nil, h.ArgErr()
 	}
 

--- a/modules/caddyhttp/rewrite/caddyfile.go
+++ b/modules/caddyhttp/rewrite/caddyfile.go
@@ -98,7 +98,7 @@ func parseCaddyfileURI(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, err
 	h.Next() // consume directive name
 
 	args := h.RemainingArgs()
-	if len(args) <= 1 {
+	if len(args) < 1 {
 		return nil, h.ArgErr()
 	}
 
@@ -106,7 +106,7 @@ func parseCaddyfileURI(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, err
 
 	switch args[0] {
 	case "strip_prefix":
-		if len(args) > 2 {
+		if len(args) != 2 {
 			return nil, h.ArgErr()
 		}
 		rewr.StripPathPrefix = args[1]
@@ -115,7 +115,7 @@ func parseCaddyfileURI(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, err
 		}
 
 	case "strip_suffix":
-		if len(args) > 2 {
+		if len(args) != 2 {
 			return nil, h.ArgErr()
 		}
 		rewr.StripPathSuffix = args[1]


### PR DESCRIPTION
All cases for args[0] require additional arguments present in the slice so doing the bounds check here covers all cases. Cases requiring additional parameters already include additional checks on the len(args)