### PR TITLE
chore: fix inconsistent function name in comment

### DIFF
--- a/modules/caddyhttp/headers/headers.go
+++ b/modules/caddyhttp/headers/headers.go
@@ -159,7 +159,7 @@ func (ops *HeaderOps) Provision(_ caddy.Context) error {
 	return nil
 }
 
-// containsCaddyPlaceholders checks if the string contains Caddy placeholder syntax {key}
+// containsPlaceholders checks if the string contains Caddy placeholder syntax {key}
 func containsPlaceholders(s string) bool {
 	openIdx := strings.Index(s, "{")
 	if openIdx == -1 {


### PR DESCRIPTION
fix inconsistent function name in comment