### PR TITLE
Add Makefile-based build option for Caddy with custom plugins in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ Requirements:
 
 - [Go 1.22.3 or newer](https://golang.org/dl/)
 
+### Automating Caddy Builds with Plugins
+
+For an alternative way to build Caddy with custom plugins, test configurations, and manage installations, the [Caddy Build Automation](https://github.com/Hansen333/caddy-automate) project provides a `Makefile`-based approach. It automates the build process with `xcaddy`, including configuration testing and backup management.
+
+Key features include:
+- **Custom Plugin Management**: Add or remove plugins for the Caddy build.
+- **Automated Testing**: Validate the Caddy configuration before installation.
+- **Backup and Restore**: Automatically back up the current Caddy binary before installing a new version.
+
+For more details, visit the project [here](https://github.com/Hansen333/caddy-automate).
+
 ### For development
 
 _**Note:** These steps [will not embed proper version information](https://github.com/golang/go/issues/29228). For that, please follow the instructions in the next section._


### PR DESCRIPTION
This pull request introduces a new section in the **Build from source** part of the `README.md`, which provides an alternative method for building Caddy with custom plugins using a `Makefile`.

### Summary of Changes:
- Added a section under **Build from source** that introduces a `Makefile`-based approach for automating the process of building Caddy with custom plugins.
- This method leverages `xcaddy` and simplifies tasks such as configuration testing, plugin management, and backup/restore of the Caddy binary.
  
### Key Features of the Makefile Approach:
- **Custom Plugin Management**: Easily add or remove plugins during the Caddy build process.
- **Automated Testing**: Validate the Caddy configuration before installation.
- **Backup and Restore**: Automatically back up the current Caddy binary before installing a new version.
- **Automation**: Utilize `make` commands to streamline the build, install, and restart process.

This addition is intended to provide developers an alternative method for automating their Caddy builds with plugins.

Please let me know if any further adjustments are needed or if there are suggestions to improve this section.
