### PR TITLE
caddytls: Give a better error message when given encrypted private keys

### DIFF
--- a/modules/caddytls/folderloader.go
+++ b/modules/caddytls/folderloader.go
@@ -150,6 +150,12 @@ func tlsCertFromCertAndKeyPEMBundle(bundle []byte) (tls.Certificate, error) {
 		return tls.Certificate{}, fmt.Errorf("no private key block found")
 	}
 
+	// if the start of the key file looks like an encrypted private key,
+	// reject it with a helpful error message
+	if strings.HasPrefix(string(keyPEMBytes[:40]), "ENCRYPTED") {
+		return tls.Certificate{}, fmt.Errorf("encrypted private keys are not supported; please decrypt the key first")
+	}
+
 	cert, err := tls.X509KeyPair(certPEMBytes, keyPEMBytes)
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("making X509 key pair: %v", err)


### PR DESCRIPTION
A user recently pointed out that they were misled because they tried to use an encrypted private key, which we don't support (see https://github.com/caddyserver/caddy/issues/4873).

I chose to read the first 40 characters of the PEM to see if it has `ENCRYPTED` to guess whether it was encrypted. I chose 40 because the length of the ASCII armor `-----BEGIN ENCRYPTED PRIVATE KEY-----` is 37, just a rough estimate of the input. I don't know how EC encrypted keys look but I assume it also uses `ENCRYPTED` in the header?

Before this, the error was:

```
Error: loading initial config: loading new config: loading http app module: provision http: getting tls app: loading tls app module: provision tls: loading certificates: tls: failed to parse private key
```

Now:

```
Error: loading initial config: loading new config: loading http app module: provision http: getting tls app: loading tls app module: provision tls: loading certificates: encrypted private keys are not supported; please decrypt the key first
```