### PR TITLE
feat: automatically set GOMEMLIMIT

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -75,7 +75,17 @@ func Main() {
 		caddy.Log().Warn("failed to set GOMAXPROCS", zap.Error(err))
 	}
 
-	_, _ = memlimit.SetGoMemLimitWithOpts(memlimit.WithLogger(slog.New(zapslog.NewHandler(caddy.Log().Core()))))
+	_, _ = memlimit.SetGoMemLimitWithOpts(
+		memlimit.WithLogger(
+			slog.New(zapslog.NewHandler(caddy.Log().Core())),
+		),
+		memlimit.WithProvider(
+			memlimit.ApplyFallback(
+				memlimit.FromCgroup,
+				memlimit.FromSystem,
+			),
+		),
+	)
 
 	if err := defaultFactory.Build().Execute(); err != nil {
 		var exitError *exitError

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,12 +69,16 @@ func Main() {
 		os.Exit(caddy.ExitCodeFailedStartup)
 	}
 
+	// Configure the maximum number of CPUs to use to match the Linux container quota (if any)
+	// See https://pkg.go.dev/runtime#GOMAXPROCS
 	undo, err := maxprocs.Set()
 	defer undo()
 	if err != nil {
 		caddy.Log().Warn("failed to set GOMAXPROCS", zap.Error(err))
 	}
 
+	// Configure the maximum memory to use to match the Linux container quota (if any) or system memory
+	// See https://pkg.go.dev/runtime/debug#SetMemoryLimit
 	_, _ = memlimit.SetGoMemLimitWithOpts(
 		memlimit.WithLogger(
 			slog.New(zapslog.NewHandler(caddy.Log().Core())),

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"io/fs"
 	"log"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -33,10 +34,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/KimMachineGun/automemlimit/memlimit"
 	"github.com/caddyserver/certmagic"
 	"github.com/spf13/pflag"
 	"go.uber.org/automaxprocs/maxprocs"
 	"go.uber.org/zap"
+	"go.uber.org/zap/exp/zapslog"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
@@ -71,6 +74,8 @@ func Main() {
 	if err != nil {
 		caddy.Log().Warn("failed to set GOMAXPROCS", zap.Error(err))
 	}
+
+	_, _ = memlimit.SetGoMemLimitWithOpts(memlimit.WithLogger(slog.New(zapslog.NewHandler(caddy.Log().Core()))))
 
 	if err := defaultFactory.Build().Execute(); err != nil {
 		var exitError *exitError

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,9 +69,11 @@ func Main() {
 		os.Exit(caddy.ExitCodeFailedStartup)
 	}
 
+	logger := caddy.Log()
+
 	// Configure the maximum number of CPUs to use to match the Linux container quota (if any)
 	// See https://pkg.go.dev/runtime#GOMAXPROCS
-	undo, err := maxprocs.Set()
+	undo, err := maxprocs.Set(maxprocs.Logger(logger.Sugar().Infof))
 	defer undo()
 	if err != nil {
 		caddy.Log().Warn("failed to set GOMAXPROCS", zap.Error(err))
@@ -81,7 +83,7 @@ func Main() {
 	// See https://pkg.go.dev/runtime/debug#SetMemoryLimit
 	_, _ = memlimit.SetGoMemLimitWithOpts(
 		memlimit.WithLogger(
-			slog.New(zapslog.NewHandler(caddy.Log().Core())),
+			slog.New(zapslog.NewHandler(logger.Core())),
 		),
 		memlimit.WithProvider(
 			memlimit.ApplyFallback(

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 
 require (
 	dario.cat/mergo v1.0.1 // indirect
+	github.com/KimMachineGun/automemlimit v0.7.0 // indirect
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -63,6 +64,7 @@ require (
 	github.com/google/pprof v0.0.0-20231212022811-ec68065c825e // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	github.com/onsi/ginkgo/v2 v2.13.2 // indirect
+	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/smallstep/go-attestation v0.4.4-0.20240109183208-413678f90935 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/KimMachineGun/automemlimit v0.7.0 h1:7G06p/dMSf7G8E6oq+f2uOPuVncFyIlDI/pBWK49u88=
+github.com/KimMachineGun/automemlimit v0.7.0/go.mod h1:QZxpHaGOQoYvFhv/r4u3U0JTC2ZcOwbSr11UZF46UBM=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
@@ -366,6 +368,8 @@ github.com/onsi/ginkgo/v2 v2.13.2/go.mod h1:XStQ8QcGwLyF4HdfcZB8SFOS/MWCgDuXMSBe
 github.com/onsi/gomega v1.29.0 h1:KIA/t2t5UBzoirT4H9tsML45GEbo3ouUnBHsCfD2tVg=
 github.com/onsi/gomega v1.29.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv/v3 v3.0.1 h1:x06SQA46+PKIUftmEujdwSEpIx8kR+M9eLYsUxeYveU=
 github.com/peterbourgon/diskv/v3 v3.0.1/go.mod h1:kJ5Ny7vLdARGU3WUuy6uzO6T0nb/2gWcT1JiBvRmb5o=


### PR DESCRIPTION
Setting the [Go runtime memory limit](https://pkg.go.dev/runtime/debug#SetMemoryLimit) can improve significantly the performance of Caddy (and FrankenPHP and Mercure, according to our tests), especially on low-resources machines and containers.

This patch uses [github.com/KimMachineGun/automemlimit](https://github.com/KimMachineGun/automemlimit) to automatically find a good limit using the currently configured groups. This is especially useful when setting limits to containers using Docker, Kubernetes, LXC, and the like.

This PR is similar to #6047, which does the same things go the max number of processors.

Thanks to @flovntp for the idea and for finding this library!