### PR TITLE
feat/tests: tests for error handling & metrics in admin endpoints

### DIFF
--- a/admin_test.go
+++ b/admin_test.go
@@ -15,12 +15,18 @@
 package caddy
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"sync"
 	"testing"
+
+	"github.com/caddyserver/certmagic"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
 
 var testCfg = []byte(`{
@@ -201,5 +207,538 @@ func TestETags(t *testing.T) {
 func BenchmarkLoad(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Load(testCfg, true)
+	}
+}
+
+func TestAdminHandlerErrorHandling(t *testing.T) {
+	initAdminMetrics()
+
+	handler := adminHandler{
+		mux: http.NewServeMux(),
+	}
+
+	handler.mux.Handle("/error", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := fmt.Errorf("test error")
+		handler.handleError(w, r, err)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/error", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code == http.StatusOK {
+		t.Error("expected error response, got success")
+	}
+
+	var apiErr APIError
+	if err := json.NewDecoder(rr.Body).Decode(&apiErr); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if apiErr.Message != "test error" {
+		t.Errorf("expected error message 'test error', got '%s'", apiErr.Message)
+	}
+}
+
+func initAdminMetrics() {
+	if adminMetrics.requestErrors != nil {
+		prometheus.Unregister(adminMetrics.requestErrors)
+	}
+	if adminMetrics.requestCount != nil {
+		prometheus.Unregister(adminMetrics.requestCount)
+	}
+
+	adminMetrics.requestErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "caddy",
+		Subsystem: "admin_http",
+		Name:      "request_errors_total",
+		Help:      "Number of errors that occurred handling admin endpoint requests",
+	}, []string{"handler", "path", "method"})
+
+	adminMetrics.requestCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "caddy",
+		Subsystem: "admin_http",
+		Name:      "requests_total",
+		Help:      "Count of requests to the admin endpoint",
+	}, []string{"handler", "path", "code", "method"}) // Added code and method labels
+
+	prometheus.MustRegister(adminMetrics.requestErrors)
+	prometheus.MustRegister(adminMetrics.requestCount)
+}
+
+func TestAdminHandlerBuiltinRouteErrors(t *testing.T) {
+	initAdminMetrics()
+
+	cfg := &Config{
+		Admin: &AdminConfig{
+			Listen: "localhost:2019",
+		},
+	}
+
+	err := replaceLocalAdminServer(cfg, Context{})
+	if err != nil {
+		t.Fatalf("setting up admin server: %v", err)
+	}
+	defer func() {
+		stopAdminServer(localAdminServer)
+	}()
+
+	tests := []struct {
+		name           string
+		path           string
+		method         string
+		expectedStatus int
+	}{
+		{
+			name:           "stop endpoint wrong method",
+			path:           "/stop",
+			method:         http.MethodGet,
+			expectedStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:           "config endpoint wrong content-type",
+			path:           "/config/",
+			method:         http.MethodPost,
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "config ID missing ID",
+			path:           "/id/",
+			method:         http.MethodGet,
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(test.method, fmt.Sprintf("http://localhost:2019%s", test.path), nil)
+			rr := httptest.NewRecorder()
+
+			localAdminServer.Handler.ServeHTTP(rr, req)
+
+			if rr.Code != test.expectedStatus {
+				t.Errorf("expected status %d but got %d", test.expectedStatus, rr.Code)
+			}
+
+			metricValue := testGetMetricValue(map[string]string{
+				"path":    test.path,
+				"handler": "admin",
+				"method":  test.method,
+			})
+			if metricValue != 1 {
+				t.Errorf("expected error metric to be incremented once, got %v", metricValue)
+			}
+		})
+	}
+}
+
+func testGetMetricValue(labels map[string]string) float64 {
+	promLabels := prometheus.Labels{}
+	for k, v := range labels {
+		promLabels[k] = v
+	}
+
+	metric, err := adminMetrics.requestErrors.GetMetricWith(promLabels)
+	if err != nil {
+		return 0
+	}
+
+	pb := &dto.Metric{}
+	metric.Write(pb)
+	return pb.GetCounter().GetValue()
+}
+
+type mockRouter struct {
+	routes []AdminRoute
+}
+
+func (m mockRouter) Routes() []AdminRoute {
+	return m.routes
+}
+
+type mockModule struct {
+	mockRouter
+}
+
+func (m *mockModule) CaddyModule() ModuleInfo {
+	return ModuleInfo{
+		ID: "admin.api.mock",
+		New: func() Module {
+			mm := &mockModule{
+				mockRouter: mockRouter{
+					routes: m.routes,
+				},
+			}
+			return mm
+		},
+	}
+}
+
+func TestNewAdminHandlerRouterRegistration(t *testing.T) {
+	originalModules := make(map[string]ModuleInfo)
+	for k, v := range modules {
+		originalModules[k] = v
+	}
+	defer func() {
+		modules = originalModules
+	}()
+
+	mockRoute := AdminRoute{
+		Pattern: "/mock",
+		Handler: AdminHandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+			w.WriteHeader(http.StatusOK)
+			return nil
+		}),
+	}
+
+	mock := &mockModule{
+		mockRouter: mockRouter{
+			routes: []AdminRoute{mockRoute},
+		},
+	}
+	RegisterModule(mock)
+
+	addr, err := ParseNetworkAddress("localhost:2019")
+	if err != nil {
+		t.Fatalf("Failed to parse address: %v", err)
+	}
+
+	admin := &AdminConfig{
+		EnforceOrigin: false,
+	}
+	handler := admin.newAdminHandler(addr, false, Context{})
+
+	req := httptest.NewRequest("GET", "/mock", nil)
+	req.Host = "localhost:2019"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status code %d but got %d", http.StatusOK, rr.Code)
+		t.Logf("Response body: %s", rr.Body.String())
+	}
+
+	if len(admin.routers) != 1 {
+		t.Errorf("Expected 1 router to be stored, got %d", len(admin.routers))
+	}
+}
+
+type mockProvisionableRouter struct {
+	mockRouter
+	provisionErr error
+	provisioned  bool
+}
+
+func (m *mockProvisionableRouter) Provision(Context) error {
+	m.provisioned = true
+	return m.provisionErr
+}
+
+type mockProvisionableModule struct {
+	*mockProvisionableRouter
+}
+
+func (m *mockProvisionableModule) CaddyModule() ModuleInfo {
+	return ModuleInfo{
+		ID: "admin.api.mock_provision",
+		New: func() Module {
+			mm := &mockProvisionableModule{
+				mockProvisionableRouter: &mockProvisionableRouter{
+					mockRouter:   m.mockRouter,
+					provisionErr: m.provisionErr,
+				},
+			}
+			return mm
+		},
+	}
+}
+
+func TestAdminRouterProvisioning(t *testing.T) {
+	tests := []struct {
+		name         string
+		provisionErr error
+		wantErr      bool
+		routersAfter int // expected number of routers after provisioning
+	}{
+		{
+			name:         "successful provisioning",
+			provisionErr: nil,
+			wantErr:      false,
+			routersAfter: 0,
+		},
+		{
+			name:         "provisioning error",
+			provisionErr: fmt.Errorf("provision failed"),
+			wantErr:      true,
+			routersAfter: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			originalModules := make(map[string]ModuleInfo)
+			for k, v := range modules {
+				originalModules[k] = v
+			}
+			defer func() {
+				modules = originalModules
+			}()
+
+			mockRoute := AdminRoute{
+				Pattern: "/mock",
+				Handler: AdminHandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+					return nil
+				}),
+			}
+
+			// Create provisionable module
+			mock := &mockProvisionableModule{
+				mockProvisionableRouter: &mockProvisionableRouter{
+					mockRouter: mockRouter{
+						routes: []AdminRoute{mockRoute},
+					},
+					provisionErr: test.provisionErr,
+				},
+			}
+			RegisterModule(mock)
+
+			admin := &AdminConfig{}
+			addr, err := ParseNetworkAddress("localhost:2019")
+			if err != nil {
+				t.Fatalf("Failed to parse address: %v", err)
+			}
+
+			_ = admin.newAdminHandler(addr, false, Context{})
+			err = admin.provisionAdminRouters(Context{})
+
+			if test.wantErr {
+				if err == nil {
+					t.Error("Expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+				}
+			}
+
+			if len(admin.routers) != test.routersAfter {
+				t.Errorf("Expected %d routers after provisioning, got %d", test.routersAfter, len(admin.routers))
+			}
+		})
+	}
+}
+
+func TestAllowedOriginsUnixSocket(t *testing.T) {
+	tests := []struct {
+		name          string
+		addr          NetworkAddress
+		origins       []string
+		expectOrigins []string
+	}{
+		{
+			name: "unix socket with default origins",
+			addr: NetworkAddress{
+				Network: "unix",
+				Host:    "/tmp/caddy.sock",
+			},
+			origins: nil, // default origins
+			expectOrigins: []string{
+				"", // empty host as per RFC 2616
+				"127.0.0.1",
+				"::1",
+			},
+		},
+		{
+			name: "unix socket with custom origins",
+			addr: NetworkAddress{
+				Network: "unix",
+				Host:    "/tmp/caddy.sock",
+			},
+			origins: []string{"example.com"},
+			expectOrigins: []string{
+				"example.com",
+			},
+		},
+		{
+			name: "tcp socket on localhost gets all loopback addresses",
+			addr: NetworkAddress{
+				Network:   "tcp",
+				Host:      "localhost",
+				StartPort: 2019,
+				EndPort:   2019,
+			},
+			origins: nil,
+			expectOrigins: []string{
+				"localhost:2019",
+				"[::1]:2019",
+				"127.0.0.1:2019",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			admin := AdminConfig{
+				Origins: test.origins,
+			}
+
+			got := admin.allowedOrigins(test.addr)
+
+			var gotOrigins []string
+			for _, u := range got {
+				gotOrigins = append(gotOrigins, u.Host)
+			}
+
+			if len(gotOrigins) != len(test.expectOrigins) {
+				t.Errorf("Expected %d origins but got %d", len(test.expectOrigins), len(gotOrigins))
+				return
+			}
+
+			expectMap := make(map[string]struct{})
+			for _, origin := range test.expectOrigins {
+				expectMap[origin] = struct{}{}
+			}
+
+			gotMap := make(map[string]struct{})
+			for _, origin := range gotOrigins {
+				gotMap[origin] = struct{}{}
+			}
+
+			if !reflect.DeepEqual(expectMap, gotMap) {
+				t.Errorf("Origins mismatch.\nExpected: %v\nGot: %v", test.expectOrigins, gotOrigins)
+			}
+		})
+	}
+}
+
+func TestReplaceRemoteAdminServer(t *testing.T) {
+	const testCert = `MIIDCTCCAfGgAwIBAgIUXsqJ1mY8pKlHQtI3HJ23x2eZPqwwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTIzMDEwMTAwMDAwMFoXDTI0MDEw
+MTAwMDAwMFowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEA4O4S6BSoYcoxvRqI+h7yPOjF6KjntjzVVm9M+uHK4lzX
+F1L3pSxJ2nDD4wZEV3FJ5yFOHVFqkG2vXG3BIczOlYG7UeNmKbQnKc5kZj3HGUrS
+VGEktA4OJbeZhhWP15gcXN5eDM2eH3g9BFXVX6AURxLiUXzhNBUEZuj/OEyH9yEF
+/qPCE+EjzVvWxvBXwgz/io4r4yok/Vq/bxJ6FlV6R7DX5oJSXyO0VEHZPi9DIyNU
+kK3F/r4U1sWiJGWOs8i3YQWZ2ejh1C0aLFZpPcCGGgMNpoF31gyYP6ZuPDUyCXsE
+g36UUw1JHNtIXYcLhnXuqj4A8TybTDpgXLqvwA9DBQIDAQABo1MwUTAdBgNVHQ4E
+FgQUc13z30pFC63rr/HGKOE7E82vjXwwHwYDVR0jBBgwFoAUc13z30pFC63rr/HG
+KOE7E82vjXwwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAHO3j
+oeiUXXJ7xD4P8Wj5t9d+E8lE1Xv1Dk3Z+EdG5+dan+RcToE42JJp9zB7FIh5Qz8g
+W77LAjqh5oyqz3A2VJcyVgfE3uJP1R1mJM7JfGHf84QH4TZF2Q1RZY4SZs0VQ6+q
+5wSlIZ4NXDy4Q4XkIJBGS61wT8IzYFXYBpx4PCP1Qj0PIE4sevEGwjsBIgxK307o
+BxF8AWe6N6e4YZmQLGjQ+SeH0iwZb6vpkHyAY8Kj2hvK+cq2P7vU3VGi0t3r1F8L
+IvrXHCvO2BMNJ/1UK1M4YNX8LYJqQhg9hEsIROe1OE/m3VhxIYMJI+qZXk9yHfgJ
+vq+SH04xKhtFudVBAQ==`
+
+	tests := []struct {
+		name    string
+		cfg     *Config
+		wantErr bool
+	}{
+		{
+			name:    "nil config",
+			cfg:     nil,
+			wantErr: false,
+		},
+		{
+			name: "nil admin config",
+			cfg: &Config{
+				Admin: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "nil remote config",
+			cfg: &Config{
+				Admin: &AdminConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid listen address",
+			cfg: &Config{
+				Admin: &AdminConfig{
+					Remote: &RemoteAdmin{
+						Listen: "invalid:address",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid config",
+			cfg: &Config{
+				Admin: &AdminConfig{
+					Identity: &IdentityConfig{},
+					Remote: &RemoteAdmin{
+						Listen: "localhost:2021",
+						AccessControl: []*AdminAccess{
+							{
+								PublicKeys:  []string{testCert},
+								Permissions: []AdminPermissions{{Methods: []string{"GET"}, Paths: []string{"/test"}}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid certificate",
+			cfg: &Config{
+				Admin: &AdminConfig{
+					Identity: &IdentityConfig{},
+					Remote: &RemoteAdmin{
+						Listen: "localhost:2021",
+						AccessControl: []*AdminAccess{
+							{
+								PublicKeys:  []string{"invalid-cert-data"},
+								Permissions: []AdminPermissions{{Methods: []string{"GET"}, Paths: []string{"/test"}}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := Context{
+				Context: context.Background(),
+				cfg:     test.cfg,
+			}
+
+			if test.cfg != nil {
+				test.cfg.storage = &certmagic.FileStorage{Path: t.TempDir()}
+			}
+
+			if test.cfg != nil && test.cfg.Admin != nil && test.cfg.Admin.Identity != nil {
+				identityCertCache = certmagic.NewCache(certmagic.CacheOptions{
+					GetConfigForCert: func(certmagic.Certificate) (*certmagic.Config, error) {
+						return &certmagic.Config{}, nil
+					},
+				})
+			}
+
+			err := replaceRemoteAdminServer(ctx, test.cfg)
+
+			if test.wantErr {
+				if err == nil {
+					t.Error("Expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+				}
+			}
+
+			// Clean up
+			if remoteAdminServer != nil {
+				_ = stopAdminServer(remoteAdminServer)
+			}
+		})
 	}
 }


### PR DESCRIPTION
 - TestAdminHandlerErrorHandling - Tests the handler.handleError()
       functionality by directly verifying error response formatting
    - TestAdminHandlerBuiltinRouteErrors - Tests the error
       handling pathway by using real admin server routes and verifying
       both error responses and prometheus metrics increments
    - provisionAdminRouters: add unit tests for admin handler registration and routing for admin.api
    - TestAllowedOriginsUnixSocket: checks unix socket with default origins are added
    - TestReplaceRemoteAdminServer: test for replaceRemoteAdminServer with certificate validation, custom origins and cleanup
    - TestManageIdentity: tests the manageIdentity function to test identifiers with configs.

this increases the test coverage of admin.go from 31% to 59%.
Increases total coverage from 37.9% to 47%.

I added this PR as a way to learn more about caddy's codebase and to contribute to caddy. I'd love to contribute more of these tests if such contributions are welcome.