### PR TITLE
chore: compile without nosql's support for Postgres and MySQL

### DIFF
--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -70,4 +70,4 @@ jobs:
         continue-on-error: true
         working-directory: ./cmd/caddy
         run: |
-          GOOS=$GOOS GOARCH=$GOARCH go build -tags nobadger -trimpath -o caddy-"$GOOS"-$GOARCH 2> /dev/null
+          GOOS=$GOOS GOARCH=$GOARCH go build -tags tags nobadger,nomysql,nopgx -trimpath -o caddy-"$GOOS"-$GOARCH 2> /dev/null

--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -70,4 +70,4 @@ jobs:
         continue-on-error: true
         working-directory: ./cmd/caddy
         run: |
-          GOOS=$GOOS GOARCH=$GOARCH go build -tags nobadger,nomysql,nopgx -trimpath -o caddy-"$GOOS"-$GOARCH 2> /dev/null
+          GOOS=$GOOS GOARCH=$GOARCH go build -tags=nobadger,nomysql,nopgx -trimpath -o caddy-"$GOOS"-$GOARCH 2> /dev/null

--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -70,4 +70,4 @@ jobs:
         continue-on-error: true
         working-directory: ./cmd/caddy
         run: |
-          GOOS=$GOOS GOARCH=$GOARCH go build -tags tags nobadger,nomysql,nopgx -trimpath -o caddy-"$GOOS"-$GOARCH 2> /dev/null
+          GOOS=$GOOS GOARCH=$GOARCH go build -tags nobadger,nomysql,nopgx -trimpath -o caddy-"$GOOS"-$GOARCH 2> /dev/null

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -83,6 +83,8 @@ builds:
   - -s -w
   tags:
   - nobadger
+  - nomysql
+  - nopgx
 
 signs:
   - cmd: cosign

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ $ xcaddy build
 4. Initialize a Go module: `go mod init caddy`
 5. (Optional) Pin Caddy version: `go get github.com/caddyserver/caddy/v2@version` replacing `version` with a git tag, commit, or branch name.
 6. (Optional) Add plugins by adding their import: `_ "import/path/here"`
-7. Compile: `go build -tags nobadger,nomysql,nopgx`
+7. Compile: `go build -tags=nobadger,nomysql,nopgx`
 
 
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ $ xcaddy build
 4. Initialize a Go module: `go mod init caddy`
 5. (Optional) Pin Caddy version: `go get github.com/caddyserver/caddy/v2@version` replacing `version` with a git tag, commit, or branch name.
 6. (Optional) Add plugins by adding their import: `_ "import/path/here"`
-7. Compile: `go build`
+7. Compile: `go build -tags nobadger,nomysql,nopgx`
 
 
 


### PR DESCRIPTION
I had issues with nosql that only supports old versions of Badger while upgrading [Mercure](https://mercure.rocks) dependencies: https://github.com/dunglas/mercure/pull/960. While working on this, I figured out that we could disable compilation of Badger support for nosql (already done by Caddy), but also of MySQL and Postgres.

This reduce the build time and the binary size.
This also has the nice side effect of fixing https://github.com/caddyserver/caddy/issues/6613 because this dependency will not be included in the binary at all anymore.

When https://github.com/caddyserver/caddy/pull/6097 will be finished, we may need to add back support for MySQL and Postgres, but that's not sure because the new version of nosql may provide adapters in separate modules, that users will cherry-pick (that would be the best option IMHO). 

Closes https://github.com/caddyserver/caddy/issues/6613.