### PR TITLE
add: encode header Content-Type graphql-response

### DIFF
--- a/modules/caddyhttp/encode/encode.go
+++ b/modules/caddyhttp/encode/encode.go
@@ -92,6 +92,7 @@ func (enc *Encode) Provision(ctx caddy.Context) error {
 					"application/font*",
 					"application/geo+json*",
 					"application/graphql+json*",
+					"application/graphql-response+json*",
 					"application/javascript*",
 					"application/json*",
 					"application/ld+json*",


### PR DESCRIPTION
This change adds application/graphql-response+json* to the list of default encoded header Content-Types. According to the [GraphQL specification](https://graphql.org/learn/serving-over-http/#headers), GraphQL responses should be served with this content type. Adding it to the default encoded headers ensures proper handling and encoding of GraphQL responses.

Note:
If this is merged, the website should be updated accordingly to reflect the new header type.

