### PR TITLE
fix: Remove `nil` arg from `zapslog.NewHandler` call

### DIFF
--- a/context.go
+++ b/context.go
@@ -577,11 +577,11 @@ func (ctx Context) Slogger() *slog.Logger {
 		if err != nil {
 			panic("config missing, unable to create dev logger: " + err.Error())
 		}
-		return slog.New(zapslog.NewHandler(l.Core(), nil))
+		return slog.New(zapslog.NewHandler(l.Core()))
 	}
 	mod := ctx.Module()
 	if mod == nil {
-		return slog.New(zapslog.NewHandler(Log().Core(), nil))
+		return slog.New(zapslog.NewHandler(Log().Core()))
 	}
 	return slog.New(zapslog.NewHandler(ctx.cfg.Logging.Logger(mod).Core(),
 		zapslog.WithName(string(mod.CaddyModule().ID)),


### PR DESCRIPTION
`opts` argument in the `zapslog.NewHandler` function should not be passed as `nil`

https://github.com/uber-go/zap/blob/7db06bc9b095571d3dc3d4eebdfbe4dd9bd20405/exp/zapslog/handler.go#L53