### PR TITLE
logging: Ensure `slog` error level logs don't print stack traces

### DIFF
--- a/caddytest/integration/acme_test.go
+++ b/caddytest/integration/acme_test.go
@@ -51,7 +51,7 @@ func TestACMEServerWithDefaults(t *testing.T) {
 		Client: &acme.Client{
 			Directory:  "https://acme.localhost:9443/acme/local/directory",
 			HTTPClient: tester.Client,
-			Logger:     slog.New(zapslog.NewHandler(logger.Core())),
+			Logger:     slog.New(zapslog.NewHandler(logger.Core(), zapslog.WithName("acmez"))),
 		},
 		ChallengeSolvers: map[string]acmez.Solver{
 			acme.ChallengeTypeHTTP01: &naiveHTTPSolver{logger: logger},
@@ -120,7 +120,7 @@ func TestACMEServerWithMismatchedChallenges(t *testing.T) {
 		Client: &acme.Client{
 			Directory:  "https://acme.localhost:9443/acme/local/directory",
 			HTTPClient: tester.Client,
-			Logger:     slog.New(zapslog.NewHandler(logger.Core())),
+			Logger:     slog.New(zapslog.NewHandler(logger.Core(), zapslog.WithName("acmez"))),
 		},
 		ChallengeSolvers: map[string]acmez.Solver{
 			acme.ChallengeTypeHTTP01: &naiveHTTPSolver{logger: logger},

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -484,7 +484,13 @@ func setResourceLimits(logger *zap.Logger) func() {
 	// See https://pkg.go.dev/runtime/debug#SetMemoryLimit
 	_, _ = memlimit.SetGoMemLimitWithOpts(
 		memlimit.WithLogger(
-			slog.New(zapslog.NewHandler(logger.Core())),
+			slog.New(zapslog.NewHandler(
+				logger.Core(),
+				zapslog.WithName("memlimit"),
+				// the default enables traces at ERROR level, this disables
+				// them by setting it to a level higher than any other level
+				zapslog.AddStacktraceAt(slog.Level(127)),
+			)),
 		),
 		memlimit.WithProvider(
 			memlimit.ApplyFallback(

--- a/context.go
+++ b/context.go
@@ -608,6 +608,11 @@ func (ctx Context) Slogger() *slog.Logger {
 		core     zapcore.Core
 		moduleID string
 	)
+
+	// the default enables traces at ERROR level, this disables
+	// them by setting it to a level higher than any other level
+	tracesOpt := zapslog.AddStacktraceAt(slog.Level(127))
+
 	if ctx.cfg == nil {
 		// often the case in tests; just use a dev logger
 		l, err := zap.NewDevelopment()
@@ -616,16 +621,16 @@ func (ctx Context) Slogger() *slog.Logger {
 		}
 
 		core = l.Core()
-		handler = zapslog.NewHandler(core)
+		handler = zapslog.NewHandler(core, tracesOpt)
 	} else {
 		mod := ctx.Module()
 		if mod == nil {
 			core = Log().Core()
-			handler = zapslog.NewHandler(core)
+			handler = zapslog.NewHandler(core, tracesOpt)
 		} else {
 			moduleID = string(mod.CaddyModule().ID)
 			core = ctx.cfg.Logging.Logger(mod).Core()
-			handler = zapslog.NewHandler(core, zapslog.WithName(moduleID))
+			handler = zapslog.NewHandler(core, zapslog.WithName(moduleID), tracesOpt)
 		}
 	}
 


### PR DESCRIPTION
I noticed while testing an error case in cert issuance that sometimes we get stack traces in some logs, which is needlessly noisy (not useful for users, vaguely useful for devs sometimes but we can just enable it as needed while dev-ing).

I realized that `zapslog` (the zap-slog adapter) sets stack traces to be enabled at ERROR level by default. So we need to set it to a big number to make it not be turned on at all.

The actual problematic one was in certmagic, but I found a couple spots we could adjust in caddy as well. Certmagic PR to follow. https://github.com/caddyserver/certmagic/pull/372

## Assistance Disclosure
Used Github Copilot to learn that 