### PR TITLE
admin: rate-limit pprof/profile and pprof/trace endpoints

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -263,9 +263,9 @@ func (admin *AdminConfig) newAdminHandler(addr NetworkAddress, remote bool, _ Co
 	// register debugging endpoints
 	addRouteWithMetrics("/debug/pprof/", handlerLabel, http.HandlerFunc(pprof.Index))
 	addRouteWithMetrics("/debug/pprof/cmdline", handlerLabel, http.HandlerFunc(pprof.Cmdline))
-	addRouteWithMetrics("/debug/pprof/profile", handlerLabel, http.HandlerFunc(pprof.Profile))
+	addRouteWithMetrics("/debug/pprof/profile", handlerLabel, pprofRateLimited(http.HandlerFunc(pprof.Profile)))
 	addRouteWithMetrics("/debug/pprof/symbol", handlerLabel, http.HandlerFunc(pprof.Symbol))
-	addRouteWithMetrics("/debug/pprof/trace", handlerLabel, http.HandlerFunc(pprof.Trace))
+	addRouteWithMetrics("/debug/pprof/trace", handlerLabel, pprofRateLimited(http.HandlerFunc(pprof.Trace)))
 	addRouteWithMetrics("/debug/vars", handlerLabel, expvar.Handler())
 
 	// register third-party module endpoints
@@ -1354,6 +1354,24 @@ func (e APIError) Error() string {
 		return e.Err.Error()
 	}
 	return e.Message
+}
+
+// pprofSem limits concurrent CPU-intensive pprof operations (profile, trace)
+// to prevent a DoS via repeated 30-second profiling sessions.
+var pprofSem = make(chan struct{}, 1)
+
+// pprofRateLimited wraps an http.Handler so that at most one request is
+// served at a time. Additional concurrent callers receive 429.
+func pprofRateLimited(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case pprofSem <- struct{}{}:
+			defer func() { <-pprofSem }()
+			h.ServeHTTP(w, r)
+		default:
+			http.Error(w, "too many profiling requests; try again later", http.StatusTooManyRequests)
+		}
+	})
 }
 
 // parseAdminListenAddr extracts a singular listen address from either addr


### PR DESCRIPTION
   /debug/pprof/profile and /debug/pprof/trace each block for up to 30
   seconds while collecting a CPU or execution trace. Without any
   concurrency guard, any process that can reach the admin socket can
   hammer these endpoints to cause sustained CPU overhead and degrade
   server performance.

   Add pprofRateLimited(), a semaphore-based wrapper (capacity 1) that
   allows at most one in-flight profiling request at a time and returns
   429 Too Many Requests to any concurrent caller. The fast snapshot
   endpoints (index, cmdline, symbol) are left unwrapped




## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

_This PR is missing an assistance disclosure._
