### PR TITLE
core: use reflect.TypeFor to check for encoding/json.RawMessage

### DIFF
--- a/modules.go
+++ b/modules.go
@@ -345,9 +345,15 @@ func StrictUnmarshalJSON(data []byte, v any) error {
 	return dec.Decode(v)
 }
 
+var jsonTypes = [][2]string{
+	{"encoding/json", "RawMessage"},     // default type
+	{"encoding/json/jsontext", "Value"}, // GOEXPERIMENT=jsonv2 type
+}
+
 // isJSONRawMessage returns true if the type is encoding/json.RawMessage.
 func isJSONRawMessage(typ reflect.Type) bool {
-	return typ.PkgPath() == "encoding/json" && typ.Name() == "RawMessage"
+	jt := [2]string{typ.PkgPath(), typ.Name()}
+	return jt == jsonTypes[0] || jt == jsonTypes[1]
 }
 
 // isModuleMapType returns true if the type is map[string]json.RawMessage.

--- a/modules.go
+++ b/modules.go
@@ -345,15 +345,11 @@ func StrictUnmarshalJSON(data []byte, v any) error {
 	return dec.Decode(v)
 }
 
-var jsonTypes = [][2]string{
-	{"encoding/json", "RawMessage"},     // default type
-	{"encoding/json/jsontext", "Value"}, // GOEXPERIMENT=jsonv2 type
-}
+var JSONRawMessageType = reflect.TypeFor[json.RawMessage]()
 
 // isJSONRawMessage returns true if the type is encoding/json.RawMessage.
 func isJSONRawMessage(typ reflect.Type) bool {
-	jt := [2]string{typ.PkgPath(), typ.Name()}
-	return jt == jsonTypes[0] || jt == jsonTypes[1]
+	return typ == JSONRawMessageType
 }
 
 // isModuleMapType returns true if the type is map[string]json.RawMessage.


### PR DESCRIPTION
If `GOEXPERIMENT=jsonv2` is used to compile caddy, caddy will panic if tls is used:

```
panic: expected ModuleMap because inline_key is empty; but we do not recognize this type: caddy.ModuleMap
goroutine 1 [running]:
github.com/caddyserver/caddy/v2.Context.loadModulesFromSomeMap({{0x2362c30, 0xc000748be0}, 0xc0000c9c80, 0xc00042b680, {0xc000420280, 0x2, 0x2}, {0x0, 0x0, 0x0}, ...}, ...)
        github.com/caddyserver/caddy/v2@v2.10.2/context.go:296 +0x1c5
github.com/caddyserver/caddy/v2.Context.LoadModule({{0x2362c30, 0xc000748be0}, 0xc0000c9c80, 0xc00042b680, {0xc000420280, 0x2, 0x2}, {0x0, 0x0, 0x0}, ...}, ...)
        github.com/caddyserver/caddy/v2@v2.10.2/context.go:265 +0x585
github.com/caddyserver/caddy/v2/modules/caddytls.(*TLS).Provision(0xc0005fa280, {{0x2362c30, 0xc000748be0}, 0xc0000c9c80, 0xc00042b680, {0xc000420280, 0x2, 0x2}, {0x0, 0x0, ...}, ...})
        github.com/caddyserver/caddy/v2@v2.10.2/modules/caddytls/tls.go:215 +0x753
github.com/caddyserver/caddy/v2.Context.LoadModuleByID({{0x2362c30, 0xc000748be0}, 0xc0000c9c80, 0xc00042b680, {0xc000420280, 0x2, 0x2}, {0x0, 0x0, 0x0}, ...}, ...)
        github.com/caddyserver/caddy/v2@v2.10.2/context.go:417 +0x895
github.com/caddyserver/caddy/v2.Context.App({{0x2362c30, 0xc000748be0}, 0xc0000c9c80, 0xc00042b680, {0xc0005e0530, 0x1, 0x1}, {0x0, 0x0, 0x0}, ...}, ...)
        github.com/caddyserver/caddy/v2@v2.10.2/context.go:505 +0x1ce
github.com/caddyserver/caddy/v2/modules/caddyhttp.(*App).Provision(0xc00016f380, {{0x2362c30, 0xc000748be0}, 0xc0000c9c80, 0xc00042b680, {0xc0005e0530, 0x1, 0x1}, {0x0, 0x0, ...}, ...})
        github.com/caddyserver/caddy/v2@v2.10.2/modules/caddyhttp/app.go:177 +0x125
```

This is due to [`json.RawMessage`](https://pkg.go.dev/encoding/json#RawMessage) is now an alias for [`jsontext.Value`](https://pkg.go.dev/encoding/json/jsontext#Value).

Now both types are checked to see if a type is `encoding/json.RawMessage`.

## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

No AI was used.