### PR TITLE
refactor: use slices.Equal to simplify code

### DIFF
--- a/modules/caddyhttp/encode/encode_test.go
+++ b/modules/caddyhttp/encode/encode_test.go
@@ -2,6 +2,7 @@ package encode
 
 import (
 	"net/http"
+	"slices"
 	"sync"
 	"testing"
 )
@@ -112,7 +113,7 @@ func TestPreferOrder(t *testing.T) {
 			}
 			enc.Prefer = test.prefer
 			result := AcceptedEncodings(r, enc.Prefer)
-			if !sliceEqual(result, test.expected) {
+			if !slices.Equal(result, test.expected) {
 				t.Errorf("AcceptedEncodings() actual: %s expected: %s",
 					result,
 					test.expected)
@@ -121,17 +122,6 @@ func TestPreferOrder(t *testing.T) {
 	}
 }
 
-func sliceEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
 
 func TestValidate(t *testing.T) {
 	type testCase struct {


### PR DESCRIPTION
In the Go 1.21 standard library, a new function has been introduced that enhances code conciseness and readability. It can be find  [here](https://pkg.go.dev/slices@go1.21.1#Equal).