### PR TITLE
fix: prevent error handler from overriding sub handler matchers

### DIFF
--- a/caddytest/integration/caddyfile_adapt/error_example.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/error_example.caddyfiletest
@@ -106,20 +106,29 @@ example.com {
 										"handler": "subroute",
 										"routes": [
 											{
-												"group": "group0",
 												"handle": [
 													{
-														"handler": "rewrite",
-														"uri": "/{http.error.status_code}.html"
-													}
-												]
-											},
-											{
-												"handle": [
-													{
-														"handler": "file_server",
-														"hide": [
-															"./Caddyfile"
+														"handler": "subroute",
+														"routes": [
+															{
+																"group": "group0",
+																"handle": [
+																	{
+																		"handler": "rewrite",
+																		"uri": "/{http.error.status_code}.html"
+																	}
+																]
+															},
+															{
+																"handle": [
+																	{
+																		"handler": "file_server",
+																		"hide": [
+																			"./Caddyfile"
+																		]
+																	}
+																]
+															}
 														]
 													}
 												]

--- a/caddytest/integration/caddyfile_adapt/error_multi_site_blocks.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/error_multi_site_blocks.caddyfiletest
@@ -165,8 +165,17 @@ bar.localhost {
 											{
 												"handle": [
 													{
-														"body": "404 or 410 error",
-														"handler": "static_response"
+														"handler": "subroute",
+														"routes": [
+															{
+																"handle": [
+																	{
+																		"body": "404 or 410 error",
+																		"handler": "static_response"
+																	}
+																]
+															}
+														]
 													}
 												],
 												"match": [
@@ -178,8 +187,17 @@ bar.localhost {
 											{
 												"handle": [
 													{
-														"body": "Error In range [500 .. 599]",
-														"handler": "static_response"
+														"handler": "subroute",
+														"routes": [
+															{
+																"handle": [
+																	{
+																		"body": "Error In range [500 .. 599]",
+																		"handler": "static_response"
+																	}
+																]
+															}
+														]
 													}
 												],
 												"match": [
@@ -208,8 +226,17 @@ bar.localhost {
 											{
 												"handle": [
 													{
-														"body": "404 or 410 error from second site",
-														"handler": "static_response"
+														"handler": "subroute",
+														"routes": [
+															{
+																"handle": [
+																	{
+																		"body": "404 or 410 error from second site",
+																		"handler": "static_response"
+																	}
+																]
+															}
+														]
 													}
 												],
 												"match": [
@@ -221,8 +248,17 @@ bar.localhost {
 											{
 												"handle": [
 													{
-														"body": "Error In range [500 .. 599] from second site",
-														"handler": "static_response"
+														"handler": "subroute",
+														"routes": [
+															{
+																"handle": [
+																	{
+																		"body": "Error In range [500 .. 599] from second site",
+																		"handler": "static_response"
+																	}
+																]
+															}
+														]
 													}
 												],
 												"match": [

--- a/caddytest/integration/caddyfile_adapt/error_range_codes.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/error_range_codes.caddyfiletest
@@ -96,8 +96,17 @@ localhost:3010 {
 											{
 												"handle": [
 													{
-														"body": "Error in the [400 .. 499] range",
-														"handler": "static_response"
+														"handler": "subroute",
+														"routes": [
+															{
+																"handle": [
+																	{
+																		"body": "Error in the [400 .. 499] range",
+																		"handler": "static_response"
+																	}
+																]
+															}
+														]
 													}
 												],
 												"match": [

--- a/caddytest/integration/caddyfile_adapt/error_range_simple_codes.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/error_range_simple_codes.caddyfiletest
@@ -116,8 +116,17 @@ localhost:2099 {
 											{
 												"handle": [
 													{
-														"body": "Error in the [400 .. 499] range",
-														"handler": "static_response"
+														"handler": "subroute",
+														"routes": [
+															{
+																"handle": [
+																	{
+																		"body": "Error in the [400 .. 499] range",
+																		"handler": "static_response"
+																	}
+																]
+															}
+														]
 													}
 												],
 												"match": [
@@ -129,8 +138,17 @@ localhost:2099 {
 											{
 												"handle": [
 													{
-														"body": "Error code is equal to 500 or in the [300..399] range",
-														"handler": "static_response"
+														"handler": "subroute",
+														"routes": [
+															{
+																"handle": [
+																	{
+																		"body": "Error code is equal to 500 or in the [300..399] range",
+																		"handler": "static_response"
+																	}
+																]
+															}
+														]
 													}
 												],
 												"match": [

--- a/caddytest/integration/caddyfile_adapt/error_simple_codes.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/error_simple_codes.caddyfiletest
@@ -96,8 +96,17 @@ localhost:3010 {
 											{
 												"handle": [
 													{
-														"body": "404 or 410 error",
-														"handler": "static_response"
+														"handler": "subroute",
+														"routes": [
+															{
+																"handle": [
+																	{
+																		"body": "404 or 410 error",
+																		"handler": "static_response"
+																	}
+																]
+															}
+														]
 													}
 												],
 												"match": [

--- a/caddytest/integration/caddyfile_adapt/error_sort.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/error_sort.caddyfiletest
@@ -116,8 +116,17 @@ localhost:2099 {
 											{
 												"handle": [
 													{
-														"body": "Error in the [400 .. 499] range",
-														"handler": "static_response"
+														"handler": "subroute",
+														"routes": [
+															{
+																"handle": [
+																	{
+																		"body": "Error in the [400 .. 499] range",
+																		"handler": "static_response"
+																	}
+																]
+															}
+														]
 													}
 												],
 												"match": [
@@ -129,8 +138,17 @@ localhost:2099 {
 											{
 												"handle": [
 													{
-														"body": "Fallback route: code outside the [400..499] range",
-														"handler": "static_response"
+														"handler": "subroute",
+														"routes": [
+															{
+																"handle": [
+																	{
+																		"body": "Fallback route: code outside the [400..499] range",
+																		"handler": "static_response"
+																	}
+																]
+															}
+														]
 													}
 												]
 											}

--- a/caddytest/integration/caddyfile_adapt/error_subhandlers.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/error_subhandlers.caddyfiletest
@@ -1,0 +1,260 @@
+{
+	http_port 2099
+}
+localhost:2099 {
+	root * /var/www/
+	file_server
+
+	handle_errors 404 {
+		handle /en/* {
+			respond "not found" 404
+		}
+		handle /es/* {
+			respond "no encontrado"
+		}
+		handle {
+			respond "default not found"
+		}
+	}
+	handle_errors {
+		handle /en/* {
+			respond "English error"
+		}
+		handle /es/* {
+			respond "Spanish error"
+		}
+		handle {
+			respond "Default error"
+		}
+	}
+}
+----------
+{
+	"apps": {
+		"http": {
+			"http_port": 2099,
+			"servers": {
+				"srv0": {
+					"listen": [
+						":2099"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"localhost"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"handler": "vars",
+													"root": "/var/www/"
+												},
+												{
+													"handler": "file_server",
+													"hide": [
+														"./Caddyfile"
+													]
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					],
+					"errors": {
+						"routes": [
+							{
+								"match": [
+									{
+										"host": [
+											"localhost"
+										]
+									}
+								],
+								"handle": [
+									{
+										"handler": "subroute",
+										"routes": [
+											{
+												"handle": [
+													{
+														"handler": "subroute",
+														"routes": [
+															{
+																"group": "group3",
+																"handle": [
+																	{
+																		"handler": "subroute",
+																		"routes": [
+																			{
+																				"handle": [
+																					{
+																						"body": "not found",
+																						"handler": "static_response",
+																						"status_code": 404
+																					}
+																				]
+																			}
+																		]
+																	}
+																],
+																"match": [
+																	{
+																		"path": [
+																			"/en/*"
+																		]
+																	}
+																]
+															},
+															{
+																"group": "group3",
+																"handle": [
+																	{
+																		"handler": "subroute",
+																		"routes": [
+																			{
+																				"handle": [
+																					{
+																						"body": "no encontrado",
+																						"handler": "static_response"
+																					}
+																				]
+																			}
+																		]
+																	}
+																],
+																"match": [
+																	{
+																		"path": [
+																			"/es/*"
+																		]
+																	}
+																]
+															},
+															{
+																"group": "group3",
+																"handle": [
+																	{
+																		"handler": "subroute",
+																		"routes": [
+																			{
+																				"handle": [
+																					{
+																						"body": "default not found",
+																						"handler": "static_response"
+																					}
+																				]
+																			}
+																		]
+																	}
+																]
+															}
+														]
+													}
+												],
+												"match": [
+													{
+														"expression": "{http.error.status_code} in [404]"
+													}
+												]
+											},
+											{
+												"handle": [
+													{
+														"handler": "subroute",
+														"routes": [
+															{
+																"group": "group8",
+																"handle": [
+																	{
+																		"handler": "subroute",
+																		"routes": [
+																			{
+																				"handle": [
+																					{
+																						"body": "English error",
+																						"handler": "static_response"
+																					}
+																				]
+																			}
+																		]
+																	}
+																],
+																"match": [
+																	{
+																		"path": [
+																			"/en/*"
+																		]
+																	}
+																]
+															},
+															{
+																"group": "group8",
+																"handle": [
+																	{
+																		"handler": "subroute",
+																		"routes": [
+																			{
+																				"handle": [
+																					{
+																						"body": "Spanish error",
+																						"handler": "static_response"
+																					}
+																				]
+																			}
+																		]
+																	}
+																],
+																"match": [
+																	{
+																		"path": [
+																			"/es/*"
+																		]
+																	}
+																]
+															},
+															{
+																"group": "group8",
+																"handle": [
+																	{
+																		"handler": "subroute",
+																		"routes": [
+																			{
+																				"handle": [
+																					{
+																						"body": "Default error",
+																						"handler": "static_response"
+																					}
+																				]
+																			}
+																		]
+																	}
+																]
+															}
+														]
+													}
+												]
+											}
+										]
+									}
+								],
+								"terminal": true
+							}
+						]
+					}
+				}
+			}
+		}
+	}
+}
+

--- a/caddytest/integration/caddyfile_test.go
+++ b/caddytest/integration/caddyfile_test.go
@@ -783,6 +783,46 @@ func TestHandleErrorRangeAndCodes(t *testing.T) {
 	tester.AssertGetResponse("http://localhost:9080/private", 410, "Error in the [400 .. 499] range")
 }
 
+func TestHandleErrorSubHandlers(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`{
+		admin localhost:2999
+		http_port     9080
+	}
+	localhost:9080 {
+		root * /srv
+		file_server
+		error /*/internalerr* "Internal Server Error" 500
+
+		handle_errors 404 {
+			handle /en/* {
+				respond "not found" 404
+			}
+			handle /es/* {
+				respond "no encontrado" 404
+			}
+			handle {
+				respond "default not found"
+			}
+		}
+		handle_errors {
+			handle {
+				respond "Default error"
+			}
+			handle /en/* {
+				respond "English error"
+			}
+		}
+	}
+	`, "caddyfile")
+	// act and assert
+	tester.AssertGetResponse("http://localhost:9080/en/notfound", 404, "not found")
+	tester.AssertGetResponse("http://localhost:9080/es/notfound", 404, "no encontrado")
+	tester.AssertGetResponse("http://localhost:9080/notfound", 404, "default not found")
+	tester.AssertGetResponse("http://localhost:9080/es/internalerr", 500, "Default error")
+	tester.AssertGetResponse("http://localhost:9080/en/internalerr", 500, "English error")
+}
+
 func TestInvalidSiteAddressesAsDirectives(t *testing.T) {
 	type testCase struct {
 		config, expectedError string


### PR DESCRIPTION
Fixes: #6957

It make sure that all routes within the handle_errors are within a subroute.
