### PR TITLE
ci: prevent jobs running on PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
   s390x-test:
     name: test (s390x on IBM Z)
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.head.repo.full_name == 'caddyserver/caddy' && github.actor != 'dependabot[bot]'
     continue-on-error: true  # August 2020: s390x VM is down due to weather and power issues
     steps:
       - name: Checkout code
@@ -194,7 +194,7 @@ jobs:
 
   goreleaser-check:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'caddyserver' && github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.head.repo.full_name == 'caddyserver/caddy' && github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
I tried to have the jobs of s390x and goreleaser check work in both PRs and direct pushes to the repo, but failed. So now I replicated the condition we have for s390x to goreleaser check so they'll run only on branches from this repo.