### PR TITLE
chore: replace `interface{}` with `any` for modernization

### DIFF
--- a/modules/caddyhttp/reverseproxy/headers_test.go
+++ b/modules/caddyhttp/reverseproxy/headers_test.go
@@ -17,7 +17,7 @@ func TestAddForwardedHeadersNonIP(t *testing.T) {
 
 	// Mock the context variables required by Caddy.
 	// We need to inject the variable map manually since we aren't running the full server.
-	vars := map[string]interface{}{
+	vars := map[string]any{
 		caddyhttp.TrustedProxyVarKey: false,
 	}
 	ctx := context.WithValue(req.Context(), caddyhttp.VarsCtxKey, vars)
@@ -42,7 +42,7 @@ func TestAddForwardedHeaders_UnixSocketTrusted(t *testing.T) {
 	req.Header.Set("X-Forwarded-Proto", "https")
 	req.Header.Set("X-Forwarded-Host", "original.example.com")
 
-	vars := map[string]interface{}{
+	vars := map[string]any{
 		caddyhttp.TrustedProxyVarKey: true,
 		caddyhttp.ClientIPVarKey:     "1.2.3.4",
 	}
@@ -74,7 +74,7 @@ func TestAddForwardedHeaders_UnixSocketUntrusted(t *testing.T) {
 	req.Header.Set("X-Forwarded-Proto", "https")
 	req.Header.Set("X-Forwarded-Host", "spoofed.example.com")
 
-	vars := map[string]interface{}{
+	vars := map[string]any{
 		caddyhttp.TrustedProxyVarKey: false,
 		caddyhttp.ClientIPVarKey:     "",
 	}
@@ -103,7 +103,7 @@ func TestAddForwardedHeaders_UnixSocketTrustedNoExistingHeaders(t *testing.T) {
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
 	req.RemoteAddr = "@"
 
-	vars := map[string]interface{}{
+	vars := map[string]any{
 		caddyhttp.TrustedProxyVarKey: true,
 		caddyhttp.ClientIPVarKey:     "5.6.7.8",
 	}


### PR DESCRIPTION


## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->


No AI was used.

This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.
 
As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.


