### PR TITLE
fileserver: fix try_policy when instantiating file matcher from CEL

### DIFF
--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -191,7 +191,7 @@ func (MatchFile) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 
 		var try_policy string
 		if len(values["try_policy"]) > 0 {
-			root = values["try_policy"][0]
+			try_policy = values["try_policy"][0]
 		}
 
 		m := MatchFile{

--- a/modules/caddyhttp/fileserver/matcher_test.go
+++ b/modules/caddyhttp/fileserver/matcher_test.go
@@ -354,6 +354,14 @@ var expressionTests = []struct {
 		urlTarget:  "https://example.com/nopenope.txt",
 		wantResult: false,
 	},
+	{
+		name: "file match long pattern foo.txt with try_policy (MatchFile)",
+		expression: &caddyhttp.MatchExpression{
+			Expr: `file({"try_policy": "most_recently_modified"})`,
+		},
+		urlTarget:  "https://example.com/foo.txt",
+		wantResult: true,
+	},
 }
 
 func TestMatchExpressionMatch(t *testing.T) {

--- a/modules/caddyhttp/fileserver/testdata/large.txt
+++ b/modules/caddyhttp/fileserver/testdata/large.txt
@@ -1,0 +1,3 @@
+This is a file with more content than the other files in this directory
+such that tests using the largest_size policy pick this file, or the
+smallest_size policy avoids this file.


### PR DESCRIPTION
I found a minor bug in #6623 for the `file` matcher when written as a CEL expression.

This PR corrects the current reassignment of `root`, and adds a test to ensure the correct property is set.