### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/admin_test.go
+++ b/admin_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -335,9 +336,7 @@ func TestAdminHandlerBuiltinRouteErrors(t *testing.T) {
 
 func testGetMetricValue(labels map[string]string) float64 {
 	promLabels := prometheus.Labels{}
-	for k, v := range labels {
-		promLabels[k] = v
-	}
+	maps.Copy(promLabels, labels)
 
 	metric, err := adminMetrics.requestErrors.GetMetricWith(promLabels)
 	if err != nil {
@@ -377,9 +376,7 @@ func (m *mockModule) CaddyModule() ModuleInfo {
 
 func TestNewAdminHandlerRouterRegistration(t *testing.T) {
 	originalModules := make(map[string]ModuleInfo)
-	for k, v := range modules {
-		originalModules[k] = v
-	}
+	maps.Copy(originalModules, modules)
 	defer func() {
 		modules = originalModules
 	}()
@@ -479,9 +476,7 @@ func TestAdminRouterProvisioning(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			originalModules := make(map[string]ModuleInfo)
-			for k, v := range modules {
-				originalModules[k] = v
-			}
+			maps.Copy(originalModules, modules)
 			defer func() {
 				modules = originalModules
 			}()
@@ -774,9 +769,7 @@ func (m *mockIssuerModule) CaddyModule() ModuleInfo {
 
 func TestManageIdentity(t *testing.T) {
 	originalModules := make(map[string]ModuleInfo)
-	for k, v := range modules {
-		originalModules[k] = v
-	}
+	maps.Copy(originalModules, modules)
 	defer func() {
 		modules = originalModules
 	}()

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -16,6 +16,7 @@ package httpcaddyfile
 
 import (
 	"encoding/json"
+	"maps"
 	"net"
 	"slices"
 	"sort"
@@ -365,9 +366,7 @@ func parseSegmentAsConfig(h Helper) ([]ConfigValue, error) {
 		// copy existing matcher definitions so we can augment
 		// new ones that are defined only in this scope
 		matcherDefs := make(map[string]caddy.ModuleMap, len(h.matcherDefs))
-		for key, val := range h.matcherDefs {
-			matcherDefs[key] = val
-		}
+		maps.Copy(matcherDefs, h.matcherDefs)
 
 		// find and extract any embedded matcher definitions in this scope
 		for i := 0; i < len(segments); i++ {

--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"io/fs"
 	"log"
+	"maps"
 	"net"
 	"net/http"
 	"os"
@@ -703,9 +704,7 @@ func AdminAPIRequest(adminAddr, method, uri string, headers http.Header, body io
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	for k, v := range headers {
-		req.Header[k] = v
-	}
+	maps.Copy(req.Header, headers)
 
 	// make an HTTP client that dials our network type, since admin
 	// endpoints aren't always TCP, which is what the default transport


### PR DESCRIPTION
Optimize code using a more modern writing style.