### PR TITLE
caddyfile: Prevent trailing space on line before env variable - Fixes #6881

### DIFF
--- a/caddyconfig/caddyfile/formatter.go
+++ b/caddyconfig/caddyfile/formatter.go
@@ -224,7 +224,7 @@ func Format(input []byte) []byte {
 			openBrace = false
 			if beginningOfLine {
 				indent()
-			} else if !openBraceSpace {
+			} else if !openBraceSpace || !unicode.IsSpace(last) {
 				write(' ')
 			}
 			write('{')
@@ -241,7 +241,7 @@ func Format(input []byte) []byte {
 		case ch == '{':
 			openBrace = true
 			openBraceSpace = spacePrior && !beginningOfLine
-			if openBraceSpace {
+			if openBraceSpace && newLines == 0 {
 				write(' ')
 			}
 			openBraceWritten = false

--- a/caddyconfig/caddyfile/formatter_test.go
+++ b/caddyconfig/caddyfile/formatter_test.go
@@ -444,6 +444,21 @@ block2 {
 			input:       "block {respond \"All braces should remain: {{now | date `2006`}}\"}",
 			expect:      "block {respond \"All braces should remain: {{now | date `2006`}}\"}",
 		},
+		{
+			description: "No trailing space on line before env variable",
+			input: `{
+	a
+
+	{$ENV_VAR}
+}
+`,
+			expect: `{
+	a
+
+	{$ENV_VAR}
+}
+`,
+		},
 	} {
 		// the formatter should output a trailing newline,
 		// even if the tests aren't written to expect that


### PR DESCRIPTION
## Bug

A space was being added on the previous non-empty line before the opening curly brace of an env variable.
Issue reference - #6881 

## Fix

- Do not add space if there are pending newLines (`formatter.go` line 244)
- Add space if the last character was not a space (`formatter.go` line 227)

## Assistance Disclosure

No AI was used.
