### PR TITLE
caddyhttp: Add `MatchWithError` to replace SetVar hack

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -1532,6 +1532,7 @@ func parseMatcherDefinitions(d *caddyfile.Dispenser, matchers map[string]caddy.M
 			matchers[definitionName][matcherName] = caddyconfig.JSON(rm, nil)
 			return nil
 		}
+		// nolint:staticcheck
 		if rm, ok := unm.(caddyhttp.RequestMatcher); ok {
 			matchers[definitionName][matcherName] = caddyconfig.JSON(rm, nil)
 			return nil

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -1466,9 +1466,9 @@ func (st *ServerType) compileEncodedMatcherSets(sblock serverBlock) ([]caddy.Mod
 
 	// iterate each pairing of host and path matchers and
 	// put them into a map for JSON encoding
-	var matcherSets []map[string]caddyhttp.RequestMatcher
+	var matcherSets []map[string]caddyhttp.RequestMatcherWithError
 	for _, mp := range matcherPairs {
-		matcherSet := make(map[string]caddyhttp.RequestMatcher)
+		matcherSet := make(map[string]caddyhttp.RequestMatcherWithError)
 		if len(mp.hostm) > 0 {
 			matcherSet["host"] = mp.hostm
 		}
@@ -1527,12 +1527,16 @@ func parseMatcherDefinitions(d *caddyfile.Dispenser, matchers map[string]caddy.M
 		if err != nil {
 			return err
 		}
-		rm, ok := unm.(caddyhttp.RequestMatcher)
-		if !ok {
-			return fmt.Errorf("matcher module '%s' is not a request matcher", matcherName)
+
+		if rm, ok := unm.(caddyhttp.RequestMatcherWithError); ok {
+			matchers[definitionName][matcherName] = caddyconfig.JSON(rm, nil)
+			return nil
 		}
-		matchers[definitionName][matcherName] = caddyconfig.JSON(rm, nil)
-		return nil
+		if rm, ok := unm.(caddyhttp.RequestMatcher); ok {
+			matchers[definitionName][matcherName] = caddyconfig.JSON(rm, nil)
+			return nil
+		}
+		return fmt.Errorf("matcher module '%s' is not a request matcher", matcherName)
 	}
 
 	// if the next token is quoted, we can assume it's not a matcher name
@@ -1576,7 +1580,7 @@ func parseMatcherDefinitions(d *caddyfile.Dispenser, matchers map[string]caddy.M
 	return nil
 }
 
-func encodeMatcherSet(matchers map[string]caddyhttp.RequestMatcher) (caddy.ModuleMap, error) {
+func encodeMatcherSet(matchers map[string]caddyhttp.RequestMatcherWithError) (caddy.ModuleMap, error) {
 	msEncoded := make(caddy.ModuleMap)
 	for matcherName, val := range matchers {
 		jsonBytes, err := json.Marshal(val)

--- a/modules/caddyhttp/caddyhttp.go
+++ b/modules/caddyhttp/caddyhttp.go
@@ -36,6 +36,10 @@ func init() {
 // RequestMatcher is a type that can match to a request.
 // A route matcher MUST NOT modify the request, with the
 // only exception being its context.
+//
+// DEPRECATED: Matchers should now implement RequestMatcherWithError.
+// You may remove any interface guards for RequestMatcher
+// but keep your Match() methods for backwards compatibility.
 type RequestMatcher interface {
 	Match(*http.Request) bool
 }

--- a/modules/caddyhttp/caddyhttp.go
+++ b/modules/caddyhttp/caddyhttp.go
@@ -40,6 +40,18 @@ type RequestMatcher interface {
 	Match(*http.Request) bool
 }
 
+// RequestMatcherWithError is like RequestMatcher but can return an error.
+// An error during matching will abort the request middleware chain and
+// invoke the error middleware chain.
+//
+// This will eventually replace RequestMatcher. Matcher modules
+// should implement both interfaces, and once all modules have
+// been updated to use RequestMatcherWithError, the RequestMatcher
+// interface may eventually be dropped.
+type RequestMatcherWithError interface {
+	MatchWithError(*http.Request) (bool, error)
+}
+
 // Handler is like http.Handler except ServeHTTP may return an error.
 //
 // If any handler encounters an error, it should be returned for proper

--- a/modules/caddyhttp/caddyhttp.go
+++ b/modules/caddyhttp/caddyhttp.go
@@ -37,7 +37,7 @@ func init() {
 // A route matcher MUST NOT modify the request, with the
 // only exception being its context.
 //
-// DEPRECATED: Matchers should now implement RequestMatcherWithError.
+// Deprecated: Matchers should now implement RequestMatcherWithError.
 // You may remove any interface guards for RequestMatcher
 // but keep your Match() methods for backwards compatibility.
 type RequestMatcher interface {

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -756,7 +756,6 @@ const MatcherNameCtxKey = "matcher_name"
 // Interface guards
 var (
 	_ caddy.Provisioner       = (*MatchExpression)(nil)
-	_ RequestMatcher          = (*MatchExpression)(nil)
 	_ RequestMatcherWithError = (*MatchExpression)(nil)
 	_ caddyfile.Unmarshaler   = (*MatchExpression)(nil)
 	_ json.Marshaler          = (*MatchExpression)(nil)

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -432,7 +432,7 @@ func CELMatcherImpl(macroName, funcName string, matcherDataTypes []*cel.Type, fa
 }
 
 // CELMatcherFactory converts a constant CEL value into a RequestMatcher.
-// DEPRECATED: Use CELMatcherWithErrorFactory instead.
+// Deprecated: Use CELMatcherWithErrorFactory instead.
 type CELMatcherFactory = func(data ref.Val) (RequestMatcher, error)
 
 // CELMatcherWithErrorFactory converts a constant CEL value into a RequestMatcherWithError.

--- a/modules/caddyhttp/celmatcher_test.go
+++ b/modules/caddyhttp/celmatcher_test.go
@@ -489,7 +489,11 @@ func TestMatchExpressionMatch(t *testing.T) {
 				}
 			}
 
-			if tc.expression.Match(req) != tc.wantResult {
+			matches, err := tc.expression.MatchWithError(req)
+			if err != nil {
+				t.Errorf("MatchExpression.Match() error = %v", err)
+			}
+			if matches != tc.wantResult {
 				t.Errorf("MatchExpression.Match() expected to return '%t', for expression : '%s'", tc.wantResult, tc.expression.Expr)
 			}
 		})
@@ -532,7 +536,7 @@ func BenchmarkMatchExpressionMatch(b *testing.B) {
 			}
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				tc.expression.Match(req)
+				tc.expression.MatchWithError(req)
 			}
 		})
 	}

--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -711,7 +711,7 @@ const (
 
 // Interface guards
 var (
-	_ caddy.Validator              = (*MatchFile)(nil)
-	_ caddyhttp.RequestMatcher     = (*MatchFile)(nil)
-	_ caddyhttp.CELLibraryProducer = (*MatchFile)(nil)
+	_ caddy.Validator                   = (*MatchFile)(nil)
+	_ caddyhttp.RequestMatcherWithError = (*MatchFile)(nil)
+	_ caddyhttp.CELLibraryProducer      = (*MatchFile)(nil)
 )

--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -313,12 +313,21 @@ func (m MatchFile) Validate() error {
 //   - http.matchers.file.type: file or directory
 //   - http.matchers.file.remainder: Portion remaining after splitting file path (if configured)
 func (m MatchFile) Match(r *http.Request) bool {
+	match, err := m.selectFile(r)
+	if err != nil {
+		caddyhttp.SetVar(r.Context(), caddyhttp.MatcherErrorVarKey, err)
+	}
+	return match
+}
+
+// MatchWithError returns true if r matches m.
+func (m MatchFile) MatchWithError(r *http.Request) (bool, error) {
 	return m.selectFile(r)
 }
 
 // selectFile chooses a file according to m.TryPolicy by appending
 // the paths in m.TryFiles to m.Root, with placeholder replacements.
-func (m MatchFile) selectFile(r *http.Request) (matched bool) {
+func (m MatchFile) selectFile(r *http.Request) (bool, error) {
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 
 	root := filepath.Clean(repl.ReplaceAll(m.Root, "."))
@@ -330,7 +339,7 @@ func (m MatchFile) selectFile(r *http.Request) (matched bool) {
 		if c := m.logger.Check(zapcore.ErrorLevel, "use of unregistered filesystem"); c != nil {
 			c.Write(zap.String("fs", fsName))
 		}
-		return false
+		return false, nil
 	}
 	type matchCandidate struct {
 		fullpath, relative, splitRemainder string
@@ -422,14 +431,13 @@ func (m MatchFile) selectFile(r *http.Request) (matched bool) {
 	case "", tryPolicyFirstExist:
 		for _, pattern := range m.TryFiles {
 			if err := parseErrorCode(pattern); err != nil {
-				caddyhttp.SetVar(r.Context(), caddyhttp.MatcherErrorVarKey, err)
-				return
+				return false, err
 			}
 			candidates := makeCandidates(pattern)
 			for _, c := range candidates {
 				if info, exists := m.strictFileExists(fileSystem, c.fullpath); exists {
 					setPlaceholders(c, info)
-					return true
+					return true, nil
 				}
 			}
 		}
@@ -450,10 +458,10 @@ func (m MatchFile) selectFile(r *http.Request) (matched bool) {
 			}
 		}
 		if largestInfo == nil {
-			return false
+			return false, nil
 		}
 		setPlaceholders(largest, largestInfo)
-		return true
+		return true, nil
 
 	case tryPolicySmallestSize:
 		var smallestSize int64
@@ -471,10 +479,10 @@ func (m MatchFile) selectFile(r *http.Request) (matched bool) {
 			}
 		}
 		if smallestInfo == nil {
-			return false
+			return false, nil
 		}
 		setPlaceholders(smallest, smallestInfo)
-		return true
+		return true, nil
 
 	case tryPolicyMostRecentlyMod:
 		var recent matchCandidate
@@ -491,13 +499,13 @@ func (m MatchFile) selectFile(r *http.Request) (matched bool) {
 			}
 		}
 		if recentInfo == nil {
-			return false
+			return false, nil
 		}
 		setPlaceholders(recent, recentInfo)
-		return true
+		return true, nil
 	}
 
-	return
+	return false, nil
 }
 
 // parseErrorCode checks if the input is a status

--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -430,9 +430,13 @@ func (m MatchFile) selectFile(r *http.Request) (bool, error) {
 	switch m.TryPolicy {
 	case "", tryPolicyFirstExist:
 		for _, pattern := range m.TryFiles {
+			// If the pattern is a status code, emit an error,
+			// which short-circuits the middleware pipeline and
+			// writes an HTTP error response.
 			if err := parseErrorCode(pattern); err != nil {
 				return false, err
 			}
+
 			candidates := makeCandidates(pattern)
 			for _, c := range candidates {
 				if info, exists := m.strictFileExists(fileSystem, c.fullpath); exists {

--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -173,7 +173,7 @@ func (m *MatchFile) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 func (MatchFile) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 	requestType := cel.ObjectType("http.Request")
 
-	matcherFactory := func(data ref.Val) (caddyhttp.RequestMatcher, error) {
+	matcherFactory := func(data ref.Val) (caddyhttp.RequestMatcherWithError, error) {
 		values, err := caddyhttp.CELValueToMapStrList(data)
 		if err != nil {
 			return nil, err
@@ -315,6 +315,7 @@ func (m MatchFile) Validate() error {
 func (m MatchFile) Match(r *http.Request) bool {
 	match, err := m.selectFile(r)
 	if err != nil {
+		// nolint:staticcheck
 		caddyhttp.SetVar(r.Context(), caddyhttp.MatcherErrorVarKey, err)
 	}
 	return match

--- a/modules/caddyhttp/fileserver/matcher_test.go
+++ b/modules/caddyhttp/fileserver/matcher_test.go
@@ -130,7 +130,10 @@ func TestFileMatcher(t *testing.T) {
 		req := &http.Request{URL: u}
 		repl := caddyhttp.NewTestReplacer(req)
 
-		result := m.Match(req)
+		result, err := m.MatchWithError(req)
+		if err != nil {
+			t.Errorf("Test %d: unexpected error: %v", i, err)
+		}
 		if result != tc.matched {
 			t.Errorf("Test %d: expected match=%t, got %t", i, tc.matched, result)
 		}
@@ -240,7 +243,10 @@ func TestPHPFileMatcher(t *testing.T) {
 		req := &http.Request{URL: u}
 		repl := caddyhttp.NewTestReplacer(req)
 
-		result := m.Match(req)
+		result, err := m.MatchWithError(req)
+		if err != nil {
+			t.Errorf("Test %d: unexpected error: %v", i, err)
+		}
 		if result != tc.matched {
 			t.Errorf("Test %d: expected match=%t, got %t", i, tc.matched, result)
 		}
@@ -389,7 +395,12 @@ func TestMatchExpressionMatch(t *testing.T) {
 			ctx := context.WithValue(req.Context(), caddy.ReplacerCtxKey, repl)
 			req = req.WithContext(ctx)
 
-			if tc.expression.Match(req) != tc.wantResult {
+			matches, err := tc.expression.MatchWithError(req)
+			if err != nil {
+				t.Errorf("MatchExpression.Match() error = %v", err)
+				return
+			}
+			if matches != tc.wantResult {
 				t.Errorf("MatchExpression.Match() expected to return '%t', for expression : '%s'", tc.wantResult, tc.expression.Expr)
 			}
 

--- a/modules/caddyhttp/ip_matchers.go
+++ b/modules/caddyhttp/ip_matchers.go
@@ -145,11 +145,11 @@ func (m *MatchRemoteIP) Provision(ctx caddy.Context) error {
 
 // Match returns true if r matches m.
 func (m MatchRemoteIP) Match(r *http.Request) bool {
-	matches, err := m.MatchWithError(r)
+	match, err := m.MatchWithError(r)
 	if err != nil {
 		SetVar(r.Context(), MatcherErrorVarKey, err)
 	}
-	return matches
+	return match
 }
 
 // MatchWithError returns true if r matches m.
@@ -249,11 +249,11 @@ func (m *MatchClientIP) Provision(ctx caddy.Context) error {
 
 // Match returns true if r matches m.
 func (m MatchClientIP) Match(r *http.Request) bool {
-	matches, err := m.MatchWithError(r)
+	match, err := m.MatchWithError(r)
 	if err != nil {
 		SetVar(r.Context(), MatcherErrorVarKey, err)
 	}
-	return matches
+	return match
 }
 
 // MatchWithError returns true if r matches m.
@@ -348,13 +348,11 @@ func matchIPByCidrZones(clientIP netip.Addr, zoneID string, cidrs []*netip.Prefi
 
 // Interface guards
 var (
-	_ RequestMatcher          = (*MatchRemoteIP)(nil)
 	_ RequestMatcherWithError = (*MatchRemoteIP)(nil)
 	_ caddy.Provisioner       = (*MatchRemoteIP)(nil)
 	_ caddyfile.Unmarshaler   = (*MatchRemoteIP)(nil)
 	_ CELLibraryProducer      = (*MatchRemoteIP)(nil)
 
-	_ RequestMatcher          = (*MatchClientIP)(nil)
 	_ RequestMatcherWithError = (*MatchClientIP)(nil)
 	_ caddy.Provisioner       = (*MatchClientIP)(nil)
 	_ caddyfile.Unmarshaler   = (*MatchClientIP)(nil)

--- a/modules/caddyhttp/ip_matchers.go
+++ b/modules/caddyhttp/ip_matchers.go
@@ -108,7 +108,7 @@ func (MatchRemoteIP) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		// internal data type of the MatchPath value.
 		[]*cel.Type{cel.ListType(cel.StringType)},
 		// function to convert a constant list of strings to a MatchPath instance.
-		func(data ref.Val) (RequestMatcher, error) {
+		func(data ref.Val) (RequestMatcherWithError, error) {
 			refStringList := reflect.TypeOf([]string{})
 			strList, err := data.ConvertToNative(refStringList)
 			if err != nil {
@@ -218,7 +218,7 @@ func (MatchClientIP) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		// internal data type of the MatchPath value.
 		[]*cel.Type{cel.ListType(cel.StringType)},
 		// function to convert a constant list of strings to a MatchPath instance.
-		func(data ref.Val) (RequestMatcher, error) {
+		func(data ref.Val) (RequestMatcherWithError, error) {
 			refStringList := reflect.TypeOf([]string{})
 			strList, err := data.ConvertToNative(refStringList)
 			if err != nil {

--- a/modules/caddyhttp/ip_matchers.go
+++ b/modules/caddyhttp/ip_matchers.go
@@ -166,6 +166,11 @@ func (m MatchRemoteIP) Match(r *http.Request) bool {
 	return matches
 }
 
+// MatchWithError returns true if r matches m.
+func (m MatchRemoteIP) MatchWithError(r *http.Request) (bool, error) {
+	return m.Match(r), nil
+}
+
 // CaddyModule returns the Caddy module information.
 func (MatchClientIP) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
@@ -254,6 +259,11 @@ func (m MatchClientIP) Match(r *http.Request) bool {
 	return matches
 }
 
+// MatchWithError returns true if r matches m.
+func (m MatchClientIP) MatchWithError(r *http.Request) (bool, error) {
+	return m.Match(r), nil
+}
+
 func provisionCidrsZonesFromRanges(ranges []string) ([]*netip.Prefix, []string, error) {
 	cidrs := []*netip.Prefix{}
 	zones := []string{}
@@ -326,13 +336,15 @@ func matchIPByCidrZones(clientIP netip.Addr, zoneID string, cidrs []*netip.Prefi
 
 // Interface guards
 var (
-	_ RequestMatcher        = (*MatchRemoteIP)(nil)
-	_ caddy.Provisioner     = (*MatchRemoteIP)(nil)
-	_ caddyfile.Unmarshaler = (*MatchRemoteIP)(nil)
-	_ CELLibraryProducer    = (*MatchRemoteIP)(nil)
+	_ RequestMatcher          = (*MatchRemoteIP)(nil)
+	_ RequestMatcherWithError = (*MatchRemoteIP)(nil)
+	_ caddy.Provisioner       = (*MatchRemoteIP)(nil)
+	_ caddyfile.Unmarshaler   = (*MatchRemoteIP)(nil)
+	_ CELLibraryProducer      = (*MatchRemoteIP)(nil)
 
-	_ RequestMatcher        = (*MatchClientIP)(nil)
-	_ caddy.Provisioner     = (*MatchClientIP)(nil)
-	_ caddyfile.Unmarshaler = (*MatchClientIP)(nil)
-	_ CELLibraryProducer    = (*MatchClientIP)(nil)
+	_ RequestMatcher          = (*MatchClientIP)(nil)
+	_ RequestMatcherWithError = (*MatchClientIP)(nil)
+	_ caddy.Provisioner       = (*MatchClientIP)(nil)
+	_ caddyfile.Unmarshaler   = (*MatchClientIP)(nil)
+	_ CELLibraryProducer      = (*MatchClientIP)(nil)
 )

--- a/modules/caddyhttp/ip_matchers.go
+++ b/modules/caddyhttp/ip_matchers.go
@@ -154,9 +154,12 @@ func (m MatchRemoteIP) Match(r *http.Request) bool {
 
 // MatchWithError returns true if r matches m.
 func (m MatchRemoteIP) MatchWithError(r *http.Request) (bool, error) {
-	// if handshake is not finished, we infer 0-RTT that has not verified remote IP; could be spoofed
+	// if handshake is not finished, we infer 0-RTT that has
+	// not verified remote IP; could be spoofed, so we throw
+	// HTTP 425 status to tell the client to try again after
+	// the handshake is complete
 	if r.TLS != nil && !r.TLS.HandshakeComplete {
-		return false, fmt.Errorf("TLS handshake not complete, remote IP cannot be verified")
+		return false, Error(http.StatusTooEarly, fmt.Errorf("TLS handshake not complete, remote IP cannot be verified"))
 	}
 
 	address := r.RemoteAddr
@@ -258,9 +261,12 @@ func (m MatchClientIP) Match(r *http.Request) bool {
 
 // MatchWithError returns true if r matches m.
 func (m MatchClientIP) MatchWithError(r *http.Request) (bool, error) {
-	// if handshake is not finished, we infer 0-RTT that has not verified remote IP; could be spoofed
+	// if handshake is not finished, we infer 0-RTT that has
+	// not verified remote IP; could be spoofed, so we throw
+	// HTTP 425 status to tell the client to try again after
+	// the handshake is complete
 	if r.TLS != nil && !r.TLS.HandshakeComplete {
-		return false, fmt.Errorf("TLS handshake not complete, remote IP cannot be verified")
+		return false, Error(http.StatusTooEarly, fmt.Errorf("TLS handshake not complete, remote IP cannot be verified"))
 	}
 
 	address := GetVar(r.Context(), ClientIPVarKey).(string)

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -372,7 +372,7 @@ func (MatchHost) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		"host",
 		"host_match_request_list",
 		[]*cel.Type{cel.ListType(cel.StringType)},
-		func(data ref.Val) (RequestMatcher, error) {
+		func(data ref.Val) (RequestMatcherWithError, error) {
 			refStringList := reflect.TypeOf([]string{})
 			strList, err := data.ConvertToNative(refStringList)
 			if err != nil {
@@ -654,7 +654,7 @@ func (MatchPath) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		// internal data type of the MatchPath value.
 		[]*cel.Type{cel.ListType(cel.StringType)},
 		// function to convert a constant list of strings to a MatchPath instance.
-		func(data ref.Val) (RequestMatcher, error) {
+		func(data ref.Val) (RequestMatcherWithError, error) {
 			refStringList := reflect.TypeOf([]string{})
 			strList, err := data.ConvertToNative(refStringList)
 			if err != nil {
@@ -716,7 +716,7 @@ func (MatchPathRE) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		"path_regexp",
 		"path_regexp_request_string",
 		[]*cel.Type{cel.StringType},
-		func(data ref.Val) (RequestMatcher, error) {
+		func(data ref.Val) (RequestMatcherWithError, error) {
 			pattern := data.(types.String)
 			matcher := MatchPathRE{MatchRegexp{
 				Name:    ctx.Value(MatcherNameCtxKey).(string),
@@ -733,7 +733,7 @@ func (MatchPathRE) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		"path_regexp",
 		"path_regexp_request_string_string",
 		[]*cel.Type{cel.StringType, cel.StringType},
-		func(data ref.Val) (RequestMatcher, error) {
+		func(data ref.Val) (RequestMatcherWithError, error) {
 			refStringList := reflect.TypeOf([]string{})
 			params, err := data.ConvertToNative(refStringList)
 			if err != nil {
@@ -802,7 +802,7 @@ func (MatchMethod) CELLibrary(_ caddy.Context) (cel.Library, error) {
 		"method",
 		"method_request_list",
 		[]*cel.Type{cel.ListType(cel.StringType)},
-		func(data ref.Val) (RequestMatcher, error) {
+		func(data ref.Val) (RequestMatcherWithError, error) {
 			refStringList := reflect.TypeOf([]string{})
 			strList, err := data.ConvertToNative(refStringList)
 			if err != nil {
@@ -909,7 +909,7 @@ func (MatchQuery) CELLibrary(_ caddy.Context) (cel.Library, error) {
 		"query",
 		"query_matcher_request_map",
 		[]*cel.Type{CELTypeJSON},
-		func(data ref.Val) (RequestMatcher, error) {
+		func(data ref.Val) (RequestMatcherWithError, error) {
 			mapStrListStr, err := CELValueToMapStrList(data)
 			if err != nil {
 				return nil, err
@@ -993,7 +993,7 @@ func (MatchHeader) CELLibrary(_ caddy.Context) (cel.Library, error) {
 		"header",
 		"header_matcher_request_map",
 		[]*cel.Type{CELTypeJSON},
-		func(data ref.Val) (RequestMatcher, error) {
+		func(data ref.Val) (RequestMatcherWithError, error) {
 			mapStrListStr, err := CELValueToMapStrList(data)
 			if err != nil {
 				return nil, err
@@ -1169,7 +1169,7 @@ func (MatchHeaderRE) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		"header_regexp",
 		"header_regexp_request_string_string",
 		[]*cel.Type{cel.StringType, cel.StringType},
-		func(data ref.Val) (RequestMatcher, error) {
+		func(data ref.Val) (RequestMatcherWithError, error) {
 			refStringList := reflect.TypeOf([]string{})
 			params, err := data.ConvertToNative(refStringList)
 			if err != nil {
@@ -1192,7 +1192,7 @@ func (MatchHeaderRE) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		"header_regexp",
 		"header_regexp_request_string_string_string",
 		[]*cel.Type{cel.StringType, cel.StringType, cel.StringType},
-		func(data ref.Val) (RequestMatcher, error) {
+		func(data ref.Val) (RequestMatcherWithError, error) {
 			refStringList := reflect.TypeOf([]string{})
 			params, err := data.ConvertToNative(refStringList)
 			if err != nil {
@@ -1287,7 +1287,7 @@ func (MatchProtocol) CELLibrary(_ caddy.Context) (cel.Library, error) {
 		"protocol",
 		"protocol_request_string",
 		[]*cel.Type{cel.StringType},
-		func(data ref.Val) (RequestMatcher, error) {
+		func(data ref.Val) (RequestMatcherWithError, error) {
 			protocolStr, ok := data.(types.String)
 			if !ok {
 				return nil, errors.New("protocol argument was not a string")
@@ -1603,6 +1603,10 @@ const regexpPlaceholderPrefix = "http.regexp"
 // holds an optional error emitted from a request matcher,
 // to short-circuit the handler chain, since matchers cannot
 // return errors via the RequestMatcher interface.
+//
+// DEPRECATED: Matchers should implement RequestMatcherWithError
+// which can return an error directly, instead of smuggling it
+// through the vars map.
 const MatcherErrorVarKey = "matchers.error"
 
 // Interface guards

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -355,6 +355,11 @@ outer:
 	return false
 }
 
+// MatchWithError returns true if r matches m.
+func (m MatchHost) MatchWithError(r *http.Request) (bool, error) {
+	return m.Match(r), nil
+}
+
 // CELLibrary produces options that expose this matcher for use in CEL
 // expression matchers.
 //
@@ -627,6 +632,11 @@ func (MatchPath) matchPatternWithEscapeSequence(escapedPath, matchPath string) b
 	return matches
 }
 
+// MatchWithError returns true if r matches m.
+func (m MatchPath) MatchWithError(r *http.Request) (bool, error) {
+	return m.Match(r), nil
+}
+
 // CELLibrary produces options that expose this matcher for use in CEL
 // expression matchers.
 //
@@ -685,6 +695,11 @@ func (m MatchPathRE) Match(r *http.Request) bool {
 	cleanedPath := cleanPath(r.URL.Path)
 
 	return m.MatchRegexp.Match(cleanedPath, repl)
+}
+
+// MatchWithError returns true if r matches m.
+func (m MatchPathRE) MatchWithError(r *http.Request) (bool, error) {
+	return m.Match(r), nil
 }
 
 // CELLibrary produces options that expose this matcher for use in CEL
@@ -765,6 +780,11 @@ func (m *MatchMethod) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 // Match returns true if r matches m.
 func (m MatchMethod) Match(r *http.Request) bool {
 	return slices.Contains(m, r.Method)
+}
+
+// MatchWithError returns true if r matches m.
+func (m MatchMethod) MatchWithError(r *http.Request) (bool, error) {
+	return m.Match(r), nil
 }
 
 // CELLibrary produces options that expose this matcher for use in CEL
@@ -867,6 +887,11 @@ func (m MatchQuery) Match(r *http.Request) bool {
 	return matchedKeys == len(m)
 }
 
+// MatchWithError returns true if r matches m.
+func (m MatchQuery) MatchWithError(r *http.Request) (bool, error) {
+	return m.Match(r), nil
+}
+
 // CELLibrary produces options that expose this matcher for use in CEL
 // expression matchers.
 //
@@ -942,6 +967,11 @@ func (m *MatchHeader) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 func (m MatchHeader) Match(r *http.Request) bool {
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 	return matchHeaders(r.Header, http.Header(m), r.Host, repl)
+}
+
+// MatchWithError returns true if r matches m.
+func (m MatchHeader) MatchWithError(r *http.Request) (bool, error) {
+	return m.Match(r), nil
 }
 
 // CELLibrary produces options that expose this matcher for use in CEL
@@ -1093,6 +1123,11 @@ func (m MatchHeaderRE) Match(r *http.Request) bool {
 	return true
 }
 
+// MatchWithError returns true if r matches m.
+func (m MatchHeaderRE) MatchWithError(r *http.Request) (bool, error) {
+	return m.Match(r), nil
+}
+
 // Provision compiles m's regular expressions.
 func (m MatchHeaderRE) Provision(ctx caddy.Context) error {
 	for _, rm := range m {
@@ -1214,6 +1249,11 @@ func (m MatchProtocol) Match(r *http.Request) bool {
 	return false
 }
 
+// MatchWithError returns true if r matches m.
+func (m MatchProtocol) MatchWithError(r *http.Request) (bool, error) {
+	return m.Match(r), nil
+}
+
 // UnmarshalCaddyfile implements caddyfile.Unmarshaler.
 func (m *MatchProtocol) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	// iterate to merge multiple matchers into one
@@ -1268,6 +1308,11 @@ func (m MatchTLS) Match(r *http.Request) bool {
 		}
 	}
 	return true
+}
+
+// MatchWithError returns true if r matches m.
+func (m MatchTLS) MatchWithError(r *http.Request) (bool, error) {
+	return m.Match(r), nil
 }
 
 // UnmarshalCaddyfile parses Caddyfile tokens for this matcher. Syntax:
@@ -1354,6 +1399,11 @@ func (m MatchNot) Match(r *http.Request) bool {
 		}
 	}
 	return true
+}
+
+// MatchWithError returns true if r matches m.
+func (m MatchNot) MatchWithError(r *http.Request) (bool, error) {
+	return m.Match(r), nil
 }
 
 // MatchRegexp is an embedable type for matching
@@ -1528,20 +1578,29 @@ const MatcherErrorVarKey = "matchers.error"
 
 // Interface guards
 var (
-	_ RequestMatcher    = (*MatchHost)(nil)
-	_ caddy.Provisioner = (*MatchHost)(nil)
-	_ RequestMatcher    = (*MatchPath)(nil)
-	_ RequestMatcher    = (*MatchPathRE)(nil)
-	_ caddy.Provisioner = (*MatchPathRE)(nil)
-	_ RequestMatcher    = (*MatchMethod)(nil)
-	_ RequestMatcher    = (*MatchQuery)(nil)
-	_ RequestMatcher    = (*MatchHeader)(nil)
-	_ RequestMatcher    = (*MatchHeaderRE)(nil)
-	_ caddy.Provisioner = (*MatchHeaderRE)(nil)
-	_ RequestMatcher    = (*MatchProtocol)(nil)
-	_ RequestMatcher    = (*MatchNot)(nil)
-	_ caddy.Provisioner = (*MatchNot)(nil)
-	_ caddy.Provisioner = (*MatchRegexp)(nil)
+	_ RequestMatcher          = (*MatchHost)(nil)
+	_ RequestMatcherWithError = (*MatchHost)(nil)
+	_ caddy.Provisioner       = (*MatchHost)(nil)
+	_ RequestMatcher          = (*MatchPath)(nil)
+	_ RequestMatcherWithError = (*MatchPath)(nil)
+	_ RequestMatcher          = (*MatchPathRE)(nil)
+	_ RequestMatcherWithError = (*MatchPathRE)(nil)
+	_ caddy.Provisioner       = (*MatchPathRE)(nil)
+	_ RequestMatcher          = (*MatchMethod)(nil)
+	_ RequestMatcherWithError = (*MatchMethod)(nil)
+	_ RequestMatcher          = (*MatchQuery)(nil)
+	_ RequestMatcherWithError = (*MatchQuery)(nil)
+	_ RequestMatcher          = (*MatchHeader)(nil)
+	_ RequestMatcherWithError = (*MatchHeader)(nil)
+	_ RequestMatcher          = (*MatchHeaderRE)(nil)
+	_ RequestMatcherWithError = (*MatchHeaderRE)(nil)
+	_ caddy.Provisioner       = (*MatchHeaderRE)(nil)
+	_ RequestMatcher          = (*MatchProtocol)(nil)
+	_ RequestMatcherWithError = (*MatchProtocol)(nil)
+	_ RequestMatcher          = (*MatchNot)(nil)
+	_ RequestMatcherWithError = (*MatchNot)(nil)
+	_ caddy.Provisioner       = (*MatchNot)(nil)
+	_ caddy.Provisioner       = (*MatchRegexp)(nil)
 
 	_ caddyfile.Unmarshaler = (*MatchHost)(nil)
 	_ caddyfile.Unmarshaler = (*MatchPath)(nil)

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -1604,7 +1604,7 @@ const regexpPlaceholderPrefix = "http.regexp"
 // to short-circuit the handler chain, since matchers cannot
 // return errors via the RequestMatcher interface.
 //
-// DEPRECATED: Matchers should implement RequestMatcherWithError
+// Deprecated: Matchers should implement RequestMatcherWithError
 // which can return an error directly, instead of smuggling it
 // through the vars map.
 const MatcherErrorVarKey = "matchers.error"

--- a/modules/caddyhttp/matchers_test.go
+++ b/modules/caddyhttp/matchers_test.go
@@ -158,7 +158,10 @@ func TestHostMatcher(t *testing.T) {
 			t.Errorf("Test %d %v: provisioning failed: %v", i, tc.match, err)
 		}
 
-		actual := tc.match.Match(req)
+		actual, err := tc.match.MatchWithError(req)
+		if err != nil {
+			t.Errorf("Test %d %v: matching failed: %v", i, tc.match, err)
+		}
 		if actual != tc.expect {
 			t.Errorf("Test %d %v: Expected %t, got %t for '%s'", i, tc.match, tc.expect, actual, tc.input)
 			continue
@@ -430,7 +433,10 @@ func TestPathMatcher(t *testing.T) {
 		ctx := context.WithValue(req.Context(), caddy.ReplacerCtxKey, repl)
 		req = req.WithContext(ctx)
 
-		actual := tc.match.Match(req)
+		actual, err := tc.match.MatchWithError(req)
+		if err != nil {
+			t.Errorf("Test %d %v: matching failed: %v", i, tc.match, err)
+		}
 		if actual != tc.expect {
 			t.Errorf("Test %d %v: Expected %t, got %t for '%s'", i, tc.match, tc.expect, actual, tc.input)
 			continue
@@ -451,7 +457,10 @@ func TestPathMatcherWindows(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	match := MatchPath{"*.php"}
-	matched := match.Match(req)
+	matched, err := match.MatchWithError(req)
+	if err != nil {
+		t.Errorf("Expected no error, but got: %v", err)
+	}
 	if !matched {
 		t.Errorf("Expected to match; should ignore trailing dots and spaces")
 	}
@@ -555,7 +564,10 @@ func TestPathREMatcher(t *testing.T) {
 		req = req.WithContext(ctx)
 		addHTTPVarsToReplacer(repl, req, httptest.NewRecorder())
 
-		actual := tc.match.Match(req)
+		actual, err := tc.match.MatchWithError(req)
+		if err != nil {
+			t.Errorf("Test %d %v: matching failed: %v", i, tc.match, err)
+		}
 		if actual != tc.expect {
 			t.Errorf("Test %d [%v]: Expected %t, got %t for input '%s'",
 				i, tc.match.Pattern, tc.expect, actual, tc.input)
@@ -691,7 +703,10 @@ func TestHeaderMatcher(t *testing.T) {
 		ctx := context.WithValue(req.Context(), caddy.ReplacerCtxKey, repl)
 		req = req.WithContext(ctx)
 
-		actual := tc.match.Match(req)
+		actual, err := tc.match.MatchWithError(req)
+		if err != nil {
+			t.Errorf("Test %d %v: matching failed: %v", i, tc.match, err)
+		}
 		if actual != tc.expect {
 			t.Errorf("Test %d %v: Expected %t, got %t for '%s'", i, tc.match, tc.expect, actual, tc.input)
 			continue
@@ -818,7 +833,10 @@ func TestQueryMatcher(t *testing.T) {
 		repl.Set("http.vars.debug", "1")
 		repl.Set("http.vars.key", "somekey")
 		req = req.WithContext(ctx)
-		actual := tc.match.Match(req)
+		actual, err := tc.match.MatchWithError(req)
+		if err != nil {
+			t.Errorf("Test %d %v: matching failed: %v", i, tc.match, err)
+		}
 		if actual != tc.expect {
 			t.Errorf("Test %d %v: Expected %t, got %t for '%s'", i, tc.match, tc.expect, actual, tc.input)
 			continue
@@ -887,7 +905,10 @@ func TestHeaderREMatcher(t *testing.T) {
 		req = req.WithContext(ctx)
 		addHTTPVarsToReplacer(repl, req, httptest.NewRecorder())
 
-		actual := tc.match.Match(req)
+		actual, err := tc.match.MatchWithError(req)
+		if err != nil {
+			t.Errorf("Test %d %v: matching failed: %v", i, tc.match, err)
+		}
 		if actual != tc.expect {
 			t.Errorf("Test %d [%v]: Expected %t, got %t for input '%s'",
 				i, tc.match, tc.expect, actual, tc.input)
@@ -927,7 +948,7 @@ func BenchmarkHeaderREMatcher(b *testing.B) {
 	req = req.WithContext(ctx)
 	addHTTPVarsToReplacer(repl, req, httptest.NewRecorder())
 	for run := 0; run < b.N; run++ {
-		match.Match(req)
+		match.MatchWithError(req)
 	}
 }
 
@@ -998,7 +1019,10 @@ func TestVarREMatcher(t *testing.T) {
 
 			tc.input.ServeHTTP(httptest.NewRecorder(), req, emptyHandler)
 
-			actual := tc.match.Match(req)
+			actual, err := tc.match.MatchWithError(req)
+			if err != nil {
+				t.Errorf("Test %d %v: matching failed: %v", i, tc.match, err)
+			}
 			if actual != tc.expect {
 				t.Errorf("Test %d [%v]: Expected %t, got %t for input '%s'",
 					i, tc.match, tc.expect, actual, tc.input)
@@ -1123,7 +1147,10 @@ func TestNotMatcher(t *testing.T) {
 		ctx := context.WithValue(req.Context(), caddy.ReplacerCtxKey, repl)
 		req = req.WithContext(ctx)
 
-		actual := tc.match.Match(req)
+		actual, err := tc.match.MatchWithError(req)
+		if err != nil {
+			t.Errorf("Test %d %v: matching failed: %v", i, tc.match, err)
+		}
 		if actual != tc.expect {
 			t.Errorf("Test %d %+v: Expected %t, got %t for: host=%s path=%s'", i, tc.match, tc.expect, actual, tc.host, tc.path)
 			continue
@@ -1155,7 +1182,7 @@ func BenchmarkLargeHostMatcher(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		matcher.Match(req)
+		matcher.MatchWithError(req)
 	}
 }
 
@@ -1169,7 +1196,7 @@ func BenchmarkHostMatcherWithoutPlaceholder(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		match.Match(req)
+		match.MatchWithError(req)
 	}
 }
 
@@ -1187,6 +1214,6 @@ func BenchmarkHostMatcherWithPlaceholder(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		match.Match(req)
+		match.MatchWithError(req)
 	}
 }

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -72,7 +72,7 @@ type HealthChecks struct {
 // health checks (that is, health checks which occur in a
 // background goroutine independently).
 type ActiveHealthChecks struct {
-	// DEPRECATED: Use 'uri' instead. This field will be removed. TODO: remove this field
+	// Deprecated: Use 'uri' instead. This field will be removed. TODO: remove this field
 	Path string `json:"path,omitempty"`
 
 	// The URI (path and query) to use for health checks

--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -545,11 +545,11 @@ type TLSConfig struct {
 	// Certificate authority module which provides the certificate pool of trusted certificates
 	CARaw json.RawMessage `json:"ca,omitempty" caddy:"namespace=tls.ca_pool.source inline_key=provider"`
 
-	// DEPRECATED: Use the `ca` field with the `tls.ca_pool.source.inline` module instead.
+	// Deprecated: Use the `ca` field with the `tls.ca_pool.source.inline` module instead.
 	// Optional list of base64-encoded DER-encoded CA certificates to trust.
 	RootCAPool []string `json:"root_ca_pool,omitempty"`
 
-	// DEPRECATED: Use the `ca` field with the `tls.ca_pool.source.file` module instead.
+	// Deprecated: Use the `ca` field with the `tls.ca_pool.source.file` module instead.
 	// List of PEM-encoded CA certificate files to add to the same trust
 	// store as RootCAPool (or root_ca_pool in the JSON).
 	RootCAPEMFiles []string `json:"root_ca_pem_files,omitempty"`

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -1124,7 +1124,7 @@ func (lb LoadBalancing) tryAgain(ctx caddy.Context, start time.Time, retries int
 				return false
 			}
 
-			match, err := lb.RetryMatch.AnyMatch(req)
+			match, err := lb.RetryMatch.AnyMatchWithError(req)
 			if err != nil {
 				logger.Error("error matching request for retry", zap.Error(err))
 				return false

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -496,7 +496,7 @@ func (h *Handler) proxyLoopIteration(r *http.Request, origReq *http.Request, w h
 		if proxyErr == nil {
 			proxyErr = caddyhttp.Error(http.StatusServiceUnavailable, errNoUpstream)
 		}
-		if !h.LoadBalancing.tryAgain(h.ctx, start, retries, proxyErr, r) {
+		if !h.LoadBalancing.tryAgain(h.ctx, start, retries, proxyErr, r, h.logger) {
 			return true, proxyErr
 		}
 		return false, proxyErr
@@ -562,7 +562,7 @@ func (h *Handler) proxyLoopIteration(r *http.Request, origReq *http.Request, w h
 	h.countFailure(upstream)
 
 	// if we've tried long enough, break
-	if !h.LoadBalancing.tryAgain(h.ctx, start, retries, proxyErr, r) {
+	if !h.LoadBalancing.tryAgain(h.ctx, start, retries, proxyErr, r, h.logger) {
 		return true, proxyErr
 	}
 
@@ -1089,7 +1089,7 @@ func (h *Handler) finalizeResponse(
 // If true is returned, it has already blocked long enough before
 // the next retry (i.e. no more sleeping is needed). If false is
 // returned, the handler should stop trying to proxy the request.
-func (lb LoadBalancing) tryAgain(ctx caddy.Context, start time.Time, retries int, proxyErr error, req *http.Request) bool {
+func (lb LoadBalancing) tryAgain(ctx caddy.Context, start time.Time, retries int, proxyErr error, req *http.Request, logger *zap.Logger) bool {
 	// no retries are configured
 	if lb.TryDuration == 0 && lb.Retries == 0 {
 		return false
@@ -1124,7 +1124,12 @@ func (lb LoadBalancing) tryAgain(ctx caddy.Context, start time.Time, retries int
 				return false
 			}
 
-			if !lb.RetryMatch.AnyMatch(req) {
+			match, err := lb.RetryMatch.AnyMatchWithError(req)
+			if err != nil {
+				logger.Error("error matching request for retry", zap.Error(err))
+				return false
+			}
+			if !match {
 				return false
 			}
 		}

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -1124,7 +1124,7 @@ func (lb LoadBalancing) tryAgain(ctx caddy.Context, start time.Time, retries int
 				return false
 			}
 
-			match, err := lb.RetryMatch.AnyMatchWithError(req)
+			match, err := lb.RetryMatch.AnyMatch(req)
 			if err != nil {
 				logger.Error("error matching request for retry", zap.Error(err))
 				return false

--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -254,7 +254,7 @@ func wrapRoute(route Route) Middleware {
 			nextCopy := next
 
 			// route must match at least one of the matcher sets
-			matches, err := route.MatcherSets.AnyMatchWithError(req)
+			matches, err := route.MatcherSets.AnyMatch(req)
 			if err != nil {
 				// allow matchers the opportunity to short circuit
 				// the request and trigger the error handling chain
@@ -382,25 +382,11 @@ type RawMatcherSets []caddy.ModuleMap
 // the sets.
 type MatcherSets []MatcherSet
 
-// AnyMatch returns true if req matches any of the
-// matcher sets in ms or if there are no matchers,
-// in which case the request always matches.
-//
-// Deprecated: Use AnyMatchWithError instead.
-func (ms MatcherSets) AnyMatch(req *http.Request) bool {
-	for _, m := range ms {
-		if m.Match(req) {
-			return true
-		}
-	}
-	return len(ms) == 0
-}
-
-// AnyMatchWithError returns true if req matches any of the
-// matcher sets in ms or if there are no matchers, in which
-// case the request always matches. If any matcher returns
-// an error, we cut short and return the error.
-func (ms MatcherSets) AnyMatchWithError(req *http.Request) (bool, error) {
+// AnyMatch returns true if req matches any of the matcher sets
+// in ms or if there are no matchers, in which case the request
+// always matches. If any matcher returns an error, we cut short
+// and return the error.
+func (ms MatcherSets) AnyMatch(req *http.Request) (bool, error) {
 	for _, m := range ms {
 		match, err := m.MatchWithError(req)
 		if err != nil || match {

--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -254,7 +254,7 @@ func wrapRoute(route Route) Middleware {
 			nextCopy := next
 
 			// route must match at least one of the matcher sets
-			matches, err := route.MatcherSets.AnyMatch(req)
+			matches, err := route.MatcherSets.AnyMatchWithError(req)
 			if err != nil {
 				// allow matchers the opportunity to short circuit
 				// the request and trigger the error handling chain
@@ -397,11 +397,30 @@ type RawMatcherSets []caddy.ModuleMap
 // the sets.
 type MatcherSets []MatcherSet
 
-// AnyMatch returns true if req matches any of the matcher sets
-// in ms or if there are no matchers, in which case the request
-// always matches. If any matcher returns an error, we cut short
-// and return the error.
-func (ms MatcherSets) AnyMatch(req *http.Request) (bool, error) {
+// AnyMatch returns true if req matches any of the
+// matcher sets in ms or if there are no matchers,
+// in which case the request always matches.
+//
+// Deprecated: Use AnyMatchWithError instead.
+func (ms MatcherSets) AnyMatch(req *http.Request) bool {
+	for _, m := range ms {
+		match, err := m.MatchWithError(req)
+		if err != nil {
+			SetVar(req.Context(), MatcherErrorVarKey, err)
+			return false
+		}
+		if match {
+			return match
+		}
+	}
+	return len(ms) == 0
+}
+
+// AnyMatchWithError returns true if req matches any of the
+// matcher sets in ms or if there are no matchers, in which
+// case the request always matches. If any matcher returns
+// an error, we cut short and return the error.
+func (ms MatcherSets) AnyMatchWithError(req *http.Request) (bool, error) {
 	for _, m := range ms {
 		match, err := m.MatchWithError(req)
 		if err != nil || match {

--- a/modules/caddyhttp/vars.go
+++ b/modules/caddyhttp/vars.go
@@ -225,7 +225,7 @@ func (VarsMatcher) CELLibrary(_ caddy.Context) (cel.Library, error) {
 		"vars",
 		"vars_matcher_request_map",
 		[]*cel.Type{CELTypeJSON},
-		func(data ref.Val) (RequestMatcher, error) {
+		func(data ref.Val) (RequestMatcherWithError, error) {
 			mapStrListStr, err := CELValueToMapStrList(data)
 			if err != nil {
 				return nil, err
@@ -352,7 +352,7 @@ func (MatchVarsRE) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		"vars_regexp",
 		"vars_regexp_request_string_string",
 		[]*cel.Type{cel.StringType, cel.StringType},
-		func(data ref.Val) (RequestMatcher, error) {
+		func(data ref.Val) (RequestMatcherWithError, error) {
 			refStringList := reflect.TypeOf([]string{})
 			params, err := data.ConvertToNative(refStringList)
 			if err != nil {
@@ -375,7 +375,7 @@ func (MatchVarsRE) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		"vars_regexp",
 		"vars_regexp_request_string_string_string",
 		[]*cel.Type{cel.StringType, cel.StringType, cel.StringType},
-		func(data ref.Val) (RequestMatcher, error) {
+		func(data ref.Val) (RequestMatcherWithError, error) {
 			refStringList := reflect.TypeOf([]string{})
 			params, err := data.ConvertToNative(refStringList)
 			if err != nil {

--- a/modules/caddyhttp/vars.go
+++ b/modules/caddyhttp/vars.go
@@ -207,6 +207,11 @@ func (m VarsMatcher) Match(r *http.Request) bool {
 	return false
 }
 
+// MatchWithError returns true if r matches m.
+func (m VarsMatcher) MatchWithError(r *http.Request) (bool, error) {
+	return m.Match(r), nil
+}
+
 // CELLibrary produces options that expose this matcher for use in CEL
 // expression matchers.
 //
@@ -326,6 +331,11 @@ func (m MatchVarsRE) Match(r *http.Request) bool {
 		}
 	}
 	return false
+}
+
+// MatchWithError returns true if r matches m.
+func (m MatchVarsRE) MatchWithError(r *http.Request) (bool, error) {
+	return m.Match(r), nil
 }
 
 // CELLibrary produces options that expose this matcher for use in CEL

--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -535,21 +535,21 @@ type ClientAuthentication struct {
 	CARaw json.RawMessage `json:"ca,omitempty" caddy:"namespace=tls.ca_pool.source inline_key=provider"`
 	ca    CA
 
-	// DEPRECATED: Use the `ca` field with the `tls.ca_pool.source.inline` module instead.
+	// Deprecated: Use the `ca` field with the `tls.ca_pool.source.inline` module instead.
 	// A list of base64 DER-encoded CA certificates
 	// against which to validate client certificates.
 	// Client certs which are not signed by any of
 	// these CAs will be rejected.
 	TrustedCACerts []string `json:"trusted_ca_certs,omitempty"`
 
-	// DEPRECATED: Use the `ca` field with the `tls.ca_pool.source.file` module instead.
+	// Deprecated: Use the `ca` field with the `tls.ca_pool.source.file` module instead.
 	// TrustedCACertPEMFiles is a list of PEM file names
 	// from which to load certificates of trusted CAs.
 	// Client certificates which are not signed by any of
 	// these CA certificates will be rejected.
 	TrustedCACertPEMFiles []string `json:"trusted_ca_certs_pem_files,omitempty"`
 
-	// DEPRECATED: This field is deprecated and will be removed in
+	// Deprecated: This field is deprecated and will be removed in
 	// a future version. Please use the `validators` field instead
 	// with the tls.client_auth.verifier.leaf module instead.
 	//

--- a/modules/caddytls/ondemand.go
+++ b/modules/caddytls/ondemand.go
@@ -42,7 +42,7 @@ func init() {
 // to your application whether a particular domain is allowed
 // to have a certificate issued for it.
 type OnDemandConfig struct {
-	// DEPRECATED. WILL BE REMOVED SOON. Use 'permission' instead with the `http` module.
+	// Deprecated. WILL BE REMOVED SOON. Use 'permission' instead with the `http` module.
 	Ask string `json:"ask,omitempty"`
 
 	// REQUIRED. A module that will determine whether a


### PR DESCRIPTION
As recently discussed on Slack, our `RequestMatcher` interface is sometimes insufficient in situations where matchers cannot safely operate because it can only return a boolean. Since matchers make a decision whether or not handlers can run, returning false isn't a secure decision because it may cause handlers that _must_ run (e.g. authentication) to not get run, causing possible bypass of security-critical functionality in the config.

We already had a mechanism for this, which I added in https://github.com/caddyserver/caddy/pull/4346 via putting a variable in Context and reading it back after the matcher ran. That was absolutely a hack and not the best solution. I couldn't think of a better way at the time (lack of Go skills :sweat_smile:)

To solve this, the better solution is to introduce a new `RequestMatcherWithError` interface which returns `(bool, error)`, so that an error can be returned to cancel the HTTP request pipeline if the matcher's preconditions aren't met. For now, we can make this optional (so if a matcher implements this interface we call it if possible) until we know all matcher plugins have caught up implementing with this (though unfortunately guaranteeing that is quite difficult and a multi-step process to clean up).

