### PR TITLE
reverseproxy: Use http1.1 upgrade for websocket for extended connect of http2 and http3.

### DIFF
--- a/modules/caddyhttp/reverseproxy/streaming.go
+++ b/modules/caddyhttp/reverseproxy/streaming.go
@@ -94,9 +94,9 @@ func (h *Handler) handleUpgradeResponse(logger *zap.Logger, wg *sync.WaitGroup, 
 		conn io.ReadWriteCloser
 		brw  *bufio.ReadWriter
 	)
-	// websocket over http2, assuming backend doesn't support this, the request will be modified to http1.1 upgrade
+	// websocket over http2 or http3 if extended connect is enabled, assuming backend doesn't support this, the request will be modified to http1.1 upgrade
 	// TODO: once we can reliably detect backend support this, it can be removed for those backends
-	if body, ok := caddyhttp.GetVar(req.Context(), "websocket_body").(io.ReadCloser); ok {
+	if body, ok := caddyhttp.GetVar(req.Context(), "extended_connect_websocket_body").(io.ReadCloser); ok {
 		req.Body = body
 		rw.Header().Del("Upgrade")
 		rw.Header().Del("Connection")


### PR DESCRIPTION
Hi,

This tweaks the code that modifies http2 requests to use http1.1 upgrade for websocket to do the same for http3 as well. 

The issue I was having was with homeassistant reverse proxied, it stopped working for me on the latest iOS Safari.  After some digging, I found iOS was sending http3 requests for connecting to the websocket sometimes, and these were getting sent to homeassistant as CONNECT requests, which returned 404.

It seems to work after this tweak, which just applies the same logic used for http2 to http3 as well.

This is similar to #5565 but for http3.

No AI was used. I signed the CLA.