### PR TITLE
caddyfile: Fix indentation of multiline strings in fmt (#7425)

### DIFF
--- a/caddyconfig/caddyfile/formatter.go
+++ b/caddyconfig/caddyfile/formatter.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"io"
 	"slices"
+	"strings"
 	"unicode"
 )
 
@@ -207,6 +208,15 @@ func Format(input []byte) []byte {
 			case "\"`":
 				quotes = ""
 			}
+		}
+
+		if strings.Contains(quotes, "`") {
+			if ch == '`' && space && !beginningOfLine {
+				write(' ')
+			}
+			write(ch)
+			space = false
+			continue
 		}
 
 		if unicode.IsSpace(ch) {

--- a/caddyconfig/caddyfile/formatter_test.go
+++ b/caddyconfig/caddyfile/formatter_test.go
@@ -464,6 +464,17 @@ block2 {
 }
 `,
 		},
+		{
+			description: "issue #7425: multiline backticked string indentation",
+			input: `https://localhost:8953 {
+    respond ` + "`" + `Here are some random numbers:
+
+{{randNumeric 16}}
+
+Hope this helps.` + "`" + `
+}`,
+			expect: "https://localhost:8953 {\n\trespond `Here are some random numbers:\n\n{{randNumeric 16}}\n\nHope this helps.`\n}",
+		},
 	} {
 		// the formatter should output a trailing newline,
 		// even if the tests aren't written to expect that


### PR DESCRIPTION
Fixes #7425

## Description
Previously, the formatter would incorrectly indent lines within backticked multiline strings, treating newlines inside the string as structural formatting points. This caused unintended modification of string content (e.g., templates or responses).

## Changes
- Modified `formatter.go` to detect if the current token is inside a backtick string.
- Added logic to skip the indentation loop when inside a backtick-quoted string, ensuring the original whitespace is preserved.
- Added a regression test case in `formatter_test.go` covering the scenario reported in the issue.

## Testing
- Verified locally using the reproduction case provided in the issue.
- Ran `go test -v ./caddyconfig/caddyfile/...` and confirmed all tests pass, including the new regression test.

## Assistance Disclosure
I consulted an AI assistant to help analyze the formatter logic and debug edge cases regarding whitespace handling. I implemented the fix and verified the tests myself.