### PR TITLE
cmd: Allow `caddy adapt` to read from stdin

### DIFF
--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -441,15 +441,19 @@ func cmdEnviron(fl Flags) (int, error) {
 }
 
 func cmdAdaptConfig(fl Flags) (int, error) {
-	inputFlag := fl.String("config")
+	configFlag := fl.String("config")
 	adapterFlag := fl.String("adapter")
 	prettyFlag := fl.Bool("pretty")
 	validateFlag := fl.Bool("validate")
 
 	var err error
-	inputFlag, err = configFileWithRespectToDefault(caddy.Log(), inputFlag)
+	configFlag, err = configFileWithRespectToDefault(caddy.Log(), configFlag)
 	if err != nil {
 		return caddy.ExitCodeFailedStartup, err
+	}
+	if configFlag == "" {
+		return caddy.ExitCodeFailedStartup,
+			fmt.Errorf("input file required when there is no Caddyfile in current directory (use --config flag)")
 	}
 
 	// load all additional envs as soon as possible
@@ -469,13 +473,19 @@ func cmdAdaptConfig(fl Flags) (int, error) {
 			fmt.Errorf("unrecognized config adapter: %s", adapterFlag)
 	}
 
-	input, err := os.ReadFile(inputFlag)
+	var input []byte
+	// read from stdin if the file name is "-"
+	if configFlag == "-" {
+		input, err = io.ReadAll(os.Stdin)
+	} else {
+		input, err = os.ReadFile(configFlag)
+	}
 	if err != nil {
 		return caddy.ExitCodeFailedStartup,
 			fmt.Errorf("reading input file: %v", err)
 	}
 
-	opts := map[string]any{"filename": inputFlag}
+	opts := map[string]any{"filename": configFlag}
 
 	adaptedConfig, warnings, err := cfgAdapter.Adapt(input, opts)
 	if err != nil {

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -293,6 +293,8 @@ zero exit status will be returned.
 
 If --envfile is specified, an environment file with environment variables
 in the KEY=VALUE format will be loaded into the Caddy process.
+
+If you wish to use stdin instead of a regular file, use - as the path.
 `,
 		CobraFunc: func(cmd *cobra.Command) {
 			cmd.Flags().StringP("config", "c", "", "Configuration file to adapt (required)")
@@ -390,7 +392,7 @@ lines will be prefixed with '-' and '+' where they differ. Note that
 unchanged lines are prefixed with two spaces for alignment, and that this
 is not a valid patch format.
 
-If you wish you use stdin instead of a regular file, use - as the path.
+If you wish to use stdin instead of a regular file, use - as the path.
 When reading from stdin, the --overwrite flag has no effect: the result
 is always printed to stdout.
 `,


### PR DESCRIPTION
Read input from stdin if `--config -` is passed.

Fix small typo for similar stdin usage message in `caddy fmt`.

Return same error as 'validate' when there are no args.

Resolves https://github.com/caddyserver/caddy/issues/7162