### PR TITLE
caddyhttp: Escaping placeholders in CEL, add `vars` and `vars_regexp`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,19 @@ jobs:
           go version
           go env
           printf "\n\n"
-          CGO_ENABLED=0 go test -p 1 -tags nobadger -v ./...
+          retries=3
+          exit_code=0
+          while ((retries > 0)); do
+            CGO_ENABLED=0 go test -p 1 -tags nobadger -v ./...
+            exit_code=$?
+            if ((exit_code == 0)); then
+              break
+            fi
+            echo "\n\nTest failed: \$exit_code, retrying..."
+            ((retries--))
+          done
+          echo "Remote exit code: \$exit_code"
+          exit \$exit_code
           EOF
           test_result=$?
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,13 +156,23 @@ jobs:
           # short sha is enough?
           short_sha=$(git rev-parse --short HEAD)
 
+          # To shorten the following lines
+          ssh_opts="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+          ssh_host="$CI_USER@ci-s390x.caddyserver.com"
+
           # The environment is fresh, so there's no point in keeping accepting and adding the key.
-          rsync -arz -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --progress --delete --exclude '.git' . "$CI_USER"@ci-s390x.caddyserver.com:/var/tmp/"$short_sha"
-          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -t "$CI_USER"@ci-s390x.caddyserver.com "cd /var/tmp/$short_sha; go version; go env; printf "\n\n";CGO_ENABLED=0 go test -p 1 -tags nobadger -v ./..."
+          rsync -arz -e "ssh $ssh_opts" --progress --delete --exclude '.git' . "$ssh_host":/var/tmp/"$short_sha"
+          ssh $ssh_opts -t "$ssh_host" bash <<EOF
+          cd /var/tmp/$short_sha
+          go version
+          go env
+          printf "\n\n"
+          CGO_ENABLED=0 go test -p 1 -tags nobadger -v ./...
+          EOF
           test_result=$?
 
           # There's no need leaving the files around
-          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$CI_USER"@ci-s390x.caddyserver.com "rm -rf /var/tmp/'$short_sha'"
+          ssh $ssh_opts "$ssh_host" "rm -rf /var/tmp/'$short_sha'"
 
           echo "Test exit code: $test_result"
           exit $test_result

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -171,6 +171,12 @@ issues:
     - path: modules/logging/filters.go
       linters:
         - dupl
+    - path: modules/caddyhttp/matchers.go
+      linters:
+        - dupl
+    - path: modules/caddyhttp/vars.go
+      linters:
+        - dupl
     - path: _test\.go
       linters:
         - errcheck

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/caddyserver/zerossl v0.1.3
 	github.com/dustin/go-humanize v1.0.1
 	github.com/go-chi/chi/v5 v5.0.12
-	github.com/google/cel-go v0.20.1
+	github.com/google/cel-go v0.21.0
 	github.com/google/uuid v1.6.0
 	github.com/klauspost/compress v1.17.8
 	github.com/klauspost/cpuid/v2 v2.2.7

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=
 github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
-github.com/google/cel-go v0.20.1 h1:nDx9r8S3L4pE61eDdt8igGj8rf5kjYR3ILxWIpWNi84=
-github.com/google/cel-go v0.20.1/go.mod h1:kWcIzTsPX0zmQ+H3TirHstLLf9ep5QTsZBN9u4dOYLg=
+github.com/google/cel-go v0.21.0 h1:cl6uW/gxN+Hy50tNYvI691+sXxioCnstFzLp2WO4GCI=
+github.com/google/cel-go v0.21.0/go.mod h1:rHUlWCcBKgyEk+eV03RPdZUekPp6YcJwV0FxuUksYxc=
 github.com/google/certificate-transparency-go v1.0.21/go.mod h1:QeJfpSbVSfYc7RgB3gJFj9cbuQMMchQxrWXz8Ruopmg=
 github.com/google/certificate-transparency-go v1.1.8-0.20240110162603-74a5dd331745 h1:heyoXNxkRT155x4jTAiSv5BVSVkueifPUm+Q8LUXMRo=
 github.com/google/certificate-transparency-go v1.1.8-0.20240110162603-74a5dd331745/go.mod h1:zN0wUQgV9LjwLZeFHnrAbQi8hzMVvEWePyk+MhPOk7k=

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -171,6 +171,9 @@ func (m *MatchExpression) Provision(ctx caddy.Context) error {
 		cel.Variable(CELRequestVarName, httpRequestObjectType),
 		cel.CustomTypeAdapter(m.ta),
 		ext.Strings(),
+		ext.Bindings(),
+		ext.Lists(),
+		ext.Math(),
 		matcherLib,
 	)
 	if err != nil {

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -711,7 +711,7 @@ var (
 	// The placeholder may not be preceded by a backslash; the expansion
 	// will include the preceding character if it is not a backslash.
 	placeholderRegexp    = regexp.MustCompile(`([^\\]|^){([a-zA-Z][\w.-]+)}`)
-	placeholderExpansion = `${1}placeholder(req, "${2}")`
+	placeholderExpansion = `${1}ph(req, "${2}")`
 
 	// As a second pass, we need to strip the escape character in front of
 	// the placeholder, if it exists.
@@ -724,7 +724,7 @@ var (
 var httpRequestObjectType = cel.ObjectType("http.Request")
 
 // The name of the CEL function which accesses Replacer values.
-const CELPlaceholderFuncName = "placeholder"
+const CELPlaceholderFuncName = "ph"
 
 // The name of the CEL request variable.
 const CELRequestVarName = "req"

--- a/modules/caddyhttp/celmatcher_test.go
+++ b/modules/caddyhttp/celmatcher_test.go
@@ -70,6 +70,24 @@ eqp31wM9il1n+guTNyxJd+FzVAH+hCZE5K+tCgVDdVFUlDEHHbS/wqb2PSIoouLV
 			wantResult: true,
 		},
 		{
+			name: "header matches an escaped placeholder value (MatchHeader)",
+			expression: &MatchExpression{
+				Expr: `header({'Field': '\\\{foobar}'})`,
+			},
+			urlTarget:  "https://example.com/foo",
+			httpHeader: &http.Header{"Field": []string{"{foobar}"}},
+			wantResult: true,
+		},
+		{
+			name: "header matches an placeholder replaced during the header matcher (MatchHeader)",
+			expression: &MatchExpression{
+				Expr: `header({'Field': '\{http.request.uri.path}'})`,
+			},
+			urlTarget:  "https://example.com/foo",
+			httpHeader: &http.Header{"Field": []string{"/foo"}},
+			wantResult: true,
+		},
+		{
 			name: "header error (MatchHeader)",
 			expression: &MatchExpression{
 				Expr: `header('foo')`,

--- a/modules/caddyhttp/celmatcher_test.go
+++ b/modules/caddyhttp/celmatcher_test.go
@@ -88,13 +88,18 @@ eqp31wM9il1n+guTNyxJd+FzVAH+hCZE5K+tCgVDdVFUlDEHHbS/wqb2PSIoouLV
 			wantResult: true,
 		},
 		{
-			name: "header error (MatchHeader)",
+			name: "header error, invalid escape sequence (MatchHeader)",
+			expression: &MatchExpression{
+				Expr: `header({'Field': '\\{foobar}'})`,
+			},
+			wantErr: true,
+		},
+		{
+			name: "header error, needs to be JSON syntax with field as key (MatchHeader)",
 			expression: &MatchExpression{
 				Expr: `header('foo')`,
 			},
-			urlTarget:  "https://example.com/foo",
-			httpHeader: &http.Header{"Field": []string{"foo", "bar"}},
-			wantErr:    true,
+			wantErr: true,
 		},
 		{
 			name: "header_regexp matches (MatchHeaderRE)",
@@ -128,9 +133,7 @@ eqp31wM9il1n+guTNyxJd+FzVAH+hCZE5K+tCgVDdVFUlDEHHbS/wqb2PSIoouLV
 			expression: &MatchExpression{
 				Expr: `header_regexp('foo')`,
 			},
-			urlTarget:  "https://example.com/foo",
-			httpHeader: &http.Header{"Field": []string{"foo", "bar"}},
-			wantErr:    true,
+			wantErr: true,
 		},
 		{
 			name: "host matches localhost (MatchHost)",
@@ -161,8 +164,7 @@ eqp31wM9il1n+guTNyxJd+FzVAH+hCZE5K+tCgVDdVFUlDEHHbS/wqb2PSIoouLV
 			expression: &MatchExpression{
 				Expr: `host(80)`,
 			},
-			urlTarget: "http://localhost:80",
-			wantErr:   true,
+			wantErr: true,
 		},
 		{
 			name: "method does not match (MatchMethod)",
@@ -187,9 +189,7 @@ eqp31wM9il1n+guTNyxJd+FzVAH+hCZE5K+tCgVDdVFUlDEHHbS/wqb2PSIoouLV
 			expression: &MatchExpression{
 				Expr: `method()`,
 			},
-			urlTarget:  "https://foo.example.com",
-			httpMethod: "PUT",
-			wantErr:    true,
+			wantErr: true,
 		},
 		{
 			name: "path matches substring (MatchPath)",
@@ -284,24 +284,21 @@ eqp31wM9il1n+guTNyxJd+FzVAH+hCZE5K+tCgVDdVFUlDEHHbS/wqb2PSIoouLV
 			expression: &MatchExpression{
 				Expr: `protocol()`,
 			},
-			urlTarget: "https://example.com",
-			wantErr:   true,
+			wantErr: true,
 		},
 		{
 			name: "protocol invocation error too many args (MatchProtocol)",
 			expression: &MatchExpression{
 				Expr: `protocol('grpc', 'https')`,
 			},
-			urlTarget: "https://example.com",
-			wantErr:   true,
+			wantErr: true,
 		},
 		{
 			name: "protocol invocation error wrong arg type (MatchProtocol)",
 			expression: &MatchExpression{
 				Expr: `protocol(true)`,
 			},
-			urlTarget: "https://example.com",
-			wantErr:   true,
+			wantErr: true,
 		},
 		{
 			name: "query does not match against a specific value (MatchQuery)",
@@ -348,40 +345,35 @@ eqp31wM9il1n+guTNyxJd+FzVAH+hCZE5K+tCgVDdVFUlDEHHbS/wqb2PSIoouLV
 			expression: &MatchExpression{
 				Expr: `query({1: "1"})`,
 			},
-			urlTarget: "https://example.com/foo",
-			wantErr:   true,
+			wantErr: true,
 		},
 		{
 			name: "query error typed struct instead of map (MatchQuery)",
 			expression: &MatchExpression{
 				Expr: `query(Message{field: "1"})`,
 			},
-			urlTarget: "https://example.com/foo",
-			wantErr:   true,
+			wantErr: true,
 		},
 		{
 			name: "query error bad map value type (MatchQuery)",
 			expression: &MatchExpression{
 				Expr: `query({"debug": 1})`,
 			},
-			urlTarget: "https://example.com/foo/?debug=1",
-			wantErr:   true,
+			wantErr: true,
 		},
 		{
 			name: "query error no args (MatchQuery)",
 			expression: &MatchExpression{
 				Expr: `query()`,
 			},
-			urlTarget: "https://example.com/foo/?debug=1",
-			wantErr:   true,
+			wantErr: true,
 		},
 		{
 			name: "remote_ip error no args (MatchRemoteIP)",
 			expression: &MatchExpression{
 				Expr: `remote_ip()`,
 			},
-			urlTarget: "https://example.com/foo",
-			wantErr:   true,
+			wantErr: true,
 		},
 		{
 			name: "remote_ip single IP match (MatchRemoteIP)",

--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -225,7 +225,7 @@ func celFileMatcherMacroExpander() parser.MacroExpander {
 	return func(eh parser.ExprHelper, target ast.Expr, args []ast.Expr) (ast.Expr, *common.Error) {
 		if len(args) == 0 {
 			return eh.NewCall("file",
-				eh.NewIdent("request"),
+				eh.NewIdent(caddyhttp.CELRequestVarName),
 				eh.NewMap(),
 			), nil
 		}
@@ -233,7 +233,7 @@ func celFileMatcherMacroExpander() parser.MacroExpander {
 			arg := args[0]
 			if isCELStringLiteral(arg) || isCELCaddyPlaceholderCall(arg) {
 				return eh.NewCall("file",
-					eh.NewIdent("request"),
+					eh.NewIdent(caddyhttp.CELRequestVarName),
 					eh.NewMap(eh.NewMapEntry(
 						eh.NewLiteral(types.String("try_files")),
 						eh.NewList(arg),
@@ -242,7 +242,7 @@ func celFileMatcherMacroExpander() parser.MacroExpander {
 				), nil
 			}
 			if isCELTryFilesLiteral(arg) {
-				return eh.NewCall("file", eh.NewIdent("request"), arg), nil
+				return eh.NewCall("file", eh.NewIdent(caddyhttp.CELRequestVarName), arg), nil
 			}
 			return nil, &common.Error{
 				Location: eh.OffsetLocation(arg.ID()),
@@ -259,7 +259,7 @@ func celFileMatcherMacroExpander() parser.MacroExpander {
 			}
 		}
 		return eh.NewCall("file",
-			eh.NewIdent("request"),
+			eh.NewIdent(caddyhttp.CELRequestVarName),
 			eh.NewMap(eh.NewMapEntry(
 				eh.NewLiteral(types.String("try_files")),
 				eh.NewList(args...),
@@ -634,7 +634,7 @@ func isCELCaddyPlaceholderCall(e ast.Expr) bool {
 	switch e.Kind() {
 	case ast.CallKind:
 		call := e.AsCall()
-		if call.FunctionName() == "caddyPlaceholder" {
+		if call.FunctionName() == caddyhttp.CELPlaceholderFuncName {
 			return true
 		}
 	case ast.UnspecifiedExprKind, ast.ComprehensionKind, ast.IdentKind, ast.ListKind, ast.LiteralKind, ast.MapKind, ast.SelectKind, ast.StructKind:

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -1562,8 +1562,8 @@ var (
 	_ CELLibraryProducer = (*MatchHeader)(nil)
 	_ CELLibraryProducer = (*MatchHeaderRE)(nil)
 	_ CELLibraryProducer = (*MatchProtocol)(nil)
-	// _ CELLibraryProducer = (*VarsMatcher)(nil)
-	// _ CELLibraryProducer = (*MatchVarsRE)(nil)
+	_ CELLibraryProducer = (*VarsMatcher)(nil)
+	_ CELLibraryProducer = (*MatchVarsRE)(nil)
 
 	_ json.Marshaler   = (*MatchNot)(nil)
 	_ json.Unmarshaler = (*MatchNot)(nil)

--- a/modules/caddyhttp/templates/templates.go
+++ b/modules/caddyhttp/templates/templates.go
@@ -81,6 +81,12 @@ func init() {
 // {{placeholder "http.error.status_code"}}
 // ```
 //
+// As a shortcut, `ph` is an alias for `placeholder`.
+//
+// ```
+// {{ph "http.request.method"}}
+// ```
+//
 // ##### `.Host`
 //
 // Returns the hostname portion (no port) of the Host header of the HTTP request.

--- a/modules/caddyhttp/templates/tplcontext.go
+++ b/modules/caddyhttp/templates/tplcontext.go
@@ -88,6 +88,7 @@ func (c *TemplateContext) NewTemplate(tplName string) *template.Template {
 		"fileStat":         c.funcFileStat,
 		"env":              c.funcEnv,
 		"placeholder":      c.funcPlaceholder,
+		"ph":               c.funcPlaceholder, // shortcut
 		"fileExists":       c.funcFileExists,
 		"httpError":        c.funcHTTPError,
 		"humanize":         c.funcHumanize,


### PR DESCRIPTION
Related to https://github.com/caddyserver/caddy/issues/6584, prior work in https://github.com/caddyserver/caddy/pull/4715#issuecomment-1163585563

Our current CEL placeholder regexp is too naive. It replaces everything that looks like a placeholder, and offers no good option to opt out if a literal placeholder-looking input is given to some CEL functions as input.

To solve this, we can do the placeholder replacement in two steps.
- First, we match whether the placeholder _is not_ preceded by a `\` (or start of a line) and replace it and preserving the preceding character which is matched (we now have two capture groups so `${1}` has to go to the start)
- Second, we match for a placeholder which _does_ have a preceding `\`, and drop the `\`.

That gives a way to escape through the `caddyPlaceholder()` replacement and get an input directly to the given matcher.

One interesting quirk: CEL itself has its own `\\` escape sequence, so depending on whether we want the placeholder to be replaced by the matcher (e.g. `header` matcher does do placeholder replacements on its inputs at runtime) or we want the value to be raw determines how many backslashes we need. The test shows this pretty well I think:
- If the `header` matcher should take the value as-is and not perform placeholder replacement (because the match value is also placeholder-like), then we need _three_ backslashes, like `\\\{foobar}`. This is because the last one of the three is for escaping `caddyPlaceholder()`, then the prior two are collapsed into one by CEL's parsing itself, then the last one is to escape the placeholder replacer, and the result is a clean `{foobar}` matching value.
- If the `header` matcher itself should perform placeholder replacement (not done in the CEL matcher, but deeper in the matcher itself) then a single backslash is used, like `\{http.request.uri.path}` (or `\{path}` in the Caddyfile). This only escapes past the `caddyPlaceholder()` regexp, but does not escape past the placeholder replacer which runs inside `header`.

We'll need to document this, but it's tricky :sweat_smile: 

After doing the above, I decided to also implement `vars` and `vars_regexp` support in CEL, which we skipped implementing because of the above placeholder limitations.