### PR TITLE
caddytls: Allow disabling storage cleaning, avoids writing two files

### DIFF
--- a/caddyconfig/httpcaddyfile/options.go
+++ b/caddyconfig/httpcaddyfile/options.go
@@ -39,7 +39,8 @@ func init() {
 	RegisterGlobalOption("fallback_sni", parseOptSingleString)
 	RegisterGlobalOption("order", parseOptOrder)
 	RegisterGlobalOption("storage", parseOptStorage)
-	RegisterGlobalOption("storage_clean_interval", parseOptDuration)
+	RegisterGlobalOption("storage_check", parseStorageCheck)
+	RegisterGlobalOption("storage_clean_interval", parseStorageCleanInterval)
 	RegisterGlobalOption("renew_interval", parseOptDuration)
 	RegisterGlobalOption("ocsp_interval", parseOptDuration)
 	RegisterGlobalOption("acme_ca", parseOptSingleString)
@@ -187,6 +188,40 @@ func parseOptStorage(d *caddyfile.Dispenser, _ any) (any, error) {
 		return nil, d.Errf("module %s is not a caddy.StorageConverter", modID)
 	}
 	return storage, nil
+}
+
+func parseStorageCheck(d *caddyfile.Dispenser, _ any) (any, error) {
+	d.Next() // consume option name
+	if !d.Next() {
+		return "", d.ArgErr()
+	}
+	val := d.Val()
+	if d.Next() {
+		return "", d.ArgErr()
+	}
+	if val != "off" {
+		return "", d.Errf("storage_check must be 'off'")
+	}
+	return val, nil
+}
+
+func parseStorageCleanInterval(d *caddyfile.Dispenser, _ any) (any, error) {
+	d.Next() // consume option name
+	if !d.Next() {
+		return "", d.ArgErr()
+	}
+	val := d.Val()
+	if d.Next() {
+		return "", d.ArgErr()
+	}
+	if val == "off" {
+		return false, nil
+	}
+	dur, err := caddy.ParseDuration(d.Val())
+	if err != nil {
+		return nil, d.Errf("failed to parse storage_clean_interval, must be a duration or 'off' %w", err)
+	}
+	return caddy.Duration(dur), nil
 }
 
 func parseOptDuration(d *caddyfile.Dispenser, _ any) (any, error) {

--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -349,6 +349,16 @@ func (st ServerType) buildTLSApp(
 		tlsApp.Automation.OnDemand = onDemand
 	}
 
+	// if the storage clean interval is a boolean, then it's "off" to disable cleaning
+	if sc, ok := options["storage_check"].(string); ok && sc == "off" {
+		tlsApp.DisableStorageCheck = true
+	}
+
+	// if the storage clean interval is a boolean, then it's "off" to disable cleaning
+	if sci, ok := options["storage_clean_interval"].(bool); ok && !sci {
+		tlsApp.DisableStorageClean = true
+	}
+
 	// set the storage clean interval if configured
 	if storageCleanInterval, ok := options["storage_clean_interval"].(caddy.Duration); ok {
 		if tlsApp.Automation == nil {

--- a/caddytest/integration/caddyfile_adapt/global_options.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/global_options.caddyfiletest
@@ -9,6 +9,8 @@
 	storage file_system {
 		root /data
 	}
+	storage_check off
+	storage_clean_interval off
 	acme_ca https://example.com
 	acme_ca_root /path/to/ca.crt
 	ocsp_stapling off
@@ -73,7 +75,9 @@
 					}
 				}
 			},
-			"disable_ocsp_stapling": true
+			"disable_ocsp_stapling": true,
+			"disable_storage_check": true,
+			"disable_storage_clean": true
 		}
 	}
 }


### PR DESCRIPTION
Some users want to run Caddy in a totally read-only mode, but currently storage cleaning implicitly creates two files `instance.uuid` and `last_clean.json` which are undesirable in that situation. We can simply skip starting the storage cleaning goroutine via a config option.

I noticed `storage_check off` wasn't configurable in the Caddyfile, so I added that too, while I was at it.