### PR TITLE
chore: Use slices package where possible

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -1181,7 +1181,7 @@ traverseLoop:
 				case http.MethodPatch:
 					arr[idx] = val
 				case http.MethodDelete:
-					v[part] = append(arr[:idx], arr[idx+1:]...)
+					v[part] = slices.Delete(arr, idx, idx+1)
 				default:
 					return fmt.Errorf("unrecognized method %s", method)
 				}

--- a/caddyconfig/caddyfile/dispenser.go
+++ b/caddyconfig/caddyfile/dispenser.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -442,7 +443,7 @@ func (d *Dispenser) WrapErr(err error) error {
 // did me for 3 and a half freaking hours late one night).
 func (d *Dispenser) Delete() []Token {
 	if d.cursor >= 0 && d.cursor <= len(d.tokens)-1 {
-		d.tokens = append(d.tokens[:d.cursor], d.tokens[d.cursor+1:]...)
+		d.tokens = slices.Delete(d.tokens, d.cursor, d.cursor+1)
 		d.cursor--
 	}
 	return d.tokens

--- a/caddyconfig/caddyfile/lexer.go
+++ b/caddyconfig/caddyfile/lexer.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"slices"
 	"strings"
 	"unicode"
 )
@@ -362,7 +363,7 @@ func (t Token) NumLineBreaks() int {
 func (t Token) Clone() Token {
 	return Token{
 		File:          t.File,
-		imports:       append([]string{}, t.imports...),
+		imports:       slices.Clone(t.imports),
 		Line:          t.Line,
 		Text:          t.Text,
 		wasQuoted:     t.wasQuoted,

--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -378,7 +378,7 @@ func parseSegmentAsConfig(h Helper) ([]ConfigValue, error) {
 					return nil, err
 				}
 				// remove the matcher segment (consumed), then step back the loop
-				segments = append(segments[:i], segments[i+1:]...)
+				segments = slices.Delete(segments, i, i+1)
 				i--
 			}
 		}

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -469,7 +469,7 @@ func (ServerType) extractNamedRoutes(
 
 	// copy the server blocks so we can
 	// splice out the named route ones
-	filtered := append([]serverBlock{}, serverBlocks...)
+	filtered := slices.Clone(serverBlocks)
 	index := -1
 
 	for _, sb := range serverBlocks {
@@ -479,7 +479,7 @@ func (ServerType) extractNamedRoutes(
 		}
 
 		// splice out this block, because we know it's not a real server
-		filtered = append(filtered[:index], filtered[index+1:]...)
+		filtered = slices.Delete(filtered, index, index+1)
 		index--
 
 		if len(sb.block.Segments) == 0 {
@@ -1404,7 +1404,7 @@ func consolidateRoutes(routes caddyhttp.RouteList) caddyhttp.RouteList {
 			routes[i].Group == routes[i+1].Group {
 			// keep the handlers in the same order, then splice out repetitive route
 			routes[i].HandlersRaw = append(routes[i].HandlersRaw, routes[i+1].HandlersRaw...)
-			routes = append(routes[:i+1], routes[i+2:]...)
+			routes = slices.Delete(routes, i+1, i+2)
 			i--
 		}
 	}

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -22,6 +22,7 @@ import (
 	"maps"
 	"net"
 	"net/http"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -474,14 +475,14 @@ func (app *App) Start() error {
 				// the TLSConfig was already provisioned, so... manually remove it
 				for i, np := range cp.TLSConfig.NextProtos {
 					if np == "h2" {
-						cp.TLSConfig.NextProtos = append(cp.TLSConfig.NextProtos[:i], cp.TLSConfig.NextProtos[i+1:]...)
+						cp.TLSConfig.NextProtos = slices.Delete(cp.TLSConfig.NextProtos, i, i+1)
 						break
 					}
 				}
 				// remove it from the parent connection policy too, just to keep things tidy
 				for i, alpn := range cp.ALPN {
 					if alpn == "h2" {
-						cp.ALPN = append(cp.ALPN[:i], cp.ALPN[i+1:]...)
+						cp.ALPN = slices.Delete(cp.ALPN, i, i+1)
 						break
 					}
 				}

--- a/modules/caddyhttp/logging.go
+++ b/modules/caddyhttp/logging.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 
 	"go.uber.org/zap"
@@ -148,12 +149,12 @@ func (slc *ServerLogConfig) clone() *ServerLogConfig {
 	clone := &ServerLogConfig{
 		DefaultLoggerName:    slc.DefaultLoggerName,
 		LoggerNames:          make(map[string]StringArray),
-		SkipHosts:            append([]string{}, slc.SkipHosts...),
+		SkipHosts:            slices.Clone(slc.SkipHosts),
 		SkipUnmappedHosts:    slc.SkipUnmappedHosts,
 		ShouldLogCredentials: slc.ShouldLogCredentials,
 	}
 	for k, v := range slc.LoggerNames {
-		clone.LoggerNames[k] = append([]string{}, v...)
+		clone.LoggerNames[k] = slices.Clone(v)
 	}
 	return clone
 }

--- a/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/caddyfile.go
@@ -17,6 +17,7 @@ package fastcgi
 import (
 	"encoding/json"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -328,13 +329,7 @@ func parsePHPFastCGI(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error
 				tryPolicy = ""
 			}
 
-			for _, tf := range tryFiles {
-				if tf == dirIndex {
-					dirRedir = true
-
-					break
-				}
-			}
+			dirRedir = slices.Contains(tryFiles, dirIndex)
 		}
 
 		if dirRedir {

--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -528,13 +528,7 @@ func (h *HTTPTransport) shouldUseTLS(req *http.Request) bool {
 	}
 
 	port := req.URL.Port()
-	for i := range h.TLS.ExceptPorts {
-		if h.TLS.ExceptPorts[i] == port {
-			return false
-		}
-	}
-
-	return true
+	return !slices.Contains(h.TLS.ExceptPorts, port)
 }
 
 // TLSEnabled returns true if TLS is enabled.

--- a/modules/caddyhttp/staticresp.go
+++ b/modules/caddyhttp/staticresp.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/textproto"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"text/template"
@@ -323,13 +324,7 @@ func cmdRespond(fl caddycmd.Flags) (int, error) {
 
 	// figure out if status code was explicitly specified; this lets
 	// us set a non-zero value as the default but is a little hacky
-	var statusCodeFlagSpecified bool
-	for _, fl := range os.Args {
-		if fl == "--status" {
-			statusCodeFlagSpecified = true
-			break
-		}
-	}
+	statusCodeFlagSpecified := slices.Contains(os.Args, "--status")
 
 	// try to determine what kind of parameter the unnamed argument is
 	if arg != "" {

--- a/modules/caddytls/certselection.go
+++ b/modules/caddytls/certselection.go
@@ -87,14 +87,7 @@ nextChoice:
 		}
 
 		if len(p.AnyTag) > 0 {
-			var found bool
-			for _, tag := range p.AnyTag {
-				if cert.HasTag(tag) {
-					found = true
-					break
-				}
-			}
-			if !found {
+			if !slices.ContainsFunc(p.AnyTag, cert.HasTag) {
 				continue
 			}
 		}

--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/mholt/acmez/v3"
@@ -369,13 +370,7 @@ func (p *ConnectionPolicy) buildStandardTLSConfig(ctx caddy.Context) error {
 	}
 
 	// ensure ALPN includes the ACME TLS-ALPN protocol
-	var alpnFound bool
-	for _, a := range p.ALPN {
-		if a == acmez.ACMETLS1Protocol {
-			alpnFound = true
-			break
-		}
-	}
+	alpnFound := slices.Contains(p.ALPN, acmez.ACMETLS1Protocol)
 	if !alpnFound && (cfg.NextProtos == nil || len(cfg.NextProtos) > 0) {
 		cfg.NextProtos = append(cfg.NextProtos, acmez.ACMETLS1Protocol)
 	}
@@ -1004,10 +999,8 @@ func (l LeafCertClientAuth) VerifyClientCertificate(rawCerts [][]byte, _ [][]*x5
 		return fmt.Errorf("can't parse the given certificate: %s", err.Error())
 	}
 
-	for _, trustedLeafCert := range l.trustedLeafCerts {
-		if remoteLeafCert.Equal(trustedLeafCert) {
-			return nil
-		}
+	if slices.ContainsFunc(l.trustedLeafCerts, remoteLeafCert.Equal) {
+		return nil
 	}
 
 	return fmt.Errorf("client leaf certificate failed validation")


### PR DESCRIPTION
The PR modernizes codebase. Changes:

- Replace `append(s[:i], s[i+1]...)` by `slices.Delete(s, i, i+1)`.
- Replace `append([]T(nil), s...)` by `slices.Clone(s)`.
- Replace some loops with `slices.Contains` or `slices.ContainsFunc`.

The PR is similar to #6585.