### PR TITLE
chore: upgrade .golangci.yml and workflow to v2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,7 +51,7 @@ jobs:
           check-latest: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: latest
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,27 +1,15 @@
-linters-settings:
-  errcheck:
-    exclude-functions:
-      - fmt.*
-      - (go.uber.org/zap/zapcore.ObjectEncoder).AddObject
-      - (go.uber.org/zap/zapcore.ObjectEncoder).AddArray
-  gci:
-    sections:
-      - standard # Standard section: captures all standard packages.
-      - default # Default section: contains all imports that could not be matched to another section type.
-      - prefix(github.com/caddyserver/caddy/v2/cmd) # ensure that this is always at the top and always has a line break.
-      - prefix(github.com/caddyserver/caddy) # Custom section: groups all imports with the specified Prefix.
-    # Skip generated files.
-    # Default: true
-    skip-generated: true
-    # Enable custom order of sections.
-    # If `true`, make the section order the same as the order of `sections`.
-    # Default: false
-    custom-order: true
-  exhaustive:
-    ignore-enum-types: reflect.Kind|svc.Cmd
-
+version: "2"
+run:
+  issues-exit-code: 1
+  tests: false
+output:
+  formats:
+    text:
+      path: stdout
+      print-linter-name: true
+      print-issued-lines: true
 linters:
-  disable-all: true
+  default: none
   enable:
     - asasalint
     - asciicheck
@@ -35,148 +23,93 @@ linters:
     - errcheck
     - errname
     - exhaustive
-    - gci
-    - gofmt
-    - goimports
-    - gofumpt
     - gosec
-    - gosimple
     - govet
-    - ineffassign
     - importas
+    - ineffassign
     - misspell
     - prealloc
     - promlinter
     - sloglint
     - sqlclosecheck
     - staticcheck
-    - tenv
     - testableexamples
     - testifylint
     - tparallel
-    - typecheck
     - unconvert
     - unused
     - wastedassign
     - whitespace
     - zerologlint
-  # these are implicitly disabled:
-  # - containedctx
-  # - contextcheck
-  # - cyclop
-  # - depguard
-  # - errchkjson
-  # - errorlint
-  # - exhaustruct
-  # - execinquery
-  # - exhaustruct
-  # - forbidigo
-  # - forcetypeassert
-  # - funlen
-  # - ginkgolinter
-  # - gocheckcompilerdirectives
-  # - gochecknoglobals
-  # - gochecknoinits
-  # - gochecksumtype
-  # - gocognit
-  # - goconst
-  # - gocritic
-  # - gocyclo
-  # - godot
-  # - godox
-  # - goerr113
-  # - goheader
-  # - gomnd
-  # - gomoddirectives
-  # - gomodguard
-  # - goprintffuncname
-  # - gosmopolitan
-  # - grouper
-  # - inamedparam
-  # - interfacebloat
-  # - ireturn
-  # - lll
-  # - loggercheck
-  # - maintidx
-  # - makezero
-  # - mirror
-  # - musttag
-  # - nakedret
-  # - nestif
-  # - nilerr
-  # - nilnil
-  # - nlreturn
-  # - noctx
-  # - nolintlint
-  # - nonamedreturns
-  # - nosprintfhostport
-  # - paralleltest
-  # - perfsprint
-  # - predeclared
-  # - protogetter
-  # - reassign
-  # - revive
-  # - rowserrcheck
-  # - stylecheck
-  # - tagalign
-  # - tagliatelle
-  # - testpackage
-  # - thelper
-  # - unparam
-  # - usestdlibvars
-  # - varnamelen
-  # - wrapcheck
-  # - wsl
-
-run:
-  # default concurrency is a available CPU number.
-  # concurrency: 4 # explicitly omit this value to fully utilize available resources.
-  timeout: 5m
-  issues-exit-code: 1
-  tests: false
-
-# output configuration options
-output:
-  formats:
-    - format: 'colored-line-number'
-  print-issued-lines: true
-  print-linter-name: true
-
-issues:
-  exclude-rules:
-    - text: 'G115' # TODO: Either we should fix the issues or nuke the linter if it's bad
-      linters:
-        - gosec
-    # we aren't calling unknown URL
-    - text: 'G107' # G107: Url provided to HTTP request as taint input
-      linters:
-        - gosec
-    # as a web server that's expected to handle any template, this is totally in the hands of the user.
-    - text: 'G203' # G203: Use of unescaped data in HTML templates
-      linters:
-        - gosec
-    # we're shelling out to known commands, not relying on user-defined input.
-    - text: 'G204' # G204: Audit use of command execution
-      linters:
-        - gosec
-    # the choice of weakrand is deliberate, hence the named import "weakrand"
-    - path: modules/caddyhttp/reverseproxy/selectionpolicies.go
-      text: 'G404' # G404: Insecure random number source (rand)
-      linters:
-        - gosec
-    - path: modules/caddyhttp/reverseproxy/streaming.go
-      text: 'G404' # G404: Insecure random number source (rand)
-      linters:
-        - gosec
-    - path: modules/logging/filters.go
-      linters:
-        - dupl
-    - path: modules/caddyhttp/matchers.go
-      linters:
-        - dupl
-    - path: modules/caddyhttp/vars.go
-      linters:
-        - dupl
-    - path: _test\.go
-      linters:
-        - errcheck
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt.*
+        - (go.uber.org/zap/zapcore.ObjectEncoder).AddObject
+        - (go.uber.org/zap/zapcore.ObjectEncoder).AddArray
+    exhaustive:
+      ignore-enum-types: reflect.Kind|svc.Cmd
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gosec
+        text: G115
+      - linters:
+          - gosec
+        text: G107
+      - linters:
+          - gosec
+        text: G203
+      - linters:
+          - gosec
+        text: G204
+      - linters:
+          - gosec
+        path: modules/caddyhttp/reverseproxy/selectionpolicies.go
+        text: G404
+      - linters:
+          - gosec
+        path: modules/caddyhttp/reverseproxy/streaming.go
+        text: G404
+      - linters:
+          - dupl
+        path: modules/logging/filters.go
+      - linters:
+          - dupl
+        path: modules/caddyhttp/matchers.go
+      - linters:
+          - dupl
+        path: modules/caddyhttp/vars.go
+      - linters:
+          - errcheck
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/caddyserver/caddy/v2/cmd)
+        - prefix(github.com/caddyserver/caddy)
+      custom-order: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/caddytest/integration/acme_test.go
+++ b/caddytest/integration/acme_test.go
@@ -12,13 +12,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddytest"
 	"github.com/mholt/acmez/v3"
 	"github.com/mholt/acmez/v3/acme"
 	smallstepacme "github.com/smallstep/certificates/acme"
 	"go.uber.org/zap"
 	"go.uber.org/zap/exp/zapslog"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddytest"
 )
 
 const acmeChallengePort = 9081

--- a/caddytest/integration/acmeserver_test.go
+++ b/caddytest/integration/acmeserver_test.go
@@ -9,11 +9,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/caddyserver/caddy/v2/caddytest"
 	"github.com/mholt/acmez/v3"
 	"github.com/mholt/acmez/v3/acme"
 	"go.uber.org/zap"
 	"go.uber.org/zap/exp/zapslog"
+
+	"github.com/caddyserver/caddy/v2/caddytest"
 )
 
 func TestACMEServerDirectory(t *testing.T) {

--- a/caddytest/integration/caddyfile_adapt_test.go
+++ b/caddytest/integration/caddyfile_adapt_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/caddyserver/caddy/v2/caddytest"
-
 	_ "github.com/caddyserver/caddy/v2/internal/testmocks"
 )
 

--- a/caddytest/integration/caddyfile_test.go
+++ b/caddytest/integration/caddyfile_test.go
@@ -615,7 +615,6 @@ func TestReplaceWithReplacementPlaceholder(t *testing.T) {
 	respond "{query}"`, "caddyfile")
 
 	tester.AssertGetResponse("http://localhost:9080/endpoint?placeholder=baz&foo=bar", 200, "foo=baz&placeholder=baz")
-
 }
 
 func TestReplaceWithKeyPlaceholder(t *testing.T) {

--- a/caddytest/integration/mockdns_test.go
+++ b/caddytest/integration/mockdns_test.go
@@ -3,10 +3,11 @@ package integration
 import (
 	"context"
 
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/certmagic"
 	"github.com/libdns/libdns"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
 func init() {
@@ -55,7 +56,9 @@ func (MockDNSProvider) SetRecords(ctx context.Context, zone string, recs []libdn
 }
 
 // Interface guard
-var _ caddyfile.Unmarshaler = (*MockDNSProvider)(nil)
-var _ certmagic.DNSProvider = (*MockDNSProvider)(nil)
-var _ caddy.Provisioner = (*MockDNSProvider)(nil)
-var _ caddy.Module = (*MockDNSProvider)(nil)
+var (
+	_ caddyfile.Unmarshaler = (*MockDNSProvider)(nil)
+	_ certmagic.DNSProvider = (*MockDNSProvider)(nil)
+	_ caddy.Provisioner     = (*MockDNSProvider)(nil)
+	_ caddy.Module          = (*MockDNSProvider)(nil)
+)

--- a/caddytest/integration/stream_test.go
+++ b/caddytest/integration/stream_test.go
@@ -13,9 +13,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/caddyserver/caddy/v2/caddytest"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
+
+	"github.com/caddyserver/caddy/v2/caddytest"
 )
 
 // (see https://github.com/caddyserver/caddy/issues/3556 for use case)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -235,7 +235,6 @@ func Test_isCaddyfile(t *testing.T) {
 			wantErr: false,
 		},
 		{
-
 			name: "json is not caddyfile but not error",
 			args: args{
 				configFile:  "./Caddyfile.json",
@@ -245,7 +244,6 @@ func Test_isCaddyfile(t *testing.T) {
 			wantErr: false,
 		},
 		{
-
 			name: "prefix of Caddyfile and ./ with any extension is Caddyfile",
 			args: args{
 				configFile:  "./Caddyfile.prd",
@@ -255,7 +253,6 @@ func Test_isCaddyfile(t *testing.T) {
 			wantErr: false,
 		},
 		{
-
 			name: "prefix of Caddyfile without ./ with any extension is Caddyfile",
 			args: args{
 				configFile:  "Caddyfile.prd",

--- a/listeners_test.go
+++ b/listeners_test.go
@@ -30,7 +30,7 @@ func TestSplitNetworkAddress(t *testing.T) {
 		expectErr     bool
 	}{
 		{
-			input:     "",
+			input:      "",
 			expectHost: "",
 		},
 		{
@@ -41,7 +41,7 @@ func TestSplitNetworkAddress(t *testing.T) {
 			input: ":", // empty host & empty port
 		},
 		{
-			input:     "::",
+			input:      "::",
 			expectHost: "::",
 		},
 		{
@@ -184,9 +184,8 @@ func TestParseNetworkAddress(t *testing.T) {
 		expectErr      bool
 	}{
 		{
-			input:     "",
-			expectAddr: NetworkAddress{
-			},
+			input:      "",
+			expectAddr: NetworkAddress{},
 		},
 		{
 			input:          ":",
@@ -311,9 +310,8 @@ func TestParseNetworkAddressWithDefaults(t *testing.T) {
 		expectErr      bool
 	}{
 		{
-			input:     "",
-			expectAddr: NetworkAddress{
-			},
+			input:      "",
+			expectAddr: NetworkAddress{},
 		},
 		{
 			input:          ":",

--- a/modules/caddyhttp/metrics_test.go
+++ b/modules/caddyhttp/metrics_test.go
@@ -9,8 +9,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/caddyserver/caddy/v2"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/caddyserver/caddy/v2"
 )
 
 func TestServerNameFromContext(t *testing.T) {

--- a/modules/caddyhttp/reverseproxy/upstreams_test.go
+++ b/modules/caddyhttp/reverseproxy/upstreams_test.go
@@ -52,5 +52,4 @@ func TestResolveIpVersion(t *testing.T) {
 			t.Errorf("resolveIpVersion(): Expected %s got %s", test.expectedIpVersion, ipVersion)
 		}
 	}
-
 }

--- a/modules/caddyhttp/server_test.go
+++ b/modules/caddyhttp/server_test.go
@@ -171,6 +171,7 @@ func BenchmarkServer_LogRequest_WithTrace(b *testing.B) {
 		s.logRequest(accLog, req, wrec, &duration, repl, bodyReader, false)
 	}
 }
+
 func TestServer_TrustedRealClientIP_NoTrustedHeaders(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 	req.RemoteAddr = "192.0.2.1:12345"

--- a/modules/caddytls/ech_test.go
+++ b/modules/caddytls/ech_test.go
@@ -76,7 +76,6 @@ func TestSvcParamsString(t *testing.T) {
 	// because we can't just compare string outputs
 	// since map iteration is unordered
 	for i, test := range []svcParams{
-
 		{
 			"alpn":            {"h2", "h3"},
 			"no-default-alpn": {},

--- a/modules/logging/filewriter_test.go
+++ b/modules/logging/filewriter_test.go
@@ -317,7 +317,7 @@ func TestFileModeToJSON(t *testing.T) {
 	}{
 		{
 			name:    "none zero",
-			mode:    0644,
+			mode:    0o644,
 			want:    `"0644"`,
 			wantErr: false,
 		},
@@ -358,7 +358,7 @@ func TestFileModeModification(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	fpath := path.Join(dir, "test.log")
-	f_tmp, err := os.OpenFile(fpath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, os.FileMode(0600))
+	f_tmp, err := os.OpenFile(fpath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, os.FileMode(0o600))
 	if err != nil {
 		t.Fatalf("failed to create test file: %v", err)
 	}

--- a/modules/logging/filters_test.go
+++ b/modules/logging/filters_test.go
@@ -3,9 +3,10 @@ package logging
 import (
 	"testing"
 
+	"go.uber.org/zap/zapcore"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	"go.uber.org/zap/zapcore"
 )
 
 func TestIPMaskSingleValue(t *testing.T) {


### PR DESCRIPTION
I also ran `golangci-lint fmt`, which formats all files including tests. It found a couple issues, which is good.