### PR TITLE
feat: custom slog handlers for modules (log contextual data)

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -793,8 +793,10 @@ func (s *Server) logRequest(
 	accLog *zap.Logger, r *http.Request, wrec ResponseRecorder, duration *time.Duration,
 	repl *caddy.Replacer, bodyReader *lengthReader, shouldLogCredentials bool,
 ) {
+	ctx := r.Context()
+
 	// this request may be flagged as omitted from the logs
-	if skip, ok := GetVar(r.Context(), LogSkipVar).(bool); ok && skip {
+	if skip, ok := GetVar(ctx, LogSkipVar).(bool); ok && skip {
 		return
 	}
 
@@ -812,7 +814,7 @@ func (s *Server) logRequest(
 	}
 
 	message := "handled request"
-	if nop, ok := GetVar(r.Context(), "unhandled").(bool); ok && nop {
+	if nop, ok := GetVar(ctx, "unhandled").(bool); ok && nop {
 		message = "NOP"
 	}
 
@@ -836,7 +838,7 @@ func (s *Server) logRequest(
 				reqBodyLength = bodyReader.Length
 			}
 
-			extra := r.Context().Value(ExtraLogFieldsCtxKey).(*ExtraLogFields)
+			extra := ctx.Value(ExtraLogFieldsCtxKey).(*ExtraLogFields)
 
 			fieldCount := 6
 			fields = make([]zapcore.Field, 0, fieldCount+len(extra.fields))


### PR DESCRIPTION
With this patch, contextual data can be added to all logs generated by a logger retrieved using `context.Slogger()`.

For instance, this allows FrankenPHP and Mercure to include OpenTelemetry's traceID and spanID to all logs they generate using the logger created by Caddy.
 
Modules can also register handlers to add contextual data of their own (like the Mercure update ID, for instance).

## Assistance Disclosure

No AI was used.