### PR TITLE
testing: sort force-automated hosts

### DIFF
--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -423,6 +423,7 @@ func (st ServerType) buildTLSApp(
 		}
 		al = append(al, name)
 	}
+	slices.Sort(al) // to stabilize the adapt output
 	if len(al) > 0 {
 		tlsApp.CertificatesRaw["automate"] = caddyconfig.JSON(al, &warnings)
 	}


### PR DESCRIPTION
The `forcedAutomatedNames` variable is a map, which is not guaranteed to be ordered in Go. By mere chance., the CI run on the PR #6712 was successful. The CI run on `master` after merge (https://github.com/caddyserver/caddy/actions/runs/12483804029/job/34840195488) failed with this diff showing the expected vs actual:

```diff
 - 					"automated1.example.com",
 - 					"automated2.example.com"
 + 					"automated2.example.com",
 + 					"automated1.example.com"
```

Sorted strings would have `automated1` first, so sorting the slice before marshalling ensures stable output.