### PR TITLE
chore: Dumb `prealloc` lint fix

### DIFF
--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -761,7 +761,7 @@ type ServerBlock struct {
 }
 
 func (sb ServerBlock) GetKeysText() []string {
-	res := []string{}
+	res := make([]string, 0, len(sb.Keys))
 	for _, k := range sb.Keys {
 		res = append(res, k.Text)
 	}

--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -930,6 +930,7 @@ func parseLogHelper(h Helper, globalLogNames map[string]struct{}) ([]ConfigValue
 	// modifications to the parsing behavior.
 	parseAsGlobalOption := globalLogNames != nil
 
+	// nolint:prealloc
 	var configValues []ConfigValue
 
 	// Logic below expects that a name is always present when a

--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -404,7 +404,7 @@ func (m MatchFile) selectFile(r *http.Request) (bool, error) {
 		}
 
 		// for each glob result, combine all the forms of the path
-		var candidates []matchCandidate
+		candidates := make([]matchCandidate, 0, len(globResults))
 		for _, result := range globResults {
 			candidates = append(candidates, matchCandidate{
 				fullpath:       result,

--- a/modules/caddyhttp/headers/caddyfile.go
+++ b/modules/caddyhttp/headers/caddyfile.go
@@ -168,8 +168,6 @@ func parseReqHdrCaddyfile(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, 
 	}
 	h.Next() // consume the directive name again (matcher parsing resets)
 
-	configValues := []httpcaddyfile.ConfigValue{}
-
 	if !h.NextArg() {
 		return nil, h.ArgErr()
 	}
@@ -204,7 +202,7 @@ func parseReqHdrCaddyfile(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, 
 		return nil, h.Err(err.Error())
 	}
 
-	configValues = append(configValues, h.NewRoute(matcherSet, hdr)...)
+	configValues := h.NewRoute(matcherSet, hdr)
 
 	if h.NextArg() {
 		return nil, h.ArgErr()

--- a/modules/caddyhttp/push/caddyfile.go
+++ b/modules/caddyhttp/push/caddyfile.go
@@ -64,6 +64,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 				var err error
 
 				// include current token, which we treat as an argument here
+				// nolint:prealloc
 				args := []string{h.Val()}
 				args = append(args, h.RemainingArgs()...)
 

--- a/modules/caddyhttp/rewrite/caddyfile.go
+++ b/modules/caddyhttp/rewrite/caddyfile.go
@@ -173,6 +173,7 @@ func parseCaddyfileURI(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, err
 			if hasArgs {
 				return nil, h.Err("Cannot specify uri query rewrites in both argument and block")
 			}
+			// nolint:prealloc
 			queryArgs := []string{h.Val()}
 			queryArgs = append(queryArgs, h.RemainingArgs()...)
 			err := applyQueryOps(h, rewr.Query, queryArgs)

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -1010,6 +1010,7 @@ func isTrustedClientIP(ipAddr netip.Addr, trusted []netip.Prefix) bool {
 // then the first value from those headers is used.
 func trustedRealClientIP(r *http.Request, headers []string, clientIP string) string {
 	// Read all the values of the configured client IP headers, in order
+	// nolint:prealloc
 	var values []string
 	for _, field := range headers {
 		values = append(values, r.Header.Values(field)...)

--- a/modules/caddyhttp/staticresp.go
+++ b/modules/caddyhttp/staticresp.go
@@ -257,7 +257,16 @@ func (s StaticResponse) ServeHTTP(w http.ResponseWriter, r *http.Request, next H
 	return nil
 }
 
-func buildHTTPServer(i int, port uint, addr string, statusCode int, hdr http.Header, body string, accessLog bool) (*Server, error) {
+func buildHTTPServer(
+	i int,
+	port uint,
+	addr string,
+	statusCode int,
+	hdr http.Header,
+	body string,
+	accessLog bool,
+) (*Server, error) {
+	// nolint:prealloc
 	var handlers []json.RawMessage
 
 	// response body supports a basic template; evaluate it


### PR DESCRIPTION
```
  Running [/Users/runner/golangci-lint-2.8.0-darwin-arm64/golangci-lint run  --timeout 10m] in [/Users/runner/work/caddy/caddy] ...
  Error: caddyconfig/caddyfile/parse.go:764:2: Consider preallocating res with capacity len(sb.Keys) (prealloc)
  	res := []string{}
  	^
  Error: caddyconfig/httpcaddyfile/builtins.go:933:6: Consider preallocating configValues with capacity 1 (prealloc)
  	var configValues []ConfigValue
  	    ^
  Error: modules/caddyhttp/fileserver/matcher.go:407:7: Consider preallocating candidates with capacity len(globResults) (prealloc)
  		var candidates []matchCandidate
  		    ^
  Error: modules/caddyhttp/headers/caddyfile.go:171:2: Consider preallocating configValues (prealloc)
  	configValues := []httpcaddyfile.ConfigValue{}
  	^
  Error: modules/caddyhttp/push/caddyfile.go:67:5: Consider preallocating args (prealloc)
  				args := []string{h.Val()}
  				^
  Error: modules/caddyhttp/rewrite/caddyfile.go:176:4: Consider preallocating queryArgs (prealloc)
  			queryArgs := []string{h.Val()}
  			^
  Error: modules/caddyhttp/server.go:1013:6: Consider preallocating values (prealloc)
  	var values []string
  	    ^
  Error: modules/caddyhttp/staticresp.go:261:6: Consider preallocating handlers with capacity 1 (prealloc)
  	var handlers []json.RawMessage
  	    ^
  8 issues:
  * prealloc: 8
```

## Assistance Disclosure
Used Github Copilot to apply the lint fixes, with some small manual adjustments