### PR TITLE
reverse_proxy: rewrite request buffering for fastcgi

### DIFF
--- a/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
@@ -19,6 +19,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/dustin/go-humanize"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -43,7 +45,10 @@ func init() {
 //	    dial_timeout <duration>
 //	    read_timeout <duration>
 //	    write_timeout <duration>
-//	    capture_stderr
+//	    body_buffer_disabled
+//	    body_buffer_memory_limit <size>
+//	    file_buffer_size_limit <size>
+//	    file_buffer_filepath <path>
 //	}
 func (t *Transport) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	d.Next() // consume transport name
@@ -112,6 +117,35 @@ func (t *Transport) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				return d.ArgErr()
 			}
 			t.CaptureStderr = true
+
+		case "body_buffer_disabled":
+			t.BodyBufferDisabled = true
+
+		case "body_buffer_memory_limit":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			size, err := humanize.ParseBytes(d.Val())
+			if err != nil {
+				return d.Errf("bad buffer size %s: %v", d.Val(), err)
+			}
+			t.BodyBufferMemoryLimit = int64(size)
+
+		case "file_buffer_size_limit":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			size, err := humanize.ParseBytes(d.Val())
+			if err != nil {
+				return d.Errf("bad buffer size %s: %v", d.Val(), err)
+			}
+			t.FileBufferSizeLimit = int64(size)
+
+		case "file_buffer_filepath":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			t.FileBufferFilepath = d.Val()
 
 		default:
 			return d.Errf("unrecognized subdirective %s", d.Val())
@@ -294,6 +328,35 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 				args := dispenser.RemainingArgs()
 				dispenser.DeleteN(len(args) + 1)
 				fcgiTransport.CaptureStderr = true
+
+			case "body_buffer_disabled":
+				fcgiTransport.BodyBufferDisabled = true
+
+			case "body_buffer_memory_limit":
+				if !dispenser.NextArg() {
+					return nil, dispenser.ArgErr()
+				}
+				size, err := humanize.ParseBytes(dispenser.Val())
+				if err != nil {
+					return nil, dispenser.Errf("bad buffer size %s: %v", dispenser.Val(), err)
+				}
+				fcgiTransport.BodyBufferMemoryLimit = int64(size)
+
+			case "file_buffer_size_limit":
+				if !dispenser.NextArg() {
+					return nil, dispenser.ArgErr()
+				}
+				size, err := humanize.ParseBytes(dispenser.Val())
+				if err != nil {
+					return nil, dispenser.Errf("bad buffer size %s: %v", dispenser.Val(), err)
+				}
+				fcgiTransport.FileBufferSizeLimit = int64(size)
+
+			case "file_buffer_filepath":
+				if !dispenser.NextArg() {
+					return nil, dispenser.ArgErr()
+				}
+				fcgiTransport.FileBufferFilepath = dispenser.Val()
 			}
 		}
 	}

--- a/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
@@ -330,6 +330,8 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 				fcgiTransport.CaptureStderr = true
 
 			case "body_buffer_disabled":
+				args := dispenser.RemainingArgs()
+				dispenser.DeleteN(len(args) + 1)
 				fcgiTransport.BodyBufferDisabled = true
 
 			case "body_buffer_memory_limit":
@@ -341,6 +343,7 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 					return nil, dispenser.Errf("bad buffer size %s: %v", dispenser.Val(), err)
 				}
 				fcgiTransport.BodyBufferMemoryLimit = int64(size)
+				dispenser.DeleteN(2)
 
 			case "file_buffer_size_limit":
 				if !dispenser.NextArg() {
@@ -351,12 +354,14 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 					return nil, dispenser.Errf("bad buffer size %s: %v", dispenser.Val(), err)
 				}
 				fcgiTransport.FileBufferSizeLimit = int64(size)
+				dispenser.DeleteN(2)
 
 			case "file_buffer_filepath":
 				if !dispenser.NextArg() {
 					return nil, dispenser.ArgErr()
 				}
 				fcgiTransport.FileBufferFilepath = dispenser.Val()
+				dispenser.DeleteN(2)
 			}
 		}
 	}

--- a/modules/caddyhttp/reverseproxy/fastcgi/client.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/client.go
@@ -157,12 +157,12 @@ func (c *client) Do(p map[string]string, req io.Reader) (r io.Reader, err error)
 	writer.recType = Stdin
 	if req != nil {
 		_, err = io.Copy(writer, req)
+		if err != nil {
+			return nil, err
+		}
 		// body length mismatch
 		if lr, ok := req.(*io.LimitedReader); ok && lr.N > 0 {
 			return nil, io.ErrUnexpectedEOF
-		}
-		if err != nil {
-			return nil, err
 		}
 	}
 	err = writer.FlushStream()

--- a/modules/caddyhttp/reverseproxy/fastcgi/client.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/client.go
@@ -209,6 +209,7 @@ func newErrorResponse(status int) *http.Response {
 	statusText := http.StatusText(status)
 	resp := &http.Response{
 		Status:        statusText,
+		StatusCode:    status,
 		Header:        make(http.Header),
 		Body:          io.NopCloser(strings.NewReader(statusText)),
 		ContentLength: int64(len(statusText)),

--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -239,6 +239,7 @@ func (t Transport) bufferBody(req io.Reader) (int64, io.ReadCloser, error) {
 	size, err := io.CopyN(memBuf, req, t.BodyBufferMemoryLimit)
 	var body bufferedBody // should be closed in case buffering fails
 	body.memBuf = memBuf
+	body.tempFileLimiter = t.tempFileLimiter
 	// error while reading the body
 	if err != nil {
 		// fully buffered in memory

--- a/modules/caddyhttp/reverseproxy/fastcgi/pool.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/pool.go
@@ -24,3 +24,16 @@ var bufPool = sync.Pool{
 		return new(bytes.Buffer)
 	},
 }
+
+const readBufSize = 4096
+
+var streamingBufPool = sync.Pool{
+	New: func() any {
+		// The Pool's New function should generally only return pointer
+		// types, since a pointer can be put into the return interface
+		// value without an allocation
+		// - (from the package docs)
+		b := make([]byte, readBufSize)
+		return &b
+	},
+}

--- a/modules/caddyhttp/reverseproxy/fastcgi/quota.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/quota.go
@@ -1,0 +1,34 @@
+package fastcgi
+
+import "sync"
+
+type fileQuotaLimiter struct {
+	maxUsage     int64
+	currentUsage int64
+	mu           sync.Mutex
+}
+
+func newFileQuotaLimiter(maxUsage int64) *fileQuotaLimiter {
+	return &fileQuotaLimiter{
+		maxUsage: maxUsage,
+	}
+}
+
+func (l *fileQuotaLimiter) acquire(n int64) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.currentUsage+n > l.maxUsage {
+		return false
+	}
+
+	l.currentUsage += n
+	return true
+}
+
+func (l *fileQuotaLimiter) release(n int64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.currentUsage -= n
+}


### PR DESCRIPTION
Follow up on [6637](https://github.com/caddyserver/caddy/issues/6637). Now this patch will try to buffer request body for fastcgi requests by default with memory and file based buffers. The buffering behavior can be disabled and the buffer limits can be set as well.

This makes sure caddy can work out of the box when the requests don't have a content length, typically chunked encoding, without having to configure request buffering, which will buffer all requests and will not set `content-length` if the request can't be buffered in memory. `content-length` is required when communicating with php-fpm.

If buffering is disabled, response for requests without `content-length` will be `411 Length Required`, typically for http1 requests that have `chunked` encoding. If the buffer limit is reached, the response will be `413 Request Entity Too Large`.

By default, memory buffer is `16k` per request, and all file based buffers can only use `100MB` of disk space. The buffer file path is dependent on the system, and caddy wil fail to start if caddy can't create files in this directory.

The new configuration parameters are following:

```
body_buffer_disabled
body_buffer_memory_limit <size>
file_buffer_size_limit  <size>
file_buffer_filepath <path>
```

Another fix is that now `content-length` is checked when sending the request to php-fpm, so that request size is limited to prevent client to send faulty `content-length`.