### PR TITLE
doc: Add a few lines about Etag file content

### DIFF
--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -167,6 +167,8 @@ type FileServer struct {
 	// If set, file Etags will be read from sidecar files
 	// with any of these suffixes, instead of generating
 	// our own Etag.
+	// Keep in mind that the Etag values in the files have to be quoted as per RFC7232.
+	// See https://datatracker.ietf.org/doc/html/rfc7232#section-2.3 for a few examples.
 	EtagFileExtensions []string `json:"etag_file_extensions,omitempty"`
 
 	fsmap caddy.FileSystems


### PR DESCRIPTION
Adds a bit more details to the [etag_file_extensions](https://caddyserver.com/docs/json/apps/http/servers/routes/handle/file_server/etag_file_extensions/) field, specifically how the content of the Etag files should look like.

This comes mainly from my frustration with getting it right, as can be seen in #7096.