### PR TITLE
cmd: add --json flag to list-modules

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -229,12 +229,13 @@ documentation: https://go.dev/doc/modules/version-numbers
 
 	RegisterCommand(Command{
 		Name:  "list-modules",
-		Usage: "[--packages] [--versions] [--skip-standard]",
+		Usage: "[--packages] [--versions] [--skip-standard] [--json]",
 		Short: "Lists the installed Caddy modules",
 		CobraFunc: func(cmd *cobra.Command) {
 			cmd.Flags().BoolP("packages", "", false, "Print package paths")
 			cmd.Flags().BoolP("versions", "", false, "Print version information")
 			cmd.Flags().BoolP("skip-standard", "s", false, "Skip printing standard modules")
+			cmd.Flags().BoolP("json", "", false, "Print modules in JSON format")
 			cmd.RunE = WrapCommandFuncForCobra(cmdListModules)
 		},
 	})


### PR DESCRIPTION

## Description
This PR implements the requested `--json` flag for the `list-modules` command, as proposed in #7408. 

## Motivation
Automations (like Ansible roles) need a machine-readable way to verify installed modules and their versions to ensure idempotency. The current text output is difficult to parse reliably.

## Changes
- Added `--json` flag to `list-modules` command in `cmd/commands.go`.
- Implemented JSON output logic in `cmd/commandfuncs.go` using a dedicated `jsonModuleInfo` struct.
- Maintained backward compatibility: the default text output remains unchanged.

## Testing
Tested locally with:
- `caddy list-modules --json` (Full JSON output)
- `caddy list-modules --json --skip-standard` (Correct filtering)
- `caddy list-modules` (Verified original text output is preserved)

Closes #7408


## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

_I consulted Gemini (AI) for the solution architecture and implementation details, but I authored, verified, and tested the code myself to ensure it meets Caddy's standards._
