### PR TITLE
feat: Allow configuration of private keys for TLS management (#2854)

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -124,6 +124,7 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 	var certSelector caddytls.CustomCertSelectionPolicy
 	var acmeIssuer *caddytls.ACMEIssuer
 	var keyType string
+	var keyFile string
 	var internalIssuer *caddytls.InternalIssuer
 	var issuers []certmagic.Issuer
 	var certManagers []certmagic.Manager
@@ -271,6 +272,13 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 				return nil, h.ArgErr()
 			}
 			keyType = arg[0]
+
+		case "key_file":
+			arg := h.RemainingArgs()
+			if len(arg) != 1 {
+				return nil, h.ArgErr()
+			}
+			keyFile = arg[0]
 
 		case "eab":
 			arg := h.RemainingArgs()
@@ -588,6 +596,13 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 		configVals = append(configVals, ConfigValue{
 			Class: "tls.key_type",
 			Value: keyType,
+		})
+	}
+
+	if keyFile != "" {
+		configVals = append(configVals, ConfigValue{
+			Class: "tls.key_file",
+			Value: keyFile,
 		})
 	}
 

--- a/caddyconfig/httpcaddyfile/options.go
+++ b/caddyconfig/httpcaddyfile/options.go
@@ -55,6 +55,7 @@ func init() {
 	RegisterGlobalOption("on_demand_tls", parseOptOnDemand)
 	RegisterGlobalOption("local_certs", parseOptTrue)
 	RegisterGlobalOption("key_type", parseOptSingleString)
+	RegisterGlobalOption("key_file", parseOptSingleString)
 	RegisterGlobalOption("auto_https", parseOptAutoHTTPS)
 	RegisterGlobalOption("metrics", parseMetricsOptions)
 	RegisterGlobalOption("servers", parseServerOptions)

--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -143,6 +143,10 @@ func (st ServerType) buildTLSApp(
 				ap.KeyType = keyTypeVals[0].Value.(string)
 			}
 
+			if keyFileVals, ok := sblock.pile["tls.key_file"]; ok {
+				ap.KeyFile = keyFileVals[0].Value.(string)
+			}
+
 			if renewalWindowRatioVals, ok := sblock.pile["tls.renewal_window_ratio"]; ok {
 				ap.RenewalWindowRatio = renewalWindowRatioVals[0].Value.(float64)
 			} else if globalRenewalWindowRatio, ok := options["renewal_window_ratio"]; ok {
@@ -611,9 +615,10 @@ func newBaseAutomationPolicy(
 	issuers, hasIssuers := options["cert_issuer"]
 	_, hasLocalCerts := options["local_certs"]
 	keyType, hasKeyType := options["key_type"]
+	keyFile, hasKeyFile := options["key_file"]
 	ocspStapling, hasOCSPStapling := options["ocsp_stapling"]
 	renewalWindowRatio, hasRenewalWindowRatio := options["renewal_window_ratio"]
-	hasGlobalAutomationOpts := hasIssuers || hasLocalCerts || hasKeyType || hasOCSPStapling || hasRenewalWindowRatio
+	hasGlobalAutomationOpts := hasIssuers || hasLocalCerts || hasKeyType || hasKeyFile || hasOCSPStapling || hasRenewalWindowRatio
 
 	globalACMECA := options["acme_ca"]
 	globalACMECARoot := options["acme_ca_root"]
@@ -634,6 +639,10 @@ func newBaseAutomationPolicy(
 	ap := new(caddytls.AutomationPolicy)
 	if hasKeyType {
 		ap.KeyType = keyType.(string)
+	}
+
+	if hasKeyFile {
+		ap.KeyFile = keyFile.(string)
 	}
 
 	if hasIssuers && hasLocalCerts {
@@ -727,6 +736,7 @@ outer:
 				bytes.Equal(aps[i].StorageRaw, aps[j].StorageRaw) &&
 				aps[i].MustStaple == aps[j].MustStaple &&
 				aps[i].KeyType == aps[j].KeyType &&
+				aps[i].KeyFile == aps[j].KeyFile &&
 				aps[i].OnDemand == aps[j].OnDemand &&
 				aps[i].ReusePrivateKeys == aps[j].ReusePrivateKeys &&
 				aps[i].RenewalWindowRatio == aps[j].RenewalWindowRatio {


### PR DESCRIPTION
## Assistance Disclosure

I authored the code and performed the tests. I consulted Gemini (Google's AI) for implementation strategy guidance, architectural mapping within Caddy, and initial draft snippets. All code was manually reviewed, integrated, and validated locally.

## Dependencies

⚠️ This PR depends on caddyserver/certmagic#371 and should not be merged before that PR is accepted.

## Description

This PR adds support for the `key_file` directive in the TLS app and Caddyfile.

It allows users to provide a pre-existing private key for automated certificate management (ACME or Internal), enabling key continuity across deployments, infrastructure migrations, and environments where keys are pre-provisioned.

The default behavior remains unchanged. If `key_file` is not specified, Caddy continues generating keys automatically via CertMagic.

## Relates to

Fixes #2854

## Changes

- **Caddyfile:**
  - Added `key_file` subdirective to `tls`
  - Added `key_file` as a global option

- **Automation:**
  - Extended `AutomationPolicy` with a `KeyFile` field

- **Provisioning:**
  - Added logic in `automation.go` to instantiate `certmagic.FileKeyGenerator` when a custom key file is configured

- **Policy Consolidation:**
  - Updated consolidation logic in `tlsapp.go` to prevent merging policies that reference different custom keys

- **Parsing:**
  - Updated `builtins.go` and `options.go` to parse and validate the `key_file` token

## Testing

Tested locally by:

1. Generating an EC P-384 private key:
   ```bash
   openssl ecparam -genkey -name secp384r1 -noout -out my_key.pem
   ```

2. Configuring a site block with:

   ```caddy
   tls {
       key_file my_key.pem
       issuer internal
   }
   ```

3. Verifying via `curl -v` that the server presented a certificate using the specified P-384 key (confirmed public key type and size during the TLS handshake).

4. Verifying that global options correctly propagate the `key_file` setting across automation policies.