### PR TITLE
  - admin: add missing return after Origin: null error response,

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -263,9 +263,9 @@ func (admin *AdminConfig) newAdminHandler(addr NetworkAddress, remote bool, _ Co
 	// register debugging endpoints
 	addRouteWithMetrics("/debug/pprof/", handlerLabel, http.HandlerFunc(pprof.Index))
 	addRouteWithMetrics("/debug/pprof/cmdline", handlerLabel, http.HandlerFunc(pprof.Cmdline))
-	addRouteWithMetrics("/debug/pprof/profile", handlerLabel, http.HandlerFunc(pprof.Profile))
+	addRouteWithMetrics("/debug/pprof/profile", handlerLabel, pprofRateLimited(http.HandlerFunc(pprof.Profile)))
 	addRouteWithMetrics("/debug/pprof/symbol", handlerLabel, http.HandlerFunc(pprof.Symbol))
-	addRouteWithMetrics("/debug/pprof/trace", handlerLabel, http.HandlerFunc(pprof.Trace))
+	addRouteWithMetrics("/debug/pprof/trace", handlerLabel, pprofRateLimited(http.HandlerFunc(pprof.Trace)))
 	addRouteWithMetrics("/debug/vars", handlerLabel, expvar.Handler())
 
 	// register third-party module endpoints
@@ -838,6 +838,7 @@ func (h adminHandler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 			Err:        errors.New("invalid origin 'null'"),
 			Message:    "Buggy browser is sending null Origin header.",
 		})
+		return
 	}
 
 	if h.enforceHost {
@@ -1354,6 +1355,24 @@ func (e APIError) Error() string {
 		return e.Err.Error()
 	}
 	return e.Message
+}
+
+// pprofSem limits concurrent CPU-intensive pprof operations (profile, trace)
+// to prevent a DoS via repeated 30-second profiling sessions.
+var pprofSem = make(chan struct{}, 1)
+
+// pprofRateLimited wraps an http.Handler so that at most one request is
+// served at a time. Additional concurrent callers receive 429.
+func pprofRateLimited(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case pprofSem <- struct{}{}:
+			defer func() { <-pprofSem }()
+			h.ServeHTTP(w, r)
+		default:
+			http.Error(w, "too many profiling requests; try again later", http.StatusTooManyRequests)
+		}
+	})
 }
 
 // parseAdminListenAddr extracts a singular listen address from either addr

--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -305,7 +305,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>{{html .Name}}</title>
+		<title>{{.Name}}</title>
 		<link rel="canonical" href="{{.Path}}/"  />
 		<meta charset="utf-8">
 		<meta name="color-scheme" content="light dark">
@@ -787,7 +787,7 @@ footer {
 		<div class="wrapper">
 			<div class="breadcrumbs">Folder Path</div>
 				<h1>
-					{{range $i, $crumb := .Breadcrumbs}}<a href="{{html $crumb.Link}}">{{html $crumb.Text}}</a>{{if ne $i 0}}/{{end}}{{end}}
+					{{range $i, $crumb := .Breadcrumbs}}<a href="{{$crumb.Link | safeURL}}">{{$crumb.Text}}</a>{{if ne $i 0}}/{{end}}{{end}}
 				</h1>
 			</div>
 		</header>
@@ -923,9 +923,9 @@ footer {
 				{{- if eq .Layout "grid"}}
 				{{- range .Items}}
 				<div class="entry">
-					<a href="{{html .URL}}" title='{{html (.HumanModTime "January 2, 2006 at 15:04:05")}}'>
+					<a href="{{.URL | safeURL}}" title='{{.HumanModTime "January 2, 2006 at 15:04:05"}}'>
 						{{template "icon" .}}
-						<div class="name">{{html .Name}}</div>
+						<div class="name">{{.Name}}</div>
 						<div class="size">{{.HumanSize}}</div>
 					</a>
 				</div>
@@ -1061,16 +1061,16 @@ footer {
 					<tr class="file">
 						<td></td>
 						<td>
-							<a href="{{html .URL}}">
+							<a href="{{.URL | safeURL}}">
 								{{template "icon" .}}
 								{{- if not .SymlinkPath}}
-								<span class="name">{{html .Name}}</span>
+								<span class="name">{{.Name}}</span>
 								{{- else}}
-								<span class="name">{{html .Name}} <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-arrow-narrow-right" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+								<span class="name">{{.Name}} <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-arrow-narrow-right" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
 									<path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M5 12l14 0" />
 									<path d="M15 16l4 -4" />
 									<path d="M15 8l4 4" />
-								</svg> {{html .SymlinkPath}}</span>
+								</svg> {{.SymlinkPath}}</span>
 								{{- end}}
 							</a>
 						</td>


### PR DESCRIPTION
    preventing double WriteHeader and continued handler execution
  - admin: rate-limit /debug/pprof/profile and /debug/pprof/trace to 1 concurrent request to prevent CPU-profiling DoS
  - fileserver: switch browse template from text/template to html/template for context-aware auto-escaping; replace manual {{html}} calls and add safeURL/pathEscape helpers to avoid double-encoding of pre-encoded URL fields




## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

_This PR is missing an assistance disclosure._
