### PR TITLE
fileserver: specify license for embedded JavaScript

### DIFF
--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -1176,6 +1176,7 @@ footer {
 		</footer>
 
 		<script {{ $nonceAttribute }}>
+			// @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt Apache-2.0
 			const filterEl = document.getElementById('filter');
 			filterEl?.focus({ preventScroll: true });
 
@@ -1265,6 +1266,7 @@ footer {
 			}
 			var timeList = Array.prototype.slice.call(document.getElementsByTagName("time"));
 			timeList.forEach(localizeDatetime);
+			// @license-end
 		</script>
 	</body>
 </html>


### PR DESCRIPTION
This commit adds support for [LibreJS](https://en.wikipedia.org/wiki/GNU_LibreJS).

LibreJS would block this embedded JavaScript because its license is not stated in a machine-readable format.

More info: https://www.gnu.org/software/librejs/free-your-javascript.html#magnet-link-license