### PR TITLE
fileserver: Add `file_limit` option for browse

### DIFF
--- a/caddytest/integration/caddyfile_adapt/file_server_file_limit.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/file_server_file_limit.caddyfiletest
@@ -1,0 +1,36 @@
+:80
+
+file_server {
+	browse {
+		file_limit 4000
+	}
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"browse": {
+										"file_limit": 4000
+									},
+									"handler": "file_server",
+									"hide": [
+										"./Caddyfile"
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -66,7 +66,14 @@ type Browse struct {
 	//   - `sort size` will sort by size in ascending order
 	// The first option must be `sort_by` and the second option must be `order` (if exists).
 	SortOptions []string `json:"sort,omitempty"`
+
+	// FileLimit limits the number of up to n DirEntry values in directory order.
+	FileLimit int `json:"file_limit,omitempty"`
 }
+
+const (
+	defaultMaxDirLimit = 10000
+)
 
 func (fsrv *FileServer) serveBrowse(fileSystem fs.FS, root, dirPath string, w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	if c := fsrv.logger.Check(zapcore.DebugLevel, "browse enabled; listing directory contents"); c != nil {
@@ -206,7 +213,11 @@ func (fsrv *FileServer) serveBrowse(fileSystem fs.FS, root, dirPath string, w ht
 }
 
 func (fsrv *FileServer) loadDirectoryContents(ctx context.Context, fileSystem fs.FS, dir fs.ReadDirFile, root, urlPath string, repl *caddy.Replacer) (*browseTemplateContext, error) {
-	files, err := dir.ReadDir(10000) // TODO: this limit should probably be configurable
+	dirLimit := defaultMaxDirLimit
+	if fsrv.Browse.FileLimit != 0 {
+		dirLimit = fsrv.Browse.FileLimit
+	}
+	files, err := dir.ReadDir(dirLimit)
 	if err != nil && err != io.EOF {
 		return nil, err
 	}

--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -72,7 +72,7 @@ type Browse struct {
 }
 
 const (
-	defaultMaxDirLimit = 10000
+	defaultDirEntryLimit = 10000
 )
 
 func (fsrv *FileServer) serveBrowse(fileSystem fs.FS, root, dirPath string, w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
@@ -213,7 +213,7 @@ func (fsrv *FileServer) serveBrowse(fileSystem fs.FS, root, dirPath string, w ht
 }
 
 func (fsrv *FileServer) loadDirectoryContents(ctx context.Context, fileSystem fs.FS, dir fs.ReadDirFile, root, urlPath string, repl *caddy.Replacer) (*browseTemplateContext, error) {
-	dirLimit := defaultMaxDirLimit
+	dirLimit := defaultDirEntryLimit
 	if fsrv.Browse.FileLimit != 0 {
 		dirLimit = fsrv.Browse.FileLimit
 	}

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -16,6 +16,7 @@ package fileserver
 
 import (
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/caddyserver/caddy/v2"
@@ -58,6 +59,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 //	    browse        [<template_file>]
 //	    precompressed <formats...>
 //	    status        <status>
+//	    file_limit    <limit>
 //	    disable_canonical_uris
 //	}
 //
@@ -167,6 +169,17 @@ func (fsrv *FileServer) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			}
 			falseBool := false
 			fsrv.CanonicalURIs = &falseBool
+
+		case "file_limit":
+			fileLimit := d.RemainingArgs()
+			if len(fileLimit) != 1 {
+				return d.Err("file_limit should have an integer value")
+			}
+			val, _ := strconv.Atoi(fileLimit[0])
+			if fsrv.Browse.FileLimit != 0 {
+				return d.Err("file_limit is already enabled")
+			}
+			fsrv.Browse.FileLimit = val
 
 		case "pass_thru":
 			if d.NextArg() {

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -59,7 +59,6 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 //	    browse        [<template_file>]
 //	    precompressed <formats...>
 //	    status        <status>
-//	    file_limit    <limit>
 //	    disable_canonical_uris
 //	}
 //
@@ -131,6 +130,16 @@ func (fsrv *FileServer) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 							return d.Errf("unknown sort option '%s'", dVal)
 						}
 					}
+				case "file_limit":
+					fileLimit := d.RemainingArgs()
+					if len(fileLimit) != 1 {
+						return d.Err("file_limit should have an integer value")
+					}
+					val, _ := strconv.Atoi(fileLimit[0])
+					if fsrv.Browse.FileLimit != 0 {
+						return d.Err("file_limit is already enabled")
+					}
+					fsrv.Browse.FileLimit = val
 				default:
 					return d.Errf("unknown subdirective '%s'", d.Val())
 				}
@@ -169,17 +178,6 @@ func (fsrv *FileServer) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			}
 			falseBool := false
 			fsrv.CanonicalURIs = &falseBool
-
-		case "file_limit":
-			fileLimit := d.RemainingArgs()
-			if len(fileLimit) != 1 {
-				return d.Err("file_limit should have an integer value")
-			}
-			val, _ := strconv.Atoi(fileLimit[0])
-			if fsrv.Browse.FileLimit != 0 {
-				return d.Err("file_limit is already enabled")
-			}
-			fsrv.Browse.FileLimit = val
 
 		case "pass_thru":
 			if d.NextArg() {

--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -66,6 +66,7 @@ respond with a file listing.`,
 			cmd.Flags().BoolP("templates", "t", false, "Enable template rendering")
 			cmd.Flags().BoolP("access-log", "a", false, "Enable the access log")
 			cmd.Flags().BoolP("debug", "v", false, "Enable verbose debug logs")
+			cmd.Flags().IntP("file-limit", "f", defaultMaxDirLimit, "Max directories to read")
 			cmd.Flags().BoolP("no-compress", "", false, "Disable Zstandard and Gzip compression")
 			cmd.Flags().StringSliceP("precompressed", "p", []string{}, "Specify precompression file extensions. Compression preference implied from flag order.")
 			cmd.RunE = caddycmd.WrapCommandFuncForCobra(cmdFileServer)
@@ -91,6 +92,7 @@ func cmdFileServer(fs caddycmd.Flags) (int, error) {
 	browse := fs.Bool("browse")
 	templates := fs.Bool("templates")
 	accessLog := fs.Bool("access-log")
+	fileLimit := fs.Int("file-limit")
 	debug := fs.Bool("debug")
 	revealSymlinks := fs.Bool("reveal-symlinks")
 	compress := !fs.Bool("no-compress")
@@ -151,7 +153,7 @@ func cmdFileServer(fs caddycmd.Flags) (int, error) {
 	}
 
 	if browse {
-		handler.Browse = &Browse{RevealSymlinks: revealSymlinks}
+		handler.Browse = &Browse{RevealSymlinks: revealSymlinks, FileLimit: fileLimit}
 	}
 
 	handlers = append(handlers, caddyconfig.JSONModuleObject(handler, "handler", "file_server", nil))

--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -66,7 +66,7 @@ respond with a file listing.`,
 			cmd.Flags().BoolP("templates", "t", false, "Enable template rendering")
 			cmd.Flags().BoolP("access-log", "a", false, "Enable the access log")
 			cmd.Flags().BoolP("debug", "v", false, "Enable verbose debug logs")
-			cmd.Flags().IntP("file-limit", "f", defaultMaxDirLimit, "Max directories to read")
+			cmd.Flags().IntP("file-limit", "f", defaultDirEntryLimit, "Max directories to read")
 			cmd.Flags().BoolP("no-compress", "", false, "Disable Zstandard and Gzip compression")
 			cmd.Flags().StringSliceP("precompressed", "p", []string{}, "Specify precompression file extensions. Compression preference implied from flag order.")
 			cmd.RunE = caddycmd.WrapCommandFuncForCobra(cmdFileServer)


### PR DESCRIPTION
This PR fixes the issue #6644 . I'm not sure about the config name `file_limit`, I prefer `max_dir_limit` etc.The default is still 10000.

As mentioned in the issue, this PR gave me some background on file serve, so I will try to look at paging as well. Please feel free to edit any documentation as you see fit.