### PR TITLE
httpcaddyfile: Fixes for `prefer_wildcard` mode

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -827,7 +827,7 @@ func (st *ServerType) serversFromPairings(
 						baseDomain = baseDomain[idx+1:]
 					}
 					if !strings.HasPrefix(addr.Host, "*.") && slices.Contains(wildcardHosts, baseDomain) {
-						srv.AutoHTTPS.Skip = append(srv.AutoHTTPS.Skip, addr.Host)
+						srv.AutoHTTPS.SkipCerts = append(srv.AutoHTTPS.SkipCerts, addr.Host)
 					}
 				}
 

--- a/caddytest/integration/caddyfile_adapt/auto_https_prefer_wildcard.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/auto_https_prefer_wildcard.caddyfiletest
@@ -74,7 +74,7 @@ foo.example.com {
 						}
 					],
 					"automatic_https": {
-						"skip": [
+						"skip_certificates": [
 							"foo.example.com"
 						],
 						"prefer_wildcard": true

--- a/caddytest/integration/caddyfile_adapt/auto_https_prefer_wildcard.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/auto_https_prefer_wildcard.caddyfiletest
@@ -74,6 +74,9 @@ foo.example.com {
 						}
 					],
 					"automatic_https": {
+						"skip": [
+							"foo.example.com"
+						],
 						"prefer_wildcard": true
 					}
 				}

--- a/caddytest/integration/caddyfile_adapt/auto_https_prefer_wildcard_multi.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/auto_https_prefer_wildcard_multi.caddyfiletest
@@ -1,0 +1,268 @@
+{
+	auto_https prefer_wildcard
+}
+
+# Covers two domains
+*.one.example.com {
+	tls {
+		dns mock
+	}
+	respond "one fallback"
+}
+
+# Is covered, should not get its own AP
+foo.one.example.com {
+	respond "foo one"
+}
+
+# This one has its own tls config so it doesn't get covered (escape hatch)
+bar.one.example.com {
+	respond "bar one"
+	tls bar@bar.com
+}
+
+# Covers nothing but AP gets consolidated with the first
+*.two.example.com {
+	tls {
+		dns mock
+	}
+	respond "two fallback"
+}
+
+# Is HTTP so it should not cover
+http://*.three.example.com {
+	respond "three fallback"
+}
+
+# Has no wildcard coverage so it gets an AP
+foo.three.example.com {
+	respond "foo three"
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"foo.three.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "foo three",
+													"handler": "static_response"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						},
+						{
+							"match": [
+								{
+									"host": [
+										"foo.one.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "foo one",
+													"handler": "static_response"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						},
+						{
+							"match": [
+								{
+									"host": [
+										"bar.one.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "bar one",
+													"handler": "static_response"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						},
+						{
+							"match": [
+								{
+									"host": [
+										"*.one.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "one fallback",
+													"handler": "static_response"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						},
+						{
+							"match": [
+								{
+									"host": [
+										"*.two.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "two fallback",
+													"handler": "static_response"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					],
+					"automatic_https": {
+						"skip_certificates": [
+							"foo.one.example.com",
+							"bar.one.example.com"
+						],
+						"prefer_wildcard": true
+					}
+				},
+				"srv1": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"*.three.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "three fallback",
+													"handler": "static_response"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					],
+					"automatic_https": {
+						"prefer_wildcard": true
+					}
+				}
+			}
+		},
+		"tls": {
+			"automation": {
+				"policies": [
+					{
+						"subjects": [
+							"foo.three.example.com"
+						]
+					},
+					{
+						"subjects": [
+							"bar.one.example.com"
+						],
+						"issuers": [
+							{
+								"email": "bar@bar.com",
+								"module": "acme"
+							},
+							{
+								"ca": "https://acme.zerossl.com/v2/DV90",
+								"email": "bar@bar.com",
+								"module": "acme"
+							}
+						]
+					},
+					{
+						"subjects": [
+							"*.one.example.com",
+							"*.two.example.com"
+						],
+						"issuers": [
+							{
+								"challenges": {
+									"dns": {
+										"provider": {
+											"name": "mock"
+										}
+									}
+								},
+								"module": "acme"
+							}
+						]
+					}
+				]
+			}
+		}
+	}
+}


### PR DESCRIPTION
Followup to #6146

Two fixes:

- When assembling the HTTP app, the wildcard hosts need to be collected first, then considered after, because there's no guarantee that all non-wildcards will appear after all wildcards when looping. Also we should not add a domain to Skip if it doesn't qualify for TLS anyway. But I realized we should actually add it to SkipCerts, not Skip because we do want them to still get HTTP->HTTPS redirects, just not have certs issued.

- The automation policy consolidation misbehaved if there was more than one wildcard configured, because it was comparing wildcards against eachother. This would cause all APs to disappear in some cases. Instead of handling wildcard coverage in consolidation, I reworked it to avoid adding the AP altogether if it would be covered by a wildcard. Should be more robust.