### PR TITLE
reverseproxy: add `lb_retry_match` condition on response status

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_retry_match_oneline.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_retry_match_oneline.caddyfiletest
@@ -3,8 +3,10 @@
 reverse_proxy 127.0.0.1:65535 {
 	lb_retries 3
 	lb_retry_match expression `{rp.status_code} in [502, 503]`
-	lb_retry_match expression `isTransportError() || {rp.status_code} == 502`
+	lb_retry_match expression `{rp.is_transport_error} || {rp.status_code} == 502`
 	lb_retry_match expression `method('POST') && {rp.status_code} == 503`
+	lb_retry_match `{rp.status_code} == 504`
+	lb_retry_match `{rp.is_transport_error} && method('PUT')`
 }
 ----------
 {
@@ -27,10 +29,16 @@ reverse_proxy 127.0.0.1:65535 {
 												"expression": "{http.reverse_proxy.status_code} in [502, 503]"
 											},
 											{
-												"expression": "isTransportError() || {http.reverse_proxy.status_code} == 502"
+												"expression": "{http.reverse_proxy.is_transport_error} || {http.reverse_proxy.status_code} == 502"
 											},
 											{
 												"expression": "method('POST') \u0026\u0026 {http.reverse_proxy.status_code} == 503"
+											},
+											{
+												"expression": "{http.reverse_proxy.status_code} == 504"
+											},
+											{
+												"expression": "{http.reverse_proxy.is_transport_error} \u0026\u0026 method('PUT')"
 											}
 										]
 									},

--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_retry_match_oneline.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_retry_match_oneline.caddyfiletest
@@ -1,0 +1,50 @@
+:8884
+
+reverse_proxy 127.0.0.1:65535 {
+	lb_retries 3
+	lb_retry_match expression `{rp.status_code} in [502, 503]`
+	lb_retry_match expression `isTransportError() || {rp.status_code} == 502`
+	lb_retry_match expression `method('POST') && {rp.status_code} == 503`
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8884"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "reverse_proxy",
+									"load_balancing": {
+										"retries": 3,
+										"retry_match": [
+											{
+												"expression": "{http.reverse_proxy.status_code} in [502, 503]"
+											},
+											{
+												"expression": "isTransportError() || {http.reverse_proxy.status_code} == 502"
+											},
+											{
+												"expression": "method('POST') \u0026\u0026 {http.reverse_proxy.status_code} == 503"
+											}
+										]
+									},
+									"upstreams": [
+										{
+											"dial": "127.0.0.1:65535"
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_retry_match_response.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_retry_match_response.caddyfiletest
@@ -1,0 +1,147 @@
+:8884
+
+reverse_proxy 127.0.0.1:65535 {
+	lb_retries 5
+
+	# request matchers (backward-compatible, non-expression)
+	lb_retry_match {
+		method POST PUT
+	}
+	lb_retry_match {
+		path /foo*
+	}
+	lb_retry_match {
+		header X-Idempotency-Key *
+	}
+
+	# response status code via expression
+	lb_retry_match {
+		expression `{rp.status_code} in [502, 503, 504]`
+	}
+
+	# response header via expression
+	lb_retry_match {
+		expression `{rp.header.X-Retry} == "true"`
+	}
+
+	# CEL request functions combined with response placeholders
+	lb_retry_match {
+		expression `method('POST') && {rp.status_code} >= 500`
+	}
+	lb_retry_match {
+		expression `path('/api*') && {rp.status_code} in [502, 503]`
+	}
+	lb_retry_match {
+		expression `host('example.com') && {rp.status_code} == 503`
+	}
+	lb_retry_match {
+		expression `query({'retry': 'true'}) && {rp.status_code} >= 500`
+	}
+	lb_retry_match {
+		expression `header({'X-Idempotency-Key': '*'}) && {rp.status_code} in [502, 503]`
+	}
+	lb_retry_match {
+		expression `protocol('https') && {rp.status_code} == 502`
+	}
+	lb_retry_match {
+		expression `path_regexp('^/api/v[0-9]+/') && {rp.status_code} >= 500`
+	}
+	lb_retry_match {
+		expression `header_regexp('Content-Type', '^application/json') && {rp.status_code} == 502`
+	}
+
+	# isTransportError() for transport error handling
+	lb_retry_match {
+		expression `isTransportError() || {rp.status_code} in [502, 503]`
+	}
+	lb_retry_match {
+		expression `isTransportError() && method('POST')`
+	}
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8884"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "reverse_proxy",
+									"load_balancing": {
+										"retries": 5,
+										"retry_match": [
+											{
+												"method": [
+													"POST",
+													"PUT"
+												]
+											},
+											{
+												"path": [
+													"/foo*"
+												]
+											},
+											{
+												"header": {
+													"X-Idempotency-Key": [
+														"*"
+													]
+												}
+											},
+											{
+												"expression": "{http.reverse_proxy.status_code} in [502, 503, 504]"
+											},
+											{
+												"expression": "{http.reverse_proxy.header.X-Retry} == \"true\""
+											},
+											{
+												"expression": "method('POST') \u0026\u0026 {http.reverse_proxy.status_code} \u003e= 500"
+											},
+											{
+												"expression": "path('/api*') \u0026\u0026 {http.reverse_proxy.status_code} in [502, 503]"
+											},
+											{
+												"expression": "host('example.com') \u0026\u0026 {http.reverse_proxy.status_code} == 503"
+											},
+											{
+												"expression": "query({'retry': 'true'}) \u0026\u0026 {http.reverse_proxy.status_code} \u003e= 500"
+											},
+											{
+												"expression": "header({'X-Idempotency-Key': '*'}) \u0026\u0026 {http.reverse_proxy.status_code} in [502, 503]"
+											},
+											{
+												"expression": "protocol('https') \u0026\u0026 {http.reverse_proxy.status_code} == 502"
+											},
+											{
+												"expression": "path_regexp('^/api/v[0-9]+/') \u0026\u0026 {http.reverse_proxy.status_code} \u003e= 500"
+											},
+											{
+												"expression": "header_regexp('Content-Type', '^application/json') \u0026\u0026 {http.reverse_proxy.status_code} == 502"
+											},
+											{
+												"expression": "isTransportError() || {http.reverse_proxy.status_code} in [502, 503]"
+											},
+											{
+												"expression": "isTransportError() \u0026\u0026 method('POST')"
+											}
+										]
+									},
+									"upstreams": [
+										{
+											"dial": "127.0.0.1:65535"
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_retry_match_response.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_retry_match_response.caddyfiletest
@@ -50,12 +50,12 @@ reverse_proxy 127.0.0.1:65535 {
 		expression `header_regexp('Content-Type', '^application/json') && {rp.status_code} == 502`
 	}
 
-	# isTransportError() for transport error handling
+	# transport error handling via placeholder
 	lb_retry_match {
-		expression `isTransportError() || {rp.status_code} in [502, 503]`
+		expression `{rp.is_transport_error} || {rp.status_code} in [502, 503]`
 	}
 	lb_retry_match {
-		expression `isTransportError() && method('POST')`
+		expression `{rp.is_transport_error} && method('POST')`
 	}
 }
 ----------
@@ -124,10 +124,10 @@ reverse_proxy 127.0.0.1:65535 {
 												"expression": "header_regexp('Content-Type', '^application/json') \u0026\u0026 {http.reverse_proxy.status_code} == 502"
 											},
 											{
-												"expression": "isTransportError() || {http.reverse_proxy.status_code} in [502, 503]"
+												"expression": "{http.reverse_proxy.is_transport_error} || {http.reverse_proxy.status_code} in [502, 503]"
 											},
 											{
-												"expression": "isTransportError() \u0026\u0026 method('POST')"
+												"expression": "{http.reverse_proxy.is_transport_error} \u0026\u0026 method('POST')"
 											}
 										]
 									},

--- a/caddytest/integration/reverseproxy_test.go
+++ b/caddytest/integration/reverseproxy_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/caddyserver/caddy/v2/caddytest"
@@ -561,4 +562,234 @@ func TestReverseProxyHealthCheckUnixSocketWithoutPort(t *testing.T) {
 	`, socketName), "caddyfile")
 
 	tester.AssertGetResponse("http://localhost:9080/", 200, "Hello, World!")
+}
+
+// TestReverseProxyRetryMatchStatusCode verifies that lb_retry_match with a
+// CEL expression matching on {rp.status_code} causes the request to be
+// retried on the next upstream when the first upstream returns a matching
+// status code
+func TestReverseProxyRetryMatchStatusCode(t *testing.T) {
+	// Bad upstream: returns 502
+	badSrv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+		}),
+	}
+	badLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	go badSrv.Serve(badLn)
+	t.Cleanup(func() { badSrv.Close(); badLn.Close() })
+
+	// Good upstream: returns 200
+	goodSrv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("ok"))
+		}),
+	}
+	goodLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	go goodSrv.Serve(goodLn)
+	t.Cleanup(func() { goodSrv.Close(); goodLn.Close() })
+
+	tester := caddytest.NewTester(t)
+	tester.InitServer(fmt.Sprintf(`
+	{
+		skip_install_trust
+		admin localhost:2999
+		http_port 9080
+		https_port 9443
+		grace_period 1ns
+	}
+	http://localhost:9080 {
+		reverse_proxy %s %s {
+			lb_policy round_robin
+			lb_retries 1
+			lb_retry_match {
+				expression `+"`{rp.status_code} in [502, 503]`"+`
+			}
+		}
+	}
+	`, goodLn.Addr().String(), badLn.Addr().String()), "caddyfile")
+
+	tester.AssertGetResponse("http://localhost:9080/", 200, "ok")
+}
+
+// TestReverseProxyRetryMatchHeader verifies that lb_retry_match with a CEL
+// expression matching on {rp.header.*} causes the request to be retried when
+// the upstream sets a matching response header
+func TestReverseProxyRetryMatchHeader(t *testing.T) {
+	var badHits atomic.Int32
+
+	// Bad upstream: returns 200 but signals retry via header
+	badSrv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			badHits.Add(1)
+			w.Header().Set("X-Upstream-Retry", "true")
+			w.Write([]byte("bad"))
+		}),
+	}
+	badLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	go badSrv.Serve(badLn)
+	t.Cleanup(func() { badSrv.Close(); badLn.Close() })
+
+	// Good upstream: returns 200 without retry header
+	goodSrv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("good"))
+		}),
+	}
+	goodLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	go goodSrv.Serve(goodLn)
+	t.Cleanup(func() { goodSrv.Close(); goodLn.Close() })
+
+	tester := caddytest.NewTester(t)
+	tester.InitServer(fmt.Sprintf(`
+	{
+		skip_install_trust
+		admin localhost:2999
+		http_port 9080
+		https_port 9443
+		grace_period 1ns
+	}
+	http://localhost:9080 {
+		reverse_proxy %s %s {
+			lb_policy round_robin
+			lb_retries 1
+			lb_retry_match {
+				expression `+"`{rp.header.X-Upstream-Retry} == \"true\"`"+`
+			}
+		}
+	}
+	`, goodLn.Addr().String(), badLn.Addr().String()), "caddyfile")
+
+	tester.AssertGetResponse("http://localhost:9080/", 200, "good")
+
+	if badHits.Load() != 1 {
+		t.Errorf("bad upstream hits: got %d, want 1", badHits.Load())
+	}
+}
+
+// TestReverseProxyRetryMatchCombined verifies that a CEL expression combining
+// request path matching with response status code matching works correctly -
+// only retrying when both conditions are met
+func TestReverseProxyRetryMatchCombined(t *testing.T) {
+	// Upstream: returns 502 for all requests
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+		}),
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	go srv.Serve(ln)
+	t.Cleanup(func() { srv.Close(); ln.Close() })
+
+	// Good upstream
+	goodSrv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("ok"))
+		}),
+	}
+	goodLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	go goodSrv.Serve(goodLn)
+	t.Cleanup(func() { goodSrv.Close(); goodLn.Close() })
+
+	tester := caddytest.NewTester(t)
+	tester.InitServer(fmt.Sprintf(`
+	{
+		skip_install_trust
+		admin localhost:2999
+		http_port 9080
+		https_port 9443
+		grace_period 1ns
+	}
+	http://localhost:9080 {
+		reverse_proxy %s %s {
+			lb_policy round_robin
+			lb_retries 1
+			lb_retry_match {
+				expression `+"`path('/retry*') && {rp.status_code} in [502, 503]`"+`
+			}
+		}
+	}
+	`, goodLn.Addr().String(), ln.Addr().String()), "caddyfile")
+
+	// /retry path matches the expression - should retry to good upstream
+	tester.AssertGetResponse("http://localhost:9080/retry", 200, "ok")
+
+	// /other path does NOT match - should return the 502
+	req, _ := http.NewRequest(http.MethodGet, "http://localhost:9080/other", nil)
+	tester.AssertResponse(req, 502, "")
+}
+
+// TestReverseProxyRetryMatchIsTransportError verifies that the
+// isTransportError() CEL function correctly identifies transport errors
+// and allows retrying them alongside response-based matching
+func TestReverseProxyRetryMatchIsTransportError(t *testing.T) {
+	// Good upstream: returns 200
+	goodSrv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("ok"))
+		}),
+	}
+	goodLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	go goodSrv.Serve(goodLn)
+	t.Cleanup(func() { goodSrv.Close(); goodLn.Close() })
+
+	// Broken upstream: accepts connections but closes immediately
+	brokenLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	t.Cleanup(func() { brokenLn.Close() })
+	go func() {
+		for {
+			conn, err := brokenLn.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+
+	tester := caddytest.NewTester(t)
+	tester.InitServer(fmt.Sprintf(`
+	{
+		skip_install_trust
+		admin localhost:2999
+		http_port 9080
+		https_port 9443
+		grace_period 1ns
+	}
+	http://localhost:9080 {
+		reverse_proxy %s %s {
+			lb_policy round_robin
+			lb_retries 1
+			lb_retry_match {
+				expression `+"`isTransportError() || {rp.status_code} in [502, 503]`"+`
+			}
+		}
+	}
+	`, goodLn.Addr().String(), brokenLn.Addr().String()), "caddyfile")
+
+	// Transport error on broken upstream should be retried to good upstream
+	tester.AssertGetResponse("http://localhost:9080/", 200, "ok")
 }

--- a/caddytest/integration/reverseproxy_test.go
+++ b/caddytest/integration/reverseproxy_test.go
@@ -738,7 +738,7 @@ func TestReverseProxyRetryMatchCombined(t *testing.T) {
 }
 
 // TestReverseProxyRetryMatchIsTransportError verifies that the
-// isTransportError() CEL function correctly identifies transport errors
+// {rp.is_transport_error} == true CEL function correctly identifies transport errors
 // and allows retrying them alongside response-based matching
 func TestReverseProxyRetryMatchIsTransportError(t *testing.T) {
 	// Good upstream: returns 200
@@ -784,7 +784,7 @@ func TestReverseProxyRetryMatchIsTransportError(t *testing.T) {
 			lb_policy round_robin
 			lb_retries 1
 			lb_retry_match {
-				expression `+"`isTransportError() || {rp.status_code} in [502, 503]`"+`
+				expression `+"`{rp.is_transport_error} || {rp.status_code} in [502, 503]`"+`
 			}
 		}
 	}

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -126,10 +126,6 @@ func (m *MatchExpression) Provision(ctx caddy.Context) error {
 	// light (and possibly naïve) syntactic sugar
 	m.expandedExpr = placeholderRegexp.ReplaceAllString(m.Expr, placeholderExpansion)
 
-	// rewrite isTransportError() to isTransportError(req) so the
-	// function receives the request context
-	m.expandedExpr = transportErrorRegexp.ReplaceAllString(m.expandedExpr, transportErrorExpansion)
-
 	// as a second pass, we'll strip the escape character from an escaped
 	// placeholder, so that it can be used as an input to other CEL functions
 	m.expandedExpr = escapedPlaceholderRegexp.ReplaceAllString(m.expandedExpr, escapedPlaceholderExpansion)
@@ -172,11 +168,6 @@ func (m *MatchExpression) Provision(ctx caddy.Context) error {
 			[]*cel.Type{httpRequestObjectType, cel.StringType},
 			cel.AnyType,
 		)),
-		cel.Function(CELTransportErrorFuncName, cel.SingletonUnaryBinding(isTransportErrorFunc), cel.Overload(
-			CELTransportErrorFuncName+"_httpRequest",
-			[]*cel.Type{httpRequestObjectType},
-			cel.BoolType,
-		)),
 		cel.Variable(CELRequestVarName, httpRequestObjectType),
 		cel.CustomTypeAdapter(m.ta),
 		ext.Strings(),
@@ -217,10 +208,6 @@ func (m MatchExpression) Match(r *http.Request) bool {
 	}
 	return match
 }
-
-// CanMatchResponse is a marker indicating that expression matchers
-// may reference response data via placeholders like {rp.status_code}
-func (m MatchExpression) CanMatchResponse() {}
 
 // MatchWithError returns true if r matches m.
 func (m MatchExpression) MatchWithError(r *http.Request) (bool, error) {
@@ -291,29 +278,6 @@ func (m MatchExpression) caddyPlaceholderFunc(lhs, rhs ref.Val) ref.Val {
 	val, _ := repl.Get(string(phStr))
 
 	return m.ta.NativeToValue(val)
-}
-
-// isTransportErrorFunc implements the isTransportError() CEL function
-// that returns true when the evaluation is happening during a transport
-// error retry decision (as opposed to a response-based retry decision)
-func isTransportErrorFunc(val ref.Val) ref.Val {
-	celReq, ok := val.(celHTTPRequest)
-	if !ok {
-		return types.NewErr(
-			"invalid request of type '%v' to %s(request)",
-			val.Type(),
-			CELTransportErrorFuncName,
-		)
-	}
-	repl, ok := celReq.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
-	if !ok || repl == nil {
-		return types.Bool(false)
-	}
-	v, _ := repl.Get("http.reverse_proxy.is_transport_error")
-	if b, ok := v.(bool); ok {
-		return types.Bool(b)
-	}
-	return types.Bool(false)
 }
 
 // httpRequestCELType is the type representation of a native HTTP request.
@@ -850,10 +814,6 @@ var (
 	placeholderRegexp    = regexp.MustCompile(`([^\\]|^){([a-zA-Z][\w.-]+)}`)
 	placeholderExpansion = `${1}ph(req, "${2}")`
 
-	// rewrite isTransportError() calls to pass the request object
-	transportErrorRegexp    = regexp.MustCompile(`isTransportError\(\)`)
-	transportErrorExpansion = `isTransportError(req)`
-
 	// As a second pass, we need to strip the escape character in front of
 	// the placeholder, if it exists.
 	escapedPlaceholderRegexp    = regexp.MustCompile(`\\{([a-zA-Z][\w.-]+)}`)
@@ -866,10 +826,6 @@ var httpRequestObjectType = cel.ObjectType("http.Request")
 
 // The name of the CEL function which accesses Replacer values.
 const CELPlaceholderFuncName = "ph"
-
-// The name of the CEL function that checks if the current evaluation
-// context is a transport error (connection succeeded but roundtrip failed)
-const CELTransportErrorFuncName = "isTransportError"
 
 // The name of the CEL request variable.
 const CELRequestVarName = "req"

--- a/modules/caddyhttp/celmatcher.go
+++ b/modules/caddyhttp/celmatcher.go
@@ -126,6 +126,10 @@ func (m *MatchExpression) Provision(ctx caddy.Context) error {
 	// light (and possibly naïve) syntactic sugar
 	m.expandedExpr = placeholderRegexp.ReplaceAllString(m.Expr, placeholderExpansion)
 
+	// rewrite isTransportError() to isTransportError(req) so the
+	// function receives the request context
+	m.expandedExpr = transportErrorRegexp.ReplaceAllString(m.expandedExpr, transportErrorExpansion)
+
 	// as a second pass, we'll strip the escape character from an escaped
 	// placeholder, so that it can be used as an input to other CEL functions
 	m.expandedExpr = escapedPlaceholderRegexp.ReplaceAllString(m.expandedExpr, escapedPlaceholderExpansion)
@@ -168,6 +172,11 @@ func (m *MatchExpression) Provision(ctx caddy.Context) error {
 			[]*cel.Type{httpRequestObjectType, cel.StringType},
 			cel.AnyType,
 		)),
+		cel.Function(CELTransportErrorFuncName, cel.SingletonUnaryBinding(isTransportErrorFunc), cel.Overload(
+			CELTransportErrorFuncName+"_httpRequest",
+			[]*cel.Type{httpRequestObjectType},
+			cel.BoolType,
+		)),
 		cel.Variable(CELRequestVarName, httpRequestObjectType),
 		cel.CustomTypeAdapter(m.ta),
 		ext.Strings(),
@@ -208,6 +217,10 @@ func (m MatchExpression) Match(r *http.Request) bool {
 	}
 	return match
 }
+
+// CanMatchResponse is a marker indicating that expression matchers
+// may reference response data via placeholders like {rp.status_code}
+func (m MatchExpression) CanMatchResponse() {}
 
 // MatchWithError returns true if r matches m.
 func (m MatchExpression) MatchWithError(r *http.Request) (bool, error) {
@@ -278,6 +291,29 @@ func (m MatchExpression) caddyPlaceholderFunc(lhs, rhs ref.Val) ref.Val {
 	val, _ := repl.Get(string(phStr))
 
 	return m.ta.NativeToValue(val)
+}
+
+// isTransportErrorFunc implements the isTransportError() CEL function
+// that returns true when the evaluation is happening during a transport
+// error retry decision (as opposed to a response-based retry decision)
+func isTransportErrorFunc(val ref.Val) ref.Val {
+	celReq, ok := val.(celHTTPRequest)
+	if !ok {
+		return types.NewErr(
+			"invalid request of type '%v' to %s(request)",
+			val.Type(),
+			CELTransportErrorFuncName,
+		)
+	}
+	repl, ok := celReq.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+	if !ok || repl == nil {
+		return types.Bool(false)
+	}
+	v, _ := repl.Get("http.reverse_proxy.is_transport_error")
+	if b, ok := v.(bool); ok {
+		return types.Bool(b)
+	}
+	return types.Bool(false)
 }
 
 // httpRequestCELType is the type representation of a native HTTP request.
@@ -814,6 +850,10 @@ var (
 	placeholderRegexp    = regexp.MustCompile(`([^\\]|^){([a-zA-Z][\w.-]+)}`)
 	placeholderExpansion = `${1}ph(req, "${2}")`
 
+	// rewrite isTransportError() calls to pass the request object
+	transportErrorRegexp    = regexp.MustCompile(`isTransportError\(\)`)
+	transportErrorExpansion = `isTransportError(req)`
+
 	// As a second pass, we need to strip the escape character in front of
 	// the placeholder, if it exists.
 	escapedPlaceholderRegexp    = regexp.MustCompile(`\\{([a-zA-Z][\w.-]+)}`)
@@ -826,6 +866,10 @@ var httpRequestObjectType = cel.ObjectType("http.Request")
 
 // The name of the CEL function which accesses Replacer values.
 const CELPlaceholderFuncName = "ph"
+
+// The name of the CEL function that checks if the current evaluation
+// context is a transport error (connection succeeded but roundtrip failed)
+const CELTransportErrorFuncName = "isTransportError"
 
 // The name of the CEL request variable.
 const CELRequestVarName = "req"

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -1562,6 +1562,14 @@ func ParseCaddyfileNestedMatcherSet(d *caddyfile.Dispenser) (caddy.ModuleMap, er
 	// instances of the matcher in this set
 	tokensByMatcherName := make(map[string][]caddyfile.Token)
 	for nesting := d.Nesting(); d.NextArg() || d.NextBlock(nesting); {
+		// if the token is quoted (backtick), treat it as a shorthand
+		// for an expression matcher, same as @named matcher parsing
+		if d.Token().Quoted() {
+			expressionToken := d.Token().Clone()
+			expressionToken.Text = "expression"
+			tokensByMatcherName["expression"] = append(tokensByMatcherName["expression"], expressionToken, d.Token())
+			continue
+		}
 		matcherName := d.Val()
 		tokensByMatcherName[matcherName] = append(tokensByMatcherName[matcherName], d.NextSegment()...)
 	}

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -327,13 +327,6 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			if err != nil {
 				return d.Errf("failed to parse lb_retry_match: %v", err)
 			}
-			// expression matchers and non-expression matchers cannot be
-			// mixed in the same block - expression matchers evaluate
-			// against responses while non-expression matchers evaluate
-			// against transport errors
-			if _, hasExpr := matcherSet["expression"]; hasExpr && len(matcherSet) > 1 {
-				return d.Errf("lb_retry_match: expression cannot be mixed with other matchers in the same block; use either an expression or request matchers, not both")
-			}
 			if h.LoadBalancing == nil {
 				h.LoadBalancing = new(LoadBalancing)
 			}

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -67,7 +67,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 //	    lb_retries <retries>
 //	    lb_try_duration <duration>
 //	    lb_try_interval <interval>
-//	    lb_retry_match <request-matcher>
+//	    lb_retry_match <matcher>
 //
 //	    # active health checking
 //	    health_uri          <uri>
@@ -326,6 +326,13 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			matcherSet, err := caddyhttp.ParseCaddyfileNestedMatcherSet(d)
 			if err != nil {
 				return d.Errf("failed to parse lb_retry_match: %v", err)
+			}
+			// expression matchers and non-expression matchers cannot be
+			// mixed in the same block - expression matchers evaluate
+			// against responses while non-expression matchers evaluate
+			// against transport errors
+			if _, hasExpr := matcherSet["expression"]; hasExpr && len(matcherSet) > 1 {
+				return d.Errf("lb_retry_match: expression cannot be mixed with other matchers in the same block; use either an expression or request matchers, not both")
 			}
 			if h.LoadBalancing == nil {
 				h.LoadBalancing = new(LoadBalancing)

--- a/modules/caddyhttp/reverseproxy/retries_test.go
+++ b/modules/caddyhttp/reverseproxy/retries_test.go
@@ -2,17 +2,20 @@ package reverseproxy
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"go.uber.org/zap"
 
 	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 )
 
@@ -251,6 +254,572 @@ func TestDialErrorBodyRetry(t *testing.T) {
 			}
 			if tc.wantBody != "" && rec.Body.String() != tc.wantBody {
 				t.Errorf("body: got %q, want %q", rec.Body.String(), tc.wantBody)
+			}
+		})
+	}
+}
+
+// placeholderMatcher is a test-only RequestMatcherWithError that checks
+// a Caddy replacer placeholder against a set of allowed values. This
+// lets us test the response-retry mechanism without needing to provision
+// a full CEL expression matcher (which requires a Caddy context)
+type placeholderMatcher struct {
+	placeholder string
+	values      []any
+}
+
+func (m placeholderMatcher) CanMatchResponse() {}
+
+func (m placeholderMatcher) MatchWithError(req *http.Request) (bool, error) {
+	repl, ok := req.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+	if !ok || repl == nil {
+		return false, nil
+	}
+	val, _ := repl.Get(m.placeholder)
+	for _, v := range m.values {
+		if fmt.Sprint(val) == fmt.Sprint(v) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// minimalHandlerWithRetryMatch is like minimalHandler but also configures
+// RetryMatch so that response-based retry can be tested
+func minimalHandlerWithRetryMatch(retries int, retryMatch caddyhttp.MatcherSets, upstreams ...*Upstream) *Handler {
+	h := minimalHandler(retries, upstreams...)
+	h.LoadBalancing.RetryMatch = retryMatch
+	return h
+}
+
+// TestResponseRetryStatusCode verifies that when an upstream returns a status
+// code matching a retry_match entry, the request is retried on the next
+// upstream. The retry match uses a placeholder matcher on
+// http.reverse_proxy.status_code which is how CEL expression matchers access
+// the response status at runtime
+func TestResponseRetryStatusCode(t *testing.T) {
+	var badHits atomic.Int32
+
+	// Bad upstream: returns 502
+	badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		badHits.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	t.Cleanup(badServer.Close)
+
+	// Good upstream: returns 200
+	goodServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	t.Cleanup(goodServer.Close)
+
+	tests := []struct {
+		name        string
+		matchCodes  []any
+		wantStatus  int
+		wantRetried bool // whether a retry should have happened
+	}{
+		{
+			name:        "502 matches retry_match - retries to good upstream",
+			matchCodes:  []any{502, 503},
+			wantStatus:  http.StatusOK,
+			wantRetried: true,
+		},
+		{
+			name:        "404 does not match retry_match - returns 404",
+			matchCodes:  []any{502, 503},
+			wantStatus:  http.StatusNotFound,
+			wantRetried: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			badHits.Store(0)
+
+			retryMatch := caddyhttp.MatcherSets{
+				caddyhttp.MatcherSet{
+					placeholderMatcher{
+						placeholder: "http.reverse_proxy.status_code",
+						values:      tc.matchCodes,
+					},
+				},
+			}
+
+			// Determine the bad upstream response code
+			var badUpstream *httptest.Server
+			if !tc.wantRetried {
+				// For the non-match case, use a server returning 404
+				badUpstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					badHits.Add(1)
+					w.WriteHeader(http.StatusNotFound)
+				}))
+				t.Cleanup(badUpstream.Close)
+			} else {
+				badUpstream = badServer
+			}
+
+			// RoundRobin picks index 1 first, then 0
+			upstreams := []*Upstream{
+				{Host: new(Host), Dial: goodServer.Listener.Addr().String()},
+				{Host: new(Host), Dial: badUpstream.Listener.Addr().String()},
+			}
+
+			h := minimalHandlerWithRetryMatch(1, retryMatch, upstreams...)
+
+			req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+			req = prepareTestRequest(req)
+			rec := httptest.NewRecorder()
+
+			err := h.ServeHTTP(rec, req, caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+				return nil
+			}))
+
+			gotStatus := rec.Code
+			if err != nil {
+				if herr, ok := err.(caddyhttp.HandlerError); ok {
+					gotStatus = herr.StatusCode
+				}
+			}
+
+			if gotStatus != tc.wantStatus {
+				t.Errorf("status: got %d, want %d (err=%v)", gotStatus, tc.wantStatus, err)
+			}
+
+			if tc.wantRetried && badHits.Load() != 1 {
+				t.Errorf("bad upstream hits: got %d, want 1", badHits.Load())
+			}
+		})
+	}
+}
+
+// TestResponseRetryHeader verifies that response header matching triggers
+// retries. The retry match checks http.reverse_proxy.header.X-Upstream-Retry
+// which is how CEL expressions like {rp.header.X-Upstream-Retry} access
+// response headers at runtime
+func TestResponseRetryHeader(t *testing.T) {
+	// Bad upstream: returns 200 but with X-Upstream-Retry header
+	badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Upstream-Retry", "true")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("bad"))
+	}))
+	t.Cleanup(badServer.Close)
+
+	// Good upstream: returns 200 without retry header
+	goodServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("good"))
+	}))
+	t.Cleanup(goodServer.Close)
+
+	retryMatch := caddyhttp.MatcherSets{
+		caddyhttp.MatcherSet{
+			placeholderMatcher{
+				placeholder: "http.reverse_proxy.header.X-Upstream-Retry",
+				values:      []any{"true"},
+			},
+		},
+	}
+
+	// RoundRobin picks index 1 first, then 0
+	upstreams := []*Upstream{
+		{Host: new(Host), Dial: goodServer.Listener.Addr().String()},
+		{Host: new(Host), Dial: badServer.Listener.Addr().String()},
+	}
+
+	h := minimalHandlerWithRetryMatch(1, retryMatch, upstreams...)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req = prepareTestRequest(req)
+	rec := httptest.NewRecorder()
+
+	err := h.ServeHTTP(rec, req, caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return nil
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", rec.Code, http.StatusOK)
+	}
+	if rec.Body.String() != "good" {
+		t.Errorf("body: got %q, want %q (retried to wrong upstream)", rec.Body.String(), "good")
+	}
+}
+
+// TestResponseRetryNoMatchNoRetry verifies that when no retry_match entries
+// match the response, the original response is returned without retrying
+func TestResponseRetryNoMatchNoRetry(t *testing.T) {
+	var hits atomic.Int32
+
+	// Server that returns 500 - but retry_match only matches 502/503
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	retryMatch := caddyhttp.MatcherSets{
+		caddyhttp.MatcherSet{
+			placeholderMatcher{
+				placeholder: "http.reverse_proxy.status_code",
+				values:      []any{502, 503},
+			},
+		},
+	}
+
+	upstreams := []*Upstream{
+		{Host: new(Host), Dial: server.Listener.Addr().String()},
+		{Host: new(Host), Dial: server.Listener.Addr().String()},
+	}
+
+	h := minimalHandlerWithRetryMatch(2, retryMatch, upstreams...)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req = prepareTestRequest(req)
+	rec := httptest.NewRecorder()
+
+	_ = h.ServeHTTP(rec, req, caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return nil
+	}))
+
+	// Only one hit - no retry since 500 doesn't match [502, 503]
+	if hits.Load() != 1 {
+		t.Errorf("upstream hits: got %d, want 1 (should not have retried)", hits.Load())
+	}
+}
+
+// TestResponseRetryExhaustedPreservesStatusCode verifies that when retries
+// are exhausted, the actual upstream status code (e.g. 503) is reported
+// to the client, not a generic 502
+func TestResponseRetryExhaustedPreservesStatusCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable) // 503
+	}))
+	t.Cleanup(server.Close)
+
+	retryMatch := caddyhttp.MatcherSets{
+		caddyhttp.MatcherSet{
+			placeholderMatcher{
+				placeholder: "http.reverse_proxy.status_code",
+				values:      []any{503},
+			},
+		},
+	}
+
+	upstreams := []*Upstream{
+		{Host: new(Host), Dial: server.Listener.Addr().String()},
+		{Host: new(Host), Dial: server.Listener.Addr().String()},
+	}
+
+	h := minimalHandlerWithRetryMatch(1, retryMatch, upstreams...)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req = prepareTestRequest(req)
+	rec := httptest.NewRecorder()
+
+	err := h.ServeHTTP(rec, req, caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return nil
+	}))
+
+	gotStatus := rec.Code
+	if err != nil {
+		if herr, ok := err.(caddyhttp.HandlerError); ok {
+			gotStatus = herr.StatusCode
+		}
+	}
+
+	// Must return 503 (actual upstream status), not 502 (generic proxy error)
+	if gotStatus != http.StatusServiceUnavailable {
+		t.Errorf("status: got %d, want %d (status code not preserved)", gotStatus, http.StatusServiceUnavailable)
+	}
+}
+
+// TestResponseRetryHeaderCleanup verifies that stale response header
+// placeholders from a previous upstream attempt are cleaned up before the
+// next retry evaluation. Without cleanup, a header like X-Retry: true from
+// upstream A would leak into the retry match for upstream B even if B does
+// not set that header
+func TestResponseRetryHeaderCleanup(t *testing.T) {
+	// First upstream: returns 200 with X-Retry header (triggers retry)
+	firstServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Retry", "true")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("first"))
+	}))
+	t.Cleanup(firstServer.Close)
+
+	// Second upstream: returns 200 WITHOUT X-Retry header (should NOT retry)
+	secondServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("second"))
+	}))
+	t.Cleanup(secondServer.Close)
+
+	retryMatch := caddyhttp.MatcherSets{
+		caddyhttp.MatcherSet{
+			placeholderMatcher{
+				placeholder: "http.reverse_proxy.header.X-Retry",
+				values:      []any{"true"},
+			},
+		},
+	}
+
+	// RoundRobin picks index 1 first, then 0
+	upstreams := []*Upstream{
+		{Host: new(Host), Dial: secondServer.Listener.Addr().String()},
+		{Host: new(Host), Dial: firstServer.Listener.Addr().String()},
+	}
+
+	h := minimalHandlerWithRetryMatch(2, retryMatch, upstreams...)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req = prepareTestRequest(req)
+	rec := httptest.NewRecorder()
+
+	err := h.ServeHTTP(rec, req, caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return nil
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should get "second" - the first upstream's X-Retry header must not
+	// leak into the second upstream's retry evaluation
+	if rec.Body.String() != "second" {
+		t.Errorf("body: got %q, want %q (stale header leaked between retries)", rec.Body.String(), "second")
+	}
+}
+
+// TestRequestOnlyMatcherDoesNotRetryResponses verifies that a pure request
+// matcher like method PUT in lb_retry_match does NOT trigger response-based
+// retries. Only expression matchers (which can reference response data)
+// should trigger response retries
+func TestRequestOnlyMatcherDoesNotRetryResponses(t *testing.T) {
+	var hits atomic.Int32
+
+	// Server returns 200 OK for all requests
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	t.Cleanup(server.Close)
+
+	// method PUT matcher - should NOT trigger response retries
+	retryMatch := caddyhttp.MatcherSets{
+		caddyhttp.MatcherSet{
+			caddyhttp.MatchMethod{"PUT"},
+		},
+	}
+
+	upstreams := []*Upstream{
+		{Host: new(Host), Dial: server.Listener.Addr().String()},
+		{Host: new(Host), Dial: server.Listener.Addr().String()},
+	}
+
+	h := minimalHandlerWithRetryMatch(2, retryMatch, upstreams...)
+
+	req := httptest.NewRequest(http.MethodPut, "http://example.com/", nil)
+	req = prepareTestRequest(req)
+	rec := httptest.NewRecorder()
+
+	err := h.ServeHTTP(rec, req, caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return nil
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should hit only once - no retry for 200 OK even though method matches
+	if hits.Load() != 1 {
+		t.Errorf("upstream hits: got %d, want 1 (should not retry successful responses)", hits.Load())
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+// brokenUpstreamAddr returns the address of a TCP listener that accepts
+// connections but immediately closes them, causing a transport error (not
+// a dial error). This simulates an upstream that is reachable but broken
+func brokenUpstreamAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+	return ln.Addr().String()
+}
+
+// TestTransportErrorPlaceholder verifies that the is_transport_error
+// placeholder is set to true during transport error evaluation in tryAgain()
+// and that expression matchers using isTransportError() can match it
+func TestTransportErrorPlaceholder(t *testing.T) {
+	broken := brokenUpstreamAddr(t)
+
+	goodServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	t.Cleanup(goodServer.Close)
+
+	// Matcher that checks the is_transport_error placeholder -
+	// simulates what isTransportError() does in CEL
+	retryMatch := caddyhttp.MatcherSets{
+		caddyhttp.MatcherSet{
+			placeholderMatcher{
+				placeholder: "http.reverse_proxy.is_transport_error",
+				values:      []any{true},
+			},
+		},
+	}
+
+	// RoundRobin picks index 1 first (broken), then 0 (good)
+	upstreams := []*Upstream{
+		{Host: new(Host), Dial: goodServer.Listener.Addr().String()},
+		{Host: new(Host), Dial: broken},
+	}
+
+	h := minimalHandlerWithRetryMatch(1, retryMatch, upstreams...)
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/", nil)
+	req = prepareTestRequest(req)
+	rec := httptest.NewRecorder()
+
+	err := h.ServeHTTP(rec, req, caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return nil
+	}))
+
+	gotStatus := rec.Code
+	if err != nil {
+		if herr, ok := err.(caddyhttp.HandlerError); ok {
+			gotStatus = herr.StatusCode
+		}
+	}
+
+	// POST transport error should be retried because is_transport_error matched
+	if gotStatus != http.StatusOK {
+		t.Errorf("status: got %d, want %d (transport error should have been retried)", gotStatus, http.StatusOK)
+	}
+}
+
+// TestTransportErrorPlaceholderNotSetForResponses verifies that the
+// is_transport_error placeholder is NOT set when evaluating response
+// matchers, so isTransportError() returns false for response retries
+func TestTransportErrorPlaceholderNotSetForResponses(t *testing.T) {
+	var hits atomic.Int32
+
+	// Server returns 502 - but the matcher only checks isTransportError
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	t.Cleanup(server.Close)
+
+	// Only matches transport errors, not response errors
+	retryMatch := caddyhttp.MatcherSets{
+		caddyhttp.MatcherSet{
+			placeholderMatcher{
+				placeholder: "http.reverse_proxy.is_transport_error",
+				values:      []any{true},
+			},
+		},
+	}
+
+	upstreams := []*Upstream{
+		{Host: new(Host), Dial: server.Listener.Addr().String()},
+		{Host: new(Host), Dial: server.Listener.Addr().String()},
+	}
+
+	h := minimalHandlerWithRetryMatch(2, retryMatch, upstreams...)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req = prepareTestRequest(req)
+	rec := httptest.NewRecorder()
+
+	_ = h.ServeHTTP(rec, req, caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return nil
+	}))
+
+	// Should hit only once - is_transport_error is false during response
+	// evaluation so the 502 is NOT retried
+	if hits.Load() != 1 {
+		t.Errorf("upstream hits: got %d, want 1 (isTransportError should be false for responses)", hits.Load())
+	}
+}
+
+// TestRetryMatchRejectsExpressionMixedWithOtherMatchers verifies that
+// lb_retry_match rejects a block that mixes expression with other matchers
+func TestRetryMatchRejectsExpressionMixedWithOtherMatchers(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name: "expression alone is allowed",
+			input: `reverse_proxy localhost:9080 {
+				lb_retry_match {
+					expression ` + "`{rp.status_code} in [502, 503]`" + `
+				}
+			}`,
+			wantErr: false,
+		},
+		{
+			name: "method alone is allowed",
+			input: `reverse_proxy localhost:9080 {
+				lb_retry_match {
+					method PUT
+				}
+			}`,
+			wantErr: false,
+		},
+		{
+			name: "expression mixed with method is rejected",
+			input: `reverse_proxy localhost:9080 {
+				lb_retry_match {
+					method POST
+					expression ` + "`{rp.status_code} in [502, 503]`" + `
+				}
+			}`,
+			wantErr: true,
+		},
+		{
+			name: "expression mixed with path is rejected",
+			input: `reverse_proxy localhost:9080 {
+				lb_retry_match {
+					path /api*
+					expression ` + "`{rp.status_code} == 502`" + `
+				}
+			}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &Handler{}
+			d := caddyfile.NewTestDispenser(tc.input)
+			err := h.UnmarshalCaddyfile(d)
+			if tc.wantErr && err == nil {
+				t.Error("expected error but got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
 			}
 		})
 	}

--- a/modules/caddyhttp/reverseproxy/retries_test.go
+++ b/modules/caddyhttp/reverseproxy/retries_test.go
@@ -1,8 +1,8 @@
 package reverseproxy
 
 import (
+	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -259,29 +259,16 @@ func TestDialErrorBodyRetry(t *testing.T) {
 	}
 }
 
-// placeholderMatcher is a test-only RequestMatcherWithError that checks
-// a Caddy replacer placeholder against a set of allowed values. This
-// lets us test the response-retry mechanism without needing to provision
-// a full CEL expression matcher (which requires a Caddy context)
-type placeholderMatcher struct {
-	placeholder string
-	values      []any
-}
-
-func (m placeholderMatcher) CanMatchResponse() {}
-
-func (m placeholderMatcher) MatchWithError(req *http.Request) (bool, error) {
-	repl, ok := req.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
-	if !ok || repl == nil {
-		return false, nil
+// newExpressionMatcher provisions a MatchExpression for use in tests
+func newExpressionMatcher(t *testing.T, expr string) *caddyhttp.MatchExpression {
+	t.Helper()
+	ctx, cancel := caddy.NewContext(caddy.Context{Context: context.Background()})
+	t.Cleanup(cancel)
+	m := &caddyhttp.MatchExpression{Expr: expr}
+	if err := m.Provision(ctx); err != nil {
+		t.Fatalf("failed to provision expression %q: %v", expr, err)
 	}
-	val, _ := repl.Get(m.placeholder)
-	for _, v := range m.values {
-		if fmt.Sprint(val) == fmt.Sprint(v) {
-			return true, nil
-		}
-	}
-	return false, nil
+	return m
 }
 
 // minimalHandlerWithRetryMatch is like minimalHandler but also configures
@@ -293,16 +280,11 @@ func minimalHandlerWithRetryMatch(retries int, retryMatch caddyhttp.MatcherSets,
 }
 
 // TestResponseRetryStatusCode verifies that when an upstream returns a status
-// code matching a retry_match entry, the request is retried on the next
-// upstream. The retry match uses a placeholder matcher on
-// http.reverse_proxy.status_code which is how CEL expression matchers access
-// the response status at runtime
+// code matching a retry_match expression, the request is retried on the next
+// upstream
 func TestResponseRetryStatusCode(t *testing.T) {
-	var badHits atomic.Int32
-
 	// Bad upstream: returns 502
 	badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		badHits.Add(1)
 		w.WriteHeader(http.StatusBadGateway)
 	}))
 	t.Cleanup(badServer.Close)
@@ -314,90 +296,42 @@ func TestResponseRetryStatusCode(t *testing.T) {
 	}))
 	t.Cleanup(goodServer.Close)
 
-	tests := []struct {
-		name        string
-		matchCodes  []any
-		wantStatus  int
-		wantRetried bool // whether a retry should have happened
-	}{
-		{
-			name:        "502 matches retry_match - retries to good upstream",
-			matchCodes:  []any{502, 503},
-			wantStatus:  http.StatusOK,
-			wantRetried: true,
-		},
-		{
-			name:        "404 does not match retry_match - returns 404",
-			matchCodes:  []any{502, 503},
-			wantStatus:  http.StatusNotFound,
-			wantRetried: false,
+	retryMatch := caddyhttp.MatcherSets{
+		caddyhttp.MatcherSet{
+			newExpressionMatcher(t, "{http.reverse_proxy.status_code} in [502, 503]"),
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			badHits.Store(0)
+	// RoundRobin picks index 1 first, then 0
+	upstreams := []*Upstream{
+		{Host: new(Host), Dial: goodServer.Listener.Addr().String()},
+		{Host: new(Host), Dial: badServer.Listener.Addr().String()},
+	}
 
-			retryMatch := caddyhttp.MatcherSets{
-				caddyhttp.MatcherSet{
-					placeholderMatcher{
-						placeholder: "http.reverse_proxy.status_code",
-						values:      tc.matchCodes,
-					},
-				},
-			}
+	h := minimalHandlerWithRetryMatch(1, retryMatch, upstreams...)
 
-			// Determine the bad upstream response code
-			var badUpstream *httptest.Server
-			if !tc.wantRetried {
-				// For the non-match case, use a server returning 404
-				badUpstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					badHits.Add(1)
-					w.WriteHeader(http.StatusNotFound)
-				}))
-				t.Cleanup(badUpstream.Close)
-			} else {
-				badUpstream = badServer
-			}
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req = prepareTestRequest(req)
+	rec := httptest.NewRecorder()
 
-			// RoundRobin picks index 1 first, then 0
-			upstreams := []*Upstream{
-				{Host: new(Host), Dial: goodServer.Listener.Addr().String()},
-				{Host: new(Host), Dial: badUpstream.Listener.Addr().String()},
-			}
+	err := h.ServeHTTP(rec, req, caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return nil
+	}))
 
-			h := minimalHandlerWithRetryMatch(1, retryMatch, upstreams...)
+	gotStatus := rec.Code
+	if err != nil {
+		if herr, ok := err.(caddyhttp.HandlerError); ok {
+			gotStatus = herr.StatusCode
+		}
+	}
 
-			req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
-			req = prepareTestRequest(req)
-			rec := httptest.NewRecorder()
-
-			err := h.ServeHTTP(rec, req, caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-				return nil
-			}))
-
-			gotStatus := rec.Code
-			if err != nil {
-				if herr, ok := err.(caddyhttp.HandlerError); ok {
-					gotStatus = herr.StatusCode
-				}
-			}
-
-			if gotStatus != tc.wantStatus {
-				t.Errorf("status: got %d, want %d (err=%v)", gotStatus, tc.wantStatus, err)
-			}
-
-			if tc.wantRetried && badHits.Load() != 1 {
-				t.Errorf("bad upstream hits: got %d, want 1", badHits.Load())
-			}
-		})
+	if gotStatus != http.StatusOK {
+		t.Errorf("status: got %d, want %d (err=%v)", gotStatus, http.StatusOK, err)
 	}
 }
 
 // TestResponseRetryHeader verifies that response header matching triggers
-// retries. The retry match checks http.reverse_proxy.header.X-Upstream-Retry
-// which is how CEL expressions like {rp.header.X-Upstream-Retry} access
-// response headers at runtime
+// retries via a CEL expression checking {rp.header.*}
 func TestResponseRetryHeader(t *testing.T) {
 	// Bad upstream: returns 200 but with X-Upstream-Retry header
 	badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -416,10 +350,7 @@ func TestResponseRetryHeader(t *testing.T) {
 
 	retryMatch := caddyhttp.MatcherSets{
 		caddyhttp.MatcherSet{
-			placeholderMatcher{
-				placeholder: "http.reverse_proxy.header.X-Upstream-Retry",
-				values:      []any{"true"},
-			},
+			newExpressionMatcher(t, `{http.reverse_proxy.header.X-Upstream-Retry} == "true"`),
 		},
 	}
 
@@ -464,10 +395,7 @@ func TestResponseRetryNoMatchNoRetry(t *testing.T) {
 
 	retryMatch := caddyhttp.MatcherSets{
 		caddyhttp.MatcherSet{
-			placeholderMatcher{
-				placeholder: "http.reverse_proxy.status_code",
-				values:      []any{502, 503},
-			},
+			newExpressionMatcher(t, "{http.reverse_proxy.status_code} in [502, 503]"),
 		},
 	}
 
@@ -503,10 +431,7 @@ func TestResponseRetryExhaustedPreservesStatusCode(t *testing.T) {
 
 	retryMatch := caddyhttp.MatcherSets{
 		caddyhttp.MatcherSet{
-			placeholderMatcher{
-				placeholder: "http.reverse_proxy.status_code",
-				values:      []any{503},
-			},
+			newExpressionMatcher(t, "{http.reverse_proxy.status_code} == 503"),
 		},
 	}
 
@@ -561,10 +486,7 @@ func TestResponseRetryHeaderCleanup(t *testing.T) {
 
 	retryMatch := caddyhttp.MatcherSets{
 		caddyhttp.MatcherSet{
-			placeholderMatcher{
-				placeholder: "http.reverse_proxy.header.X-Retry",
-				values:      []any{"true"},
-			},
+			newExpressionMatcher(t, `{http.reverse_proxy.header.X-Retry} == "true"`),
 		},
 	}
 
@@ -667,7 +589,7 @@ func brokenUpstreamAddr(t *testing.T) string {
 
 // TestTransportErrorPlaceholder verifies that the is_transport_error
 // placeholder is set to true during transport error evaluation in tryAgain()
-// and that expression matchers using isTransportError() can match it
+// and that expression matchers using {rp.is_transport_error} can match it
 func TestTransportErrorPlaceholder(t *testing.T) {
 	broken := brokenUpstreamAddr(t)
 
@@ -677,14 +599,9 @@ func TestTransportErrorPlaceholder(t *testing.T) {
 	}))
 	t.Cleanup(goodServer.Close)
 
-	// Matcher that checks the is_transport_error placeholder -
-	// simulates what isTransportError() does in CEL
 	retryMatch := caddyhttp.MatcherSets{
 		caddyhttp.MatcherSet{
-			placeholderMatcher{
-				placeholder: "http.reverse_proxy.is_transport_error",
-				values:      []any{true},
-			},
+			newExpressionMatcher(t, "{http.reverse_proxy.is_transport_error} == true"),
 		},
 	}
 
@@ -719,11 +636,11 @@ func TestTransportErrorPlaceholder(t *testing.T) {
 
 // TestTransportErrorPlaceholderNotSetForResponses verifies that the
 // is_transport_error placeholder is NOT set when evaluating response
-// matchers, so isTransportError() returns false for response retries
+// matchers, so {rp.is_transport_error} is false for response retries
 func TestTransportErrorPlaceholderNotSetForResponses(t *testing.T) {
 	var hits atomic.Int32
 
-	// Server returns 502 - but the matcher only checks isTransportError
+	// Server returns 502 - but the matcher only checks is_transport_error
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hits.Add(1)
 		w.WriteHeader(http.StatusBadGateway)
@@ -733,10 +650,7 @@ func TestTransportErrorPlaceholderNotSetForResponses(t *testing.T) {
 	// Only matches transport errors, not response errors
 	retryMatch := caddyhttp.MatcherSets{
 		caddyhttp.MatcherSet{
-			placeholderMatcher{
-				placeholder: "http.reverse_proxy.is_transport_error",
-				values:      []any{true},
-			},
+			newExpressionMatcher(t, "{http.reverse_proxy.is_transport_error} == true"),
 		},
 	}
 
@@ -758,55 +672,50 @@ func TestTransportErrorPlaceholderNotSetForResponses(t *testing.T) {
 	// Should hit only once - is_transport_error is false during response
 	// evaluation so the 502 is NOT retried
 	if hits.Load() != 1 {
-		t.Errorf("upstream hits: got %d, want 1 (isTransportError should be false for responses)", hits.Load())
+		t.Errorf("upstream hits: got %d, want 1 (is_transport_error should be false for responses)", hits.Load())
 	}
 }
 
-// TestRetryMatchRejectsExpressionMixedWithOtherMatchers verifies that
-// lb_retry_match rejects a block that mixes expression with other matchers
-func TestRetryMatchRejectsExpressionMixedWithOtherMatchers(t *testing.T) {
+// TestRetryMatchAllowsExpressionMixedWithOtherMatchers verifies that
+// lb_retry_match accepts a block mixing expression with other matchers
+func TestRetryMatchAllowsExpressionMixedWithOtherMatchers(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		wantErr bool
+		name  string
+		input string
 	}{
 		{
-			name: "expression alone is allowed",
+			name: "expression alone",
 			input: `reverse_proxy localhost:9080 {
 				lb_retry_match {
 					expression ` + "`{rp.status_code} in [502, 503]`" + `
 				}
 			}`,
-			wantErr: false,
 		},
 		{
-			name: "method alone is allowed",
+			name: "method alone",
 			input: `reverse_proxy localhost:9080 {
 				lb_retry_match {
 					method PUT
 				}
 			}`,
-			wantErr: false,
 		},
 		{
-			name: "expression mixed with method is rejected",
+			name: "expression mixed with method",
 			input: `reverse_proxy localhost:9080 {
 				lb_retry_match {
 					method POST
 					expression ` + "`{rp.status_code} in [502, 503]`" + `
 				}
 			}`,
-			wantErr: true,
 		},
 		{
-			name: "expression mixed with path is rejected",
+			name: "expression mixed with path",
 			input: `reverse_proxy localhost:9080 {
 				lb_retry_match {
 					path /api*
 					expression ` + "`{rp.status_code} == 502`" + `
 				}
 			}`,
-			wantErr: true,
 		},
 	}
 
@@ -815,10 +724,7 @@ func TestRetryMatchRejectsExpressionMixedWithOtherMatchers(t *testing.T) {
 			h := &Handler{}
 			d := caddyfile.NewTestDispenser(tc.input)
 			err := h.UnmarshalCaddyfile(d)
-			if tc.wantErr && err == nil {
-				t.Error("expected error but got nil")
-			}
-			if !tc.wantErr && err != nil {
+			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -664,8 +664,12 @@ func (h *Handler) proxyLoopIteration(r *http.Request, origReq *http.Request, w h
 		return true, succ.error
 	}
 
-	// remember this failure (if enabled)
-	h.countFailure(upstream)
+	// remember this failure (if enabled); response-based retries
+	// are not counted as failures since the upstream did respond
+	// successfully - only the response content triggered a retry
+	if _, isRetryableResponse := proxyErr.(retryableResponseError); !isRetryableResponse {
+		h.countFailure(upstream)
+	}
 
 	// if we've tried long enough, break
 	if !h.LoadBalancing.tryAgain(h.ctx, start, retries, proxyErr, r, h.logger) {
@@ -1049,6 +1053,54 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, origRe
 		res.Body, _ = h.bufferedBody(res.Body, h.ResponseBuffers)
 	}
 
+	// set response placeholders so they can be used in retry match
+	// expressions and handle_response routes; clear stale header
+	// placeholders from a previous attempt first so they don't
+	// leak into the next retry evaluation
+	if prev, ok := repl.Get("http.reverse_proxy.header_keys"); ok {
+		if keys, ok := prev.([]string); ok {
+			for _, k := range keys {
+				repl.Delete("http.reverse_proxy.header." + k)
+			}
+		}
+	}
+	headerKeys := make([]string, 0, len(res.Header))
+	for field, value := range res.Header {
+		repl.Set("http.reverse_proxy.header."+field, strings.Join(value, ","))
+		headerKeys = append(headerKeys, field)
+	}
+	repl.Set("http.reverse_proxy.header_keys", headerKeys)
+	repl.Set("http.reverse_proxy.status_code", res.StatusCode)
+	repl.Set("http.reverse_proxy.status_text", res.Status)
+
+	// check if the response matches a retry match entry; if so,
+	// close the body and return a retryable error so the request
+	// is retried with the next upstream. Only evaluate matcher sets
+	// that contain at least one expression matcher, since those are
+	// the ones that can reference response data ({rp.status_code},
+	// {rp.header.*}). Pure request-only matchers (method, path, etc.)
+	// are skipped to avoid retrying every response that matches a
+	// request condition
+	if h.LoadBalancing != nil && len(h.LoadBalancing.RetryMatch) > 0 {
+		for _, matcherSet := range h.LoadBalancing.RetryMatch {
+			if !matcherSetHasResponseMatcher(matcherSet) {
+				continue
+			}
+			match, err := matcherSet.MatchWithError(req)
+			if err != nil {
+				h.logger.Error("error matching request for retry", zap.Error(err))
+				break
+			}
+			if match {
+				res.Body.Close()
+				return retryableResponseError{
+					error:      fmt.Errorf("upstream response matched retry_match (status %d)", res.StatusCode),
+					statusCode: res.StatusCode,
+				}
+			}
+		}
+	}
+
 	// see if any response handler is configured for this response from the backend
 	for i, rh := range h.HandleResponse {
 		if rh.Match != nil && !rh.Match.Match(res.StatusCode, res.Header) {
@@ -1067,14 +1119,6 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, origRe
 			}
 			break
 		}
-
-		// set up the replacer so that parts of the original response can be
-		// used for routing decisions
-		for field, value := range res.Header {
-			repl.Set("http.reverse_proxy.header."+field, strings.Join(value, ","))
-		}
-		repl.Set("http.reverse_proxy.status_code", res.StatusCode)
-		repl.Set("http.reverse_proxy.status_text", res.Status)
 
 		if c := logger.Check(zapcore.DebugLevel, "handling response"); c != nil {
 			c.Write(zap.Int("handler", i))
@@ -1260,16 +1304,27 @@ func (lb LoadBalancing) tryAgain(ctx caddy.Context, start time.Time, retries int
 	// specifically a dialer error, we need to be careful
 	if proxyErr != nil {
 		_, isDialError := proxyErr.(DialError)
+		_, isRetryableResponse := proxyErr.(retryableResponseError)
 		herr, isHandlerError := proxyErr.(caddyhttp.HandlerError)
 
 		// if the error occurred after a connection was established,
 		// we have to assume the upstream received the request, and
 		// retries need to be carefully decided, because some requests
-		// are not idempotent
-		if !isDialError && (!isHandlerError || !errors.Is(herr, errNoUpstream)) {
+		// are not idempotent; retryableResponseError is excluded here
+		// because its retry decision was already made in reverseProxy()
+		// when the response matchers were evaluated
+		if !isDialError && !isRetryableResponse && (!isHandlerError || !errors.Is(herr, errNoUpstream)) {
 			if lb.RetryMatch == nil && req.Method != "GET" {
 				// by default, don't retry requests if they aren't GET
 				return false
+			}
+
+			// set transport error flag so CEL expressions can use
+			// isTransportError() to decide whether to retry
+			repl, _ := req.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+			if repl != nil {
+				repl.Set("http.reverse_proxy.is_transport_error", true)
+				defer repl.Set("http.reverse_proxy.is_transport_error", false)
 			}
 
 			match, err := lb.RetryMatch.AnyMatchWithError(req)
@@ -1501,6 +1556,12 @@ func removeConnectionHeaders(h http.Header) {
 
 // statusError returns an error value that has a status code.
 func statusError(err error) error {
+	// if a response-based retry was exhausted, use the actual upstream
+	// status code instead of a generic 502
+	if rre, ok := err.(retryableResponseError); ok {
+		return caddyhttp.Error(rre.statusCode, err)
+	}
+
 	// errors proxying usually mean there is a problem with the upstream(s)
 	statusCode := http.StatusBadGateway
 
@@ -1552,13 +1613,15 @@ type LoadBalancing struct {
 	// to spin if all backends are down and latency is very low.
 	TryInterval caddy.Duration `json:"try_interval,omitempty"`
 
-	// A list of matcher sets that restricts with which requests retries are
-	// allowed. A request must match any of the given matcher sets in order
-	// to be retried if the connection to the upstream succeeded but the
-	// subsequent round-trip failed. If the connection to the upstream failed,
-	// a retry is always allowed. If unspecified, only GET requests will be
-	// allowed to be retried. Note that a retry is done with the next available
-	// host according to the load balancing policy.
+	// A list of matcher sets that controls retry behavior. Matcher sets
+	// without expression matchers (e.g. method, path) restrict which
+	// requests are retried on transport errors - if unspecified, only
+	// GET requests will be retried. Matcher sets with CEL expression
+	// matchers are evaluated against upstream responses and can
+	// reference {rp.status_code}, {rp.header.*}, and
+	// isTransportError(). Dial errors are always retried regardless
+	// of this setting. Retries use the next available upstream per
+	// the load balancing policy
 	RetryMatchRaw caddyhttp.RawMatcherSets `json:"retry_match,omitempty" caddy:"namespace=http.matchers"`
 
 	SelectionPolicy Selector              `json:"-"`
@@ -1656,9 +1719,39 @@ type RequestHeaderOpsTransport interface {
 	RequestHeaderOps() *headers.HeaderOps
 }
 
+// canMatchResponse is implemented by matchers that may reference
+// response data via placeholders (e.g. CEL expression matchers
+// using {rp.status_code} or {rp.header.*})
+type canMatchResponse interface {
+	CanMatchResponse()
+}
+
+// matcherSetHasResponseMatcher reports whether a matcher set contains
+// at least one matcher that can reference response data. Matcher sets
+// without such matchers only test request properties and should not
+// be evaluated for response-based retry decisions
+func matcherSetHasResponseMatcher(matcherSet caddyhttp.MatcherSet) bool {
+	for _, m := range matcherSet {
+		if _, ok := m.(canMatchResponse); ok {
+			return true
+		}
+	}
+	return false
+}
+
 // roundtripSucceededError is an error type that is returned if the
 // roundtrip succeeded, but an error occurred after-the-fact.
 type roundtripSucceededError struct{ error }
+
+// retryableResponseError is returned when the upstream response matched
+// a retry_match entry, indicating the request should be retried with the
+// next upstream. It preserves the original status code so that if retries
+// are exhausted, the actual upstream status is reported instead of a
+// generic 502
+type retryableResponseError struct {
+	error
+	statusCode int
+}
 
 // bodyReadCloser is a reader that, upon closing, will return
 // its buffer to the pool and close the underlying body reader.

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -1057,19 +1057,10 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, origRe
 	// expressions and handle_response routes; clear stale header
 	// placeholders from a previous attempt first so they don't
 	// leak into the next retry evaluation
-	if prev, ok := repl.Get("http.reverse_proxy.header_keys"); ok {
-		if keys, ok := prev.([]string); ok {
-			for _, k := range keys {
-				repl.Delete("http.reverse_proxy.header." + k)
-			}
-		}
-	}
-	headerKeys := make([]string, 0, len(res.Header))
+	repl.DeleteByPrefix("http.reverse_proxy.header.")
 	for field, value := range res.Header {
 		repl.Set("http.reverse_proxy.header."+field, strings.Join(value, ","))
-		headerKeys = append(headerKeys, field)
 	}
-	repl.Set("http.reverse_proxy.header_keys", headerKeys)
 	repl.Set("http.reverse_proxy.status_code", res.StatusCode)
 	repl.Set("http.reverse_proxy.status_text", res.Status)
 
@@ -1083,7 +1074,7 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, origRe
 	// request condition
 	if h.LoadBalancing != nil && len(h.LoadBalancing.RetryMatch) > 0 {
 		for _, matcherSet := range h.LoadBalancing.RetryMatch {
-			if !matcherSetHasResponseMatcher(matcherSet) {
+			if !matcherSetHasExpressionMatcher(matcherSet) {
 				continue
 			}
 			match, err := matcherSet.MatchWithError(req)
@@ -1320,11 +1311,11 @@ func (lb LoadBalancing) tryAgain(ctx caddy.Context, start time.Time, retries int
 			}
 
 			// set transport error flag so CEL expressions can use
-			// isTransportError() to decide whether to retry
+			// {rp.is_transport_error} to decide whether to retry
 			repl, _ := req.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 			if repl != nil {
 				repl.Set("http.reverse_proxy.is_transport_error", true)
-				defer repl.Set("http.reverse_proxy.is_transport_error", false)
+				defer repl.Delete("http.reverse_proxy.is_transport_error")
 			}
 
 			match, err := lb.RetryMatch.AnyMatchWithError(req)
@@ -1619,9 +1610,9 @@ type LoadBalancing struct {
 	// GET requests will be retried. Matcher sets with CEL expression
 	// matchers are evaluated against upstream responses and can
 	// reference {rp.status_code}, {rp.header.*}, and
-	// isTransportError(). Dial errors are always retried regardless
-	// of this setting. Retries use the next available upstream per
-	// the load balancing policy
+	// {rp.is_transport_error}. Dial errors are always retried
+	// regardless of this setting. Retries use the next available
+	// upstream per the load balancing policy
 	RetryMatchRaw caddyhttp.RawMatcherSets `json:"retry_match,omitempty" caddy:"namespace=http.matchers"`
 
 	SelectionPolicy Selector              `json:"-"`
@@ -1719,20 +1710,14 @@ type RequestHeaderOpsTransport interface {
 	RequestHeaderOps() *headers.HeaderOps
 }
 
-// canMatchResponse is implemented by matchers that may reference
-// response data via placeholders (e.g. CEL expression matchers
-// using {rp.status_code} or {rp.header.*})
-type canMatchResponse interface {
-	CanMatchResponse()
-}
-
-// matcherSetHasResponseMatcher reports whether a matcher set contains
-// at least one matcher that can reference response data. Matcher sets
-// without such matchers only test request properties and should not
-// be evaluated for response-based retry decisions
-func matcherSetHasResponseMatcher(matcherSet caddyhttp.MatcherSet) bool {
+// matcherSetHasExpressionMatcher reports whether a matcher set contains
+// at least one expression matcher. Expression matchers can reference
+// response data via placeholders like {rp.status_code}. Matcher sets
+// without expression matchers only test request properties and should
+// not be evaluated for response-based retry decisions
+func matcherSetHasExpressionMatcher(matcherSet caddyhttp.MatcherSet) bool {
 	for _, m := range matcherSet {
-		if _, ok := m.(canMatchResponse); ok {
+		if _, ok := m.(*caddyhttp.MatchExpression); ok {
 			return true
 		}
 	}

--- a/replacer.go
+++ b/replacer.go
@@ -121,6 +121,18 @@ func (r *Replacer) Delete(variable string) {
 	r.mapMutex.Unlock()
 }
 
+// DeleteByPrefix removes all static variables with
+// keys starting with the given prefix
+func (r *Replacer) DeleteByPrefix(prefix string) {
+	r.mapMutex.Lock()
+	for key := range r.static {
+		if strings.HasPrefix(key, prefix) {
+			delete(r.static, key)
+		}
+	}
+	r.mapMutex.Unlock()
+}
+
 // fromStatic provides values from r.static.
 func (r *Replacer) fromStatic(key string) (any, bool) {
 	r.mapMutex.RLock()


### PR DESCRIPTION
Closes #6267

- `lb_retry_match` now handles `expression` option which evaluates against the upstream response via `{rp.status_code}`, `{rp.status_text}`, and `{rp.header.X-Header}` placeholders in CEL expressions
- Added new helper function to CEL expressions `isTransportError()`
- Using both `expression` + old syntax (I mean just a plain old `lb_retry_match` options) isn't allowed
- Fully backward-compatible

It wasn't possible to implement it like ``lb_retry_match `path('/foo*') && {rp.status_code} in [502, 503]` `` because of how `lb_retry_match` is handled, but you can use a oneliner like ``lb_retry_match expression `path('/foo*') && {rp.status_code} in [502, 503]` ``

Everything is covered with unit-tests, e2e tests and caddyfile tests.

⚠️ Initially I wanted to preserve both old syntax + new syntax to make everything AND'ed, but it wasn't possible because of how  tough the logic is: some things rely on existence of `lb_retry_match` options, some things not, and sometimes it's unclear whether something would be retried or not. 

For example, the previous logic:

```
  reverse_proxy upstream1 upstream2 {
      lb_retries 3
  }

  ┌───────────────────────┬───────────────┐
  │       Scenario        │   Behavior    │
  ├───────────────────────┼───────────────┤
  │ Dial error            │ retried       │
  ├───────────────────────┼───────────────┤
  │ Transport error, GET  │ retried       │
  ├───────────────────────┼───────────────┤
  │ Transport error, POST │ not retried   │
  ├───────────────────────┼───────────────┤
  │ Transport error, PUT  │ not retried   │
  ├───────────────────────┼───────────────┤
  │ Any response          │ proxied as-is │
  └───────────────────────┴───────────────┘
```

```
  reverse_proxy upstream1 upstream2 {
      lb_retries 3
      lb_retry_match {
          method PUT
      }
  }

  ┌───────────────────────┬───────────────┐
  │       Scenario        │   Behavior    │
  ├───────────────────────┼───────────────┤
  │ Dial error            │ retried       │
  ├───────────────────────┼───────────────┤
  │ Transport error, GET  │ not retried   │
  ├───────────────────────┼───────────────┤
  │ Transport error, POST │ not retried   │
  ├───────────────────────┼───────────────┤
  │ Transport error, PUT  │ retried       │
  ├───────────────────────┼───────────────┤
  │ Any response          │ proxied as-is │
  └───────────────────────┴───────────────┘
```

`GET` loses its' default transport error retry because `RetryMatch` is non-nil and only `PUT` is defined. Adding `expression` handling would result into even more unclear logic. That's why using `expression` with plain options isn't allowed.

Just to remind what transport error is (roughly):

- Upstream accepted the connection then reset it
- TLS handshake succeeded but upstream closed during request/response transfer
- Upstream timed out while sending the response body
- Upstream sent malformed HTTP response headers

--- 

Now examples of how the new `expression` can be used:

- Retry 502/503 responses only
```
  reverse_proxy upstream1 upstream2 {
      lb_retries 3
      lb_retry_match {
          expression `{rp.status_code} in [502, 503]`
      }
  }

  ┌──────────────────────────────┬───────────────┐
  │           Scenario           │   Behavior    │
  ├──────────────────────────────┼───────────────┤
  │ Dial error, any method       │ retried       │
  ├──────────────────────────────┼───────────────┤
  │ Transport error, any method  │ not retried   │
  ├──────────────────────────────┼───────────────┤
  │ 502/503 response, any method │ retried       │
  ├──────────────────────────────┼───────────────┤
  │ 200/500 response             │ proxied as-is │
  └──────────────────────────────┴───────────────┘
```

- Retry on response header only

```
  reverse_proxy upstream1 upstream2 {
      lb_retries 3
      lb_retry_match {
          expression `{rp.header.X-Upstream-Retry} == "true"`
      }
  }

  ┌──────────────────────────────────────┬───────────────┐
  │               Scenario               │   Behavior    │
  ├──────────────────────────────────────┼───────────────┤
  │ Dial error, any method               │ retried       │
  ├──────────────────────────────────────┼───────────────┤
  │ Transport error, any method          │ not retried   │
  ├──────────────────────────────────────┼───────────────┤
  │ Response with X-Upstream-Retry: true │ retried       │
  ├──────────────────────────────────────┼───────────────┤
  │ Response without header              │ proxied as-is │
  └──────────────────────────────────────┴───────────────┘
```

- Retry 503 only for POST

```
  reverse_proxy upstream1 upstream2 {
      lb_retries 3
      lb_retry_match {
          expression `method('POST') && {rp.status_code} == 503`
      }
  }

  ┌─────────────────────────────┬───────────────┐
  │          Scenario           │   Behavior    │
  ├─────────────────────────────┼───────────────┤
  │ Dial error, any method      │ retried       │
  ├─────────────────────────────┼───────────────┤
  │ Transport error, any method │ not retried   │
  ├─────────────────────────────┼───────────────┤
  │ 503 POST                    │ retried       │
  ├─────────────────────────────┼───────────────┤
  │ 503 GET                     │ not retried   │
  ├─────────────────────────────┼───────────────┤
  │ 502 POST                    │ not retried   │
  ├─────────────────────────────┼───────────────┤
  │ 200 POST                    │ proxied as-is │
  └─────────────────────────────┴───────────────┘
```

- Retry 5xx for /api* paths only

```
  reverse_proxy upstream1 upstream2 {
      lb_retries 3
      lb_retry_match {
          expression `path('/api*') && {rp.status_code} >= 500`
      }
  }

  ┌─────────────────────────────┬───────────────┐
  │          Scenario           │   Behavior    │
  ├─────────────────────────────┼───────────────┤
  │ Dial error, any method      │ retried       │
  ├─────────────────────────────┼───────────────┤
  │ Transport error, any method │ not retried   │
  ├─────────────────────────────┼───────────────┤
  │ 500 GET /api/foo            │ retried       │
  ├─────────────────────────────┼───────────────┤
  │ 502 POST /api/foo           │ retried       │
  ├─────────────────────────────┼───────────────┤
  │ 500 GET /other              │ not retried   │
  ├─────────────────────────────┼───────────────┤
  │ 200 GET /api/foo            │ proxied as-is │
  └─────────────────────────────┴───────────────┘
```

- Retry all transport errors + 502/503 responses

```
  reverse_proxy upstream1 upstream2 {
      lb_retries 3
      lb_retry_match {
          expression `isTransportError() || {rp.status_code} in [502, 503]`
      }
  }

  ┌──────────────────────────────┬───────────────┐
  │           Scenario           │   Behavior    │
  ├──────────────────────────────┼───────────────┤
  │ Dial error, any method       │ retried       │
  ├──────────────────────────────┼───────────────┤
  │ Transport error, any method  │ retried       │
  ├──────────────────────────────┼───────────────┤
  │ 502/503 response, any method │ retried       │
  ├──────────────────────────────┼───────────────┤
  │ 200/500 response             │ proxied as-is │
  └──────────────────────────────┴───────────────┘
```

- Retry GET transport errors + 502/503 responses

```
  reverse_proxy upstream1 upstream2 {
      lb_retries 3
      lb_retry_match {
          expression `(isTransportError() && method('GET')) || {rp.status_code} in [502, 503]`
      }
  }

  ┌──────────────────────────────┬───────────────┐
  │           Scenario           │   Behavior    │
  ├──────────────────────────────┼───────────────┤
  │ Dial error, any method       │ retried       │
  ├──────────────────────────────┼───────────────┤
  │ Transport error, GET         │ retried       │
  ├──────────────────────────────┼───────────────┤
  │ Transport error, POST        │ not retried   │
  ├──────────────────────────────┼───────────────┤
  │ 502/503 response, any method │ retried       │
  ├──────────────────────────────┼───────────────┤
  │ 200 response                 │ proxied as-is │
  └──────────────────────────────┴───────────────┘
```

- Retry PUT transport errors to /api* + any 502

```
  reverse_proxy upstream1 upstream2 {
      lb_retries 3
      lb_retry_match {
          expression `(isTransportError() && method('PUT') && path('/api*')) || {rp.status_code} == 502`
      }
  }

  ┌────────────────────────────────────┬───────────────┐
  │              Scenario              │   Behavior    │
  ├────────────────────────────────────┼───────────────┤
  │ Dial error, any method             │ retried       │
  ├────────────────────────────────────┼───────────────┤
  │ Transport error, PUT /api/foo      │ retried       │
  ├────────────────────────────────────┼───────────────┤
  │ Transport error, PUT /other        │ not retried   │
  ├────────────────────────────────────┼───────────────┤
  │ Transport error, GET /api/foo      │ not retried   │
  ├────────────────────────────────────┼───────────────┤
  │ 502 response, any method, any path │ retried       │
  ├────────────────────────────────────┼───────────────┤
  │ 200 response                       │ proxied as-is │
  └────────────────────────────────────┴───────────────┘
```

- Retry POST on 503, GET on transport errors

```
  reverse_proxy upstream1 upstream2 {
      lb_retries 3
      lb_retry_match {
          expression `method('POST') && {rp.status_code} == 503`
      }
      lb_retry_match {
          expression `isTransportError() && method('GET')`
      }
  }

  ┌────────────────────────┬───────────────────┐
  │        Scenario        │     Behavior      │
  ├────────────────────────┼───────────────────┤
  │ Dial error, any method │ retried           │
  ├────────────────────────┼───────────────────┤
  │ Transport error, GET   │ retried (block 2) │
  ├────────────────────────┼───────────────────┤
  │ Transport error, POST  │ not retried       │
  ├────────────────────────┼───────────────────┤
  │ 503 POST               │ retried (block 1) │
  ├────────────────────────┼───────────────────┤
  │ 503 GET                │ not retried       │
  ├────────────────────────┼───────────────────┤
  │ 502 POST               │ not retried       │
  └────────────────────────┴───────────────────┘
```

- Retry idempotent transport errors + 502 for specific host

```
  reverse_proxy upstream1 upstream2 {
      lb_retries 3
      lb_retry_match {
          expression `isTransportError() && (method('GET') || method('PUT') || method('DELETE'))`
      }
      lb_retry_match {
          expression `host('api.example.com') && {rp.status_code} == 502`
      }
  }

  ┌──────────────────────────┬───────────────────┐
  │         Scenario         │     Behavior      │
  ├──────────────────────────┼───────────────────┤
  │ Dial error, any method   │ retried           │
  ├──────────────────────────┼───────────────────┤
  │ Transport error, GET     │ retried (block 1) │
  ├──────────────────────────┼───────────────────┤
  │ Transport error, PUT     │ retried (block 1) │
  ├──────────────────────────┼───────────────────┤
  │ Transport error, DELETE  │ retried (block 1) │
  ├──────────────────────────┼───────────────────┤
  │ Transport error, POST    │ not retried       │
  ├──────────────────────────┼───────────────────┤
  │ 502 to api.example.com   │ retried (block 2) │
  ├──────────────────────────┼───────────────────┤
  │ 502 to other.example.com │ not retried       │
  ├──────────────────────────┼───────────────────┤
  │ 200 response             │ proxied as-is     │
  └──────────────────────────┴───────────────────┘
```

- Retry transport errors for multiple methods + 5xx for /api*

```
  reverse_proxy upstream1 upstream2 {
      lb_retries 3
      lb_retry_match {
          expression `isTransportError() && (method('GET') || method('PUT'))`
      }
      lb_retry_match {
          expression `path('/api*') && {rp.status_code} >= 500`
      }
  }

  ┌────────────────────────┬───────────────────┐
  │        Scenario        │     Behavior      │
  ├────────────────────────┼───────────────────┤
  │ Dial error, any method │ retried           │
  ├────────────────────────┼───────────────────┤
  │ Transport error, GET   │ retried (block 1) │
  ├────────────────────────┼───────────────────┤
  │ Transport error, PUT   │ retried (block 1) │
  ├────────────────────────┼───────────────────┤
  │ Transport error, POST  │ not retried       │
  ├────────────────────────┼───────────────────┤
  │ 500 GET /api/foo       │ retried (block 2) │
  ├────────────────────────┼───────────────────┤
  │ 502 POST /api/foo      │ retried (block 2) │
  ├────────────────────────┼───────────────────┤
  │ 500 GET /other         │ not retried       │
  ├────────────────────────┼───────────────────┤
  │ 200 response           │ proxied as-is     │
  └────────────────────────┴───────────────────┘
```

- Retry on response header + all transport errors

```
  reverse_proxy upstream1 upstream2 {
      lb_retries 3
      lb_retry_match {
          expression `isTransportError() || {rp.header.X-Upstream-Retry} == "true"`
      }
  }

  ┌─────────────────────────────────┬───────────────┐
  │            Scenario             │   Behavior    │
  ├─────────────────────────────────┼───────────────┤
  │ Dial error, any method          │ retried       │
  ├─────────────────────────────────┼───────────────┤
  │ Transport error, any method     │ retried       │
  ├─────────────────────────────────┼───────────────┤
  │ 200 with X-Upstream-Retry: true │ retried       │
  ├─────────────────────────────────┼───────────────┤
  │ 502 with X-Upstream-Retry: true │ retried       │
  ├─────────────────────────────────┼───────────────┤
  │ 200 without header              │ proxied as-is │
  └─────────────────────────────────┴───────────────┘
```