### PR TITLE
caddyhttp: Option to disable 0-RTT

### DIFF
--- a/caddytest/integration/caddyfile_adapt/global_server_options_single.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/global_server_options_single.caddyfiletest
@@ -21,6 +21,7 @@
 		keepalive_interval 20s
 		keepalive_idle 20s
 		keepalive_count 10
+		0rtt off
 	}
 }
 
@@ -90,7 +91,8 @@ foo.com {
 						"h2",
 						"h2c",
 						"h3"
-					]
+					],
+					"allow_0rtt": false
 				}
 			}
 		}


### PR DESCRIPTION
Closes #7481

Adds a `0rtt off` option under `servers`:

```caddy
{
	servers {
		0rtt off
	}
}
```

## Assistance Disclosure
Used GitHub Copilot to more quickly wire up the options, did some manual adjustments after.