### PR TITLE
caddyfile: Allow `block` to do nothing if nothing passed to `import`

### DIFF
--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -533,29 +533,24 @@ func (p *parser) doImport(nesting int) error {
 		}
 		// if it is {block}, we substitute with all tokens in the block
 		// if it is {blocks.*}, we substitute with the tokens in the mapping for the *
-		var skip bool
 		var tokensToAdd []Token
+		foundBlockDirective := false
 		switch {
 		case token.Text == "{block}":
+			foundBlockDirective = true
 			tokensToAdd = blockTokens
 		case strings.HasPrefix(token.Text, "{blocks.") && strings.HasSuffix(token.Text, "}"):
+			foundBlockDirective = true
 			// {blocks.foo.bar} will be extracted to key `foo.bar`
 			blockKey := strings.TrimPrefix(strings.TrimSuffix(token.Text, "}"), "{blocks.")
 			val, ok := blockMapping[blockKey]
 			if ok {
 				tokensToAdd = val
 			}
-		default:
-			skip = true
 		}
-		if !skip {
-			if len(tokensToAdd) == 0 {
-				// if there is no content in the snippet block, don't do any replacement
-				// this allows snippets which contained {block}/{block.*} before this change to continue functioning as normal
-				tokensCopy = append(tokensCopy, token)
-			} else {
-				tokensCopy = append(tokensCopy, tokensToAdd...)
-			}
+
+		if foundBlockDirective {
+			tokensCopy = append(tokensCopy, tokensToAdd...)
 			continue
 		}
 

--- a/caddytest/integration/caddyfile_adapt/import_block_snippet_non_replaced_block.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/import_block_snippet_non_replaced_block.caddyfiletest
@@ -1,0 +1,57 @@
+(snippet) {
+	header {
+		reverse_proxy localhost:3000
+		{block}
+	}
+}
+
+example.com {
+	import snippet
+}
+---------- 
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"handler": "headers",
+													"response": {
+														"set": {
+															"Reverse_proxy": [
+																"localhost:3000"
+															]
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/caddytest/integration/caddyfile_adapt/import_block_snippet_non_replaced_key_block.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/import_block_snippet_non_replaced_key_block.caddyfiletest
@@ -1,0 +1,57 @@
+(snippet) {
+	header {
+		reverse_proxy localhost:3000
+		{blocks.content_type}
+	}
+}
+
+example.com {
+	import snippet
+}
+---------- 
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"handler": "headers",
+													"response": {
+														"set": {
+															"Reverse_proxy": [
+																"localhost:3000"
+															]
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #6821 

Before the parser left the `{block}`-token (or `{blocks.key}`-token) as is during parsing, if the corresponding import did not specify any block (pasting it into the import-body as a literal).

After this change, the parser ignores `{block}` tokens, if there is no body to replace it with.

Also add two adapt-tests to pin the new behavior of `{block}` and `{blocks.key}` respectively.