### PR TITLE
cmd: Add 'caddy status' command and core StatusReporter interface

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -100,6 +100,15 @@ type App interface {
 	Stop() error
 }
 
+// StatusReporter can be implemented by Apps or Modules that wish
+// to expose runtime status information via the /status admin endpoint.
+type StatusReporter interface {
+	Status() (any, error)
+}
+
+// ProcessStartTime records when the Caddy process started.
+var ProcessStartTime = time.Now()
+
 // Run runs the given config, replacing any existing config.
 func Run(cfg *Config) error {
 	cfgJSON, err := json.Marshal(cfg)

--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -15,12 +15,12 @@ func TestCommandsAreAvailable(t *testing.T) {
 		t.Fatal("default factory failed to build")
 	}
 
-	// check that the default factory has 17 commands; it doesn't
+	// check that the default factory has 18 commands; it doesn't
 	// include the commands registered through calls to init in
 	// other packages
 	cmds := Commands()
-	if len(cmds) != 17 {
-		t.Errorf("expected 17 commands, got %d", len(cmds))
+	if len(cmds) != 18 {
+		t.Errorf("expected 18 commands, got %d", len(cmds))
 	}
 
 	commandNames := slices.Collect(maps.Keys(cmds))
@@ -30,7 +30,7 @@ func TestCommandsAreAvailable(t *testing.T) {
 		"adapt", "add-package", "build-info", "completion",
 		"environ", "fmt", "list-modules", "manpage",
 		"reload", "remove-package", "run", "start",
-		"stop", "storage", "upgrade", "validate", "version",
+		"status", "stop", "storage", "upgrade", "validate", "version",
 	}
 
 	if !reflect.DeepEqual(expectedCommandNames, commandNames) {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,106 @@
+package caddycmd
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/caddyserver/caddy/v2"
+)
+
+func init() {
+	RegisterCommand(Command{
+		Name:  "status",
+		Func:  cmdStatus,
+		Usage: "[--json] [--address <admin-api-address>] [--config <path>] [--adapter <name>]",
+		Short: "Prints the status of the running Caddy instance",
+		Flags: func() *flag.FlagSet {
+			fs := flag.NewFlagSet("status", flag.ExitOnError)
+			fs.Bool("json", false, "Output raw JSON instead of human-readable text")
+			fs.String("address", "", "The address to use to reach the admin API endpoint, if not the default")
+			fs.String("config", "", "Configuration file")
+			fs.String("adapter", "", "Name of config adapter to apply")
+			return fs
+		}(),
+	})
+}
+
+// cmdStatus implements the 'caddy status' command.
+func cmdStatus(fl Flags) (int, error) {
+	useJSON := fl.Bool("json")
+	addr := fl.String("address")
+	cfgFile := fl.String("config")
+	cfgAdapter := fl.String("adapter")
+
+	// Determine the admin API address based on provided flags or defaults
+	adminAddr, err := DetermineAdminAPIAddress(cfgFile, nil, cfgAdapter, addr)
+	if err != nil {
+		return caddy.ExitCodeFailedStartup, fmt.Errorf("could not determine admin API address: %v", err)
+	}
+
+	resp, err := AdminAPIRequest(adminAddr, http.MethodGet, "/status", nil, nil)
+	if err != nil {
+		return caddy.ExitCodeFailedStartup, fmt.Errorf("failed to query status: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return caddy.ExitCodeFailedStartup, err
+	}
+
+	// Strictly output raw JSON to stdout for CLI pipelines (e.g., jq)
+	if useJSON {
+		os.Stdout.Write(body)
+		fmt.Println()
+		return caddy.ExitCodeSuccess, nil
+	}
+
+	var status map[string]any
+	if err := json.Unmarshal(body, &status); err != nil {
+		return caddy.ExitCodeFailedStartup, fmt.Errorf("failed to parse status JSON: %v\nRaw output: %s", err, string(body))
+	}
+
+	// Format output to be human-readable
+	fmt.Printf("Caddy %v\n", status["version"])
+	fmt.Println("Status: Running")
+
+	if uptime, ok := status["uptime_secs"].(float64); ok {
+		u := int64(uptime)
+		h := u / 3600
+		m := (u % 3600) / 60
+		s := u % 60
+		if h > 0 {
+			fmt.Printf("Uptime: %dh %dm %ds\n", h, m, s)
+		} else if m > 0 {
+			fmt.Printf("Uptime: %dm %ds\n", m, s)
+		} else {
+			fmt.Printf("Uptime: %ds\n", s)
+		}
+	}
+
+	if apps, ok := status["apps"].(map[string]any); ok && len(apps) > 0 {
+		var appNames []string
+		for appName := range apps {
+			appNames = append(appNames, appName)
+		}
+		fmt.Printf("\nRunning apps: %s\n", strings.Join(appNames, ", "))
+	} else {
+		fmt.Printf("\nRunning apps: none\n")
+	}
+
+	fmt.Println("\nMemory")
+	if mem, ok := status["memory"].(map[string]any); ok {
+		allocMB := mem["allocated_bytes"].(float64) / 1024 / 1024
+		sysMB := mem["system_bytes"].(float64) / 1024 / 1024
+		fmt.Printf("Allocated: %.0f MB\nSystem: %.0f MB\n", allocMB, sysMB)
+	}
+
+	fmt.Printf("Goroutines: %v\n", status["goroutines"])
+
+	return caddy.ExitCodeSuccess, nil
+}


### PR DESCRIPTION
## Assistance Disclosure
I used an LLM (Gemini) as a pair-programming assistant to brainstorm the architecture, design the `StatusReporter` interface, and generate the initial Go code structure. I then compiled, debugged, and manually verified the correctness of the code locally to ensure it meets Caddy's standards.

Resolves Phase 1 of #7453.

As discussed in the issue, this PR introduces the core architecture and the CLI command to view the running status of a Caddy instance without duplicating `/debug/pprof` logic, setting the ground for app-specific metrics.

### What this PR does:
1. **Extensibility:** Introduces the `StatusReporter` interface in the core `caddy` package. Any App or Module can implement this interface to safely expose its internal status snapshot.
2. **Admin API:** Adds the `GET /status` endpoint. It loops through the `ActiveContext()` loaded apps, aggregating basic process data (Uptime, Memory, Goroutines, Version) and dynamically appending any app-specific status if the app implements `StatusReporter`.
3. **CLI:** Adds the `caddy status` command. By default, it outputs a human-readable summary of the JSON payload. The `--json` flag is available for raw output.

### Future Work (Phase 2):
Implementing the `StatusReporter` interface specifically inside the `http` app to track active requests, latency, and the dot-matrix scoreboard, leveraging existing Prometheus hooks.

### Demo:
**Standard Output:**
```text
Caddy v2.x.x
Status: Running
Uptime: 14m 32s

Running apps: http, tls

Memory
Allocated: 4 MB
System: 19 MB
Goroutines: 18
```

**JSON Output (`caddy status --json`):**

```json
{
  "apps": {
    "http": {"status":"running"},
    "tls": {"status":"running"}
  },
  "goroutines": 18,
  "memory": {
    "allocated_bytes": 4071992,
    "system_bytes": 19749128
  },
  "uptime_secs": 872.4,
  "version": "v2.x.x"
}