### PR TITLE
httpcaddyfile: Fix missing TLS connection policies when auto_https is default (#7325)

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -822,7 +822,7 @@ func (st *ServerType) serversFromPairings(
 				// https://caddy.community/t/making-sense-of-auto-https-and-why-disabling-it-still-serves-https-instead-of-http/9761
 				createdTLSConnPolicies, ok := sblock.pile["tls.connection_policy"]
 				hasTLSEnabled := (ok && len(createdTLSConnPolicies) > 0) ||
-					(addr.Host != "" && srv.AutoHTTPS != nil && !slices.Contains(srv.AutoHTTPS.Skip, addr.Host))
+					(addr.Host != "" && (srv.AutoHTTPS == nil || !slices.Contains(srv.AutoHTTPS.Skip, addr.Host)))
 
 				// we'll need to remember if the address qualifies for auto-HTTPS, so we
 				// can add a TLS conn policy if necessary


### PR DESCRIPTION
## Assistance Disclosure
I consulted Gemini to help analyze the issue, locate the bug, and draft the fix and regression test. I have reviewed and verified that the code and logic are correct.

---

Fixes #7325.

**What this PR does / why we need it**:
In a previous PR (#5808), a nil pointer check was added for `srv.AutoHTTPS` to prevent a panic when evaluating `srv.AutoHTTPS.Skip`. However, because `srv.AutoHTTPS` is `nil` by default (when Auto HTTPS is fully enabled), this accidentally caused `hasTLSEnabled` to evaluate to `false` for site blocks without an explicit `https://` scheme. 

As a result, global TLS options like `default_sni` and `fallback_sni` were not propagated to `tls_connection_policies` during the adapter build phase, causing SNI-less clients to fail handshakes.

This PR fixes the logic by properly handling the `nil` state of `srv.AutoHTTPS` (i.e., treating `nil` as having no skip conditions):
`srv.AutoHTTPS == nil || !slices.Contains(...)`

I've also added a regression test to ensure `default_sni` is always properly attached to the generated JSON configuration, even without an explicit `https://` block.