### PR TITLE
fix: always ignore SIGPIPE

### DIFF
--- a/sigtrap_posix.go
+++ b/sigtrap_posix.go
@@ -28,6 +28,10 @@ import (
 
 // trapSignalsPosix captures POSIX-only signals.
 func trapSignalsPosix() {
+	// Ignore all SIGPIPE signals to prevent weird issues with systemd: https://github.com/dunglas/frankenphp/issues/1020
+	// Docker/Moby has a similar hack: https://github.com/moby/moby/blob/d828b032a87606ae34267e349bf7f7ccb1f6495a/cmd/dockerd/docker.go#L87-L90
+	signal.Ignore(syscall.SIGPIPE)
+
 	go func() {
 		sigchan := make(chan os.Signal, 1)
 		signal.Notify(sigchan, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGUSR1, syscall.SIGUSR2)


### PR DESCRIPTION
Backport of https://github.com/dunglas/frankenphp/pull/1101 to Caddy itself.

Sometimes (especially when using systemd), `SIGPIPE` signals can crash the server. This patch always ignore SIGPIPE, for all file descriptors.