### PR TITLE
fix(http.fileserver): improve error message for "expanding glob" error

### DIFF
--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -398,7 +398,7 @@ func (m MatchFile) selectFile(r *http.Request) (bool, error) {
 			globResults, err = fs.Glob(fileSystem, fullPattern)
 			if err != nil {
 				if c := m.logger.Check(zapcore.ErrorLevel, "expanding glob"); c != nil {
-					c.Write(zap.Error(err))
+					c.Write(zap.Error(fmt.Errorf("%w: %s", err, fullPattern)))
 				}
 			}
 		}


### PR DESCRIPTION
_"No AI was used."_

While migrating a high traffic website to caddy we noticed occasional errors we could not reproduce (yet).

The error is `expanding glob / syntax error in pattern`, we suspect it might be malicious request, but we dont really know.
This PR tries to bring some light by also logging the faulty pattern (where the `fs.Glob` can throw this error)

## versions

* frankenphp : 1.9.1
* caddy: 2.10.2

## caddy config

```caddy
{
	metrics # used for datadog

	log default {
		output stdout
		format json
	}

	# see https://frankenphp.dev/docs/config/#caddyfile-config
	# see https://frankenphp.dev/docs/performance/#number-of-threads-and-workers
	frankenphp {
	    num_threads 45  # memory / 50MB per Request - a little headroom
		max_threads 270 # 6 times num_threads
		max_wait_time 20s
	}

	servers {
		trusted_proxies cloudfront {
			# add all cloudfront ips as trusted proxies, so caddy forwards the X-Forwarded headers
			interval 1h
		}
	}
}

#ssl is already terminated (LB) at this point
http:// {
	log

	# modify headers
	@assets path *.js *.css *.ico
	header @assets Cache-Control "s-maxage=31536000, must-revalidate, proxy-revalidate"
	header /* -Server -Expires

	# Enable compression (optional)
	encode zstd br gzip

	# Execute PHP files in the current directory and serve assets
	php_server {
		resolve_root_symlink false
		try_files {path} /index.php
		root /path/to/web
	}

	# error pages
	handle_errors 5xx {
		rewrite * /path/to/static_errors/50x.html
		file_server
	}
}
```

## error log (only ocassionally)

```js
{
  error: "syntax error in pattern",
  level: "error",
  logger: "http.matchers.file"
}
```

after revisting the config, it might be the `error pages` ?
frankphp implicitly (afaik) create a fileserver as well for serving assets