### PR TITLE
caddytls: Fix sni_regexp matcher to obtain layer4 contexts

### DIFF
--- a/modules/caddytls/matchers.go
+++ b/modules/caddytls/matchers.go
@@ -15,6 +15,7 @@
 package caddytls
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -224,13 +225,26 @@ func (MatchServerNameRE) CaddyModule() caddy.ModuleInfo {
 
 // Match matches hello based on SNI using a regular expression.
 func (m MatchServerNameRE) Match(hello *tls.ClientHelloInfo) bool {
-	repl := caddy.NewReplacer()
+	var repl *caddy.Replacer
 	// caddytls.TestServerNameMatcher calls this function without any context
 	if ctx := hello.Context(); ctx != nil {
 		// In some situations the existing context may have no replacer
 		if replAny := ctx.Value(caddy.ReplacerCtxKey); replAny != nil {
 			repl = replAny.(*caddy.Replacer)
 		}
+	} else if mayHaveContext, ok := hello.Conn.(interface{ GetContext() context.Context }); ok {
+		// layer4.Connection implements GetContext() to pass its context here,
+		// since hello.Context() returns nil
+		if ctx = mayHaveContext.GetContext(); ctx != nil {
+			// In some situations the existing context may have no replacer
+			if replAny := ctx.Value(caddy.ReplacerCtxKey); replAny != nil {
+				repl = replAny.(*caddy.Replacer)
+			}
+		}
+	}
+
+	if repl == nil {
+		repl = caddy.NewReplacer()
 	}
 
 	return m.MatchRegexp.Match(hello.ServerName, repl)


### PR DESCRIPTION
This PR is the mainline part of the fix described [here](https://github.com/mholt/caddy-l4/issues/241#issuecomment-2610292874) for the issue with missing `{tls.regexp.*}` placeholders reported [here](https://github.com/mholt/caddy-l4/issues/241#issuecomment-2609215818).