### PR TITLE
httpcaddyfile: Implement log `sampling` config

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins_test.go
+++ b/caddyconfig/httpcaddyfile/builtins_test.go
@@ -62,6 +62,20 @@ func TestLogDirectiveSyntax(t *testing.T) {
 			output:      `{"logging":{"logs":{"default":{"exclude":["http.log.access.name-override"]},"name-override":{"writer":{"filename":"foo.log","output":"file"},"core":{"module":"mock"},"include":["http.log.access.name-override"]}}},"apps":{"http":{"servers":{"srv0":{"listen":[":8080"],"logs":{"default_logger_name":"name-override"}}}}}}`,
 			expectError: false,
 		},
+		{
+			input: `:8080 {
+				log {
+					sampling {
+						interval 2
+						first 3
+						thereafter 4
+					}
+				}
+			}
+			`,
+			output:      `{"logging":{"logs":{"default":{"exclude":["http.log.access.log0"]},"log0":{"sampling":{"interval":2,"first":3,"thereafter":4},"include":["http.log.access.log0"]}}},"apps":{"http":{"servers":{"srv0":{"listen":[":8080"],"logs":{"default_logger_name":"log0"}}}}}}`,
+			expectError: false,
+		},
 	} {
 
 		adapter := caddyfile.Adapter{

--- a/caddytest/integration/caddyfile_adapt/global_options_log_sampling.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/global_options_log_sampling.caddyfiletest
@@ -1,0 +1,23 @@
+{
+	log {
+		sampling {
+			interval 300
+			first 50
+			thereafter 40
+		}
+	}
+}
+----------
+{
+	"logging": {
+		"logs": {
+			"default": {
+				"sampling": {
+					"interval": 300,
+					"first": 50,
+					"thereafter": 40
+				}
+			}
+		}
+	}
+}

--- a/caddytest/integration/caddyfile_adapt/log_sampling.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/log_sampling.caddyfiletest
@@ -1,0 +1,45 @@
+:80 {
+	log {
+		sampling {
+			interval 300
+			first 50
+			thereafter 40
+		}
+	}
+}
+----------
+{
+	"logging": {
+		"logs": {
+			"default": {
+				"exclude": [
+					"http.log.access.log0"
+				]
+			},
+			"log0": {
+				"sampling": {
+					"interval": 300,
+					"first": 50,
+					"thereafter": 40
+				},
+				"include": [
+					"http.log.access.log0"
+				]
+			}
+		}
+	},
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"logs": {
+						"default_logger_name": "log0"
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes https://github.com/caddyserver/caddy/issues/6680

Support log samplig in Caddyfile

```caddyfile
{
	auto_https off
	log {
		sampling {
			interval 100
			first 100
			thereafter 100
		}
	}
}
```