### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/modules/caddyhttp/reverseproxy/fastcgi/client_test.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/client_test.go
@@ -244,15 +244,15 @@ func DisabledTest(t *testing.T) {
 	sendFcgi(0, fcgiParams, []byte("c4ca4238a0b923820dcc509a6f75849b=1&7b8b965ad4bca0e41ab51de7b31363a1=n"), nil, nil)
 
 	log.Println("test:", "post data (more than 60KB)")
-	var data strings.Builder
+	data := ""
 	for i := 0x00; i < 0xff; i++ {
 		v0 := strings.Repeat(fmt.Sprint(i), 256)
 		h := md5.New()
 		_, _ = io.WriteString(h, v0)
 		k0 := fmt.Sprintf("%x", h.Sum(nil))
-		data.WriteString(k0 + "=" + url.QueryEscape(v0) + "&")
+		data += k0 + "=" + url.QueryEscape(v0) + "&"
 	}
-	sendFcgi(0, fcgiParams, []byte(data.String()), nil, nil)
+	sendFcgi(0, fcgiParams, []byte(data), nil, nil)
 
 	log.Println("test:", "post form (use url.Values)")
 	p0 := make(map[string]string, 1)

--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -112,11 +112,12 @@ func (r Route) Empty() bool {
 
 func (r Route) String() string {
 	var handlersRaw strings.Builder
-	handlersRaw.WriteString("[")
+	handlersRaw.WriteByte('[')
 	for _, hr := range r.HandlersRaw {
-		handlersRaw.WriteString(" " + string(hr))
+		handlersRaw.WriteByte(' ')
+		handlersRaw.WriteString(string(hr))
 	}
-	handlersRaw.WriteString("]")
+	handlersRaw.WriteByte(']')
 
 	return fmt.Sprintf(`{Group:"%s" MatcherSetsRaw:%s HandlersRaw:%s Terminal:%t}`,
 		r.Group, r.MatcherSetsRaw, handlersRaw.String(), r.Terminal)
@@ -443,13 +444,14 @@ func (ms *MatcherSets) FromInterface(matcherSets any) error {
 // TODO: Is this used?
 func (ms MatcherSets) String() string {
 	var result strings.Builder
-	result.WriteString("[")
+	result.WriteByte('[')
 	for _, matcherSet := range ms {
 		for _, matcher := range matcherSet {
 			result.WriteString(fmt.Sprintf(" %#v", matcher))
 		}
 	}
-	return result.String() + " ]"
+	result.WriteByte(']')
+	return result.String()
 }
 
 var routeGroupCtxKey = caddy.CtxKey("route_group")

--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -255,7 +255,7 @@ func (m IPMaskFilter) Filter(in zapcore.Field) zapcore.Field {
 }
 
 func (m IPMaskFilter) mask(s string) string {
-	var output strings.Builder
+	parts := make([]string, 0)
 	for value := range strings.SplitSeq(s, ",") {
 		value = strings.TrimSpace(value)
 		host, port, err := net.SplitHostPort(value)
@@ -264,7 +264,7 @@ func (m IPMaskFilter) mask(s string) string {
 		}
 		ipAddr := net.ParseIP(host)
 		if ipAddr == nil {
-			output.WriteString(value + ", ")
+			parts = append(parts, value)
 			continue
 		}
 		mask := m.v4Mask
@@ -273,13 +273,13 @@ func (m IPMaskFilter) mask(s string) string {
 		}
 		masked := ipAddr.Mask(mask)
 		if port == "" {
-			output.WriteString(masked.String() + ", ")
+			parts = append(parts, masked.String())
 			continue
 		}
 
-		output.WriteString(net.JoinHostPort(masked.String(), port) + ", ")
+		parts = append(parts, net.JoinHostPort(masked.String(), port))
 	}
-	return strings.TrimSuffix(output.String(), ", ")
+	return strings.Join(parts, ", ")
 }
 
 type filterAction string


### PR DESCRIPTION


## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)
