### PR TITLE
forward_auth: `copy_headers` does not strip client-supplied identity headers (Fixes GHSA-7r4p-vjf4-gxv4)

### DIFF
--- a/caddytest/integration/caddyfile_adapt/forward_auth_authelia.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/forward_auth_authelia.caddyfiletest
@@ -51,6 +51,18 @@ app.example.com {
 																		{
 																			"handler": "headers",
 																			"request": {
+																				"delete": [
+																					"Remote-Email"
+																				]
+																			}
+																		}
+																	]
+																},
+																{
+																	"handle": [
+																		{
+																			"handler": "headers",
+																			"request": {
 																				"set": {
 																					"Remote-Email": [
 																						"{http.reverse_proxy.header.Remote-Email}"
@@ -70,6 +82,18 @@ app.example.com {
 																					}
 																				}
 																			]
+																		}
+																	]
+																},
+																{
+																	"handle": [
+																		{
+																			"handler": "headers",
+																			"request": {
+																				"delete": [
+																					"Remote-Groups"
+																				]
+																			}
 																		}
 																	]
 																},
@@ -105,6 +129,18 @@ app.example.com {
 																		{
 																			"handler": "headers",
 																			"request": {
+																				"delete": [
+																					"Remote-Name"
+																				]
+																			}
+																		}
+																	]
+																},
+																{
+																	"handle": [
+																		{
+																			"handler": "headers",
+																			"request": {
 																				"set": {
 																					"Remote-Name": [
 																						"{http.reverse_proxy.header.Remote-Name}"
@@ -124,6 +160,18 @@ app.example.com {
 																					}
 																				}
 																			]
+																		}
+																	]
+																},
+																{
+																	"handle": [
+																		{
+																			"handler": "headers",
+																			"request": {
+																				"delete": [
+																					"Remote-User"
+																				]
+																			}
 																		}
 																	]
 																},

--- a/caddytest/integration/caddyfile_adapt/forward_auth_copy_headers_strip.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/forward_auth_copy_headers_strip.caddyfiletest
@@ -1,0 +1,146 @@
+:8080
+
+forward_auth 127.0.0.1:9091 {
+	uri /
+	copy_headers X-User-Id X-User-Role
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8080"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handle_response": [
+										{
+											"match": {
+												"status_code": [
+													2
+												]
+											},
+											"routes": [
+												{
+													"handle": [
+														{
+															"handler": "vars"
+														}
+													]
+												},
+												{
+													"handle": [
+														{
+															"handler": "headers",
+															"request": {
+																"delete": [
+																	"X-User-Id"
+																]
+															}
+														}
+													]
+												},
+												{
+													"handle": [
+														{
+															"handler": "headers",
+															"request": {
+																"set": {
+																	"X-User-Id": [
+																		"{http.reverse_proxy.header.X-User-Id}"
+																	]
+																}
+															}
+														}
+													],
+													"match": [
+														{
+															"not": [
+																{
+																	"vars": {
+																		"{http.reverse_proxy.header.X-User-Id}": [
+																			""
+																		]
+																	}
+																}
+															]
+														}
+													]
+												},
+												{
+													"handle": [
+														{
+															"handler": "headers",
+															"request": {
+																"delete": [
+																	"X-User-Role"
+																]
+															}
+														}
+													]
+												},
+												{
+													"handle": [
+														{
+															"handler": "headers",
+															"request": {
+																"set": {
+																	"X-User-Role": [
+																		"{http.reverse_proxy.header.X-User-Role}"
+																	]
+																}
+															}
+														}
+													],
+													"match": [
+														{
+															"not": [
+																{
+																	"vars": {
+																		"{http.reverse_proxy.header.X-User-Role}": [
+																			""
+																		]
+																	}
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									],
+									"handler": "reverse_proxy",
+									"headers": {
+										"request": {
+											"set": {
+												"X-Forwarded-Method": [
+													"{http.request.method}"
+												],
+												"X-Forwarded-Uri": [
+													"{http.request.uri}"
+												]
+											}
+										}
+									},
+									"rewrite": {
+										"method": "GET",
+										"uri": "/"
+									},
+									"upstreams": [
+										{
+											"dial": "127.0.0.1:9091"
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/caddytest/integration/caddyfile_adapt/forward_auth_rename_headers.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/forward_auth_rename_headers.caddyfiletest
@@ -40,6 +40,18 @@ forward_auth localhost:9000 {
 														{
 															"handler": "headers",
 															"request": {
+																"delete": [
+																	"1"
+																]
+															}
+														}
+													]
+												},
+												{
+													"handle": [
+														{
+															"handler": "headers",
+															"request": {
 																"set": {
 																	"1": [
 																		"{http.reverse_proxy.header.A}"
@@ -59,6 +71,18 @@ forward_auth localhost:9000 {
 																	}
 																}
 															]
+														}
+													]
+												},
+												{
+													"handle": [
+														{
+															"handler": "headers",
+															"request": {
+																"delete": [
+																	"B"
+																]
+															}
 														}
 													]
 												},
@@ -94,6 +118,18 @@ forward_auth localhost:9000 {
 														{
 															"handler": "headers",
 															"request": {
+																"delete": [
+																	"3"
+																]
+															}
+														}
+													]
+												},
+												{
+													"handle": [
+														{
+															"handler": "headers",
+															"request": {
 																"set": {
 																	"3": [
 																		"{http.reverse_proxy.header.C}"
@@ -121,6 +157,18 @@ forward_auth localhost:9000 {
 														{
 															"handler": "headers",
 															"request": {
+																"delete": [
+																	"D"
+																]
+															}
+														}
+													]
+												},
+												{
+													"handle": [
+														{
+															"handler": "headers",
+															"request": {
 																"set": {
 																	"D": [
 																		"{http.reverse_proxy.header.D}"
@@ -140,6 +188,18 @@ forward_auth localhost:9000 {
 																	}
 																}
 															]
+														}
+													]
+												},
+												{
+													"handle": [
+														{
+															"handler": "headers",
+															"request": {
+																"delete": [
+																	"5"
+																]
+															}
 														}
 													]
 												},

--- a/caddytest/integration/forwardauth_test.go
+++ b/caddytest/integration/forwardauth_test.go
@@ -1,0 +1,206 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/caddytest"
+)
+
+// TestForwardAuthCopyHeadersStripsClientHeaders is a regression test for the
+// header injection vulnerability in forward_auth copy_headers.
+//
+// When the auth service returns 200 OK without one of the copy_headers headers,
+// the MatchNot guard skips the Set operation. Before this fix, the original
+// client-supplied header survived unchanged into the backend request, allowing
+// privilege escalation with only a valid (non-privileged) bearer token. After
+// the fix, an unconditional delete route runs first, so the backend always
+// sees an absent header rather than the attacker-supplied value.
+func TestForwardAuthCopyHeadersStripsClientHeaders(t *testing.T) {
+	// Mock auth service: accepts any Bearer token, returns 200 OK with NO
+	// identity headers. This is the stateless JWT validator pattern that
+	// triggers the vulnerability.
+	authSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer authSrv.Close()
+
+	// Mock backend: records the identity headers it receives. A real application
+	// would use X-User-Id / X-User-Role to make authorization decisions.
+	type received struct{ userID, userRole string }
+	var (
+		mu   sync.Mutex
+		last received
+	)
+	backendSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		last = received{
+			userID:   r.Header.Get("X-User-Id"),
+			userRole: r.Header.Get("X-User-Role"),
+		}
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "ok")
+	}))
+	defer backendSrv.Close()
+
+	authAddr := strings.TrimPrefix(authSrv.URL, "http://")
+	backendAddr := strings.TrimPrefix(backendSrv.URL, "http://")
+
+	tester := caddytest.NewTester(t)
+	tester.InitServer(fmt.Sprintf(`
+	{
+		skip_install_trust
+		admin localhost:2999
+		http_port 9080
+		https_port 9443
+		grace_period 1ns
+	}
+	http://localhost:9080 {
+		forward_auth %s {
+			uri /
+			copy_headers X-User-Id X-User-Role
+		}
+		reverse_proxy %s
+	}
+	`, authAddr, backendAddr), "caddyfile")
+
+	// Case 1: no token. Auth must still reject the request even when the client
+	// includes identity headers. This confirms the auth check is not bypassed.
+	req, _ := http.NewRequest(http.MethodGet, "http://localhost:9080/", nil)
+	req.Header.Set("X-User-Id", "injected")
+	req.Header.Set("X-User-Role", "injected")
+	resp := tester.AssertResponseCode(req, http.StatusUnauthorized)
+	resp.Body.Close()
+
+	// Case 2: valid token, no injected headers. The backend should see absent
+	// identity headers (the auth service never returns them).
+	req, _ = http.NewRequest(http.MethodGet, "http://localhost:9080/", nil)
+	req.Header.Set("Authorization", "Bearer token123")
+	tester.AssertResponse(req, http.StatusOK, "ok")
+	mu.Lock()
+	gotID, gotRole := last.userID, last.userRole
+	mu.Unlock()
+	if gotID != "" {
+		t.Errorf("baseline: X-User-Id should be absent, got %q", gotID)
+	}
+	if gotRole != "" {
+		t.Errorf("baseline: X-User-Role should be absent, got %q", gotRole)
+	}
+
+	// Case 3 (the security regression): valid token plus forged identity headers.
+	// The fix must strip those values so the backend never sees them.
+	req, _ = http.NewRequest(http.MethodGet, "http://localhost:9080/", nil)
+	req.Header.Set("Authorization", "Bearer token123")
+	req.Header.Set("X-User-Id", "admin")        // forged
+	req.Header.Set("X-User-Role", "superadmin") // forged
+	tester.AssertResponse(req, http.StatusOK, "ok")
+	mu.Lock()
+	gotID, gotRole = last.userID, last.userRole
+	mu.Unlock()
+	if gotID != "" {
+		t.Errorf("injection: X-User-Id must be stripped, got %q", gotID)
+	}
+	if gotRole != "" {
+		t.Errorf("injection: X-User-Role must be stripped, got %q", gotRole)
+	}
+}
+
+// TestForwardAuthCopyHeadersAuthResponseWins verifies that when the auth
+// service does include a copy_headers header in its response, that value
+// is forwarded to the backend and takes precedence over any client-supplied
+// value for the same header.
+func TestForwardAuthCopyHeadersAuthResponseWins(t *testing.T) {
+	const wantUserID = "service-user-42"
+	const wantUserRole = "editor"
+
+	// Auth service: accepts bearer token and sets identity headers.
+	authSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+			w.Header().Set("X-User-Id", wantUserID)
+			w.Header().Set("X-User-Role", wantUserRole)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer authSrv.Close()
+
+	type received struct{ userID, userRole string }
+	var (
+		mu   sync.Mutex
+		last received
+	)
+	backendSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		last = received{
+			userID:   r.Header.Get("X-User-Id"),
+			userRole: r.Header.Get("X-User-Role"),
+		}
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "ok")
+	}))
+	defer backendSrv.Close()
+
+	authAddr := strings.TrimPrefix(authSrv.URL, "http://")
+	backendAddr := strings.TrimPrefix(backendSrv.URL, "http://")
+
+	tester := caddytest.NewTester(t)
+	tester.InitServer(fmt.Sprintf(`
+	{
+		skip_install_trust
+		admin localhost:2999
+		http_port 9080
+		https_port 9443
+		grace_period 1ns
+	}
+	http://localhost:9080 {
+		forward_auth %s {
+			uri /
+			copy_headers X-User-Id X-User-Role
+		}
+		reverse_proxy %s
+	}
+	`, authAddr, backendAddr), "caddyfile")
+
+	// The client sends forged headers; the auth service overrides them with
+	// its own values. The backend must receive the auth service values.
+	req, _ := http.NewRequest(http.MethodGet, "http://localhost:9080/", nil)
+	req.Header.Set("Authorization", "Bearer token123")
+	req.Header.Set("X-User-Id", "forged-id")   // must be overwritten
+	req.Header.Set("X-User-Role", "forged-role") // must be overwritten
+	tester.AssertResponse(req, http.StatusOK, "ok")
+
+	mu.Lock()
+	gotID, gotRole := last.userID, last.userRole
+	mu.Unlock()
+	if gotID != wantUserID {
+		t.Errorf("X-User-Id: want %q, got %q", wantUserID, gotID)
+	}
+	if gotRole != wantUserRole {
+		t.Errorf("X-User-Role: want %q, got %q", wantUserRole, gotRole)
+	}
+}

--- a/modules/caddyhttp/reverseproxy/forwardauth/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/forwardauth/caddyfile.go
@@ -208,6 +208,24 @@ func parseCaddyfile(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error)
 	for _, from := range sortedHeadersToCopy {
 		to := http.CanonicalHeaderKey(headersToCopy[from])
 		placeholderName := "http.reverse_proxy.header." + http.CanonicalHeaderKey(from)
+
+		// Always delete the client-supplied header before conditionally setting
+		// it from the auth response. Without this, a client that pre-supplies a
+		// header listed in copy_headers can inject arbitrary values when the auth
+		// service does not return that header: the MatchNot guard below would
+		// skip the Set entirely, leaving the original client-controlled value
+		// intact and forwarding it to the backend.
+		copyHeaderRoutes = append(copyHeaderRoutes, caddyhttp.Route{
+			HandlersRaw: []json.RawMessage{caddyconfig.JSONModuleObject(
+				&headers.Handler{
+					Request: &headers.HeaderOps{
+						Delete: []string{to},
+					},
+				},
+				"handler", "headers", nil,
+			)},
+		})
+
 		handler := &headers.Handler{
 			Request: &headers.HeaderOps{
 				Set: http.Header{


### PR DESCRIPTION
## What is the problem?

The `forward_auth` directive with `copy_headers` does not remove client-supplied headers before forwarding the request to the backend.

An attacker with any valid authentication token can send a request that includes forged identity headers like `X-User-Id: admin` or `X-User-Role: superadmin`. If the auth service validates the token and returns 200 OK without including those headers in its response, Caddy skips the Set operation (the MatchNot guard added by PR #6608 fires) and never removes the original client-supplied values. The backend receives the attacker's values and may grant elevated access.

This is a regression introduced by PR #6608 (November 2024). All stable releases from v2.10.0 onward are affected.

Common patterns that trigger this:
- Stateless JWT validators that verify the signature but do not return
  claims as response headers (the backend decodes the JWT itself)
- Auth services that only return identity headers for some requests
- Auth middleware like Authelia configured with bypass rules

## What does this change?

For each entry in `copy_headers`, a new unconditional delete route is added immediately before the existing conditional set route. The delete runs always. The set still only runs when the auth service includes that header in its response.

Result:
- Client-supplied headers are always removed
- When the auth service returns the header, the backend gets that value
- When the auth service does not return the header, the backend gets nothing

Existing behavior is unchanged for deployments where the auth service returns all configured `copy_headers` entries.

## Changes

- `modules/caddyhttp/reverseproxy/forwardauth/caddyfile.go`: core fix
- Updated `forward_auth_authelia.caddyfiletest` and `forward_auth_rename_headers.caddyfiletest` to reflect new delete routes
  in expected JSON output
- Added `forward_auth_copy_headers_strip.caddyfiletest` for the security scenario
- Added `forwardauth_test.go` with two integration tests: one that confirms  injected headers are stripped when the auth service does not return them, and one that confirms the auth service value wins when it does return them

## Fact-Check Report

### 1. Core Fix — `caddyfile.go`

- **`to` is the correct variable:** `to = http.CanonicalHeaderKey(headersToCopy[from])` is the destination header name. For `A>1`, `to = "1"`. Clients inject the destination header (e.g., `1: admin`), so we must delete `to`.
- **Unconditional delete is correct:** The delete route has no `MatcherSetsRaw` → `omitempty` means no `"match"` key → route always executes.
- **Route order:** The loop appends `[delete, conditional-set]` per header. Delete fires first (removes any client-supplied value), then set fires only if the auth service returned that header. When auth does not return it: delete removed the forge, set is skipped → backend sees absent header.
- **Scoped to 2xx only:** All routes are inside `goodResponseHandler` which has `StatusCode: []int{2}`. The reverseproxy code (`reverseproxy.go:1047`) skips any handler whose `rh.Match` does not match the status code. So 4xx/5xx from auth bypasses the delete entirely — client sees the exact error response.

### 2. JSON Fixture Structure — Confirmed Mechanism

Resolved the `"handle"` before `"match"` ordering: routes embedded inside handlers go through `caddyconfig.JSONModuleObject`, which does `json.Marshal → unmarshal to map[string]any → add "handler" key → json.Marshal(map)`. Go's `json.Marshal` on maps sorts keys alphabetically. `"handle"` (h) < `"match"` (m), so inner routes have `"handle"` first. This is verified by the pre-existing upstream fixtures that pass Caddy's CI.

- `forward_auth_rename_headers` — 5 delete routes, destination names (`"1"`,`"B"`,`"3"`,`"D"`,`"5"`), 12-tab depth.
- `forward_auth_authelia` — 4 delete routes, destination names (Remote-Email/Groups/Name/User sorted), 16-tab depth (4 more due to subroute wrapper from `app.example.com` hostname matcher).
- `forward_auth_copy_headers_strip` (new) — deletes X-User-Id and X-User-Role, 12-tab depth, mirrors rename_headers structure exactly.
- All delete routes have no `"match"` key (`omitempty`).

### 3. Integration Test — `forwardauth_test.go`

- **Module registration:** `caddytest` imports `_ "github.com/caddyserver/caddy/v2/modules/standard"` which chains to `caddyhttp/standard/imports.go` which includes `_ ".../reverseproxy/forwardauth"`. The `forward_auth` directive is registered.
- **Ports:** `admin localhost:2999` and `http_port 9080` are the standard Caddy test ports used by all other integration tests.
- **No `t.Run` anti-pattern:** Sequential assertions using the outer `*testing.T`. `tc.t.Fatalf` correctly fails the outer test.
- **Race safety:** `sync.Mutex` protects `last`. `AssertResponse` waits for a complete HTTP round-trip; by the time it returns, the backend handler has already written to `last`.
- **Test logic:**
  - Case 1 (no token): auth returns 401 → `goodResponseHandler` skipped → client sees 401 as-is
  - Case 2 (valid token, no forged headers): delete fires, set skipped → backend sees absent headers
  - Case 3 (valid token + forged headers): delete removes forge, set skipped → backend sees absent headers (regression test)
  - `TestForwardAuthCopyHeadersAuthResponseWins`: auth returns headers → delete removes forge, set copies auth value → backend gets auth value

### 4. No New Security Bugs

Property | Verdict
-- | --
Only fires on 2xx auth responses | Scoped inside goodResponseHandler
Operates on request headers only | ApplyToRequest → r.Header.Del()
No wildcard deletion | Only specific named to values
Placeholder source | repl.Set in reverseproxy from res.Header (Auth response, not request)
HTTP header canonicalization | Go normalizes all incoming headers
Sequential route execution | Single-threaded route chain; no races

Fixes GHSA-7r4p-vjf4-gxv4