### PR TITLE
caddytls: fix preferred chains options by appending values instead of replacing

### DIFF
--- a/modules/caddytls/acmeissuer.go
+++ b/modules/caddytls/acmeissuer.go
@@ -671,7 +671,7 @@ func ParseCaddyfilePreferredChainsOptions(d *caddyfile.Dispenser) (*ChainPrefere
 		switch d.Val() {
 		case "root_common_name":
 			rootCommonNameOpt := d.RemainingArgs()
-			chainPref.RootCommonName = rootCommonNameOpt
+			chainPref.RootCommonName = append(chainPref.RootCommonName, rootCommonNameOpt...)
 			if rootCommonNameOpt == nil {
 				return nil, d.ArgErr()
 			}
@@ -681,7 +681,7 @@ func ParseCaddyfilePreferredChainsOptions(d *caddyfile.Dispenser) (*ChainPrefere
 
 		case "any_common_name":
 			anyCommonNameOpt := d.RemainingArgs()
-			chainPref.AnyCommonName = anyCommonNameOpt
+			chainPref.AnyCommonName = append(chainPref.AnyCommonName, anyCommonNameOpt...)
 			if anyCommonNameOpt == nil {
 				return nil, d.ArgErr()
 			}


### PR DESCRIPTION
```
{
  preferred_chains {
    root_common_name "Example root name"
    root_common_name "Example root name 2"
  }
}
```
I mainly noticed that when I write multiple lines for root_common_name, the last line always overrides the previous ones, and there is no warning or indication that this is not allowed. I attempted to modify it so that multiple lines can be used. Thank you for all your work on this project.

## Assistance Disclosure
No AI was used.