### PR TITLE
caddyhttp: prevent use of admin ports by listeners

### DIFF
--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -424,7 +424,7 @@ func (app *App) Validate() error {
 			// we do not use <= here because PortRangeSize() adds 1 to EndPort for us
 			for i := uint(0); i < listenAddr.PortRangeSize(); i++ {
 				addr := caddy.JoinNetworkAddress(listenAddr.Network, listenAddr.Host, strconv.FormatUint(uint64(listenAddr.StartPort+i), 10))
-				if sn, ok := lnAddrs[addr]; ok {
+				if sn, ok := lnAddrs[addr]; ok || !caddy.CanBindAddress(listenAddr.Network, listenAddr.Host, listenAddr.StartPort+i) {
 					return fmt.Errorf("server %s: listener address repeated: %s (already claimed by server '%s')", srvName, addr, sn)
 				}
 				lnAddrs[addr] = srvName


### PR DESCRIPTION
This PR fixes #7053.

### Description
Added a function CanBindAddress(netw, host string, port uint) bool in listeners.go

This function checks the addresses of the local and remote admin servers, and returns false if any of them conflict with the given port

Added a test to cover the behavior

Please kindly review the PR.