### PR TITLE
admin: fix warnings and status code in /load API

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -40,6 +40,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/caddyserver/caddy/v2/caddyconfig/warning"
 	"github.com/caddyserver/certmagic"
 	"github.com/cespare/xxhash/v2"
 	"github.com/prometheus/client_golang/prometheus"
@@ -1361,9 +1362,10 @@ func (f AdminHandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) erro
 // and client responses. If Message is unset, then
 // Err.Error() will be serialized in its place.
 type APIError struct {
-	HTTPStatus int    `json:"-"`
-	Err        error  `json:"-"`
-	Message    string `json:"error"`
+	HTTPStatus int               `json:"-"`
+	Err        error             `json:"-"`
+	Message    string            `json:"error"`
+	Warnings   []warning.Warning `json:"warnings,omitempty"`
 }
 
 func (e APIError) Error() string {

--- a/admin.go
+++ b/admin.go
@@ -40,12 +40,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/caddyserver/caddy/v2/caddyconfig/warning"
 	"github.com/caddyserver/certmagic"
 	"github.com/cespare/xxhash/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/caddyserver/caddy/v2/caddyconfig/warning"
 )
 
 // testCertMagicStorageOverride is a package-level test hook. Tests may set

--- a/caddyconfig/configadapters.go
+++ b/caddyconfig/configadapters.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/warning"
 )
 
 // Adapter is a type which can adapt a configuration to Caddy JSON.
@@ -28,20 +29,7 @@ type Adapter interface {
 }
 
 // Warning represents a warning or notice related to conversion.
-type Warning struct {
-	File      string `json:"file,omitempty"`
-	Line      int    `json:"line,omitempty"`
-	Directive string `json:"directive,omitempty"`
-	Message   string `json:"message,omitempty"`
-}
-
-func (w Warning) String() string {
-	var directive string
-	if w.Directive != "" {
-		directive = fmt.Sprintf(" (%s)", w.Directive)
-	}
-	return fmt.Sprintf("%s:%d%s: %s", w.File, w.Line, directive, w.Message)
-}
+type Warning = warning.Warning
 
 // JSON encodes val as JSON, returning it as a json.RawMessage. Any
 // marshaling errors (which are highly unlikely with correct code)

--- a/caddyconfig/load.go
+++ b/caddyconfig/load.go
@@ -91,23 +91,19 @@ func (adminLoad) handleLoad(w http.ResponseWriter, r *http.Request) error {
 	}
 	body := buf.Bytes()
 
+	var warnings []Warning
 	// if the config is formatted other than Caddy's native
 	// JSON, we need to adapt it before loading it
 	if ctHeader := r.Header.Get("Content-Type"); ctHeader != "" {
-		result, warnings, err := adaptByContentType(ctHeader, body)
+		result, wns, err := adaptByContentType(ctHeader, body)
 		if err != nil {
 			return caddy.APIError{
 				HTTPStatus: http.StatusBadRequest,
 				Err:        err,
+				Warnings:   wns,
 			}
 		}
-		if len(warnings) > 0 {
-			respBody, err := json.Marshal(warnings)
-			if err != nil {
-				caddy.Log().Named("admin.api.load").Error(err.Error())
-			}
-			_, _ = w.Write(respBody) //nolint:gosec // false positive: no XSS here
-		}
+		warnings = wns
 		body = result
 	}
 
@@ -118,6 +114,7 @@ func (adminLoad) handleLoad(w http.ResponseWriter, r *http.Request) error {
 		return caddy.APIError{
 			HTTPStatus: http.StatusBadRequest,
 			Err:        fmt.Errorf("loading config: %v", err),
+			Warnings:   warnings,
 		}
 	}
 
@@ -129,6 +126,16 @@ func (adminLoad) handleLoad(w http.ResponseWriter, r *http.Request) error {
 		r.Header.Get("Caddy-Config-Source-Adapter"))
 
 	caddy.Log().Named("admin.api").Info("load complete")
+
+	// Send any warnings back even if there were no errors
+	if len(warnings) > 0 {
+		out := struct {
+			Warnings []Warning `json:"warnings"`
+		}{
+			Warnings: warnings,
+		}
+		return json.NewEncoder(w).Encode(out)
+	}
 
 	return nil
 }

--- a/caddyconfig/warning/warning.go
+++ b/caddyconfig/warning/warning.go
@@ -1,0 +1,19 @@
+package warning
+
+import "fmt"
+
+// Warning represents a warning or notice related to conversion.
+type Warning struct {
+	File      string `json:"file,omitempty"`
+	Line      int    `json:"line,omitempty"`
+	Directive string `json:"directive,omitempty"`
+	Message   string `json:"message,omitempty"`
+}
+
+func (w Warning) String() string {
+	var directive string
+	if w.Directive != "" {
+		directive = fmt.Sprintf(" (%s)", w.Directive)
+	}
+	return fmt.Sprintf("%s:%d%s: %s", w.File, w.Line, directive, w.Message)
+}


### PR DESCRIPTION
## Description
This PR fixes [#7246](https://github.com/caddyserver/caddy/issues/7246)
where the Admin API /load endpoint returned 200 OK instead of 400 Bad Request when an invalid Caddyfile also produced adapter warnings.

The problem happened because the warnings were written to the response first, which made http.ResponseWriter default to 200 OK. As a result, the response contained two separate JSON objects (warnings + error) stuck together, which was invalid JSON.

### Changes
- add "warnings" as valid JSON structure alongside to "errors" in JSON response.
- Make sure the correct status code (`400 Bad Request`) is returned for invalid configs.

### Behavior Before

```bash
curl -v --unix-socket /run/uncloud/caddy/admin.sock \
  -H "Content-Type: text/caddyfile" \
  --data-binary @Caddyfile \
  http://localhost/load
*   Trying /run/uncloud/caddy/admin.sock:0...
* Connected to localhost (/run/uncloud/caddy/admin.sock) port 0
* using HTTP/1.x
> POST /load HTTP/1.1
> Host: localhost
> User-Agent: curl/8.14.1
> Accept: */*
> Content-Type: text/caddyfile
> Content-Length: 81
> 
* upload completely sent off: 81 bytes
< HTTP/1.1 200 OK
< Date: Fri, 19 Sep 2025 15:21:18 GMT
< Content-Length: 336
< Content-Type: text/plain; charset=utf-8
< Connection: close
< 
[{"file":"Caddyfile","line":2,"message":"Caddyfile input is not formatted; run 'caddy fmt --overwrite' to fix inconsistencies"}]{"error":"loading config: loading new config: loading http app module: provision http: getting tls app: loading tls app module: provision tls: loading certificates: open cert.pem: no such file or directory"}
* shutting down connection #0
```
### Behavior After
```bash
curl -v --unix-socket /run/uncloud/caddy/admin.sock \
  -H "Content-Type: text/caddyfile" \
  --data-binary @Caddyfile \
  http://localhost/load
*   Trying /run/uncloud/caddy/admin.sock:0...
* Connected to localhost (/run/uncloud/caddy/admin.sock) port 0
* using HTTP/1.x
> POST /load HTTP/1.1
> Host: localhost
> User-Agent: curl/8.14.1
> Accept: */*
> Content-Type: text/caddyfile
> Content-Length: 81
> 
* upload completely sent off: 81 bytes
< HTTP/1.1 400 Bad Request
< Date: Fri, 19 Sep 2025 15:26:41 GMT
< Content-Length: 348
< Content-Type: text/plain; charset=utf-8
< Connection: close
< 
{"error":"loading config: loading new config: loading http app module: provision http: getting tls app: loading tls app module: provision tls: loading certificates: open cert.pem: no such file or directory","warnings":[{"file":"Caddyfile","line":2,"message":"Caddyfile input is not formatted; run 'caddy fmt --overwrite' to fix inconsistencies"}]}
* shutting down connection #0