### PR TITLE
tracing: Add `spanID` field to access logs and `http.vars.span_id` placeholder

### DIFF
--- a/modules/caddyhttp/server_test.go
+++ b/modules/caddyhttp/server_test.go
@@ -69,12 +69,13 @@ func TestServer_LogRequest(t *testing.T) {
 	}`, buf.String())
 }
 
-func TestServer_LogRequest_WithTraceID(t *testing.T) {
+func TestServer_LogRequest_WithTrace(t *testing.T) {
 	s := &Server{}
 
 	extra := new(ExtraLogFields)
 	ctx := context.WithValue(context.Background(), ExtraLogFieldsCtxKey, extra)
 	extra.Add(zap.String("traceID", "1234567890abcdef"))
+	extra.Add(zap.String("spanID", "12345678"))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
 	rec := httptest.NewRecorder()
@@ -93,7 +94,8 @@ func TestServer_LogRequest_WithTraceID(t *testing.T) {
 		"msg":"handled request", "level":"info", "bytes_read":0,
 		"duration":"50ms", "resp_headers": {}, "size":0,
 		"status":0, "user_id":"",
-		"traceID":"1234567890abcdef"
+		"traceID":"1234567890abcdef",
+		"spanID":"12345678"
 	}`, buf.String())
 }
 
@@ -144,12 +146,13 @@ func BenchmarkServer_LogRequest_NopLogger(b *testing.B) {
 	}
 }
 
-func BenchmarkServer_LogRequest_WithTraceID(b *testing.B) {
+func BenchmarkServer_LogRequest_WithTrace(b *testing.B) {
 	s := &Server{}
 
 	extra := new(ExtraLogFields)
 	ctx := context.WithValue(context.Background(), ExtraLogFieldsCtxKey, extra)
 	extra.Add(zap.String("traceID", "1234567890abcdef"))
+	extra.Add(zap.String("spanID", "12345678"))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
 	rec := httptest.NewRecorder()

--- a/modules/caddyhttp/tracing/tracer.go
+++ b/modules/caddyhttp/tracing/tracer.go
@@ -88,11 +88,13 @@ func (ot *openTelemetryWrapper) serveHTTP(w http.ResponseWriter, r *http.Request
 	spanCtx := trace.SpanContextFromContext(ctx)
 	if spanCtx.IsValid() {
 		traceID := spanCtx.TraceID().String()
+		spanID := spanCtx.SpanID().String()
 		// Add a trace_id placeholder, accessible via `{http.vars.trace_id}`.
 		caddyhttp.SetVar(ctx, "trace_id", traceID)
-		// Add the trace id to the log fields for the request.
+		// Add the traceID and spanID to the log fields for the request.
 		if extra, ok := ctx.Value(caddyhttp.ExtraLogFieldsCtxKey).(*caddyhttp.ExtraLogFields); ok {
 			extra.Add(zap.String("traceID", traceID))
+			extra.Add(zap.String("spanID", spanID))
 		}
 	}
 	next := ctx.Value(nextCallCtxKey).(*nextCall)

--- a/modules/caddyhttp/tracing/tracer.go
+++ b/modules/caddyhttp/tracing/tracer.go
@@ -91,6 +91,8 @@ func (ot *openTelemetryWrapper) serveHTTP(w http.ResponseWriter, r *http.Request
 		spanID := spanCtx.SpanID().String()
 		// Add a trace_id placeholder, accessible via `{http.vars.trace_id}`.
 		caddyhttp.SetVar(ctx, "trace_id", traceID)
+		// Add a span_id placeholder, accessible via `{http.vars.span_id}`.
+		caddyhttp.SetVar(ctx, "span_id", spanID)
 		// Add the traceID and spanID to the log fields for the request.
 		if extra, ok := ctx.Value(caddyhttp.ExtraLogFieldsCtxKey).(*caddyhttp.ExtraLogFields); ok {
 			extra.Add(zap.String("traceID", traceID))


### PR DESCRIPTION
In [PR #5507](https://github.com/caddyserver/caddy/pull/5507), the `traceid` was added to the logs. To further align with the [OpenTelemetry Log Correlation specification](https://opentelemetry.io/docs/specs/otel/logs/#log-correlation) and achieve complete log correlation using trace context, we have now included the `spanid` alongside the `traceid`.

### Benchmark Comparison
I conducted benchmarks to assess the performance impact of adding the `spanid`. Since `traceid` and `spanid` are always used together, I modified the existing benchmarks for `traceid` to include `spanid`. Below is the performance comparison before and after adding the `spanid`:
<details> <summary>Before:</summary>
  <pre><code>
$ go test -benchtime=3s -count=10 -benchmem -run=^$ -bench ^BenchmarkServer ./modules/caddyhttp | tee before.txt
goos: linux
goarch: amd64
pkg: github.com/caddyserver/caddy/v2/modules/caddyhttp
cpu: AMD EPYC 9754 128-Core Processor               
BenchmarkServer_LogRequest-64                    3140806              1174 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3026678              1161 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3103068              1156 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3121268              1152 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3098882              1163 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3171706              1147 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3098536              1128 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3198552              1143 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3118201              1159 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3211209              1151 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         27751924               127.9 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         28101333               125.2 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         28519773               124.9 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         27652406               126.6 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         28332801               124.6 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         28507286               125.0 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         28651822               126.3 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         28575466               130.1 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         28702560               128.1 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         28392454               125.5 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2870023              1248 ns/op             484 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2934045              1239 ns/op             484 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2897414              1240 ns/op             484 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2886142              1240 ns/op             484 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2973252              1241 ns/op             484 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2958910              1214 ns/op             484 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2922925              1219 ns/op             484 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2962358              1230 ns/op             484 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2883412              1225 ns/op             484 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          3014709              1151 ns/op             484 B/op          4 allocs/op
PASS
ok      github.com/caddyserver/caddy/v2/modules/caddyhttp       133.403s
  </code></pre>
</details>



<details> <summary>After:</summary>
  <pre><code>
$ go test -benchtime=3s -count=10 -benchmem -run=^$ -bench ^BenchmarkServer ./modules/caddyhttp | tee after.txt
goos: linux
goarch: amd64
pkg: github.com/caddyserver/caddy/v2/modules/caddyhttp
cpu: AMD EPYC 9754 128-Core Processor               
BenchmarkServer_LogRequest-64                    3152115              1158 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3094155              1143 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3174631              1132 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3161185              1133 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3190516              1136 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3090571              1154 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3119666              1153 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3145326              1144 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3134314              1135 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest-64                    3138734              1136 ns/op             419 B/op          4 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         28379570               133.5 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         28388329               134.3 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         28012402               124.0 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         28187100               126.3 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         28356514               125.5 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         26432298               125.4 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         27307333               124.9 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         27985292               133.6 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         28657483               132.7 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_NopLogger-64         28491796               124.5 ns/op             8 B/op          1 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2783799              1273 ns/op             548 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2767974              1324 ns/op             548 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2786803              1295 ns/op             548 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2805546              1269 ns/op             548 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2816472              1287 ns/op             548 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2801752              1299 ns/op             548 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2732166              1316 ns/op             548 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2740275              1316 ns/op             548 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2766216              1293 ns/op             548 B/op          4 allocs/op
BenchmarkServer_LogRequest_WithTrace-64          2706841              1348 ns/op             548 B/op          4 allocs/op
PASS
ok      github.com/caddyserver/caddy/v2/modules/caddyhttp       134.236s
  </code></pre>
</details>

### Diff:
```diff
$ benchstat before.txt after.txt
goos: linux
goarch: amd64
pkg: github.com/caddyserver/caddy/v2/modules/caddyhttp
cpu: AMD EPYC 9754 128-Core Processor               
                               │ before.txt  │             after.txt              │
                               │   sec/op    │   sec/op     vs base               │
Server_LogRequest-64             1.154µ ± 1%   1.140µ ± 1%       ~ (p=0.055 n=10)
Server_LogRequest_NopLogger-64   125.9n ± 2%   125.9n ± 6%       ~ (p=0.698 n=10)
Server_LogRequest_WithTrace-64   1.235µ ± 2%   1.297µ ± 2%  +5.06% (p=0.000 n=10)
geomean                          564.0n        570.9n       +1.23%

                               │ before.txt │              after.txt               │
                               │    B/op    │    B/op     vs base                  │
Server_LogRequest-64             419.0 ± 0%   419.0 ± 0%        ~ (p=1.000 n=10) ¹
Server_LogRequest_NopLogger-64   8.000 ± 0%   8.000 ± 0%        ~ (p=1.000 n=10) ¹
Server_LogRequest_WithTrace-64   484.0 ± 0%   548.0 ± 0%  +13.22% (p=0.000 n=10)
geomean                          117.5        122.5        +4.23%
¹ all samples are equal

                               │ before.txt │              after.txt              │
                               │ allocs/op  │ allocs/op   vs base                 │
Server_LogRequest-64             4.000 ± 0%   4.000 ± 0%       ~ (p=1.000 n=10) ¹
Server_LogRequest_NopLogger-64   1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
Server_LogRequest_WithTrace-64   4.000 ± 0%   4.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                          2.520        2.520       +0.00%
¹ all samples are equal
```
The addition of `spanid` to the logs led to a slight increase (~5%) in processing time. Memory usage increased in ~13%, as expected.

I also added the `http.vars.span_id` placeholder, similar to what was done in [PR #6308](https://github.com/caddyserver/caddy/pull/6308) for the `http.vars.trace_id` placeholder.