### PR TITLE
Fix TrustedCACerts backwards compatibility

### DIFF
--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -749,10 +749,14 @@ func (clientauth *ClientAuthentication) provision(ctx caddy.Context) error {
 
 	// if we have TrustedCACerts explicitly set, create an 'inline' CA and return
 	if len(clientauth.TrustedCACerts) > 0 {
-		clientauth.ca = InlineCAPool{
+		caPool := InlineCAPool{
 			TrustedCACerts: clientauth.TrustedCACerts,
 		}
-		return nil
+		err := caPool.Provision(ctx)
+		if err != nil {
+			return nil
+		}
+		clientauth.ca = caPool
 	}
 
 	// if we don't have any CARaw set, there's not much work to do

--- a/modules/caddytls/connpolicy_test.go
+++ b/modules/caddytls/connpolicy_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
@@ -274,6 +275,53 @@ func TestClientAuthenticationUnmarshalCaddyfileWithDirectiveName(t *testing.T) {
 			}
 			if !tt.wantErr && !reflect.DeepEqual(&tt.expected, ca) {
 				t.Errorf("ClientAuthentication.UnmarshalCaddyfile() = %v, want %v", ca, tt.expected)
+			}
+		})
+	}
+}
+
+func TestClientAuthenticationProvision(t *testing.T) {
+	tests := []struct {
+		name     string
+		ca       ClientAuthentication
+		expected ClientAuthentication
+		wantErr  bool
+	}{
+		{
+			name: "specifying both 'CARaw' and 'TrustedCACerts' produces an error",
+			ca: ClientAuthentication{
+				CARaw:          json.RawMessage(`{"provider":"inline","trusted_ca_certs":["foo"]}`),
+				TrustedCACerts: []string{"foo"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "specifying both 'CARaw' and 'TrustedCACertPEMFiles' produces an error",
+			ca: ClientAuthentication{
+				CARaw:                 json.RawMessage(`{"provider":"inline","trusted_ca_certs":["foo"]}`),
+				TrustedCACertPEMFiles: []string{"foo"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "setting 'TrustedCACerts' provisions the cert pool",
+			ca: ClientAuthentication{
+				TrustedCACerts: []string{test_der_1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.ca.provision(caddy.Context{})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ClientAuthentication.provision() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if tt.ca.ca.CertPool() == nil {
+					t.Error("CertPool is nil, expected non-nil value")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
I'm very late to the party, but I was in the process of bumping our Caddy dependency and noticed https://github.com/caddyserver/caddy/pull/5784 has a slight bug with the backwards compatibility of the now-deprecated `TrustedCACerts` option. 

The Caddyfile bit works fine because [it converts it to a `CARaw`](https://github.com/jjiang-stripe/caddy/blob/b130e430a00a97db6381c0aa092eeff237d03d37/modules/caddytls/connpolicy.go#L701-L707), but if you specify the option directly via JSON, we don't end up [populating `icp.pool` since we're not calling `Provision()`](https://github.com/caddyserver/caddy/blob/d57ab215a2f198a465ea33abe4588bb5696e7abd/modules/caddytls/capools.go#L70)

I wrote up a quick test to validate the behaviour with the additional call to `Provision()` and also tested it on our instance of Caddy. It'd be nice to cherrypick this onto the 2.8.0+ releases (I'm specifically looking at 2.9.1) to make sure this option still works while it's deprecated! I plan to migrate us to the new config options, but our deploy process makes that a bit difficult to do simultaneously with the Caddy upgrade 😅 