### PR TITLE
fileserver: Add support for .avif image format

### DIFF
--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -26,7 +26,7 @@
 		<path d="M9 7l4 0"/>
 		<path d="M9 11l4 0"/>
 	</svg>
-	{{- else if .HasExt ".jpg" ".jpeg" ".png" ".gif" ".webp" ".tiff" ".bmp" ".heif" ".heic" ".svg"}}
+	{{- else if .HasExt ".jpg" ".jpeg" ".png" ".gif" ".webp" ".tiff" ".bmp" ".heif" ".heic" ".svg" ".avif"}}
 		{{- if eq .Tpl.Layout "grid"}}
 		<img loading="lazy" src="{{.Name | pathEscape}}">
 		{{- else}}
@@ -802,7 +802,7 @@ footer {
 							<b>{{.NumFiles}}</b> file{{if ne 1 .NumFiles}}s{{end}}
 						</span>
 						<span class="meta-item">
-							<b>{{.HumanTotalFileSize}}</b> total 
+							<b>{{.HumanTotalFileSize}}</b> total
 						</span>
 						{{- if ne 0 .Limit}}
 						<span class="meta-item">
@@ -868,7 +868,7 @@ footer {
 								</svg>
 							</a>
 							{{- end}}
-							
+
 							{{- if and (eq .Sort "name") (ne .Order "desc")}}
 							<a href="?sort=name&order=desc{{if ne 0 .Limit}}&limit={{.Limit}}{{end}}{{if ne 0 .Offset}}&offset={{.Offset}}{{end}}">
 								Name


### PR DESCRIPTION
This pull request adds support for `.avif` image files in the file browser. The `.avif` extension has been included in the list of recognized image formats.

See also https://caddy.community/t/caddy-fails-to-img-avif-in-file-server-grid-layout/30680/2