### PR TITLE
fix golangci-lint error G602 in caddyhttp

### DIFF
--- a/modules/caddyhttp/reverseproxy/fastcgi/writer.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/writer.go
@@ -112,8 +112,7 @@ func encodeSize(b []byte, size uint32) int {
 		binary.BigEndian.PutUint32(b, size)
 		return 4
 	}
-	// #nosec G602 - b input as [>=4]byte; index 0 is always in-bounds
-	b[0] = byte(size)
+	b[0] = byte(size) //nolint:gosec // false positive; b is made 8 bytes long, then this function is always called with b being at least 4 or 1 byte long
 	return 1
 }
 


### PR DESCRIPTION
Commit ddec1838b39a1b61432db4e78f2e752f27c3c769 was failing CI due to lint error:
```
  Running [/Users/runner/golangci-lint-2.6.0-darwin-arm64/golangci-lint run  --timeout 10m] in [/Users/runner/work/caddy/caddy] ...
  Error: modules/caddyhttp/reverseproxy/fastcgi/writer.go:115:3: G602: slice index out of range (gosec)
  	b[0] = byte(size)
  	 ^
```
This linter-failing line is from an old PR. Looking at older CI logs, it appears a successful cache of this file's lint recently expired, causing the error to appear

Code chunk is safe because function is only used when passing in a buffer of size >=4, but the linter is unable to guarantee this

I tested code changes to make the linter pass, but the error remained unless an explicit size check was added. It does not feel necessary to check the size of buffer every time in `encodeSize` when we guaranteed in caller that buffer is big enough. As such commenting to disable the linter error felt like the least invasive solution. Happy to change to whatever fits best the project's, I found this project recently, have enjoyed using it on my own, and wanted to make a small first PR_


## Assistance Disclosure
Used AI to test code changes that would disable linter. No AI code (or really any code) entered this PR