### PR TITLE
Move local admin server replacement logic below data structure initia…

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -505,14 +505,6 @@ func provisionContext(newCfg *Config, replaceAdminServer bool) (Context, error) 
 		return ctx, err
 	}
 
-	// start the admin endpoint (and stop any prior one)
-	if replaceAdminServer {
-		err = replaceLocalAdminServer(newCfg, ctx)
-		if err != nil {
-			return ctx, fmt.Errorf("starting caddy administration endpoint: %v", err)
-		}
-	}
-
 	// create the new filesystem map
 	newCfg.fileSystems = &filesystems.FileSystemMap{}
 
@@ -542,6 +534,14 @@ func provisionContext(newCfg *Config, replaceAdminServer bool) (Context, error) 
 	}()
 	if err != nil {
 		return ctx, err
+	}
+
+	// start the admin endpoint (and stop any prior one)
+	if replaceAdminServer {
+		err = replaceLocalAdminServer(newCfg, ctx)
+		if err != nil {
+			return ctx, fmt.Errorf("starting caddy administration endpoint: %v", err)
+		}
 	}
 
 	// Load and Provision each app and their submodules


### PR DESCRIPTION
…lizations in provisionContext()

Fixes #7001 

**Background**

When Caddy starts, `provisionContext` calls `replaceLocalAdminServer` which calls `provisionAdminRouters`. Changes introduced in #6997 to make sure that module state is accurately reconstructed across module (re)loads makes the assumption that the config.apps member exists at the time the provisioner is called.

However in modules like `caddypki/adminapi.go`, the provisioner tries to access the `pki` app, which in many situations does have a configuration entry, which triggers the module loader. The module loader (`LoadModuleByID()`) then fails to assign the app to `ctx.cfg.apps` because it hasn't been initialized yet.

**Solution proposed in this PR**
This modification moves the local admin server replacement to the end of the context provisioning phase, which ensures that the `Config.apps` map is initialized, so that the module loader (which can be called from various provisioners via `AppIfConfigured()`) can work correctly. 
