### PR TITLE
Fix memory reclaim for speed in serve

### DIFF
--- a/caddyconfig/load.go
+++ b/caddyconfig/load.go
@@ -80,7 +80,7 @@ func (adminLoad) handleLoad(w http.ResponseWriter, r *http.Request) error {
 
 	buf := bufPool.Get().(*bytes.Buffer)
 	buf.Reset()
-	defer bufPool.Put(buf)
+	defer putBuf(buf)
 
 	_, err := io.Copy(buf, r.Body)
 	if err != nil {
@@ -144,7 +144,7 @@ func (adminLoad) handleAdapt(w http.ResponseWriter, r *http.Request) error {
 
 	buf := bufPool.Get().(*bytes.Buffer)
 	buf.Reset()
-	defer bufPool.Put(buf)
+	defer putBuf(buf)
 
 	_, err := io.Copy(buf, r.Body)
 	if err != nil {
@@ -219,3 +219,16 @@ var bufPool = sync.Pool{
 		return new(bytes.Buffer)
 	},
 }
+
+// putBuf returns a buffer to the pool if its capacity
+// does not exceed maxBufferSize, otherwise it is discarded
+// so memory can be reclaimed after load subsides.
+func putBuf(buf *bytes.Buffer) {
+	if buf.Cap() > maxBufferSize {
+		return
+	}
+	buf.Reset()
+	bufPool.Put(buf)
+}
+
+const maxBufferSize = 64 * 1024

--- a/modules/caddyhttp/reverseproxy/fastcgi/client.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/client.go
@@ -150,7 +150,7 @@ func (c *client) Do(p map[string]string, req io.Reader) (r io.Reader, err error)
 	writer := &streamWriter{c: c}
 	writer.buf = bufPool.Get().(*bytes.Buffer)
 	writer.buf.Reset()
-	defer bufPool.Put(writer.buf)
+	defer putBuf(writer.buf)
 
 	err = writer.writeBeginRequest(uint16(Responder), 0)
 	if err != nil {

--- a/modules/caddyhttp/reverseproxy/fastcgi/pool.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/pool.go
@@ -24,3 +24,16 @@ var bufPool = sync.Pool{
 		return new(bytes.Buffer)
 	},
 }
+
+// putBuf returns a buffer to the pool if its capacity
+// does not exceed maxBufferSize, otherwise it is discarded
+// so memory can be reclaimed after load subsides.
+func putBuf(buf *bytes.Buffer) {
+	if buf.Cap() > maxBufferSize {
+		return
+	}
+	buf.Reset()
+	bufPool.Put(buf)
+}
+
+const maxBufferSize = 64 * 1024

--- a/modules/caddyhttp/templates/templates.go
+++ b/modules/caddyhttp/templates/templates.go
@@ -410,7 +410,7 @@ func (t *Templates) Validate() error {
 func (t *Templates) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	buf := bufPool.Get().(*bytes.Buffer)
 	buf.Reset()
-	defer bufPool.Put(buf)
+	defer putBuf(buf)
 
 	// shouldBuf determines whether to execute templates on this response,
 	// since generally we will not want to execute for images or CSS, etc.

--- a/modules/caddyhttp/templates/tplcontext_test.go
+++ b/modules/caddyhttp/templates/tplcontext_test.go
@@ -242,7 +242,7 @@ func TestNestedInclude(t *testing.T) {
 
 		buf = bufPool.Get().(*bytes.Buffer)
 		buf.Reset()
-		defer bufPool.Put(buf)
+		defer putBuf(buf)
 		buf.WriteString(test.child)
 		err = context.executeTemplateInBuffer(test.childFile, buf)
 


### PR DESCRIPTION
This pull request introduces a memory optimization for buffer pool management across several packages. The main change is the introduction of a new `putBuf` helper function, which ensures that only buffers below a certain size (`maxBufferSize`) are returned to the pool, allowing oversized buffers to be discarded and memory to be reclaimed after high load. This pattern is applied consistently throughout the codebase, and relevant tests are added to verify the new behavior.

**Buffer Pool Memory Optimization:**

* Added `putBuf` helper function in multiple files (`admin.go`, `caddyconfig/load.go`, `modules/caddyhttp/fileserver/browse.go`, `modules/caddyhttp/intercept/intercept.go`, `modules/caddyhttp/reverseproxy/fastcgi/pool.go`, `modules/caddyhttp/reverseproxy/reverseproxy.go`, `modules/caddyhttp/templates/tplcontext.go`) to only return buffers to the pool if their capacity does not exceed `maxBufferSize` (64KB), otherwise discarding them to prevent memory bloat. [[1]](diffhunk://#diff-cb488ad8239edeaaf8b0c1f469cc15c03fde53cbf22ee996e2f3922b3cc6a0c9R994-R1006) [[2]](diffhunk://#diff-0c8bfec4802d5d401d81e1e2e4867055a211b8cf5a404c7ae16ef2e8419cb98fR222-R234) [[3]](diffhunk://#diff-60d1a49e0d78a723705d615618606ee184e68e9fde6af86f98fe57b7e6f7a593R356-R368) [[4]](diffhunk://#diff-63bbb89517afc4a3a57572686b807c324334605f16060cc3f98a37920ad7cc35R100-R112) [[5]](diffhunk://#diff-57c02220d91de96d7aefffeadeed5bac0a63dae87b6129925495a8d80b49d1ddR27-R39) [[6]](diffhunk://#diff-a248c9a1ec018edea8b377d155bc1df1a642bf79d00ababb5cdacc6b86c5733dR1631-R1648) [[7]](diffhunk://#diff-09c30b4e7f53426f0d4a02cb246c2aec7f7d3ea800385319d6aa31240a8e3c0aR585-R597)

* Replaced all `defer bufPool.Put(buf)` calls with `defer putBuf(buf)` (or `defer putBuf(&bufPool, buf)` where appropriate) throughout the codebase to use the new logic, ensuring consistent buffer cleanup and memory management. [[1]](diffhunk://#diff-cb488ad8239edeaaf8b0c1f469cc15c03fde53cbf22ee996e2f3922b3cc6a0c9L1005-R1018) [[2]](diffhunk://#diff-cb488ad8239edeaaf8b0c1f469cc15c03fde53cbf22ee996e2f3922b3cc6a0c9L1040-R1053) [[3]](diffhunk://#diff-0c8bfec4802d5d401d81e1e2e4867055a211b8cf5a404c7ae16ef2e8419cb98fL83-R83) [[4]](diffhunk://#diff-0c8bfec4802d5d401d81e1e2e4867055a211b8cf5a404c7ae16ef2e8419cb98fL147-R147) [[5]](diffhunk://#diff-60d1a49e0d78a723705d615618606ee184e68e9fde6af86f98fe57b7e6f7a593L145-R145) [[6]](diffhunk://#diff-63bbb89517afc4a3a57572686b807c324334605f16060cc3f98a37920ad7cc35L131-R144) [[7]](diffhunk://#diff-704d0cf138fc604375b83fd6eab74382b1277998511a0cc2e2876644346fa2d5L153-R153) [[8]](diffhunk://#diff-a248c9a1ec018edea8b377d155bc1df1a642bf79d00ababb5cdacc6b86c5733dL468-R468) [[9]](diffhunk://#diff-a248c9a1ec018edea8b377d155bc1df1a642bf79d00ababb5cdacc6b86c5733dL1623-R1622) [[10]](diffhunk://#diff-0f96761ecf5ef376140d9291a6dffa8a31ce54880dabc7a57d8fb048025c6170L413-R413) [[11]](diffhunk://#diff-09c30b4e7f53426f0d4a02cb246c2aec7f7d3ea800385319d6aa31240a8e3c0aL115-R115) [[12]](diffhunk://#diff-09c30b4e7f53426f0d4a02cb246c2aec7f7d3ea800385319d6aa31240a8e3c0aL139-R139) [[13]](diffhunk://#diff-09c30b4e7f53426f0d4a02cb246c2aec7f7d3ea800385319d6aa31240a8e3c0aL190-R190) [[14]](diffhunk://#diff-09c30b4e7f53426f0d4a02cb246c2aec7f7d3ea800385319d6aa31240a8e3c0aL226-R226) [[15]](diffhunk://#diff-09c30b4e7f53426f0d4a02cb246c2aec7f7d3ea800385319d6aa31240a8e3c0aL373-R373) [[16]](diffhunk://#diff-60805a004c6a24dc0463732135bb9af4c6e322e46c6143d718b4cbe632f0ffaeL245-R245)

**Testing Improvements:**

* Added a new test `TestPutBufDiscardOversized` in `modules/caddyhttp/reverseproxy/buffering_test.go` to verify that oversized buffers are not returned to the pool and that small buffers are properly reset and pooled. [[1]](diffhunk://#diff-099c965f064f4aee55265668c8f7aed3b43dcbc2c5ffebc6d0e76d274977c9a4R86-R122) [[2]](diffhunk://#diff-099c965f064f4aee55265668c8f7aed3b43dcbc2c5ffebc6d0e76d274977c9a4R4)

These changes help prevent the buffer pool from retaining large buffers after periods of high load, reducing memory usage and improving the application's resilience under varying workloads.