### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/modules/caddyhttp/caddyauth/basicauth.go
+++ b/modules/caddyhttp/caddyauth/basicauth.go
@@ -236,10 +236,7 @@ func (c *Cache) makeRoom() {
 	// the cache is on a long tail, we can save a lot of CPU
 	// time by doing a whole bunch of deletions now and then
 	// we won't have to do them again for a while
-	numToDelete := len(c.cache) / 10
-	if numToDelete < 1 {
-		numToDelete = 1
-	}
+	numToDelete := max(len(c.cache)/10, 1)
 	for deleted := 0; deleted <= numToDelete; deleted++ {
 		// Go maps are "nondeterministic" not actually random,
 		// so although we could just chop off the "front" of the

--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -219,10 +219,7 @@ func (r RandomChoiceSelection) Validate() error {
 
 // Select returns an available host, if any.
 func (r RandomChoiceSelection) Select(pool UpstreamPool, _ *http.Request, _ http.ResponseWriter) *Upstream {
-	k := r.Choose
-	if k > len(pool) {
-		k = len(pool)
-	}
+	k := min(r.Choose, len(pool))
 	choices := make([]*Upstream, k)
 	for i, upstream := range pool {
 		if !upstream.Available() {


### PR DESCRIPTION

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.