### PR TITLE
perf: improve try_files matcher

### DIFF
--- a/modules/caddyhttp/fileserver/matcher_test.go
+++ b/modules/caddyhttp/fileserver/matcher_test.go
@@ -416,3 +416,24 @@ func TestMatchExpressionMatch(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkFileMatcher(b *testing.B) {
+	m := &MatchFile{
+		fsmap:    &filesystems.FilesystemMap{},
+		Root:     "./testdata",
+		TryFiles: []string{"{http.request.uri.path}"},
+	}
+
+	u, _ := url.Parse("/foo.txt")
+	req := &http.Request{URL: u}
+	caddyhttp.NewTestReplacer(req)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		ok, _ := m.MatchWithError(req)
+		if !ok {
+			panic("unexpected match result")
+		}
+	}
+}


### PR DESCRIPTION
This is an experiment to use `repl.Match()` to (likely) prevent useless string manipulations.
This improve the performance of 2%, but consumes 10% more memory. I'm not sure if it is worth it. (the gain is likely a better on Windows)

Before:

```
goos: darwin
goarch: arm64
pkg: github.com/caddyserver/caddy/v2/modules/caddyhttp/fileserver
cpu: Apple M1 Pro
BenchmarkFileMatcher
BenchmarkFileMatcher-10    	   81501	     14692 ns/op	     920 B/op	      22 allocs/op
PASS
```

After:

```
goos: darwin
goarch: arm64
pkg: github.com/caddyserver/caddy/v2/modules/caddyhttp/fileserver
cpu: Apple M1 Pro
BenchmarkFileMatcher
BenchmarkFileMatcher-10    	   81658	     14410 ns/op	    1022 B/op	      20 allocs/op
PASS
```
