### PR TITLE
headers: Make ApplyTo nil-safe

### DIFF
--- a/modules/caddyhttp/headers/headers.go
+++ b/modules/caddyhttp/headers/headers.go
@@ -217,7 +217,10 @@ type RespHeaderOps struct {
 }
 
 // ApplyTo applies ops to hdr using repl.
-func (ops HeaderOps) ApplyTo(hdr http.Header, repl *caddy.Replacer) {
+func (ops *HeaderOps) ApplyTo(hdr http.Header, repl *caddy.Replacer) {
+	if ops == nil {
+		return
+	}
 	// before manipulating headers in other ways, check if there
 	// is configuration to delete all headers, and do that first
 	// because if a header is to be added, we don't want to delete


### PR DESCRIPTION
When JSON config contains "response": {} in reverse_proxy or headers middleware, the RespHeaderOps struct is created but the embedded *HeaderOps pointer is nil. Calling ApplyTo on this nil pointer causes a panic.

This is a follow-up to af2d33af which made Provision nil-safe for the same reason. This change applies the same pattern to ApplyTo.

Related to #6893




## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

Claude Code was consulted for this code, but I authored/coded it myself.
