### PR TITLE
caddyhttp: `{http.request.body_base64}` placeholder

### DIFF
--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -51,6 +51,7 @@ func init() {
 // Placeholder | Description
 // ------------|---------------
 // `{http.request.body}` | The request body (⚠️ inefficient; use only for debugging)
+// `{http.request.body_base64}` | The request body, base64-encoded (⚠️ for debugging)
 // `{http.request.cookie.*}` | HTTP request cookie
 // `{http.request.duration}` | Time up to now spent handling the request (after decoding headers from client)
 // `{http.request.duration_ms}` | Same as 'duration', but in milliseconds.


### PR DESCRIPTION
I was debugging a request coming from an app which was sending a `zstd` payload to an upstream app. I was using `log_append req_body {http.request.body}` to try to log it, but since it's binary, the log output was basically junk (JSON encoded binary, very hard to pull back out into something useful). So I realized we need a base64 variant to handle debugging binary bodies. Super simple, just a copy of the other placeholder case and added a base64 encode call at the end.

## Assistance Disclosure
None used.