### PR TITLE
Use KeepAliveConfig to pass keepalive_interval to listener's accepted sockets

### DIFF
--- a/listen.go
+++ b/listen.go
@@ -107,7 +107,8 @@ func listenReusable(ctx context.Context, lnKey string, network, address string, 
 	if err != nil {
 		return nil, err
 	}
-	return &fakeCloseListener{sharedListener: sharedLn.(*sharedListener), keepAlivePeriod: config.KeepAlive}, nil
+
+	return &fakeCloseListener{sharedListener: sharedLn.(*sharedListener), keepAliveConfig: config.KeepAliveConfig}, nil
 }
 
 // fakeCloseListener is a private wrapper over a listener that
@@ -121,12 +122,11 @@ func listenReusable(ctx context.Context, lnKey string, network, address string, 
 type fakeCloseListener struct {
 	closed          int32 // accessed atomically; belongs to this struct only
 	*sharedListener       // embedded, so we also become a net.Listener
-	keepAlivePeriod time.Duration
+	keepAliveConfig net.KeepAliveConfig
 }
 
-type canSetKeepAlive interface {
-	SetKeepAlivePeriod(d time.Duration) error
-	SetKeepAlive(bool) error
+type canSetKeepAliveConfig interface {
+	SetKeepAliveConfig(config net.KeepAliveConfig) error
 }
 
 func (fcl *fakeCloseListener) Accept() (net.Conn, error) {
@@ -140,12 +140,8 @@ func (fcl *fakeCloseListener) Accept() (net.Conn, error) {
 	if err == nil {
 		// if 0, do nothing, Go's default is already set
 		// and if the connection allows setting KeepAlive, set it
-		if tconn, ok := conn.(canSetKeepAlive); ok && fcl.keepAlivePeriod != 0 {
-			if fcl.keepAlivePeriod > 0 {
-				err = tconn.SetKeepAlivePeriod(fcl.keepAlivePeriod)
-			} else { // negative
-				err = tconn.SetKeepAlive(false)
-			}
+		if tconn, ok := conn.(canSetKeepAliveConfig); ok && fcl.keepAliveConfig.Enable {
+			err = tconn.SetKeepAliveConfig(fcl.keepAliveConfig)
 			if err != nil {
 				Log().With(zap.String("server", fcl.sharedListener.key)).Warn("unable to set keepalive for new connection:", zap.Error(err))
 			}

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -531,7 +531,12 @@ func (app *App) Start() error {
 
 				if h1ok || h2ok && useTLS || h2cok {
 					// create the listener for this socket
-					lnAny, err := listenAddr.Listen(app.ctx, portOffset, net.ListenConfig{KeepAlive: time.Duration(srv.KeepAliveInterval)})
+					lnAny, err := listenAddr.Listen(app.ctx, portOffset, net.ListenConfig{
+						KeepAliveConfig: net.KeepAliveConfig{
+							Enable:   srv.KeepAliveInterval != 0,
+							Interval: time.Duration(srv.KeepAliveInterval),
+						},
+					})
 					if err != nil {
 						return fmt.Errorf("listening on %s: %v", listenAddr.At(portOffset), err)
 					}


### PR DESCRIPTION
This pull request should resolve https://github.com/caddyserver/caddy/issues/7144 by passing keepalive_interval ultimately via KeepAliveConfig instead of KeepAlive.