### PR TITLE
Add custom labels support for metrics

### DIFF
--- a/caddyconfig/httpcaddyfile/options.go
+++ b/caddyconfig/httpcaddyfile/options.go
@@ -472,8 +472,20 @@ func unmarshalCaddyfileMetricsOptions(d *caddyfile.Dispenser) (any, error) {
 		switch d.Val() {
 		case "per_host":
 			metrics.PerHost = true
+		case "labels":
+			if metrics.Labels == nil {
+				metrics.Labels = make(map[string]string)
+			}
+			for nesting := d.Nesting(); d.NextBlock(nesting); {
+				key := d.Val()
+				if !d.NextArg() {
+					return nil, d.ArgErr()
+				}
+				value := d.Val()
+				metrics.Labels[key] = value
+			}
 		default:
-			return nil, d.Errf("unrecognized servers option '%s'", d.Val())
+			return nil, d.Errf("unrecognized metrics option '%s'", d.Val())
 		}
 	}
 	return metrics, nil

--- a/caddyconfig/httpcaddyfile/options_test.go
+++ b/caddyconfig/httpcaddyfile/options_test.go
@@ -58,7 +58,65 @@ func TestGlobalLogOptionSyntax(t *testing.T) {
 		}
 
 		if string(out) != tc.output {
-			t.Errorf("Test %d error output mismatch Expected: %s, got %s", i, tc.output, out)
+			t.Errorf("Test %d error output mismatch Expected: %s, got %s", i, tc.output, string(out))
+		}
+	}
+}
+
+func TestGlobalMetricsOptionSyntax(t *testing.T) {
+	for i, tc := range []struct {
+		input       string
+		expectError bool
+	}{
+		{
+			input: `{
+				metrics {
+					per_host
+				}
+			}`,
+			expectError: false,
+		},
+		{
+			input: `{
+				metrics {
+					labels {
+						proto "{http.request.proto}"
+						method "{http.request.method}"
+					}
+				}
+			}`,
+			expectError: false,
+		},
+		{
+			input: `{
+				metrics {
+					per_host
+					labels {
+						proto "{http.request.proto}"
+						host "{http.request.host}"
+					}
+				}
+			}`,
+			expectError: false,
+		},
+		{
+			input: `{
+				metrics {
+					unknown_option
+				}
+			}`,
+			expectError: true,
+		},
+	} {
+		adapter := caddyfile.Adapter{
+			ServerType: ServerType{},
+		}
+
+		out, _, err := adapter.Adapt([]byte(tc.input), nil)
+
+		if err != nil != tc.expectError {
+			t.Errorf("Test %d error expectation failed Expected: %v, got %v", i, tc.expectError, err)
+			continue
 		}
 	}
 }

--- a/caddytest/integration/caddyfile_adapt/custom_labels_metrics.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/custom_labels_metrics.caddyfiletest
@@ -1,0 +1,47 @@
+{
+	metrics {
+		labels {
+			proto "{http.request.proto}"
+			method "{http.request.method}"
+			client_ip "{http.request.remote}"
+			host "{http.request.host}"
+		}
+	}
+}
+
+:8080 {
+	respond "Hello World" 200
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8080"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"body": "Hello World",
+									"handler": "static_response",
+									"status_code": 200
+								}
+							]
+						}
+					]
+				}
+			},
+			"metrics": {
+				"labels": {
+					"client_ip": "{http.request.remote}",
+					"host": "{http.request.host}",
+					"method": "{http.request.method}",
+					"proto": "{http.request.proto}"
+				}
+			}
+		}
+	}
+} 


### PR DESCRIPTION
close https://github.com/caddyserver/caddy/issues/7205
close https://github.com/caddyserver/caddy/issues/7161

With this fix, we can specify labels in the metric settings like below.
placeholders are automatically converted to real values, and static values that don't include placeholders are left in.

```
{
	metrics {
		labels {
		 	key "static value"
		 	proto "Protocol is {http.request.proto}"
		 	orig_uri "{http.request.orig_uri}"
		 	remote "{http.request.remote}"
		 	scheme "{http.request.scheme}"
		 	tls_version "{http.request.tls.version}"
		}
	}
}

:2015

respond "Hello, world!"
```

Also, since this PR allows us to add a `proto` label, I think we can just close [this PR](https://github.com/caddyserver/caddy/pull/7201) without merging it.