### PR TITLE
Add a valid Upstream to the DialInfo when doing active health checks

### DIFF
--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -17,7 +17,6 @@ package reverseproxy
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"net/netip"
 	"strconv"
 	"sync/atomic"
@@ -100,8 +99,7 @@ func (u *Upstream) Full() bool {
 
 // fillDialInfo returns a filled DialInfo for upstream u, using the request
 // context. Note that the returned value is not a pointer.
-func (u *Upstream) fillDialInfo(r *http.Request) (DialInfo, error) {
-	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+func (u *Upstream) fillDialInfo(repl *caddy.Replacer) (DialInfo, error) {
 	var addr caddy.NetworkAddress
 
 	// use provided dial address

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -532,7 +532,7 @@ func (h *Handler) proxyLoopIteration(r *http.Request, origReq *http.Request, w h
 	// the dial address may vary per-request if placeholders are
 	// used, so perform those replacements here; the resulting
 	// DialInfo struct should have valid network address syntax
-	dialInfo, err := upstream.fillDialInfo(r)
+	dialInfo, err := upstream.fillDialInfo(repl)
 	if err != nil {
 		return true, fmt.Errorf("making dial info: %v", err)
 	}


### PR DESCRIPTION
Currently if we extract the `DialInfo` from a `Request` `Context` in a custom `Transport` during an active health check, then the `Upstream` in the `DialInfo` will be nil.

This PR attempts to set the `Upstream` to a sensible value, based on wether or not the `Upstream` has been overridden in the active health check's config.

This is useful when using a custom Transport for the `reverse_proxy` module, as it makes `GetDialInfo` behave similarly in active health check requests and client requests. 