### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/modules/caddyhttp/matchers_test.go
+++ b/modules/caddyhttp/matchers_test.go
@@ -992,7 +992,6 @@ func TestVarREMatcher(t *testing.T) {
 			expect: true,
 		},
 	} {
-		tc := tc // capture range value
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 			// compile the regexp and validate its name


### PR DESCRIPTION


## Assistance Disclosure



The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore
