### PR TITLE
caddyhttp: refactor to use reflect.TypeFor

### DIFF
--- a/modules/caddyhttp/ip_matchers.go
+++ b/modules/caddyhttp/ip_matchers.go
@@ -20,7 +20,6 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
-	"reflect"
 	"strings"
 
 	"github.com/google/cel-go/cel"
@@ -109,7 +108,7 @@ func (MatchRemoteIP) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		[]*cel.Type{cel.ListType(cel.StringType)},
 		// function to convert a constant list of strings to a MatchPath instance.
 		func(data ref.Val) (RequestMatcherWithError, error) {
-			refStringList := reflect.TypeOf([]string{})
+			refStringList := stringSliceType
 			strList, err := data.ConvertToNative(refStringList)
 			if err != nil {
 				return nil, err
@@ -222,7 +221,7 @@ func (MatchClientIP) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		[]*cel.Type{cel.ListType(cel.StringType)},
 		// function to convert a constant list of strings to a MatchPath instance.
 		func(data ref.Val) (RequestMatcherWithError, error) {
-			refStringList := reflect.TypeOf([]string{})
+			refStringList := stringSliceType
 			strList, err := data.ConvertToNative(refStringList)
 			if err != nil {
 				return nil, err

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -23,7 +23,6 @@ import (
 	"net/textproto"
 	"net/url"
 	"path"
-	"reflect"
 	"regexp"
 	"runtime"
 	"slices"
@@ -373,7 +372,7 @@ func (MatchHost) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		"host_match_request_list",
 		[]*cel.Type{cel.ListType(cel.StringType)},
 		func(data ref.Val) (RequestMatcherWithError, error) {
-			refStringList := reflect.TypeOf([]string{})
+			refStringList := stringSliceType
 			strList, err := data.ConvertToNative(refStringList)
 			if err != nil {
 				return nil, err
@@ -654,7 +653,7 @@ func (MatchPath) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		[]*cel.Type{cel.ListType(cel.StringType)},
 		// function to convert a constant list of strings to a MatchPath instance.
 		func(data ref.Val) (RequestMatcherWithError, error) {
-			refStringList := reflect.TypeOf([]string{})
+			refStringList := stringSliceType
 			strList, err := data.ConvertToNative(refStringList)
 			if err != nil {
 				return nil, err
@@ -733,7 +732,7 @@ func (MatchPathRE) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		"path_regexp_request_string_string",
 		[]*cel.Type{cel.StringType, cel.StringType},
 		func(data ref.Val) (RequestMatcherWithError, error) {
-			refStringList := reflect.TypeOf([]string{})
+			refStringList := stringSliceType
 			params, err := data.ConvertToNative(refStringList)
 			if err != nil {
 				return nil, err
@@ -802,7 +801,7 @@ func (MatchMethod) CELLibrary(_ caddy.Context) (cel.Library, error) {
 		"method_request_list",
 		[]*cel.Type{cel.ListType(cel.StringType)},
 		func(data ref.Val) (RequestMatcherWithError, error) {
-			refStringList := reflect.TypeOf([]string{})
+			refStringList := stringSliceType
 			strList, err := data.ConvertToNative(refStringList)
 			if err != nil {
 				return nil, err
@@ -1173,7 +1172,7 @@ func (MatchHeaderRE) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		"header_regexp_request_string_string",
 		[]*cel.Type{cel.StringType, cel.StringType},
 		func(data ref.Val) (RequestMatcherWithError, error) {
-			refStringList := reflect.TypeOf([]string{})
+			refStringList := stringSliceType
 			params, err := data.ConvertToNative(refStringList)
 			if err != nil {
 				return nil, err
@@ -1196,7 +1195,7 @@ func (MatchHeaderRE) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		"header_regexp_request_string_string_string",
 		[]*cel.Type{cel.StringType, cel.StringType, cel.StringType},
 		func(data ref.Val) (RequestMatcherWithError, error) {
-			refStringList := reflect.TypeOf([]string{})
+			refStringList := stringSliceType
 			params, err := data.ConvertToNative(refStringList)
 			if err != nil {
 				return nil, err

--- a/modules/caddyhttp/vars.go
+++ b/modules/caddyhttp/vars.go
@@ -28,6 +28,8 @@ import (
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
+var stringSliceType = reflect.TypeFor[[]string]()
+
 func init() {
 	caddy.RegisterModule(VarsMiddleware{})
 	caddy.RegisterModule(VarsMatcher{})
@@ -353,7 +355,7 @@ func (MatchVarsRE) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		"vars_regexp_request_string_string",
 		[]*cel.Type{cel.StringType, cel.StringType},
 		func(data ref.Val) (RequestMatcherWithError, error) {
-			refStringList := reflect.TypeOf([]string{})
+			refStringList := stringSliceType
 			params, err := data.ConvertToNative(refStringList)
 			if err != nil {
 				return nil, err
@@ -376,7 +378,7 @@ func (MatchVarsRE) CELLibrary(ctx caddy.Context) (cel.Library, error) {
 		"vars_regexp_request_string_string_string",
 		[]*cel.Type{cel.StringType, cel.StringType, cel.StringType},
 		func(data ref.Val) (RequestMatcherWithError, error) {
-			refStringList := reflect.TypeOf([]string{})
+			refStringList := stringSliceType
 			params, err := data.ConvertToNative(refStringList)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
**why you might use `reflect.TypeFor` instead of `reflect.TypeOf` in Go**.

---

### **Background**
In Go, the `reflect` package provides two similar-looking functions:

- **`reflect.TypeOf(x)`**  
  Takes a value `x` and returns its `reflect.Type`.  
  Example:  
  ```go
  t := reflect.TypeOf(123) // type: int
  ```

- **`reflect.TypeFor[T]()`** *(introduced in Go 1.22)*  
  A generic function that returns the `reflect.Type` for a type parameter `T` **without needing a value**.  
  Example:  
  ```go
  t := reflect.TypeFor[int]() // type: int
  ```

---

### **Why use `reflect.TypeFor` instead of `reflect.TypeOf`?**

1. **No value needed**  
   - `reflect.TypeOf` requires an actual value at runtime.  
     If you only know the type (not a value), you have to create a dummy value:
     ```go
     t := reflect.TypeOf((*MyStruct)(nil)).Elem()
     ```
   - `reflect.TypeFor` works directly with the type parameter:
     ```go
     t := reflect.TypeFor[MyStruct]()
     ```
     This is cleaner and avoids allocating or creating dummy values.

2. **Compile-time type safety**  
   - With `reflect.TypeOf`, the type is determined from a runtime value, so mistakes may only show up at runtime.
   - With `reflect.TypeFor`, the type is determined at compile time from the generic type parameter, so it’s safer and clearer.

3. **Better for generic code**  
   - In generic functions, you often have a type parameter `T` but no value of type `T`.  
     `reflect.TypeOf` can’t be used without creating a zero value:
     ```go
     func PrintType[T any]() {
         var zero T
         fmt.Println(reflect.TypeOf(zero))
     }
     ```
     With `reflect.TypeFor`, you can simply do:
     ```go
     func PrintType[T any]() {
         fmt.Println(reflect.TypeFor[T]())
     }
     ```

4. **Avoids unnecessary allocations**  
   - Creating a dummy value for `reflect.TypeOf` may allocate memory (especially for composite types).  
   - `reflect.TypeFor` avoids this overhead entirely.

---

### **Summary Table**

| Feature                  | `reflect.TypeOf`                  | `reflect.TypeFor` (Go 1.22+) |
|--------------------------|------------------------------------|------------------------------|
| Requires a value         | ✅ Yes                             | ❌ No                        |
| Works without allocation | ❌ Sometimes allocates             | ✅ Yes                       |
| Compile-time type safety | ❌ Runtime only                    | ✅ Compile-time              |
| Good for generics        | ❌ Needs zero value                | ✅ Directly works            |

---

✅ **Recommendation:**  
Use `reflect.TypeFor` when:
- You know the type at compile time (especially in generic code).
- You don’t have or don’t want to create a value.
- You want cleaner, safer, and allocation-free code.

Use `reflect.TypeOf` when:
- You already have a value and want its type at runtime.