### PR TITLE
reverseproxy: Use correct cases for websocket related headers

### DIFF
--- a/modules/caddyhttp/reverseproxy/streaming.go
+++ b/modules/caddyhttp/reverseproxy/streaming.go
@@ -63,11 +63,10 @@ func (h *Handler) handleUpgradeResponse(logger *zap.Logger, wg *sync.WaitGroup, 
 		return
 	}
 
-	normalizeWebsocketHeaders(res.Header)
-
 	// write header first, response headers should not be counted in size
 	// like the rest of handler chain.
 	copyHeader(rw.Header(), res.Header)
+	normalizeWebsocketHeaders(rw.Header())
 	rw.WriteHeader(res.StatusCode)
 
 	logger.Debug("upgrading connection")

--- a/modules/caddyhttp/reverseproxy/streaming.go
+++ b/modules/caddyhttp/reverseproxy/streaming.go
@@ -63,8 +63,8 @@ func (h *Handler) handleUpgradeResponse(logger *zap.Logger, wg *sync.WaitGroup, 
 		return
 	}
 
-	// normalize websocket header
-	normalizeWsHeader(res.Header)
+	normalizeWebsocketHeaders(res.Header)
+
 	// write header first, response headers should not be counted in size
 	// like the rest of handler chain.
 	copyHeader(rw.Header(), res.Header)

--- a/modules/caddyhttp/reverseproxy/streaming.go
+++ b/modules/caddyhttp/reverseproxy/streaming.go
@@ -63,6 +63,8 @@ func (h *Handler) handleUpgradeResponse(logger *zap.Logger, wg *sync.WaitGroup, 
 		return
 	}
 
+	// normalize websocket header
+	normalizeWsHeader(res.Header)
 	// write header first, response headers should not be counted in size
 	// like the rest of handler chain.
 	copyHeader(rw.Header(), res.Header)


### PR DESCRIPTION
Fix https://caddy.community/t/websockets-fail-venus-os-cerbo-gx-victron/25685

Although websocket related headers should be handled case insensitively. Some legacy servers and clients do handle them strictly according to rfc. traefik [handles this case](https://github.com/traefik/traefik/blob/06e64af9e9b4fffd3e0d2772343a31bc0de23c40/pkg/proxy/httputil/proxy.go#L75) too. Popular golang websocket libraries such as [gorilla](https://github.com/gorilla/websocket/blob/5e002381133d322c5f1305d171f3bdd07decf229/client.go#L209) also use the correct case.