### PR TITLE
fileserver: Add `first_exist_fallback` strategy for `try_files`

### DIFF
--- a/caddytest/integration/caddyfile_adapt/php_fastcgi_handle_response.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/php_fastcgi_handle_response.caddyfiletest
@@ -58,6 +58,7 @@
 											"{http.request.uri.path}/index.php",
 											"index.php"
 										],
+										"try_policy": "first_exist_fallback",
 										"split_path": [
 											".php"
 										]

--- a/caddytest/integration/caddyfile_adapt/php_fastcgi_matcher.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/php_fastcgi_matcher.caddyfiletest
@@ -73,7 +73,8 @@ php_fastcgi @test localhost:9000
 																			"{http.request.uri.path}",
 																			"{http.request.uri.path}/index.php",
 																			"index.php"
-																		]
+																		],
+																		"try_policy": "first_exist_fallback"
 																	}
 																}
 															]

--- a/caddytest/integration/caddyfile_adapt/php_fastcgi_subdirectives.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/php_fastcgi_subdirectives.caddyfiletest
@@ -59,6 +59,7 @@ php_fastcgi localhost:9000 {
 											"{http.request.uri.path}/index.php5",
 											"index.php5"
 										],
+										"try_policy": "first_exist_fallback",
 										"split_path": [
 											".php",
 											".php5"

--- a/caddytest/integration/caddyfile_adapt/php_fastcgi_try_files_override_no_dir_index.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/php_fastcgi_try_files_override_no_dir_index.caddyfiletest
@@ -32,6 +32,7 @@ php_fastcgi localhost:9000 {
 											"{http.request.uri.path}",
 											"index.php"
 										],
+										"try_policy": "first_exist_fallback",
 										"split_path": [
 											".php",
 											".php5"

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -274,7 +274,7 @@ func parseTryFiles(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error) 
 			tryPolicy = h.Val()
 
 			switch tryPolicy {
-			case tryPolicyFirstExist, tryPolicyLargestSize, tryPolicySmallestSize, tryPolicyMostRecentlyMod:
+			case tryPolicyFirstExist, tryPolicyFirstExistFallback, tryPolicyLargestSize, tryPolicySmallestSize, tryPolicyMostRecentlyMod:
 			default:
 				return nil, h.Errf("unrecognized try policy: %s", tryPolicy)
 			}

--- a/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
@@ -16,6 +16,10 @@ package fastcgi
 
 import (
 	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -24,9 +28,6 @@ import (
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/fileserver"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/rewrite"
-	"net/http"
-	"strconv"
-	"strings"
 )
 
 func init() {


### PR DESCRIPTION
When using modern frameworks such as Symfony and Laravel, by convention, all requests are handled by a front controller named `index.php` in the document root.

Currently, Caddy does a call to `fs.Stat()` at each request to check that this file exists, but in case we use such a framework, this call is useless because we know that the file exists.

This PR adds a new `first_exist_fallback` policy that assumes that the last file in the list always exists.