### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,go.sum,.codespellrc,.golangci.yml
+check-hidden = true
+# ignore-regex = 
+ignore-words-list = ot,te,ond,fo,tread

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/caddyconfig/caddyfile/lexer.go
+++ b/caddyconfig/caddyfile/lexer.go
@@ -155,7 +155,7 @@ func (l *lexer) next() (bool, error) {
 			// want to keep.
 			if ch == '\n' {
 				if len(val) == 2 {
-					return false, fmt.Errorf("missing opening heredoc marker on line #%d; must contain only alpha-numeric characters, dashes and underscores; got empty string", l.line)
+					return false, fmt.Errorf("missing opening heredoc marker on line #%d; must contain only alphanumeric characters, dashes and underscores; got empty string", l.line)
 				}
 
 				// check if there's too many <
@@ -165,7 +165,7 @@ func (l *lexer) next() (bool, error) {
 
 				heredocMarker = string(val[2:])
 				if !heredocMarkerRegexp.Match([]byte(heredocMarker)) {
-					return false, fmt.Errorf("heredoc marker on line #%d must contain only alpha-numeric characters, dashes and underscores; got '%s'", l.line, heredocMarker)
+					return false, fmt.Errorf("heredoc marker on line #%d must contain only alphanumeric characters, dashes and underscores; got '%s'", l.line, heredocMarker)
 				}
 
 				inHeredoc = true

--- a/caddyconfig/caddyfile/lexer_test.go
+++ b/caddyconfig/caddyfile/lexer_test.go
@@ -424,7 +424,7 @@ EOF
 		{
 			input:        []byte("not-a-heredoc <<\n"),
 			expectErr:    true,
-			errorMessage: "missing opening heredoc marker on line #1; must contain only alpha-numeric characters, dashes and underscores; got empty string",
+			errorMessage: "missing opening heredoc marker on line #1; must contain only alphanumeric characters, dashes and underscores; got empty string",
 		},
 		{
 			input: []byte(`heredoc <<<EOF

--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -92,7 +92,7 @@ func (st ServerType) buildTLSApp(
 		tlsApp.Automation.Policies = append(tlsApp.Automation.Policies, catchAllAP)
 	}
 
-	// collect all hosts that have a wildcard in them, and arent HTTP
+	// collect all hosts that have a wildcard in them, and aren't HTTP
 	wildcardHosts := []string{}
 	// hosts that have been explicitly marked to be automated,
 	// even if covered by another wildcard

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -149,7 +149,7 @@ type FileServer struct {
 	// the status code will typically be 200, or 206 for partial content.
 	StatusCode caddyhttp.WeakString `json:"status_code,omitempty"`
 
-	// If pass-thru mode is enabled and a requested file is not found,
+	// If passthrough mode is enabled and a requested file is not found,
 	// it will invoke the next handler in the chain instead of returning
 	// a 404 error. By default, this is false (disabled).
 	PassThru bool `json:"pass_thru,omitempty"`
@@ -696,7 +696,7 @@ func fileHidden(filename string, hide []string) bool {
 	return false
 }
 
-// notFound returns a 404 error or, if pass-thru is enabled,
+// notFound returns a 404 error or, if passthrough is enabled,
 // it calls the next handler in the chain.
 func (fsrv *FileServer) notFound(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	if fsrv.PassThru {

--- a/modules/caddyhttp/httpredirectlistener.go
+++ b/modules/caddyhttp/httpredirectlistener.go
@@ -162,7 +162,7 @@ func (c *httpRedirectConn) Read(p []byte) (int, error) {
 // looks like it might've been a misdirected plaintext HTTP request.
 func firstBytesLookLikeHTTP(hdr []byte) bool {
 	switch string(hdr[:5]) {
-	case "GET /", "HEAD ", "POST ", "PUT /", "OPTIO":
+	case "GET /", "HEAD ", "POST ", "PUT /", "OPTIO":  // codespell:ignore
 		return true
 	}
 	return false

--- a/modules/caddyhttp/metrics_test.go
+++ b/modules/caddyhttp/metrics_test.go
@@ -33,7 +33,7 @@ func TestMetricsInstrumentedHandler(t *testing.T) {
 		init:        sync.Once{},
 		httpMetrics: &httpMetrics{},
 	}
-	handlerErr := errors.New("oh noes")
+	handlerErr := errors.New("oh no")
 	response := []byte("hello world!")
 	h := HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		if actual := testutil.ToFloat64(metrics.httpMetrics.requestInFlight); actual != 1.0 {
@@ -209,7 +209,7 @@ func TestMetricsInstrumentedHandlerPerHost(t *testing.T) {
 		init:        sync.Once{},
 		httpMetrics: &httpMetrics{},
 	}
-	handlerErr := errors.New("oh noes")
+	handlerErr := errors.New("oh no")
 	response := []byte("hello world!")
 	h := HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		if actual := testutil.ToFloat64(metrics.httpMetrics.requestInFlight); actual != 1.0 {

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -510,7 +510,7 @@ func (h *Handler) doActiveHealthCheck(dialInfo DialInfo, hostAddr string, networ
 		body = io.LimitReader(body, h.HealthChecks.Active.MaxSize)
 	}
 	defer func() {
-		// drain any remaining body so connection could be re-used
+		// drain any remaining body so connection could be reused
 		_, _ = io.Copy(io.Discard, body)
 		resp.Body.Close()
 	}()

--- a/modules/caddyhttp/reverseproxy/streaming.go
+++ b/modules/caddyhttp/reverseproxy/streaming.go
@@ -146,7 +146,7 @@ func (h *Handler) handleUpgradeResponse(logger *zap.Logger, wg *sync.WaitGroup, 
 	// adopted from https://github.com/golang/go/commit/8bcf2834afdf6a1f7937390903a41518715ef6f5
 	backConnCloseCh := make(chan struct{})
 	go func() {
-		// Ensure that the cancelation of a request closes the backend.
+		// Ensure that the cancellation of a request closes the backend.
 		// See issue https://golang.org/issue/35559.
 		select {
 		case <-req.Context().Done():

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -70,7 +70,7 @@ type Server struct {
 	WriteTimeout caddy.Duration `json:"write_timeout,omitempty"`
 
 	// IdleTimeout is the maximum time to wait for the next request
-	// when keep-alives are enabled. If zero, a default timeout of
+	// when keep-alive are enabled. If zero, a default timeout of
 	// 5m is applied to help avoid resource exhaustion.
 	IdleTimeout caddy.Duration `json:"idle_timeout,omitempty"`
 

--- a/modules/caddytls/certmanagers.go
+++ b/modules/caddytls/certmanagers.go
@@ -44,7 +44,7 @@ func (ts *Tailscale) Provision(ctx caddy.Context) error {
 func (ts Tailscale) GetCertificate(ctx context.Context, hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	canGetCert, err := ts.canHazCertificate(ctx, hello)
 	if err == nil && !canGetCert {
-		return nil, nil // pass-thru: Tailscale can't offer a cert for this name
+		return nil, nil // passthrough: Tailscale can't offer a cert for this name
 	}
 	if err != nil {
 		if c := ts.logger.Check(zapcore.WarnLevel, "could not get status; will try to get certificate anyway"); c != nil {


### PR DESCRIPTION
Got inspired by

```shell
❯ git log origin/master | grep typo | nl
     1	    Fix typo in TLS group x25519mlkem768
...
     6	    I'm so tired of typos
...
  44	    Fix README typo, sigh...
```

although currently there is pretty much no typos left (good job!). With codespell -- it could stay like that.

More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.