### PR TITLE
forwardauth: Skip copying missing response headers

### DIFF
--- a/caddytest/integration/caddyfile_adapt/forward_auth_authelia.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/forward_auth_authelia.caddyfiletest
@@ -1,6 +1,6 @@
 app.example.com {
 	forward_auth authelia:9091 {
-		uri /api/verify?rd=https://authelia.example.com
+		uri /api/authz/forward-auth
 		copy_headers Remote-User Remote-Groups Remote-Name Remote-Email
 	}
 
@@ -42,23 +42,115 @@ app.example.com {
 																{
 																	"handle": [
 																		{
+																			"handler": "vars"
+																		}
+																	]
+																},
+																{
+																	"handle": [
+																		{
 																			"handler": "headers",
 																			"request": {
 																				"set": {
 																					"Remote-Email": [
 																						"{http.reverse_proxy.header.Remote-Email}"
-																					],
+																					]
+																				}
+																			}
+																		}
+																	],
+																	"match": [
+																		{
+																			"not": [
+																				{
+																					"vars": {
+																						"{http.reverse_proxy.header.Remote-Email}": [
+																							""
+																						]
+																					}
+																				}
+																			]
+																		}
+																	]
+																},
+																{
+																	"handle": [
+																		{
+																			"handler": "headers",
+																			"request": {
+																				"set": {
 																					"Remote-Groups": [
 																						"{http.reverse_proxy.header.Remote-Groups}"
-																					],
+																					]
+																				}
+																			}
+																		}
+																	],
+																	"match": [
+																		{
+																			"not": [
+																				{
+																					"vars": {
+																						"{http.reverse_proxy.header.Remote-Groups}": [
+																							""
+																						]
+																					}
+																				}
+																			]
+																		}
+																	]
+																},
+																{
+																	"handle": [
+																		{
+																			"handler": "headers",
+																			"request": {
+																				"set": {
 																					"Remote-Name": [
 																						"{http.reverse_proxy.header.Remote-Name}"
-																					],
+																					]
+																				}
+																			}
+																		}
+																	],
+																	"match": [
+																		{
+																			"not": [
+																				{
+																					"vars": {
+																						"{http.reverse_proxy.header.Remote-Name}": [
+																							""
+																						]
+																					}
+																				}
+																			]
+																		}
+																	]
+																},
+																{
+																	"handle": [
+																		{
+																			"handler": "headers",
+																			"request": {
+																				"set": {
 																					"Remote-User": [
 																						"{http.reverse_proxy.header.Remote-User}"
 																					]
 																				}
 																			}
+																		}
+																	],
+																	"match": [
+																		{
+																			"not": [
+																				{
+																					"vars": {
+																						"{http.reverse_proxy.header.Remote-User}": [
+																							""
+																						]
+																					}
+																				}
+																			]
 																		}
 																	]
 																}
@@ -80,7 +172,7 @@ app.example.com {
 													},
 													"rewrite": {
 														"method": "GET",
-														"uri": "/api/verify?rd=https://authelia.example.com"
+														"uri": "/api/authz/forward-auth"
 													},
 													"upstreams": [
 														{

--- a/caddytest/integration/caddyfile_adapt/forward_auth_rename_headers.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/forward_auth_rename_headers.caddyfiletest
@@ -31,26 +31,142 @@ forward_auth localhost:9000 {
 												{
 													"handle": [
 														{
+															"handler": "vars"
+														}
+													]
+												},
+												{
+													"handle": [
+														{
 															"handler": "headers",
 															"request": {
 																"set": {
 																	"1": [
 																		"{http.reverse_proxy.header.A}"
-																	],
-																	"3": [
-																		"{http.reverse_proxy.header.C}"
-																	],
-																	"5": [
-																		"{http.reverse_proxy.header.E}"
-																	],
+																	]
+																}
+															}
+														}
+													],
+													"match": [
+														{
+															"not": [
+																{
+																	"vars": {
+																		"{http.reverse_proxy.header.A}": [
+																			""
+																		]
+																	}
+																}
+															]
+														}
+													]
+												},
+												{
+													"handle": [
+														{
+															"handler": "headers",
+															"request": {
+																"set": {
 																	"B": [
 																		"{http.reverse_proxy.header.B}"
-																	],
+																	]
+																}
+															}
+														}
+													],
+													"match": [
+														{
+															"not": [
+																{
+																	"vars": {
+																		"{http.reverse_proxy.header.B}": [
+																			""
+																		]
+																	}
+																}
+															]
+														}
+													]
+												},
+												{
+													"handle": [
+														{
+															"handler": "headers",
+															"request": {
+																"set": {
+																	"3": [
+																		"{http.reverse_proxy.header.C}"
+																	]
+																}
+															}
+														}
+													],
+													"match": [
+														{
+															"not": [
+																{
+																	"vars": {
+																		"{http.reverse_proxy.header.C}": [
+																			""
+																		]
+																	}
+																}
+															]
+														}
+													]
+												},
+												{
+													"handle": [
+														{
+															"handler": "headers",
+															"request": {
+																"set": {
 																	"D": [
 																		"{http.reverse_proxy.header.D}"
 																	]
 																}
 															}
+														}
+													],
+													"match": [
+														{
+															"not": [
+																{
+																	"vars": {
+																		"{http.reverse_proxy.header.D}": [
+																			""
+																		]
+																	}
+																}
+															]
+														}
+													]
+												},
+												{
+													"handle": [
+														{
+															"handler": "headers",
+															"request": {
+																"set": {
+																	"5": [
+																		"{http.reverse_proxy.header.E}"
+																	]
+																}
+															}
+														}
+													],
+													"match": [
+														{
+															"not": [
+																{
+																	"vars": {
+																		"{http.reverse_proxy.header.E}": [
+																			""
+																		]
+																	}
+																}
+															]
 														}
 													]
 												}


### PR DESCRIPTION
Reported here: https://caddy.community/t/copy-header-copying-empty-headers-with-authelia/25885, but I think it has been mentioned elsewhere before as well. Fixes #6610

Basically, because we use `ReplaceKnown` in the `request_header` handler for placeholders, the `copy_header` shortcut for `forward_auth` would cause the request headers to be set to the placeholder string itself instead of skipping, when the response was missing that header.

The fix is to use a `not vars` matcher to check that the response header placeholder has a non-empty value first.

Unfortunately this produces some super verbose JSON config, but the behaviour will be more correct.