### PR TITLE
cmd: `fmt` prevents multiple files passed as args, add support for `--config`

### DIFF
--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -560,10 +560,15 @@ func cmdValidateConfig(fl Flags) (int, error) {
 
 func cmdFmt(fl Flags) (int, error) {
 	configFile := fl.Arg(0)
-	if configFile == "" {
-		configFile = "Caddyfile"
+	configFlag := fl.String("config")
+	if (len(fl.Args()) > 1) || (configFlag != "" && configFile != "") {
+		return caddy.ExitCodeFailedStartup, fmt.Errorf("fmt does not support multiple files %s %s", configFlag, strings.Join(fl.Args(), " "))
 	}
-
+	if configFile == "" && configFlag == "" {
+		configFile = "Caddyfile"
+	} else if configFile == "" {
+		configFile = configFlag
+	}
 	// as a special case, read from stdin if the file name is "-"
 	if configFile == "-" {
 		input, err := io.ReadAll(os.Stdin)

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -388,6 +388,7 @@ When reading from stdin, the --overwrite flag has no effect: the result
 is always printed to stdout.
 `,
 		CobraFunc: func(cmd *cobra.Command) {
+			cmd.Flags().StringP("config", "c", "", "Configuration file")
 			cmd.Flags().BoolP("overwrite", "w", false, "Overwrite the input file with the results")
 			cmd.Flags().BoolP("diff", "d", false, "Print the differences between the input file and the formatted output")
 			cmd.RunE = WrapCommandFuncForCobra(cmdFmt)


### PR DESCRIPTION
Addresses #6702 by explicitely preventing more than one config file passed to the fmt command. 
Also Enables the (--config/-c) flags support for the fmt command. 

@francislavoie I am not quite sure on what would be the best way to approach formatting imports as well. would we get all the import statements from the root config file and check if they refer to a file that we can resolve the path to, and then recursively do the same for the files we extracted?