### PR TITLE
caddyhttp: Fix listener wrapper regression from #6573

### DIFF
--- a/listeners.go
+++ b/listeners.go
@@ -183,12 +183,12 @@ func (na NetworkAddress) listen(ctx context.Context, portOffset uint, config net
 		}
 	}
 
-	if ln == nil {
-		return nil, fmt.Errorf("unsupported network type: %s", na.Network)
-	}
-
 	if err != nil {
 		return nil, err
+	}
+
+	if ln == nil {
+		return nil, fmt.Errorf("unsupported network type: %s", na.Network)
 	}
 
 	if IsUnixNetwork(na.Network) {

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -535,11 +535,6 @@ func (app *App) Start() error {
 						return fmt.Errorf("network '%s' cannot handle HTTP/1 or HTTP/2 connections", listenAddr.Network)
 					}
 
-					if useTLS {
-						// create TLS listener - this enables and terminates TLS
-						ln = tls.NewListener(ln, tlsCfg)
-					}
-
 					// wrap listener before TLS (up to the TLS placeholder wrapper)
 					var lnWrapperIdx int
 					for i, lnWrapper := range srv.listenerWrappers {
@@ -548,6 +543,11 @@ func (app *App) Start() error {
 							break
 						}
 						ln = lnWrapper.WrapListener(ln)
+					}
+
+					if useTLS {
+						// create TLS listener - this enables and terminates TLS
+						ln = tls.NewListener(ln, tlsCfg)
 					}
 
 					// finish wrapping listener where we left off before TLS


### PR DESCRIPTION
feat. a right side in TLS listener wrapper and more descriptive error handling in `listen`