### PR TITLE
caddytls: Fixes regarding internal-named domains, issuer configs

### DIFF
--- a/caddytest/integration/pki_test.go
+++ b/caddytest/integration/pki_test.go
@@ -103,5 +103,5 @@ func TestIntermediateLifetimeLessThanRoot(t *testing.T) {
         }
       }
     }
-	`, "json", "intermediate certificate lifetime must be less than root certificate lifetime (86400h0m0s)")
+	`, "json", "intermediate certificate lifetime must be less than actual root certificate lifetime (86400h0m0s)")
 }

--- a/modules/caddytls/automation.go
+++ b/modules/caddytls/automation.go
@@ -404,8 +404,12 @@ func (ap *AutomationPolicy) isWildcardOrDefault() bool {
 // DefaultIssuers returns empty Issuers (not provisioned) to be used as defaults.
 // This function is experimental and has no compatibility promises.
 func DefaultIssuers(userEmail string) []certmagic.Issuer {
-	issuers := []certmagic.Issuer{new(ACMEIssuer)}
-	if strings.TrimSpace(userEmail) != "" {
+	issuers := []certmagic.Issuer{
+		&ACMEIssuer{
+			Email: userEmail,
+		},
+	}
+	if strings.TrimSpace(userEmail) != "" { // ZeroSSL requires an email address
 		issuers = append(issuers, &ACMEIssuer{
 			CA:    certmagic.ZeroSSLProductionCA,
 			Email: userEmail,


### PR DESCRIPTION
Should address #7147


## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

No AI was used.