### PR TITLE
httpcaddyfile: Validates TLS DNS challenge options

### DIFF
--- a/caddytest/integration/caddyfile_adapt/tls_dns_multiple_options_without_provider.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/tls_dns_multiple_options_without_provider.caddyfiletest
@@ -1,0 +1,9 @@
+localhost
+
+tls {
+	propagation_delay 10s
+	dns_ttl 5m
+}
+
+----------
+parsing caddyfile tokens for 'tls': setting DNS challenge options [propagation_delay, dns_ttl] requires a DNS provider (set with the 'dns' subdirective or 'acme_dns' global option), at Caddyfile:6

--- a/caddytest/integration/caddyfile_adapt/tls_dns_propagation_timeout_without_provider.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/tls_dns_propagation_timeout_without_provider.caddyfiletest
@@ -1,0 +1,7 @@
+:443 {
+	tls {
+		propagation_timeout 30s
+	}
+}
+----------
+parsing caddyfile tokens for 'tls': setting DNS challenge options [propagation_timeout] requires a DNS provider (set with the 'dns' subdirective or 'acme_dns' global option), at Caddyfile:4

--- a/caddytest/integration/caddyfile_adapt/tls_dns_propagation_without_provider.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/tls_dns_propagation_without_provider.caddyfiletest
@@ -1,0 +1,7 @@
+:443 {
+	tls {
+		propagation_delay 30s
+	}
+}
+----------
+parsing caddyfile tokens for 'tls': setting DNS challenge options [propagation_delay] requires a DNS provider (set with the 'dns' subdirective or 'acme_dns' global option), at Caddyfile:4

--- a/caddytest/integration/caddyfile_adapt/tls_dns_ttl.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/tls_dns_ttl.caddyfiletest
@@ -2,6 +2,7 @@ localhost
 
 respond "hello from localhost"
 tls {
+	dns mock
 	dns_ttl 5m10s
 }
 ----------
@@ -54,6 +55,9 @@ tls {
 							{
 								"challenges": {
 									"dns": {
+										"provider": {
+											"name": "mock"
+										},
 										"ttl": 310000000000
 									}
 								},

--- a/caddytest/integration/caddyfile_adapt/tls_propagation_options.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/tls_propagation_options.caddyfiletest
@@ -2,6 +2,7 @@ localhost
 
 respond "hello from localhost"
 tls {
+	dns mock
 	propagation_delay 5m10s
 	propagation_timeout 10m20s
 }
@@ -56,7 +57,10 @@ tls {
 								"challenges": {
 									"dns": {
 										"propagation_delay": 310000000000,
-										"propagation_timeout": 620000000000
+										"propagation_timeout": 620000000000,
+										"provider": {
+											"name": "mock"
+										}
 									}
 								},
 								"module": "acme"


### PR DESCRIPTION
Closes #7097

Adds validation to the TLS Caddyfile adapter to ensure that when DNS challenge options (such as propagation_delay or dns_ttl) are specified, a DNS provider is also configured.

Adds new integration tests to verify this validation logic, and implements a new mechanism for adapt tests to assert a config adapt error.