### PR TITLE
ci: escape backticks in changelogs embedded in JS

### DIFF
--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -160,8 +160,9 @@ jobs:
           fi
           
           # Store changelog for PR body
+          CLEANSED_COMMITS=$(echo "$COMMITS" | sed 's/`/\\`/g')
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
-          echo "$COMMITS" >> $GITHUB_OUTPUT
+          echo "$CLEANSED_COMMITS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
           
           # Create empty commit for the PR


### PR DESCRIPTION
change logs tend to have text in backticks, e.g. `foo`, for code related identifiers or keywords.. The wreak havoc when injected into JS.

## Assistance Disclosure

No AI was used.
