### PR TITLE
reverse_proxy: set default values for keepalive if only some of them are set

### DIFF
--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -204,11 +204,16 @@ func (h *HTTPTransport) Provision(ctx caddy.Context) error {
 func (h *HTTPTransport) NewTransport(caddyCtx caddy.Context) (*http.Transport, error) {
 	// Set keep-alive defaults if it wasn't otherwise configured
 	if h.KeepAlive == nil {
-		h.KeepAlive = &KeepAlive{
-			ProbeInterval:       caddy.Duration(30 * time.Second),
-			IdleConnTimeout:     caddy.Duration(2 * time.Minute),
-			MaxIdleConnsPerHost: 32, // seems about optimal, see #2805
-		}
+		h.KeepAlive = new(KeepAlive)
+	}
+	if h.KeepAlive.ProbeInterval == 0 {
+		h.KeepAlive.ProbeInterval = caddy.Duration(30 * time.Second)
+	}
+	if h.KeepAlive.IdleConnTimeout == 0 {
+		h.KeepAlive.IdleConnTimeout = caddy.Duration(2 * time.Minute)
+	}
+	if h.KeepAlive.MaxIdleConnsPerHost == 0 {
+		h.KeepAlive.MaxIdleConnsPerHost = 32 // seems about optimal, see #2805
 	}
 
 	// Set a relatively short default dial timeout.


### PR DESCRIPTION
If only some of values are set for http keepalive, the default parameters (`keepalive`, `keepalive_interval`, `keepalive_idle_conns_per_host`) won't be set. This make sure these parameters are set for if other parameters are set.

## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

No AI was used.
