### PR TITLE
Add support for named socket activation

### DIFF
--- a/listeners.go
+++ b/listeners.go
@@ -314,14 +314,8 @@ func getFdByName(name string) (int, error) {
 	}
 
 	fdNamesStr := os.Getenv("LISTEN_FDNAMES")
-	fdCountStr := os.Getenv("LISTEN_FDS")
-
 	if fdNamesStr == "" {
 		return 0, fmt.Errorf("LISTEN_FDNAMES environment variable not set")
-	}
-
-	if fdCountStr == "" {
-		return 0, fmt.Errorf("LISTEN_FDS environment variable not set")
 	}
 
 	// Parse the socket names

--- a/listeners_test.go
+++ b/listeners_test.go
@@ -658,7 +658,6 @@ func TestSplitUnixSocketPermissionsBits(t *testing.T) {
 func TestGetFdByName(t *testing.T) {
 	// Save original environment
 	originalFdNames := os.Getenv("LISTEN_FDNAMES")
-	originalFds := os.Getenv("LISTEN_FDS")
 
 	// Restore environment after test
 	defer func() {
@@ -667,17 +666,11 @@ func TestGetFdByName(t *testing.T) {
 		} else {
 			os.Unsetenv("LISTEN_FDNAMES")
 		}
-		if originalFds != "" {
-			os.Setenv("LISTEN_FDS", originalFds)
-		} else {
-			os.Unsetenv("LISTEN_FDS")
-		}
 	}()
 
 	tests := []struct {
 		name        string
 		fdNames     string
-		fdCount     string
 		socketName  string
 		expectedFd  int
 		expectError bool
@@ -685,56 +678,42 @@ func TestGetFdByName(t *testing.T) {
 		{
 			name:       "simple http socket",
 			fdNames:    "http",
-			fdCount:    "1",
 			socketName: "http",
 			expectedFd: 3,
 		},
 		{
 			name:       "multiple sockets - first",
 			fdNames:    "http:https:dns",
-			fdCount:    "3",
 			socketName: "http",
 			expectedFd: 3,
 		},
 		{
 			name:       "multiple sockets - second",
 			fdNames:    "http:https:dns",
-			fdCount:    "3",
 			socketName: "https",
 			expectedFd: 4,
 		},
 		{
 			name:       "multiple sockets - third",
 			fdNames:    "http:https:dns",
-			fdCount:    "3",
 			socketName: "dns",
 			expectedFd: 5,
 		},
 		{
 			name:        "socket not found",
 			fdNames:     "http:https",
-			fdCount:     "2",
 			socketName:  "missing",
 			expectError: true,
 		},
 		{
 			name:        "empty socket name",
 			fdNames:     "http",
-			fdCount:     "1",
 			socketName:  "",
 			expectError: true,
 		},
 		{
 			name:        "missing LISTEN_FDNAMES",
 			fdNames:     "",
-			fdCount:     "1",
-			socketName:  "http",
-			expectError: true,
-		},
-		{
-			name:        "missing LISTEN_FDS",
-			fdNames:     "http",
-			fdCount:     "",
 			socketName:  "http",
 			expectError: true,
 		},
@@ -747,11 +726,6 @@ func TestGetFdByName(t *testing.T) {
 				os.Setenv("LISTEN_FDNAMES", tc.fdNames)
 			} else {
 				os.Unsetenv("LISTEN_FDNAMES")
-			}
-			if tc.fdCount != "" {
-				os.Setenv("LISTEN_FDS", tc.fdCount)
-			} else {
-				os.Unsetenv("LISTEN_FDS")
 			}
 
 			// Test the function
@@ -777,23 +751,16 @@ func TestGetFdByName(t *testing.T) {
 func TestParseNetworkAddressFdName(t *testing.T) {
 	// Save and restore environment
 	originalFdNames := os.Getenv("LISTEN_FDNAMES")
-	originalFds := os.Getenv("LISTEN_FDS")
 	defer func() {
 		if originalFdNames != "" {
 			os.Setenv("LISTEN_FDNAMES", originalFdNames)
 		} else {
 			os.Unsetenv("LISTEN_FDNAMES")
 		}
-		if originalFds != "" {
-			os.Setenv("LISTEN_FDS", originalFds)
-		} else {
-			os.Unsetenv("LISTEN_FDS")
-		}
 	}()
 
 	// Set up test environment
 	os.Setenv("LISTEN_FDNAMES", "http:https:dns")
-	os.Setenv("LISTEN_FDS", "3")
 
 	tests := []struct {
 		input      string


### PR DESCRIPTION
This PR implements support for named socket activation in systemd, allowing users to reference sockets by name using `fdname/name` and `fdgramname/name` syntax instead of only numeric `fd/N` and `fdgram/N` references.

## Solution Logic

The implementation uses an early normalization approach:

1. **New function `getFdByName()`** - reads systemd environment variable `LISTEN_FDNAMES` and maps socket names to file descriptor numbers

2. **Extended `ParseNetworkAddressWithDefaults()`** - detects `fdname/` and `fdgramname/` prefixes and converts them to standard `fd/N` and `fdgram/N` syntax internally

3. **Backward compatibility** - existing `fd/N` syntax continues to work unchanged

The conversion happens at parse time, so all downstream code continues to work with the standard fd syntax without modifications.

## Testing Results

### Unit Tests

- **TestGetFdByName**: 7 test cases covering environment variable parsing, multiple sockets, error handling
- **TestParseNetworkAddressFdName**: 9 test cases covering address parsing with both old and new syntax

### Manual Testing

- Verified backward compatibility with `fd/3` and `fdgram/4` syntax
- Tested new `fdname/http` and `fdgramname/dns` syntax with environment variables
- Confirmed proper error handling for missing environment variables and invalid socket names

## Usage Examples

### Before (numeric references)
```
fd/3
fdgram/4
```

### After (named references)
```
fdname/http
fdgramname/dns
```


**Assistance Disclosure**
I consulted Claude to understand the project architecture, but I authored/coded the fix myself

Resolves https://github.com/caddyserver/caddy/issues/6792