### PR TITLE
metrics: add `go` and `process` collectors

### DIFF
--- a/context.go
+++ b/context.go
@@ -110,6 +110,8 @@ func (ctx *Context) GetMetricsRegistry() *prometheus.Registry {
 func (ctx *Context) initMetrics() {
 	ctx.metricsRegistry.MustRegister(
 		collectors.NewBuildInfoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+		collectors.NewGoCollector(),
 		adminMetrics.requestCount,
 		adminMetrics.requestErrors,
 		globalMetrics.configSuccess,


### PR DESCRIPTION
They're automatically registered in the Default Registry, which we were using but not anymore. Adding them to match old behavior.

Noted in: https://github.com/caddyserver/caddy/pull/6531#issuecomment-2494938615

Thanks @ueffel 