### PR TITLE
fileserver: Fix policy `Validate()` oversight

### DIFF
--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -297,6 +297,7 @@ func (m MatchFile) Validate() error {
 	switch m.TryPolicy {
 	case "",
 		tryPolicyFirstExist,
+		tryPolicyFirstExistFallback,
 		tryPolicyLargestSize,
 		tryPolicySmallestSize,
 		tryPolicyMostRecentlyMod:


### PR DESCRIPTION
Fix https://github.com/caddyserver/caddy/issues/6726, oversight from #6699 (FYI @dunglas)