### PR TITLE
autohttps: Ensure CertMagic config is recreated after autohttps runs

### DIFF
--- a/modules/caddyhttp/autohttps.go
+++ b/modules/caddyhttp/autohttps.go
@@ -580,6 +580,27 @@ func (app *App) createAutomationPolicies(ctx caddy.Context, internalNames, tails
 		}
 	}
 
+	// Ensure automation policies' CertMagic configs are rebuilt when
+	// ACME issuer templates may have been modified above (for example,
+	// alternate ports filled in by the HTTP app). If a policy is already
+	// provisioned, perform a lightweight rebuild of the CertMagic config
+	// so issuers receive SetConfig with the updated templates; otherwise
+	// run a normal Provision to initialize the policy.
+	for i, ap := range app.tlsApp.Automation.Policies {
+		// If the policy is already provisioned, rebuild only the CertMagic
+		// config so issuers get SetConfig with updated templates. Otherwise
+		// provision the policy normally (which may load modules).
+		if ap.IsProvisioned() {
+			if err := ap.RebuildCertMagic(app.tlsApp); err != nil {
+				return fmt.Errorf("rebuilding certmagic config for automation policy %d: %v", i, err)
+			}
+		} else {
+			if err := ap.Provision(app.tlsApp); err != nil {
+				return fmt.Errorf("provisioning automation policy %d after auto-HTTPS defaults: %v", i, err)
+			}
+		}
+	}
+
 	if basePolicy == nil {
 		// no base policy found; we will make one
 		basePolicy = new(caddytls.AutomationPolicy)


### PR DESCRIPTION
Context: https://caddy.community/t/80-bind-error-when-starting-with-tls-internal/33491

Auto-HTTPS was setting the port "too late" after the issuer was provisioned so the CertMagic config was already created with the wrong `AltHTTPPort`. This way, it will reconfigure CertMagic afterwards to ensure it's all good.

## Assistance Disclosure
Used a long session with Github Copilot to figure out what was going wrong, used it to apply the fix then I polished it and tested it by hand.