### PR TITLE
metrics: introduce custom registry

### DIFF
--- a/modules/metrics/adminmetrics.go
+++ b/modules/metrics/adminmetrics.go
@@ -18,8 +18,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/caddyserver/caddy/v2"
 )
 
@@ -33,7 +31,7 @@ func init() {
 // See the Metrics module for a configurable endpoint that is usable if the
 // Admin API is disabled.
 type AdminMetrics struct {
-	registry *prometheus.Registry
+	registry caddy.RegistererGatherer
 
 	metricsHandler http.Handler
 }

--- a/modules/metrics/metrics.go
+++ b/modules/metrics/metrics.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 
@@ -112,7 +111,7 @@ var (
 	_ caddyfile.Unmarshaler       = (*Metrics)(nil)
 )
 
-func createMetricsHandler(logger promhttp.Logger, enableOpenMetrics bool, registry *prometheus.Registry) http.Handler {
+func createMetricsHandler(logger promhttp.Logger, enableOpenMetrics bool, registry caddy.RegistererGatherer) http.Handler {
 	return promhttp.InstrumentMetricHandler(registry,
 		promhttp.HandlerFor(registry, promhttp.HandlerOpts{
 			// will only log errors if logger is non-nil


### PR DESCRIPTION
Module developers who add custom metrics are used to wrapping the registration with a `sync.Once` to avoid duplicate registration panic and control the registration. However, the flow of `caddy reload` doesn't play nice with this idiom.

Since the introduction of registry-per-context, we've told some users to ignore the duplicate registration error if received. However, checking for this particular error is annoying. I wonder if owning the `sync.Once` and tracking the registration is better. I don't know if this is the best flow.