### PR TITLE
caddyfile: reject blocks in log_skip directive

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -1166,6 +1166,11 @@ func parseLogSkip(h Helper) (caddyhttp.MiddlewareHandler, error) {
 	if h.NextArg() {
 		return nil, h.ArgErr()
 	}
+
+	if h.NextBlock(0) {
+		return nil, h.Err("log_skip directive does not accept blocks")
+	}
+
 	return caddyhttp.VarsMiddleware{"log_skip": true}, nil
 }
 


### PR DESCRIPTION
Fixes #7050

The log_skip directive was designed not to accept arguments.
Blocks should not be passed through, but there was a bug that allowed them to be passed through, so I fixed the code to detect blocks and return an error.
Thank you.