### PR TITLE
httpcaddyfile: Override global `dns` with `acme_dns` (fix #7294)

### DIFF
--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -548,9 +548,8 @@ func fillInGlobalACMEDefaults(issuer certmagic.Issuer, options map[string]any) e
 		if acmeIssuer.Challenges.DNS == nil {
 			acmeIssuer.Challenges.DNS = new(caddytls.DNSChallengeConfig)
 		}
-		// If global `dns` is set, do NOT set provider in issuer, just set empty dns config
-		if globalDNS == nil && acmeIssuer.Challenges.DNS.ProviderRaw == nil {
-			// Set a global DNS provider if `acme_dns` is set and `dns` is NOT set
+		if globalACMEDNS != nil && acmeIssuer.Challenges.DNS.ProviderRaw == nil {
+			// Set a global DNS provider if `acme_dns` is set
 			acmeIssuer.Challenges.DNS.ProviderRaw = caddyconfig.JSONModuleObject(globalACMEDNS, "name", globalACMEDNS.(caddy.Module).CaddyModule().ID.Name(), nil)
 		}
 	}

--- a/caddytest/integration/caddyfile_adapt/tls_acme_dns_override_global_dns.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/tls_acme_dns_override_global_dns.caddyfiletest
@@ -1,0 +1,83 @@
+{
+	dns mock foo
+	acme_dns mock bar
+}
+
+localhost {
+	tls {
+		resolvers 8.8.8.8 8.8.4.4
+	}
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"localhost"
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		},
+		"tls": {
+			"automation": {
+				"policies": [
+					{
+						"subjects": [
+							"localhost"
+						],
+						"issuers": [
+							{
+								"challenges": {
+									"dns": {
+										"provider": {
+											"argument": "bar",
+											"name": "mock"
+										},
+										"resolvers": [
+											"8.8.8.8",
+											"8.8.4.4"
+										]
+									}
+								},
+								"module": "acme"
+							}
+						]
+					},
+					{
+						"issuers": [
+							{
+								"challenges": {
+									"dns": {
+										"provider": {
+											"argument": "bar",
+											"name": "mock"
+										}
+									}
+								},
+								"module": "acme"
+							}
+						]
+					}
+				]
+			},
+			"dns": {
+				"argument": "foo",
+				"name": "mock"
+			}
+		}
+	}
+}


### PR DESCRIPTION
This brings the behaviour in line with what the documentation implies (see #7294).

## Assistance Disclosure
No AI was used.