### PR TITLE
Fix caddy fmt breaks backquote wrapped braces in template

### DIFF
--- a/caddyconfig/caddyfile/formatter.go
+++ b/caddyconfig/caddyfile/formatter.go
@@ -61,7 +61,8 @@ func Format(input []byte) []byte {
 		heredocMarker        []rune
 		heredocClosingMarker []rune
 
-		nesting int // indentation level
+		nesting         int // indentation level
+		withinBackquote bool
 	)
 
 	write := func(ch rune) {
@@ -87,6 +88,9 @@ func Format(input []byte) []byte {
 				break
 			}
 			panic(err)
+		}
+		if ch == '`' {
+			withinBackquote = !withinBackquote
 		}
 
 		// detect whether we have the start of a heredoc
@@ -236,14 +240,23 @@ func Format(input []byte) []byte {
 		switch {
 		case ch == '{':
 			openBrace = true
-			openBraceWritten = false
 			openBraceSpace = spacePrior && !beginningOfLine
 			if openBraceSpace {
 				write(' ')
 			}
+			openBraceWritten = false
+			if withinBackquote {
+				write('{')
+				openBraceWritten = true
+				continue
+			}
 			continue
 
 		case ch == '}' && (spacePrior || !openBrace):
+			if withinBackquote {
+				write('}')
+				continue
+			}
 			if last != '\n' {
 				nextLine()
 			}

--- a/caddyconfig/caddyfile/formatter_test.go
+++ b/caddyconfig/caddyfile/formatter_test.go
@@ -434,6 +434,16 @@ block2 {
 }
 `,
 		},
+		{
+			description: "Preserve braces wrapped by backquotes",
+			input:       "block {respond `All braces should remain: {{now | date \"2006\"}}`}",
+			expect:      "block {respond `All braces should remain: {{now | date \"2006\"}}`}",
+		},
+		{
+			description: "Preserve braces wrapped by quotes",
+			input:       "block {respond \"All braces should remain: {{now | date `2006`}}\"}",
+			expect:      "block {respond \"All braces should remain: {{now | date `2006`}}\"}",
+		},
 	} {
 		// the formatter should output a trailing newline,
 		// even if the tests aren't written to expect that


### PR DESCRIPTION
This addresses issue #6859 by writing the opening and closing braces and ignoring indentation when it detects that we the cursor is currently within a backquote section. 

I have added 2 new tests for the two cases where the braces are wrapped with regular quotes and backquotes. I have confirmed that it works at  least with the following example:
```
block {
	header Content-Type text/plain
	templates
	respond "Home page date: {{now | date `2006`}}"

	handle /path {
		header Content-Type text/plain
		templates
		respond `Path page date: {{now | date "2006"}}`
	}
}
```