### PR TITLE
caddytls: Enable debug logging for DNSManager

### DIFF
--- a/modules/caddytls/acmeissuer.go
+++ b/modules/caddytls/acmeissuer.go
@@ -178,6 +178,7 @@ func (iss *ACMEIssuer) Provision(ctx caddy.Context) error {
 				PropagationTimeout: time.Duration(iss.Challenges.DNS.PropagationTimeout),
 				Resolvers:          iss.Challenges.DNS.Resolvers,
 				OverrideDomain:     iss.Challenges.DNS.OverrideDomain,
+				Logger:             iss.logger.Named("dns_manager"),
 			},
 		}
 	}


### PR DESCRIPTION
Context https://github.com/caddyserver/caddy/issues/7484

Apparently we never enabled debug logging for DNSManager which would be helpful to discover what's going on during DNS TXT record writing and propagation checks.

## Assistance Disclosure
Used GitHub Copilot to scan for logical issues, which found that there's an optional Logger we weren't using.