### PR TITLE
httpcaddyfile: wildcard `get_certificate` not applying to specific subdomains

### DIFF
--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -703,9 +703,11 @@ func consolidateAutomationPolicies(aps []*caddytls.AutomationPolicy) []*caddytls
 		emptyAP.SubjectsRaw = aps[i].SubjectsRaw
 		if reflect.DeepEqual(aps[i], emptyAP) {
 			emptyAPCount++
-			if !automationPolicyHasAllPublicNames(aps[i]) {
-				// if this automation policy has internal names, we might as well remove it
-				// so auto-https can implicitly use the internal issuer
+			if !automationPolicyHasAllPublicNames(aps[i]) ||
+				automationPolicyCoveredByWildcard(aps[i], aps[i+1:]) {
+				// remove this empty policy if it has internal names (so auto-https
+				// can implicitly use the internal issuer), or if every subject is
+				// covered by a later wildcard policy with managers (#7559)
 				aps = slices.Delete(aps, i, i+1)
 				i--
 			}
@@ -834,6 +836,36 @@ func automationPolicyHasAllPublicNames(ap *caddytls.AutomationPolicy) bool {
 	return !slices.ContainsFunc(ap.SubjectsRaw, func(i string) bool {
 		return !subjectQualifiesForPublicCert(ap, i) || isTailscaleDomain(i)
 	})
+}
+
+// automationPolicyCoveredByWildcard returns true if every subject in ap is
+// covered by a wildcard subject in one of the later policies that has
+// managers (get_certificate).
+func automationPolicyCoveredByWildcard(ap *caddytls.AutomationPolicy, laterPolicies []*caddytls.AutomationPolicy) bool {
+	if len(ap.SubjectsRaw) == 0 {
+		return false
+	}
+	for _, subj := range ap.SubjectsRaw {
+		covered := false
+		for _, other := range laterPolicies {
+			if len(other.ManagersRaw) == 0 {
+				continue
+			}
+			for _, otherSubj := range other.SubjectsRaw {
+				if certmagic.MatchWildcard(subj, otherSubj) {
+					covered = true
+					break
+				}
+			}
+			if covered {
+				break
+			}
+		}
+		if !covered {
+			return false
+		}
+	}
+	return true
 }
 
 func isTailscaleDomain(name string) bool {

--- a/caddyconfig/httpcaddyfile/tlsapp_test.go
+++ b/caddyconfig/httpcaddyfile/tlsapp_test.go
@@ -1,6 +1,7 @@
 package httpcaddyfile
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
@@ -51,6 +52,44 @@ func TestAutomationPolicyIsSubset(t *testing.T) {
 		apB := &caddytls.AutomationPolicy{SubjectsRaw: test.b}
 		if actual := automationPolicyIsSubset(apA, apB); actual != test.expect {
 			t.Errorf("Test %d: Expected %t but got %t (A: %v  B: %v)", i, test.expect, actual, test.a, test.b)
+		}
+	}
+}
+
+func TestConsolidateAutomationPoliciesWildcardManager(t *testing.T) {
+	httpManager := json.RawMessage(`{"via":"http"}`)
+
+	for i, test := range []struct {
+		policies []*caddytls.AutomationPolicy
+		expect   int // expected number of policies after consolidation; -1 means nil
+	}{
+		{
+			// empty subdomain policy should be removed when covered by
+			// a wildcard policy with get_certificate (#7559)
+			policies: []*caddytls.AutomationPolicy{
+				{SubjectsRaw: []string{"foo.example.com"}},
+				{SubjectsRaw: []string{"*.example.com"}, ManagersRaw: []json.RawMessage{httpManager}},
+			},
+			expect: 1,
+		},
+		{
+			// empty policy with no wildcard coverage should be kept
+			policies: []*caddytls.AutomationPolicy{
+				{SubjectsRaw: []string{"example.com"}},
+				{SubjectsRaw: []string{"*.other.com"}, ManagersRaw: []json.RawMessage{httpManager}},
+			},
+			expect: 2,
+		},
+	} {
+		result := consolidateAutomationPolicies(test.policies)
+		var got int
+		if result == nil {
+			got = -1
+		} else {
+			got = len(result)
+		}
+		if got != test.expect {
+			t.Errorf("Test %d: Expected %d policies but got %d", i, test.expect, got)
 		}
 	}
 }

--- a/caddytest/integration/caddyfile_adapt/tls_automation_wildcard_get_certificate.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/tls_automation_wildcard_get_certificate.caddyfiletest
@@ -1,0 +1,93 @@
+*.example.com {
+	tls {
+		get_certificate http http://localhost:9000/certs
+	}
+	respond "Wildcard"
+}
+
+foo.example.com {
+	respond "Foo"
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"foo.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "Foo",
+													"handler": "static_response"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						},
+						{
+							"match": [
+								{
+									"host": [
+										"*.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "Wildcard",
+													"handler": "static_response"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		},
+		"tls": {
+			"automation": {
+				"policies": [
+					{
+						"subjects": [
+							"*.example.com"
+						],
+						"get_certificate": [
+							{
+								"url": "http://localhost:9000/certs",
+								"via": "http"
+							}
+						]
+					}
+				]
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #7559 

## Assistance Disclosure 
Claude Opus 4.6 generated all code with my guiding. 
I verified the results using the same runtime method as in [repro](https://github.com/filiabel/caddy-repro-7559) with a build of the PR.

---

_Analysis and fix by Claude Opus 4.6_
> When a Caddyfile defines a wildcard site with get_certificate (e.g. *.example.com) alongside a specific subdomain site without explicit TLS config (e.g. foo.example.com), the subdomain fails TLS handshakes with "no certificate available."
> 
> Root cause: During config adaptation, consolidateAutomationPolicies creates an empty automation policy for foo.example.com (no issuers, no managers) and a separate policy for *.example.com with the get_certificate manager. Since policies are matched most-specific-first, foo.example.com hits the empty policy and never reaches the wildcard's get_certificate handler.
> 
> The existing consolidation logic only removed empty policies for internal/non-public names. This fix also removes empty policies whose subjects are entirely covered by a later wildcard policy that has get_certificate managers, allowing the subdomain to fall through to the wildcard policy.
> 