### PR TITLE
reverse_proxy: use http1 for outbound tls requests with placeholder t…

### DIFF
--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -281,3 +281,7 @@ const proxyProtocolInfoVarKey = "reverse_proxy.proxy_protocol_info"
 type ProxyProtocolInfo struct {
 	AddrPort netip.AddrPort
 }
+
+// tlsH1OnlyVarKey is the key used that indicates the connection will use h1 only for TLS.
+// https://github.com/caddyserver/caddy/issues/7292
+const tlsH1OnlyVarKey = "reverse_proxy.tls_h1_only"

--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -409,6 +409,14 @@ func (h *HTTPTransport) NewTransport(caddyCtx caddy.Context) (*http.Transport, e
 				repl := ctx.Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 				tlsConfig := rt.TLSClientConfig.Clone()
 				tlsConfig.ServerName = repl.ReplaceAll(tlsConfig.ServerName, "")
+
+				// h1 only
+				if caddyhttp.GetVar(ctx, tlsH1OnlyVarKey) == true {
+					// stdlib does this
+					// https://github.com/golang/go/blob/4837fbe4145cd47b43eed66fee9eed9c2b988316/src/net/http/transport.go#L1701
+					tlsConfig.NextProtos = nil
+				}
+
 				tlsConn := tls.Client(conn, tlsConfig)
 
 				// complete the handshake before returning the connection

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -726,6 +726,12 @@ func (h Handler) prepareRequest(req *http.Request, repl *caddy.Replacer) (*http.
 	proxyProtocolInfo := ProxyProtocolInfo{AddrPort: addrPort}
 	caddyhttp.SetVar(req.Context(), proxyProtocolInfoVarKey, proxyProtocolInfo)
 
+	// some of the outbound requests require h1 (e.g. websocket)
+	// https://github.com/golang/go/blob/4837fbe4145cd47b43eed66fee9eed9c2b988316/src/net/http/request.go#L1579
+	if isWebsocket(req) {
+		caddyhttp.SetVar(req.Context(), tlsH1OnlyVarKey, true)
+	}
+
 	// Add the supported X-Forwarded-* headers
 	err = h.addForwardedHeaders(req)
 	if err != nil {


### PR DESCRIPTION
…hat are likely websockets

Fix  [7292](https://github.com/caddyserver/caddy/issues/7292).

## Assistance Disclosure

No AI was used.