### PR TITLE
cmd: Pass configFile, not configFlag, for reload command

### DIFF
--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -757,7 +757,6 @@ func handleEnvFileFlag(fl Flags) error {
 // need to interact with a running instance of Caddy via the admin API.
 func AdminAPIRequest(adminAddr, method, uri string, headers http.Header, body io.Reader) (*http.Response, error) {
 	parsedAddr, err := caddy.ParseNetworkAddress(adminAddr)
-	log.Println("ADMIN ADDR:", adminAddr, parsedAddr)
 	if err != nil || parsedAddr.PortRangeSize() > 1 {
 		return nil, fmt.Errorf("invalid admin address %s: %v", adminAddr, err)
 	}


### PR DESCRIPTION
This *should* fix #7528.

I believe we don't need configFlag after we pass it into `LoadConfig()`, which uses it to load the config, and we get the resulting `configFile` used from that function.

Without this patch, `caddy reload` was definitely not using the adjacent Caddyfile unless I did `caddy reload --config Caddyfile`, which shouldn't be necessary.

## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

No AI was used. Just my dumb self