### PR TITLE
forwardproxy: reference correct field name in LoadModule

### DIFF
--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -353,7 +353,7 @@ func (h *HTTPTransport) NewTransport(caddyCtx caddy.Context) (*http.Transport, e
 		h.NetworkProxyRaw = caddyconfig.JSONModuleObject(u, "from", "url", nil)
 	}
 	if len(h.NetworkProxyRaw) != 0 {
-		proxyMod, err := caddyCtx.LoadModule(h, "ForwardProxyRaw")
+		proxyMod, err := caddyCtx.LoadModule(h, "NetworkProxyRaw")
 		if err != nil {
 			return nil, fmt.Errorf("failed to load network_proxy module: %v", err)
 		}

--- a/modules/caddytls/acmeissuer.go
+++ b/modules/caddytls/acmeissuer.go
@@ -220,7 +220,7 @@ func (iss *ACMEIssuer) makeIssuerTemplate(ctx caddy.Context) (certmagic.ACMEIssu
 	}
 
 	if len(iss.NetworkProxyRaw) != 0 {
-		proxyMod, err := ctx.LoadModule(iss, "ForwardProxyRaw")
+		proxyMod, err := ctx.LoadModule(iss, "NetworkProxyRaw")
 		if err != nil {
 			return template, fmt.Errorf("failed to load network_proxy module: %v", err)
 		}


### PR DESCRIPTION
Oops

Fix #6976 