### PR TITLE
chore: Enable modernize linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
     - importas
     - ineffassign
     - misspell
+    - modernize
     - prealloc
     - promlinter
     - sloglint

--- a/caddyconfig/caddyfile/dispenser.go
+++ b/caddyconfig/caddyfile/dispenser.go
@@ -270,7 +270,7 @@ func (d *Dispenser) File() string {
 // targets are left unchanged. If all the targets are filled,
 // then true is returned.
 func (d *Dispenser) Args(targets ...*string) bool {
-	for i := 0; i < len(targets); i++ {
+	for i := range targets {
 		if !d.NextArg() {
 			return false
 		}

--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -616,7 +616,7 @@ func (p *parser) doSingleImport(importFile string) ([]Token, error) {
 	if err != nil {
 		return nil, p.Errf("Failed to get absolute path of file: %s: %v", importFile, err)
 	}
-	for i := 0; i < len(importedTokens); i++ {
+	for i := range importedTokens {
 		importedTokens[i].File = filename
 	}
 

--- a/caddyconfig/httploader.go
+++ b/caddyconfig/httploader.go
@@ -151,7 +151,7 @@ func doHttpCallWithRetries(ctx caddy.Context, client *http.Client, request *http
 	var err error
 	const maxAttempts = 10
 
-	for i := 0; i < maxAttempts; i++ {
+	for i := range maxAttempts {
 		resp, err = attemptHttpCall(client, request)
 		if err != nil && i < maxAttempts-1 {
 			select {

--- a/listeners.go
+++ b/listeners.go
@@ -229,7 +229,7 @@ func (na NetworkAddress) JoinHostPort(offset uint) string {
 func (na NetworkAddress) Expand() []NetworkAddress {
 	size := na.PortRangeSize()
 	addrs := make([]NetworkAddress, size)
-	for portOffset := uint(0); portOffset < size; portOffset++ {
+	for portOffset := range size {
 		addrs[portOffset] = na.At(portOffset)
 	}
 	return addrs

--- a/modules/caddyhttp/headers/headers.go
+++ b/modules/caddyhttp/headers/headers.go
@@ -161,11 +161,11 @@ func (ops *HeaderOps) Provision(_ caddy.Context) error {
 
 // containsPlaceholders checks if the string contains Caddy placeholder syntax {key}
 func containsPlaceholders(s string) bool {
-	openIdx := strings.Index(s, "{")
-	if openIdx == -1 {
+	_, after, ok := strings.Cut(s, "{")
+	if !ok {
 		return false
 	}
-	closeIdx := strings.Index(s[openIdx+1:], "}")
+	closeIdx := strings.Index(after, "}")
 	if closeIdx == -1 {
 		return false
 	}

--- a/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
@@ -442,7 +442,7 @@ func (t Transport) splitPos(path string) int {
 	for _, split := range t.SplitPath {
 		splitLen := len(split)
 
-		for i := 0; i < pathLen; i++ {
+		for i := range pathLen {
 			if path[i] >= utf8.RuneSelf {
 				if _, end := splitSearchNonASCII.IndexString(path, split); end > -1 {
 					return end
@@ -456,7 +456,7 @@ func (t Transport) splitPos(path string) int {
 			}
 
 			match := true
-			for j := 0; j < splitLen; j++ {
+			for j := range splitLen {
 				c := path[i+j]
 
 				if c >= utf8.RuneSelf {

--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -312,7 +312,7 @@ func (r *RoundRobinSelection) Select(pool UpstreamPool, _ *http.Request, _ http.
 	if n == 0 {
 		return nil
 	}
-	for i := uint32(0); i < n; i++ {
+	for range n {
 		robin := atomic.AddUint32(&r.robin, 1)
 		host := pool[robin%n]
 		if host.Available() {

--- a/modules/caddyhttp/reverseproxy/streaming.go
+++ b/modules/caddyhttp/reverseproxy/streaming.go
@@ -536,7 +536,7 @@ func maskBytes(key [4]byte, pos int, b []byte) int {
 	// Mask one word at a time.
 	n := (len(b) / wordSize) * wordSize
 	for i := 0; i < n; i += wordSize {
-		*(*uintptr)(unsafe.Pointer(uintptr(unsafe.Pointer(&b[0])) + uintptr(i))) ^= kw
+		*(*uintptr)(unsafe.Add(unsafe.Pointer(&b[0]), i)) ^= kw
 	}
 
 	// Mask one byte at a time for remaining bytes.

--- a/modules/logging/filewriter.go
+++ b/modules/logging/filewriter.go
@@ -63,7 +63,7 @@ func (m *fileMode) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON satisfies json.Marshaler.
 func (m *fileMode) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("\"%04o\"", *m)), nil
+	return fmt.Appendf(nil, "\"%04o\"", *m), nil
 }
 
 // parseFileMode parses a file mode string,


### PR DESCRIPTION
This PR enables `modernize` linter (has the same fixes as [go fix](https://go.dev/blog/gofix)) and fixes lint issues via `golangci-lint run --enable-only modernize --fix`.

## Assistance Disclosure

No AI was used.