### PR TITLE
reverse_proxy: use interfaces to modify the behaviors of the transports

### DIFF
--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -888,8 +888,11 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			if commonScheme == "http" && te.TLSEnabled() {
 				return d.Errf("upstream address scheme is HTTP but transport is configured for HTTP+TLS (HTTPS)")
 			}
-			if te, ok := transport.(*HTTPTransport); ok && commonScheme == "h2c" {
-				te.Versions = []string{"h2c", "2"}
+			if h2ct, ok := transport.(H2CTransport); ok && commonScheme == "h2c" {
+				err := h2ct.EnableH2C()
+				if err != nil {
+					return err
+				}
 			}
 		} else if commonScheme == "https" {
 			return d.Errf("upstreams are configured for HTTPS but transport module does not support TLS: %T", transport)

--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -112,6 +112,20 @@ func (t *Transport) Provision(ctx caddy.Context) error {
 	return nil
 }
 
+// DefaultBufferSizes enables request buffering for fastcgi if not configured.
+// This is because most fastcgi servers are php-fpm that require the content length to be set to read the body, golang
+// std has fastcgi implementation that doesn't need this value to process the body, but we can safely assume that's
+// not used.
+// http3 requests have a negative content length for GET and HEAD requests, if that header is not sent.
+// see: https://github.com/caddyserver/caddy/issues/6678#issuecomment-2472224182
+// Though it appears even if CONTENT_LENGTH is invalid, php-fpm can handle just fine if the body is empty (no Stdin records sent).
+// php-fpm will hang if there is any data in the body though, https://github.com/caddyserver/caddy/issues/5420#issuecomment-2415943516
+
+// TODO: better default buffering for fastcgi requests without content length, in theory a value of 1 should be enough, make it bigger anyway
+func (t Transport) DefaultBufferSizes() (int64, int64) {
+	return 4096, 0
+}
+
 // RoundTrip implements http.RoundTripper.
 func (t Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 	server := r.Context().Value(caddyhttp.ServerCtxKey).(*caddyhttp.Server)
@@ -427,6 +441,7 @@ var headerNameReplacer = strings.NewReplacer(" ", "_", "-", "_")
 var (
 	_ zapcore.ObjectMarshaler = (*loggableEnv)(nil)
 
-	_ caddy.Provisioner = (*Transport)(nil)
-	_ http.RoundTripper = (*Transport)(nil)
+	_ caddy.Provisioner              = (*Transport)(nil)
+	_ http.RoundTripper              = (*Transport)(nil)
+	_ reverseproxy.BufferedTransport = (*Transport)(nil)
 )

--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -564,6 +564,26 @@ func (h *HTTPTransport) EnableTLS(base *TLSConfig) error {
 	return nil
 }
 
+// EnableH2C enables H2C (HTTP/2 over Cleartext) on the transport.
+func (h *HTTPTransport) EnableH2C() error {
+	h.Versions = []string{"h2c", "2"}
+	return nil
+}
+
+// OverrideHealthCheckScheme overrides the scheme of the given URL
+// used for health checks.
+func (h HTTPTransport) OverrideHealthCheckScheme(base *url.URL, port string) {
+	// if tls is enabled and the port isn't in the except list, use HTTPs
+	if h.TLSEnabled() && !slices.Contains(h.TLS.ExceptPorts, port) {
+		base.Scheme = "https"
+	}
+}
+
+// ProxyProtocolEnabled returns true if proxy protocol is enabled.
+func (h HTTPTransport) ProxyProtocolEnabled() bool {
+	return h.ProxyProtocol != ""
+}
+
 // Cleanup implements caddy.CleanerUpper and closes any idle connections.
 func (h HTTPTransport) Cleanup() error {
 	if h.Transport == nil {
@@ -820,8 +840,11 @@ func decodeBase64DERCert(certStr string) (*x509.Certificate, error) {
 
 // Interface guards
 var (
-	_ caddy.Provisioner  = (*HTTPTransport)(nil)
-	_ http.RoundTripper  = (*HTTPTransport)(nil)
-	_ caddy.CleanerUpper = (*HTTPTransport)(nil)
-	_ TLSTransport       = (*HTTPTransport)(nil)
+	_ caddy.Provisioner                   = (*HTTPTransport)(nil)
+	_ http.RoundTripper                   = (*HTTPTransport)(nil)
+	_ caddy.CleanerUpper                  = (*HTTPTransport)(nil)
+	_ TLSTransport                        = (*HTTPTransport)(nil)
+	_ H2CTransport                        = (*HTTPTransport)(nil)
+	_ HealthCheckSchemeOverriderTransport = (*HTTPTransport)(nil)
+	_ ProxyProtocolTransport              = (*HTTPTransport)(nil)
 )


### PR DESCRIPTION
Some behaviors of the transports used by reverse proxy rely on type assertion to an actual type to modify the behavior of the transports,

1. enabling h2c
2. enabling request buffering for fastcgi (this one is particularly ugly because it checks the transport module name)
3. overriding the scheme of the active health check requests
4. changing the host keys used in the connection pool if proxy protocol is enabled

By using interfaces, it's possible for third party transport implementations to implement them to automatically get the behaviors we want.

## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

No AI was used.
