### PR TITLE
ci: add `{base,head}-ref` to  dep review check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,3 +85,6 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           comment-summary-in-pr: on-failure
+          # https://github.com/actions/dependency-review-action/issues/430#issuecomment-1468975566
+          base-ref: ${{ github.event.pull_request.base.sha || 'master' }}
+          head-ref: ${{ github.event.pull_request.head.sha || github.ref }}


### PR DESCRIPTION
Some things don't fail on PRs 🤷🏼 