### PR TITLE
caddyfile: Fix comma edgecase in address parsing

### DIFF
--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -264,8 +264,13 @@ func (p *parser) addresses() error {
 				return p.Errf("Site addresses cannot contain a comma ',': '%s' - put a space after the comma to separate site addresses", value)
 			}
 
-			token.Text = value
-			p.block.Keys = append(p.block.Keys, token)
+			// After the above, a comma surrounded by spaces would result
+			// in an empty token which we should ignore
+			if value != "" {
+				// Add the token as a site address
+				token.Text = value
+				p.block.Keys = append(p.block.Keys, token)
+			}
 		}
 
 		// Advance token and possibly break out of loop or return error

--- a/caddyconfig/caddyfile/parse_test.go
+++ b/caddyconfig/caddyfile/parse_test.go
@@ -555,6 +555,10 @@ func TestParseAll(t *testing.T) {
 			{"localhost:1234", "http://host2"},
 		}},
 
+		{`foo.example.com   ,   example.com`, false, [][]string{
+			{"foo.example.com", "example.com"},
+		}},
+
 		{`localhost:1234, http://host2,`, true, [][]string{}},
 
 		{`http://host1.com, http://host2.com {
@@ -614,8 +618,8 @@ func TestParseAll(t *testing.T) {
 		}
 		for j, block := range blocks {
 			if len(block.Keys) != len(test.keys[j]) {
-				t.Errorf("Test %d: Expected %d keys in block %d, got %d",
-					i, len(test.keys[j]), j, len(block.Keys))
+				t.Errorf("Test %d: Expected %d keys in block %d, got %d: %v",
+					i, len(test.keys[j]), j, len(block.Keys), block.Keys)
 				continue
 			}
 			for k, addr := range block.GetKeysText() {


### PR DESCRIPTION
When the site address line looks like `foo  ,  bar` (i.e. spaces around the `,` and not simply a comma trailing an address), then it would cause the site address to include an empty space which messes up parsing in subtle ways. This fixes that case.

Closes https://github.com/caddyserver/website/issues/395

Given this Caddyfile:

```
foo.example.com , example.com , www.example.com {
    respond "foo"
}
```

Before (for some reason, no host matchers are produced, but it does automate the names):
```
{"apps":{"http":{"servers":{"srv0":{"listen":[":443"],"routes":[{"handle":[{"body":"foo","handler":"static_response"}]}]}}},"tls":{"certificates":{"automate":["foo.example.com","example.com","www.example.com"]}}}}
```

After (properly matching the hosts, later resulting in Auto HTTPS automating):
```
{"apps":{"http":{"servers":{"srv0":{"listen":[":443"],"routes":[{"match":[{"host":["foo.example.com","example.com","www.example.com"]}],"handle":[{"handler":"subroute","routes":[{"handle":[{"body":"foo","handler":"static_response"}]}]}],"terminal":true}]}}}}}
```