### PR TITLE
caddytls: Drop `rate_limit` and `burst`, has been deprecated

### DIFF
--- a/caddyconfig/httpcaddyfile/options.go
+++ b/caddyconfig/httpcaddyfile/options.go
@@ -394,36 +394,10 @@ func parseOptOnDemand(d *caddyfile.Dispenser, _ any) (any, error) {
 			ond.PermissionRaw = caddyconfig.JSONModuleObject(perm, "module", modName, nil)
 
 		case "interval":
-			if !d.NextArg() {
-				return nil, d.ArgErr()
-			}
-			dur, err := caddy.ParseDuration(d.Val())
-			if err != nil {
-				return nil, err
-			}
-			if ond == nil {
-				ond = new(caddytls.OnDemandConfig)
-			}
-			if ond.RateLimit == nil {
-				ond.RateLimit = new(caddytls.RateLimit)
-			}
-			ond.RateLimit.Interval = caddy.Duration(dur)
+			return nil, d.Errf("the on_demand_tls 'interval' option is no longer supported, remove it from your config")
 
 		case "burst":
-			if !d.NextArg() {
-				return nil, d.ArgErr()
-			}
-			burst, err := strconv.Atoi(d.Val())
-			if err != nil {
-				return nil, err
-			}
-			if ond == nil {
-				ond = new(caddytls.OnDemandConfig)
-			}
-			if ond.RateLimit == nil {
-				ond.RateLimit = new(caddytls.RateLimit)
-			}
-			ond.RateLimit.Burst = burst
+			return nil, d.Errf("the on_demand_tls 'burst' option is no longer supported, remove it from your config")
 
 		default:
 			return nil, d.Errf("unrecognized parameter '%s'", d.Val())

--- a/caddytest/integration/caddyfile_adapt/global_options.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/global_options.caddyfiletest
@@ -17,8 +17,6 @@
 	admin off
 	on_demand_tls {
 		ask https://example.com
-		interval 30s
-		burst 20
 	}
 	local_certs
 	key_type ed25519
@@ -72,10 +70,6 @@
 					"permission": {
 						"endpoint": "https://example.com",
 						"module": "http"
-					},
-					"rate_limit": {
-						"interval": 30000000000,
-						"burst": 20
 					}
 				}
 			},

--- a/caddytest/integration/caddyfile_adapt/global_options_acme.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/global_options_acme.caddyfiletest
@@ -17,8 +17,6 @@
 	admin off
 	on_demand_tls {
 		ask https://example.com
-		interval 30s
-		burst 20
 	}
 	storage_clean_interval 7d
 	renew_interval 1d
@@ -89,10 +87,6 @@
 					"permission": {
 						"endpoint": "https://example.com",
 						"module": "http"
-					},
-					"rate_limit": {
-						"interval": 30000000000,
-						"burst": 20
 					}
 				},
 				"ocsp_interval": 172800000000000,

--- a/caddytest/integration/caddyfile_adapt/global_options_admin.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/global_options_admin.caddyfiletest
@@ -16,8 +16,6 @@
 	}
 	on_demand_tls {
 		ask https://example.com
-		interval 30s
-		burst 20
 	}
 	local_certs
 	key_type ed25519
@@ -74,10 +72,6 @@
 					"permission": {
 						"endpoint": "https://example.com",
 						"module": "http"
-					},
-					"rate_limit": {
-						"interval": 30000000000,
-						"burst": 20
 					}
 				}
 			}

--- a/modules/caddytls/automation.go
+++ b/modules/caddytls/automation.go
@@ -322,12 +322,6 @@ func (ap *AutomationPolicy) Provision(tlsApp *TLS) error {
 					return err
 				}
 
-				// check the rate limiter last because
-				// doing so makes a reservation
-				if !onDemandRateLimiter.Allow() {
-					return fmt.Errorf("on-demand rate limit exceeded")
-				}
-
 				return nil
 			},
 			Managers: ap.Managers,

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -188,17 +188,6 @@ func (t *TLS) Provision(ctx caddy.Context) error {
 		t.Automation.OnDemand.permission = val.(OnDemandPermission)
 	}
 
-	// on-demand rate limiting (TODO: deprecated, and should be removed later; rate limiting is ineffective now that permission modules are required)
-	if t.Automation != nil && t.Automation.OnDemand != nil && t.Automation.OnDemand.RateLimit != nil {
-		t.logger.Warn("DEPRECATED: on_demand.rate_limit will be removed in a future release; use permission modules or external certificate managers instead")
-		onDemandRateLimiter.SetMaxEvents(t.Automation.OnDemand.RateLimit.Burst)
-		onDemandRateLimiter.SetWindow(time.Duration(t.Automation.OnDemand.RateLimit.Interval))
-	} else {
-		// remove any existing rate limiter
-		onDemandRateLimiter.SetWindow(0)
-		onDemandRateLimiter.SetMaxEvents(0)
-	}
-
 	// run replacer on ask URL (for environment variables) -- return errors to prevent surprises (#5036)
 	if t.Automation != nil && t.Automation.OnDemand != nil && t.Automation.OnDemand.Ask != "" {
 		t.Automation.OnDemand.Ask, err = repl.ReplaceOrErr(t.Automation.OnDemand.Ask, true, true)


### PR DESCRIPTION
It's time to get rid of these, they're not working correctly and introduce more problems than they solve, when used.