### PR TITLE
[DRAFT] Prevent user listeners from conflicting with Admin API

### DIFF
--- a/listeners.go
+++ b/listeners.go
@@ -697,3 +697,15 @@ type ListenerWrapper interface {
 var listenerPool = NewUsagePool()
 
 const maxPortSpan = 65535
+
+func ConflictWithAdminAddr(addr NetworkAddress) bool {
+	adminAddr := NetworkAddress{
+		StartPort: uint(2019),
+		EndPort:   uint(2019),
+	}
+	if addr.StartPort <= adminAddr.EndPort && addr.EndPort >= adminAddr.StartPort {
+		Log().Error("conflict with admin api", zap.Uint("addr", addr.StartPort), zap.Uint("admin", adminAddr.StartPort))
+		return true
+	}
+	return false
+}

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -417,6 +417,10 @@ func (app *App) Validate() error {
 		// each server must use distinct listener addresses
 		for _, addr := range srv.Listen {
 			listenAddr, err := caddy.ParseNetworkAddress(addr)
+			// check for conflict with admin API
+			if caddy.ConflictWithAdminAddr(listenAddr) {
+				return fmt.Errorf("listener address '%s' already claimed by admin API", addr)
+			}
 			if err != nil {
 				return fmt.Errorf("invalid listener address '%s': %v", addr, err)
 			}


### PR DESCRIPTION
**Problem:**
Currently, it's possible for user-defined Caddy listeners (e.g., for HTTP sites) to attempt to bind to the same network address as Caddy's internal Admin API, which can lead to conflicts.

**Proposed Initial Solution (for feedback):**
This PR introduces a basic validation mechanism in `listeners.go` that compares the port of a requested listener address with a **hardcoded Admin API port (2019)**. This validation is then used by `app.go` to prevent the use of this specific port by other applications.

**Current Limitations & Open Questions:**

1.  **Port-only Comparison:** I believe a comparison based solely on ports is insufficient. It would restrict the use of the Admin API port on different network interfaces/hosts, even if there's no actual conflict with the Admin API's specific binding.
2.  **Hardcoded Admin Port:** The Admin API's port can be configured differently (e.g., via Caddyfile/JSON or environment variables). Hardcoding `2019` in the validation will lead to incorrect behavior if the Admin port is changed.
3.  **Missing Utilities:** I couldn't find native methods within the Caddy codebase to:
    * Perform a robust `NetworkAddress` comparison (considering network types, hosts/IPs, and port ranges).
    * Dynamically retrieve the Admin API's actual `NetworkAddress` at runtime, rather than relying on a hardcoded value.

**Proposed Next Steps / Seeking Guidance:**
To address these limitations, I am considering:
* Creating a `(NetworkAddress).conflictsWith(other NetworkAddress)` method in `listeners.go` for comprehensive address comparison.
* Implementing a getter function (e.g., `caddy.GetAdminListenAddress()`) to dynamically retrieve the Admin API's actual address.

However, I'm concerned about whether these proposed additions would break any existing architectural patterns or development principles within the project, especially regarding state management or visibility.

I've opened this PR in **draft mode** to solicit early feedback on this initial approach and guidance on the best way to proceed with a more robust and idiomatic solution.


Fixes #7053 