### PR TITLE
caddytls: fix regression in external certificate manager support

### DIFF
--- a/modules/caddytls/automation.go
+++ b/modules/caddytls/automation.go
@@ -173,6 +173,9 @@ type AutomationPolicy struct {
 	subjects []string
 	magic    *certmagic.Config
 	storage  certmagic.Storage
+
+	// Whether this policy had explicit managers configured directly on it.
+	hadExplicitManagers bool
 }
 
 // Provision sets up ap and builds its underlying CertMagic config.
@@ -209,9 +212,8 @@ func (ap *AutomationPolicy) Provision(tlsApp *TLS) error {
 	// store them on the policy before putting it on the config
 
 	// load and provision any cert manager modules
-	var hadExplicitManagers bool
 	if ap.ManagersRaw != nil {
-		hadExplicitManagers = true
+		ap.hadExplicitManagers = true
 		vals, err := tlsApp.ctx.LoadModule(ap, "ManagersRaw")
 		if err != nil {
 			return fmt.Errorf("loading external certificate manager modules: %v", err)
@@ -271,9 +273,9 @@ func (ap *AutomationPolicy) Provision(tlsApp *TLS) error {
 		// prevent issuance from Issuers (when Managers don't provide a certificate) if there's no
 		// permission module configured
 		noProtections := ap.isWildcardOrDefault() && !ap.onlyInternalIssuer() && (tlsApp.Automation == nil || tlsApp.Automation.OnDemand == nil || tlsApp.Automation.OnDemand.permission == nil)
-		failClosed := noProtections && !hadExplicitManagers // don't allow on-demand issuance (other than implicit managers) if no managers have been explicitly configured
+		failClosed := noProtections && !ap.hadExplicitManagers // don't allow on-demand issuance (other than implicit managers) if no managers have been explicitly configured
 		if noProtections {
-			if !hadExplicitManagers {
+			if !ap.hadExplicitManagers {
 				// no managers, no explicitly-configured permission module, this is a config error
 				return fmt.Errorf("on-demand TLS cannot be enabled without a permission module to prevent abuse; please refer to documentation for details")
 			}


### PR DESCRIPTION
The fix for #6901 ( e276994174983dbb190d4bb9acaab157ef14373b ) appears to have broken support for modules that provide ondemand TLS, such as https://github.com/tailscale/caddy-tailscale

This issue was previously fixed in #6328 but the commit linked above reverts that change. I have tested starting Caddy with the following config after reverting the changes to `automation.go`, and it appears to still work fine, so I don't think any changes to that file were required to fix #6901 

> ```Caddyfile
> {
> 	on_demand_tls {
> 		ask http://localhost:9123/ask
> 	}
> }
> 
> https:// {
> 	tls {
> 		on_demand
> 	}
> }
> ```
 _Originally posted by @jonaharagon in [#6901](https://github.com/caddyserver/caddy/issues/6901#issuecomment-2730246096)_

in summary - tracking `hadExplicitManagers` within an `AutomationPolicy` does not break the config above, and also fixes external certificate provider modules