### PR TITLE
httpcaddyfile: Fix `acme_dns` regression

### DIFF
--- a/caddytest/integration/caddyfile_adapt/acme_dns_configured.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/acme_dns_configured.caddyfiletest
@@ -1,0 +1,68 @@
+{
+	acme_dns mock foo
+}
+
+example.com {
+	respond "Hello World"
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "Hello World",
+													"handler": "static_response"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		},
+		"tls": {
+			"automation": {
+				"policies": [
+					{
+						"issuers": [
+							{
+								"challenges": {
+									"dns": {
+										"provider": {
+											"name": "mock"
+										}
+									}
+								},
+								"module": "acme"
+							}
+						]
+					}
+				]
+			}
+		}
+	}
+}

--- a/caddytest/integration/caddyfile_adapt/acme_dns_naked_without_dns.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/acme_dns_naked_without_dns.caddyfiletest
@@ -1,0 +1,9 @@
+{
+	acme_dns
+}
+
+example.com {
+	respond "Hello World"
+}
+----------
+acme_dns specified without DNS provider config, but no provider specified with 'dns' global option


### PR DESCRIPTION
Fixes regression from https://github.com/caddyserver/caddy/commit/0badb071efc38bb9cc055076f0a48d1725fe8cc8 reported in https://github.com/caddyserver/caddy/issues/7197

AI Disclosure: I used Roo Code + GPT-4.1 to make the necessary adjustments to fix the logic to match the new test cases I added by hand as coverage