### PR TITLE
cmd: Custom binary names through `CustomBinaryName` and `CustomLongDescription`

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -929,6 +929,34 @@ func InstanceID() (uuid.UUID, error) {
 // for example.
 var CustomVersion string
 
+// CustomBinaryName is an optional string that overrides the root
+// command name from the default of "caddy". This is useful for
+// downstream projects that embed Caddy but use a different binary
+// name. Shell completions and help text will use this name instead
+// of "caddy".
+//
+// Set this variable during `go build` with `-ldflags`:
+//
+//	-ldflags '-X github.com/caddyserver/caddy/v2.CustomBinaryName=my_custom_caddy'
+//
+// for example.
+var CustomBinaryName string
+
+// CustomLongDescription is an optional string that overrides the
+// long description of the root Cobra command. This is useful for
+// downstream projects that embed Caddy but want different help
+// output.
+//
+// Set this variable in an init() function of a package that is
+// imported by your main:
+//
+//	func init() {
+//	    caddy.CustomLongDescription = "My custom server based on Caddy..."
+//	}
+//
+// for example.
+var CustomLongDescription string
+
 // Version returns the Caddy version in a simple/short form, and
 // a full version string. The short form will not have spaces and
 // is intended for User-Agent strings and similar, but may be

--- a/cmd/cobra.go
+++ b/cmd/cobra.go
@@ -9,9 +9,14 @@ import (
 )
 
 var defaultFactory = newRootCommandFactory(func() *cobra.Command {
-	return &cobra.Command{
-		Use: "caddy",
-		Long: `Caddy is an extensible server platform written in Go.
+	bin := caddy.CustomBinaryName
+	if bin == "" {
+		bin = "caddy"
+	}
+
+	long := caddy.CustomLongDescription
+	if long == "" {
+		long = `Caddy is an extensible server platform written in Go.
 
 At its core, Caddy merely manages configuration. Modules are plugged
 in statically at compile-time to provide useful functionality. Caddy's
@@ -91,7 +96,12 @@ package installers: https://caddyserver.com/docs/install
 
 Instructions for running Caddy in production are also available:
 https://caddyserver.com/docs/running
-`,
+`
+	}
+
+	return &cobra.Command{
+		Use:  bin,
+		Long: long,
 		Example: `  $ caddy run
   $ caddy run --config caddy.json
   $ caddy reload --config caddy.json


### PR DESCRIPTION
No AI was used.

I wonder if we should also make the `Long` description configurable?

This change would make https://github.com/php/frankenphp/pull/2010 possible: using another binary name when autocompletion scripts are generated.