### PR TITLE
chore: bump Go to v1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,13 @@ jobs:
           - mac
           - windows
         go:
-          - '1.24'
+          - '1.25'
 
         include:
         # Set the minimum Go patch version for the given Go minor
         # Usable via ${{ matrix.GO_SEMVER }}
-        - go: '1.24'
-          GO_SEMVER: '~1.24.1'
+        - go: '1.25'
+          GO_SEMVER: '~1.25.0'
 
         # Set some variables per OS, usable via ${{ matrix.VAR }}
         # OS_LABEL: the VM label from GitHub Actions (see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
@@ -234,7 +234,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "~1.24"
+          go-version: "~1.25"
           check-latest: true
       - name: Install xcaddy
         run: |

--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -34,13 +34,13 @@ jobs:
           - 'darwin'
           - 'netbsd'
         go:
-          - '1.24'
+          - '1.25'
 
         include:
         # Set the minimum Go patch version for the given Go minor
         # Usable via ${{ matrix.GO_SEMVER }}
-        - go: '1.24'
-          GO_SEMVER: '~1.24.1'
+        - go: '1.25'
+          GO_SEMVER: '~1.25.0'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '~1.24'
+          go-version: '~1.25'
           check-latest: true
 
       - name: golangci-lint
@@ -80,7 +80,7 @@ jobs:
       - name: govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
-          go-version-input: '~1.24.1'
+          go-version-input: '~1.25.0'
           check-latest: true
   
   dependency-review:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,13 @@ jobs:
         os: 
           - ubuntu-latest
         go: 
-          - '1.24'
+          - '1.25'
 
         include:
         # Set the minimum Go patch version for the given Go minor
         # Usable via ${{ matrix.GO_SEMVER }}
-        - go: '1.24'
-          GO_SEMVER: '~1.24.1'
+        - go: '1.25'
+          GO_SEMVER: '~1.25.0'
 
     runs-on: ${{ matrix.os }}
     # https://github.com/sigstore/cosign/issues/1258#issuecomment-1002251233

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ See [our online documentation](https://caddyserver.com/docs/install) for other i
 
 Requirements:
 
-- [Go 1.24.0 or newer](https://golang.org/dl/)
+- [Go 1.25.0 or newer](https://golang.org/dl/)
 
 ### For development
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/caddyserver/caddy/v2
 
-go 1.24
+go 1.25
 
 require (
 	github.com/BurntSushi/toml v1.5.0


### PR DESCRIPTION
I'm not sure if we want to continue supporting Go 1.24 or not.