### PR TITLE
admin: Make sure that any admin routers are provisioned when local/re…

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -426,7 +426,10 @@ func replaceLocalAdminServer(cfg *Config, ctx Context) error {
 
 	// run the provisioners for loaded modules to make sure local
 	// state is properly re-initialized in the new admin server
-	cfg.Admin.provisionAdminRouters(ctx)
+	err = cfg.Admin.provisionAdminRouters(ctx)
+	if err != nil {
+		return err
+	}
 
 	ln, err := addr.Listen(context.TODO(), 0, net.ListenConfig{})
 	if err != nil {
@@ -551,7 +554,10 @@ func replaceRemoteAdminServer(ctx Context, cfg *Config) error {
 
 	// run the provisioners for loaded modules to make sure local
 	// state is properly re-initialized in the new admin server
-	cfg.Admin.provisionAdminRouters(ctx)
+	err = cfg.Admin.provisionAdminRouters(ctx)
+	if err != nil {
+		return err
+	}
 
 	// create client certificate pool for TLS mutual auth, and extract public keys
 	// so that we can enforce access controls at the application layer

--- a/admin.go
+++ b/admin.go
@@ -424,6 +424,10 @@ func replaceLocalAdminServer(cfg *Config, ctx Context) error {
 
 	handler := cfg.Admin.newAdminHandler(addr, false, ctx)
 
+	// run the provisioners for loaded modules to make sure local
+	// state is properly re-initialized in the new admin server
+	cfg.Admin.provisionAdminRouters(ctx)
+
 	ln, err := addr.Listen(context.TODO(), 0, net.ListenConfig{})
 	if err != nil {
 		return err
@@ -544,6 +548,10 @@ func replaceRemoteAdminServer(ctx Context, cfg *Config) error {
 	// make the HTTP handler but disable Host/Origin enforcement
 	// because we are using TLS authentication instead
 	handler := cfg.Admin.newAdminHandler(addr, true, ctx)
+
+	// run the provisioners for loaded modules to make sure local
+	// state is properly re-initialized in the new admin server
+	cfg.Admin.provisionAdminRouters(ctx)
 
 	// create client certificate pool for TLS mutual auth, and extract public keys
 	// so that we can enforce access controls at the application layer


### PR DESCRIPTION
…mote admin servers are replaced at runtime.

Fixes issue #6931 

**Background**

When the remote admin servers are reloaded at runtime (or as part of the final initialization phase at boot), the local state in the new instances aren't fully initialized. This is due to `New()`ing each module up during the call to `newAdminHandler`, but never actually provisioning it. As a result, the `metricsHandler` and `registry` members are `nil`, causing the metrics endpoint to crash and return an empty response when invoked via the remote admin API.

This change makes sure that we call the `provisionAdminRouters` method when both local and remote admin servers are reloaded and replaced. This should ensure consistent behavior in the future between reloads.