### PR TITLE
reverseproxy: Set `Host` to `{upstream_hostport}` automatically if TLS

### DIFF
--- a/modules/caddyhttp/reverseproxy/httptransport_test.go
+++ b/modules/caddyhttp/reverseproxy/httptransport_test.go
@@ -94,3 +94,24 @@ func TestHTTPTransportUnmarshalCaddyFileWithCaPools(t *testing.T) {
 		})
 	}
 }
+
+func TestHTTPTransport_RequestHeaderOps_TLS(t *testing.T) {
+	var ht HTTPTransport
+	// When TLS is nil, expect no header ops
+	if ops := ht.RequestHeaderOps(); ops != nil {
+		t.Fatalf("expected nil HeaderOps when TLS is nil, got: %#v", ops)
+	}
+
+	// When TLS is configured, expect a HeaderOps that sets Host
+	ht.TLS = &TLSConfig{}
+	ops := ht.RequestHeaderOps()
+	if ops == nil {
+		t.Fatal("expected non-nil HeaderOps when TLS is set")
+	}
+	if ops.Set == nil {
+		t.Fatalf("expected ops.Set to be non-nil, got nil")
+	}
+	if got := ops.Set.Get("Host"); got != "{http.reverse_proxy.upstream.hostport}" {
+		t.Fatalf("unexpected Host value; want placeholder, got: %s", got)
+	}
+}


### PR DESCRIPTION
For almost the entire life of Caddy v2, [we've had a recommendation](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#https) to set `header_up Host {upstream_hostport}` when configuring `reverse_proxy` for HTTPS.

I think it's time that we make this the default. It's sensible to make the `Host` header match the upstream address when we know the server is configured with TLS. If the user needs something different, it's fine, their own `header_up` rules will be applied afterwards and take priority, e.g. with `header_up Host {host}` to reset it to the default host. This is so rare to be correct though, in our experience.

This also fixes some major footguns when you _forget_ to set `header_up Host {upstream_hostport}` which can cause tricky misbehaviour depending on the upstream's handling of the `Host` header.

## Assistance Disclosure
I used Copilot to iterate on the changes, but finished and tested it by hand.
