### PR TITLE
fix: disable h3 for unix domain socket

### DIFF
--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -529,40 +529,6 @@ func (app *App) Start() error {
 				// enable TLS if there is a policy and if this is not the HTTP port
 				useTLS := len(srv.TLSConnPolicies) > 0 && int(listenAddr.StartPort+portOffset) != app.httpPort()
 
-				// Can't serve HTTP/3 on the same socket as HTTP/1 and 2 because it uses
-				// a different transport mechanism... which is fine, but the OS doesn't
-				// differentiate between a SOCK_STREAM file and a SOCK_DGRAM file; they
-				// are still one file on the system. So even though "unixpacket" and
-				// "unixgram" are different network types just as "tcp" and "udp" are,
-				// the OS will not let us use the same file as both STREAM and DGRAM.
-				if h3ok && listenAddr.IsUnixNetwork() {
-					app.logger.Warn("HTTP/3 disabled because Unix can't multiplex STREAM and DGRAM on same socket",
-						zap.String("file", hostport))
-					for i := range srv.Protocols {
-						if srv.Protocols[i] == "h3" {
-							srv.Protocols = append(srv.Protocols[:i], srv.Protocols[i+1:]...)
-							break
-						}
-					}
-					delete(protocolsUnique, "h3")
-					h3ok = false
-				}
-
-				// enable HTTP/3 if configured
-				if h3ok && useTLS {
-					app.logger.Info("enabling HTTP/3 listener", zap.String("addr", hostport))
-					if err := srv.serveHTTP3(listenAddr.At(portOffset), tlsCfg); err != nil {
-						return err
-					}
-				}
-
-				if h3ok && !useTLS {
-					// Can only serve h3 with TLS enabled
-					app.logger.Warn("HTTP/3 skipped because it requires TLS",
-						zap.String("network", listenAddr.Network),
-						zap.String("addr", hostport))
-				}
-
 				if h1ok || h2ok && useTLS || h2cok {
 					// create the listener for this socket
 					lnAny, err := listenAddr.Listen(app.ctx, portOffset, net.ListenConfig{KeepAlive: time.Duration(srv.KeepAliveInterval)})
@@ -632,6 +598,33 @@ func (app *App) Start() error {
 					app.logger.Warn("HTTP/2 skipped because it requires TLS",
 						zap.String("network", listenAddr.Network),
 						zap.String("addr", hostport))
+				}
+
+				if h3ok {
+					// Can't serve HTTP/3 on the same socket as HTTP/1 and 2 because it uses
+					// a different transport mechanism... which is fine, but the OS doesn't
+					// differentiate between a SOCK_STREAM file and a SOCK_DGRAM file; they
+					// are still one file on the system. So even though "unixpacket" and
+					// "unixgram" are different network types just as "tcp" and "udp" are,
+					// the OS will not let us use the same file as both STREAM and DGRAM.
+					if listenAddr.IsUnixNetwork() {
+						app.logger.Warn("HTTP/3 disabled because Unix can't multiplex STREAM and DGRAM on same socket",
+							zap.String("file", hostport))
+						continue
+					}
+
+					if useTLS {
+						// enable HTTP/3 if configured
+						app.logger.Info("enabling HTTP/3 listener", zap.String("addr", hostport))
+						if err := srv.serveHTTP3(listenAddr.At(portOffset), tlsCfg); err != nil {
+							return err
+						}
+					} else {
+						// Can only serve h3 with TLS enabled
+						app.logger.Warn("HTTP/3 skipped because it requires TLS",
+							zap.String("network", listenAddr.Network),
+							zap.String("addr", hostport))
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Related Issue: #6760 

Disable HTTP/3 for unix domain socket

**Caddyfile**
```Caddyfile
example.com {
  bind unix/@test
  respond 200
}
```

**Preview**
```txt
2025/01/05 05:28:28.361	INFO	using adjacent Caddyfile
2025/01/05 05:28:28.361	INFO	adapted config to JSON	{"adapter": "caddyfile"}
2025/01/05 05:28:28.361	WARN	Caddyfile input is not formatted; run 'caddy fmt --overwrite' to fix inconsistencies	{"adapter": "caddyfile", "file": "Caddyfile", "line": 2}
2025/01/05 05:28:28.363	INFO	admin	admin endpoint started	{"address": "localhost:2019", "enforce_origin": false, "origins": ["//localhost:2019", "//[::1]:2019", "//127.0.0.1:2019"]}
2025/01/05 05:28:28.363	INFO	http.auto_https	enabling automatic HTTP->HTTPS redirects	{"server_name": "srv0"}
2025/01/05 05:28:28.363	WARN	http	HTTP/3 disabled because Unix can't multiplex STREAM and DGRAM on same socket	{"file": "@test"}
2025/01/05 05:28:28.363	INFO	tls.cache.maintenance	started background certificate maintenance	{"cache": "0x14000625400"}
2025/01/05 05:28:28.364	INFO	http.log	server running	{"name": "srv0", "protocols": ["h1", "h2"]}
2025/01/05 05:28:28.364	INFO	http	enabling automatic TLS certificate management	{"domains": ["example.com"]}
2025/01/05 05:28:28.365	INFO	autosaved config (load with --resume flag)	{"file": "/Users/user/.config/caddy/autosave.json"}
2025/01/05 05:28:28.365	INFO	serving initial configuration
2025/01/05 05:28:28.370	INFO	tls	storage cleaning happened too recently; skipping for now	{"storage": "FileStorage:/Users/user/.local/share/caddy", "instance": "534925d6-3750-47c4-9f3b-703fce2d2263", "try_again": "2025/01/06 05:28:28.370", "try_again_in": 86399.99999975}
2025/01/05 05:28:28.371	INFO	tls	finished cleaning storage units
2025/01/05 05:28:28.373	INFO	tls.obtain	acquiring lock	{"identifier": "example.com"}
```

It's the same behavior with version 2.8.4

Please tell me if there is another points that I have to care about.

---

BTW, do you mind if caddy to provide HTTP/3 uds connection (with only SOCK_DGRAM)? 
Maybe it'll be good if caddy provides optional uds connection with configuration in Caddyfile.
Like below...

```Caddyfile
example.com {
  bind_http3 unix/@test
  respond 200
}
```

If you have mind with it, I'll make a new issue.

Thanks.