### PR TITLE
Enable dependabot for Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,12 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      go.opentelemetry.io:
+        patterns:
+          - "go.opentelemetry.io/*"
+    open-pull-requests-limit: 20


### PR DESCRIPTION
Update Go modules montly using dependabot. This will help keep packages up to date for security fixes and other improvements.