### PR TITLE
Add TLSA HTTP handler module for client certificate TLSA record logging

### DIFF
--- a/modules/standard/imports.go
+++ b/modules/standard/imports.go
@@ -15,4 +15,6 @@ import (
 	_ "github.com/caddyserver/caddy/v2/modules/filestorage"
 	_ "github.com/caddyserver/caddy/v2/modules/logging"
 	_ "github.com/caddyserver/caddy/v2/modules/metrics"
+	_ "github.com/caddyserver/caddy/v2/modules/tlsa"
+
 )

--- a/modules/tlsa/tlsa.go
+++ b/modules/tlsa/tlsa.go
@@ -1,0 +1,75 @@
+package tlsa
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+func init() {
+	caddy.RegisterModule(TLSAHook{})
+	httpcaddyfile.RegisterHandlerDirective("tlsa", parseCaddyfile)
+}
+
+func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
+	var handler TLSAHook
+	err := handler.UnmarshalCaddyfile(h.Dispenser)
+	return &handler, err
+}
+
+type TLSAHook struct{}
+
+func (TLSAHook) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "http.handlers.tlsa",
+		New: func() caddy.Module { return new(TLSAHook) },
+	}
+}
+
+func (h *TLSAHook) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
+	if r.TLS != nil {
+		caddy.Log().Named("tlsa").Info(fmt.Sprintf("TLS connection state: PeerCertificates count=%d", len(r.TLS.PeerCertificates)))
+		if len(r.TLS.PeerCertificates) > 0 {
+			h.printTLSA(r.TLS.PeerCertificates[0])
+		} else {
+			caddy.Log().Named("tlsa").Info("No peer certificates presented")
+		}
+	} else {
+		caddy.Log().Named("tlsa").Info("No TLS connection")
+	}
+	return next.ServeHTTP(w, r)
+}
+
+func (h *TLSAHook) printTLSA(cert *x509.Certificate) {
+	if cert == nil {
+		return
+	}
+	pubKeyDER, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
+	if err != nil {
+		caddy.Log().Named("tlsa").Error(fmt.Sprintf("failed to marshal public key: %v", err))
+		return
+	}
+	hash := sha256.Sum256(pubKeyDER)
+	hashHex := hex.EncodeToString(hash[:])
+	fmt.Printf("[TLSA] TLSA Record: _443._tcp.%s. IN TLSA 3 1 1 %s\n", cert.Subject.CommonName, hashHex)
+}
+
+func (h *TLSAHook) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.NextBlock(0) {
+		return d.Errf("unexpected tokens in 'tlsa' block")
+	}
+	return nil
+}
+
+var (
+	_ caddy.Module                 = (*TLSAHook)(nil)
+	_ caddyhttp.MiddlewareHandler = (*TLSAHook)(nil)
+	_ caddyfile.Unmarshaler        = (*TLSAHook)(nil)
+)


### PR DESCRIPTION
Implement custom TLSA HTTP handler module for Caddy

- Added `tlsa` HTTP handler module that logs TLSA DNS record of client TLS certs
- TLSA records are output in standard format: _443._tcp.<commonName>. IN TLSA 3 1 1 <hash>
- Registered `tlsa` as a route handler directive in Caddyfile adapter
- Supports client certificate authentication (requires and verifies client certs)
- Handles errors on public key marshaling with proper logging
- Tested locally with curl client certs to confirm correct TLSA output

Example Caddyfile snippet to use module:

test.localhost:8443 {
    tls {
        client_auth {
            mode require_and_verify
            trust_pool /full/path/to/ca.pem
        }
    }
    route {
        tlsa
        respond "TLSA handler executed"
    }
}

Note: The handler processes only the first client certificate, keeping it lightweight and focused.