### PR TITLE
caddytls: Refactor sni matcher

### DIFF
--- a/modules/caddytls/matchers.go
+++ b/modules/caddytls/matchers.go
@@ -56,13 +56,17 @@ func (MatchServerName) CaddyModule() caddy.ModuleInfo {
 
 // Match matches hello based on SNI.
 func (m MatchServerName) Match(hello *tls.ClientHelloInfo) bool {
-	repl := caddy.NewReplacer()
+	var repl *caddy.Replacer
 	// caddytls.TestServerNameMatcher calls this function without any context
 	if ctx := hello.Context(); ctx != nil {
 		// In some situations the existing context may have no replacer
 		if replAny := ctx.Value(caddy.ReplacerCtxKey); replAny != nil {
 			repl = replAny.(*caddy.Replacer)
 		}
+	}
+
+	if repl == nil {
+		repl = caddy.NewReplacer()
 	}
 
 	for _, name := range m {


### PR DESCRIPTION
This is a consistency fix to make `sni` matcher code in line with `sni_regexp` as adjusted by 7b8f3505e33139de0d542566478e98b361bb84bf. This way a new replacer is only created if no existing replacer/context has been found.