### PR TITLE
chore: Add `provides` to `.deb` releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -192,6 +192,9 @@ nfpms:
       preremove: ./caddy-dist/scripts/preremove.sh
       postremove: ./caddy-dist/scripts/postremove.sh
 
+    provides:
+      - httpd
+
 release:
   github:
     owner: caddyserver


### PR DESCRIPTION
Fixes https://github.com/caddyserver/dist/issues/91
