### PR TITLE
caddytls: Return errors instead of nil in client auth provisioning

### DIFF
--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -784,7 +784,7 @@ func (clientauth *ClientAuthentication) provision(ctx caddy.Context) error {
 		for _, fpath := range clientauth.TrustedCACertPEMFiles {
 			ders, err := convertPEMFilesToDER(fpath)
 			if err != nil {
-				return nil
+				return err
 			}
 			clientauth.TrustedCACerts = append(clientauth.TrustedCACerts, ders...)
 		}
@@ -797,7 +797,7 @@ func (clientauth *ClientAuthentication) provision(ctx caddy.Context) error {
 		}
 		err := caPool.Provision(ctx)
 		if err != nil {
-			return nil
+			return err
 		}
 		clientauth.ca = caPool
 	}


### PR DESCRIPTION
## Summary

- Two error returns in `ClientAuthentication.provision()` were returning `nil` instead of the actual error, silently swallowing failures when converting PEM files to DER (`connpolicy.go:787`) and when provisioning the inline CA pool (`connpolicy.go:800`)
- This could cause mTLS client authentication to silently fall back to the system trust store, accepting any client certificate signed by a public CA instead of restricting to the configured trust anchors

## Test plan

- [x] `go test ./modules/caddytls/...` passes
- [x] Verify with a Caddyfile that configures `client_auth` with an invalid PEM file path — should now return an error instead of silently proceeding

*This issue was identified with the assistance of an LLM (Claude), per the project's security reporting policy.*