### PR TITLE
implement Unwrap for interceptedResponseHandler

### DIFF
--- a/modules/caddyhttp/intercept/intercept.go
+++ b/modules/caddyhttp/intercept/intercept.go
@@ -119,6 +119,11 @@ func (irh interceptedResponseHandler) WriteHeader(statusCode int) {
 }
 
 // EXPERIMENTAL: Subject to change or removal.
+func (irh interceptedResponseHandler) Unwrap() http.ResponseWriter {
+	return irh.ResponseRecorder
+}
+
+// EXPERIMENTAL: Subject to change or removal.
 func (ir Intercept) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	buf := bufPool.Get().(*bytes.Buffer)
 	buf.Reset()


### PR DESCRIPTION
fix [`not a flusher`](https://github.com/dunglas/frankenphp/issues/1543) when `intercept` is used.