### PR TITLE
Use `WithLazy` to prevent eager serialization of the event data

### DIFF
--- a/modules/caddyevents/app.go
+++ b/modules/caddyevents/app.go
@@ -262,7 +262,7 @@ func (app *App) Emit(ctx caddy.Context, eventName string, data map[string]any) E
 		return nil, false
 	})
 
-	logger = logger.With(zap.Any("data", e.Data))
+	logger = logger.WithLazy(zap.Any("data", e.Data))
 
 	logger.Debug("event")
 


### PR DESCRIPTION
Found while load testing: Even with the "events" app not logging out on "DEBUG" it would still go through the pain of serializing the event data. Especially for `tls_get_certificate` that is painful.

Comparison before/after:
![image](https://github.com/user-attachments/assets/3b1b13a9-872f-40f1-bf36-e821e5ccc2f1)
![image](https://github.com/user-attachments/assets/eb07538d-f349-4744-b6eb-2ed61b2c15a3)
