### PR TITLE
fileserver: document hide case-sensitivity (F-CADDY-FILESERVER-HIDE-CASE-001)

### DIFF
--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -125,6 +125,11 @@ type FileServer struct {
 	// When possible, all paths are resolved to their absolute form before
 	// comparisons are made. For maximum clarity and explictness, use complete,
 	// absolute paths; or, for greater portability, use relative paths instead.
+	//
+	// Note that hide comparisons are case-sensitive. On case-insensitive
+	// filesystems, requests with different path casing may still resolve to the
+	// same file or directory on disk, so hide should not be treated as a
+	// security boundary for sensitive paths.
 	Hide []string `json:"hide,omitempty"`
 
 	// The names of files to try as index files if a folder is requested.


### PR DESCRIPTION
this is a docs-only change clarifying that file_server hide comparisons are case-sensitive. on case-insensitive filesystems, a differently-cased request path may still resolve to the same on-disk path, so hide should not be treated as a security boundary for sensitive paths.