### PR TITLE
requestbody: Type-based error handling for `MaxBytesError`

### DIFF
--- a/modules/caddyhttp/requestbody/requestbody.go
+++ b/modules/caddyhttp/requestbody/requestbody.go
@@ -15,6 +15,7 @@
 package requestbody
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"time"
@@ -94,7 +95,8 @@ type errorWrapper struct {
 
 func (ew errorWrapper) Read(p []byte) (n int, err error) {
 	n, err = ew.ReadCloser.Read(p)
-	if _, ok := err.(*http.MaxBytesError); ok {
+	var mbe *http.MaxBytesError
+	if errors.As(err, &mbe) {
 		err = caddyhttp.Error(http.StatusRequestEntityTooLarge, err)
 	}
 	return


### PR DESCRIPTION
Replaced the hardcoded error string comparison with a type assertion for http.MaxBytesError to make the code more robust and idiomatic.

Before:
```
if err != nil && err.Error() == "http: request body too large" {
    err = caddyhttp.Error(http.StatusRequestEntityTooLarge, err)
}
```
After:
```
if err != nil {
    if _, ok := err.(*http.MaxBytesError); ok {
        err = caddyhttp.Error(http.StatusRequestEntityTooLarge, err)
    }
}
```

Related to #6700 