### PR TITLE
chore: Disable windows/arm build target (Go 1.26 disabled)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ before:
     - cp cmd/caddy/main.go caddy-build/main.go
     - /bin/sh -c 'cd ./caddy-build && go mod init caddy'
     # prepare syso files for windows embedding
-    - /bin/sh -c 'for a in amd64 arm arm64; do XCADDY_SKIP_BUILD=1 GOOS=windows GOARCH=$a xcaddy build {{.Env.TAG}}; done'
+    - /bin/sh -c 'for a in amd64 arm64; do XCADDY_SKIP_BUILD=1 GOOS=windows GOARCH=$a xcaddy build {{.Env.TAG}}; done'
     - /bin/sh -c 'mv /tmp/buildenv_*/*.syso caddy-build'
     # GoReleaser doesn't seem to offer {{.Tag}} at this stage, so we have to embed it into the env
     # so we run: TAG=$(git describe --abbrev=0) goreleaser release --rm-dist --skip-publish --skip-validate
@@ -67,6 +67,8 @@ builds:
       goarch: s390x
     - goos: windows
       goarch: riscv64
+    - goos: windows
+      goarch: arm
     - goos: freebsd
       goarch: ppc64le
     - goos: freebsd


### PR DESCRIPTION
Our release build for 2.11.0 failed because `windows/arm` is no longer a valid build target. https://github.com/caddyserver/caddy/actions/runs/22241325885/job/64345389827

## Assistance Disclosure
Used GitHub Copilot to sanity check the change, it noticed the `arm` entry in the loop for syso files.