### PR TITLE
logging: Buffer the logs before config is loaded

### DIFF
--- a/internal/logbuffer.go
+++ b/internal/logbuffer.go
@@ -1,0 +1,72 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"sync"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// LogBufferCore is a zapcore.Core that buffers log entries in memory.
+type LogBufferCore struct {
+	mu      sync.Mutex
+	entries []zapcore.Entry
+	fields  [][]zapcore.Field
+	level   zapcore.LevelEnabler
+}
+
+func NewLogBufferCore(level zapcore.LevelEnabler) *LogBufferCore {
+	return &LogBufferCore{
+		level: level,
+	}
+}
+
+func (c *LogBufferCore) Enabled(lvl zapcore.Level) bool {
+	return c.level.Enabled(lvl)
+}
+
+func (c *LogBufferCore) With(fields []zapcore.Field) zapcore.Core {
+	return c
+}
+
+func (c *LogBufferCore) Check(entry zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(entry.Level) {
+		return ce.AddCore(entry, c)
+	}
+	return ce
+}
+
+func (c *LogBufferCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = append(c.entries, entry)
+	c.fields = append(c.fields, fields)
+	return nil
+}
+
+func (c *LogBufferCore) Sync() error { return nil }
+
+// FlushTo flushes buffered logs to the given zap.Logger.
+func (c *LogBufferCore) FlushTo(logger *zap.Logger) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for idx, entry := range c.entries {
+		logger.WithOptions().Check(entry.Level, entry.Message).Write(c.fields[idx]...)
+	}
+	c.entries = nil
+	c.fields = nil
+}


### PR DESCRIPTION
Fixes https://github.com/caddyserver/caddy/issues/7209 and probably multiple other issues we've had in the past.

My idea to solve this was:
- At the start of `caddy run`, set up a temporary in-memory log buffer and capture all logs into that
- If `caddy run` fails at any point before config is loaded, flush the buffer directly to the default logger (stderr, effectively)
- Once the config is loaded successfully, flush the buffer through the configured logger (so they're formatted and written out as the user wants)

To test this, I used this config:

```caddyfile
{
	admin localhost:2020
	log {
		output file ./test.log
		level info
		format console {
			level_format upper
		}
	}
}

:2021 {
	respond "Hello, Caddy!"
}
```

Then simply running `caddy run` on that Caddyfile, seeing that _all logs_ end up in `test.log`.

If I make a change like removing a `{` to produce a config error, I see this in my terminal, as expected:

```
2025/09/07 02:43:59.760 INFO    maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined
2025/09/07 02:43:59.760 INFO    GOMEMLIMIT is updated   {"GOMEMLIMIT": 30849878016, "previous": 9223372036854775807}
2025/09/07 02:43:59.760 INFO    using config from file  {"file": "Caddyfile.test2"}
Error: adapting config using caddyfile: unexpected EOF, at Caddyfile:12
```


## Assistance Disclosure

I used RooCode + GPT-4.1 to ideate, and it produced the `logbuffer.go` implementation, I wrote the remainder.