### PR TITLE
http: disable keepalive when KeepAliveInterval is negative

### DIFF
--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -533,7 +533,7 @@ func (app *App) Start() error {
 					// create the listener for this socket
 					lnAny, err := listenAddr.Listen(app.ctx, portOffset, net.ListenConfig{
 						KeepAliveConfig: net.KeepAliveConfig{
-							Enable:   srv.KeepAliveInterval != 0,
+							Enable:   srv.KeepAliveInterval >= 0,
 							Interval: time.Duration(srv.KeepAliveInterval),
 						},
 					})


### PR DESCRIPTION
In [7151](https://github.com/caddyserver/caddy/pull/7151), [`net.KeepAliveConfig`](https://pkg.go.dev/net#KeepAliveConfig) is used instead of `KeepAlive`. However, this made disabling keep alive impossible, as a negative value of `Interval` will just left the underlying socket option unchanged.

For now, disable keep alive when KeepAliveInterval is negative, when it's zero, a system dependent default is chosen automatically.