### PR TITLE
reverseproxy: Add per-upstream metrics

### DIFF
--- a/modules/caddyhttp/reverseproxy/metrics.go
+++ b/modules/caddyhttp/reverseproxy/metrics.go
@@ -11,11 +11,14 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/internal/metrics"
 )
 
 var reverseProxyMetrics = struct {
 	once             sync.Once
 	upstreamsHealthy *prometheus.GaugeVec
+	upstreamRequests *prometheus.CounterVec
+	upstreamDuration *prometheus.HistogramVec
 	logger           *zap.Logger
 }{}
 
@@ -23,12 +26,29 @@ func initReverseProxyMetrics(handler *Handler, registry *prometheus.Registry) {
 	const ns, sub = "caddy", "reverse_proxy"
 
 	upstreamsLabels := []string{"upstream"}
+	upstreamRequestLabels := []string{"upstream", "code", "method"}
+
 	reverseProxyMetrics.once.Do(func() {
 		reverseProxyMetrics.upstreamsHealthy = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,
 			Subsystem: sub,
 			Name:      "upstreams_healthy",
 			Help:      "Health status of reverse proxy upstreams.",
+		}, upstreamsLabels)
+
+		reverseProxyMetrics.upstreamRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Subsystem: sub,
+			Name:      "upstream_requests_total",
+			Help:      "Counter of requests made to upstreams.",
+		}, upstreamRequestLabels)
+
+		reverseProxyMetrics.upstreamDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: ns,
+			Subsystem: sub,
+			Name:      "upstream_request_duration_seconds",
+			Help:      "Histogram of request durations to upstreams.",
+			Buckets:   prometheus.DefBuckets,
 		}, upstreamsLabels)
 	})
 
@@ -39,6 +59,22 @@ func initReverseProxyMetrics(handler *Handler, registry *prometheus.Registry) {
 		!errors.Is(err, prometheus.AlreadyRegisteredError{
 			ExistingCollector: reverseProxyMetrics.upstreamsHealthy,
 			NewCollector:      reverseProxyMetrics.upstreamsHealthy,
+		}) {
+		panic(err)
+	}
+
+	if err := registry.Register(reverseProxyMetrics.upstreamRequests); err != nil &&
+		!errors.Is(err, prometheus.AlreadyRegisteredError{
+			ExistingCollector: reverseProxyMetrics.upstreamRequests,
+			NewCollector:      reverseProxyMetrics.upstreamRequests,
+		}) {
+		panic(err)
+	}
+
+	if err := registry.Register(reverseProxyMetrics.upstreamDuration); err != nil &&
+		!errors.Is(err, prometheus.AlreadyRegisteredError{
+			ExistingCollector: reverseProxyMetrics.upstreamDuration,
+			NewCollector:      reverseProxyMetrics.upstreamDuration,
 		}) {
 		panic(err)
 	}
@@ -96,4 +132,24 @@ func (m *metricsUpstreamsHealthyUpdater) update() {
 
 		reverseProxyMetrics.upstreamsHealthy.With(labels).Set(gaugeValue)
 	}
+}
+
+func recordUpstreamMetrics(upstream string, method string, statusCode int, duration time.Duration) {
+	// Guard for test cases that bypass Provision()
+	if reverseProxyMetrics.upstreamRequests == nil {
+		return
+	}
+
+	code := metrics.SanitizeCode(statusCode)
+	method = metrics.SanitizeMethod(method)
+
+	reverseProxyMetrics.upstreamRequests.With(prometheus.Labels{
+		"upstream": upstream,
+		"code":     code,
+		"method":   method,
+	}).Inc()
+
+	reverseProxyMetrics.upstreamDuration.With(prometheus.Labels{
+		"upstream": upstream,
+	}).Observe(duration.Seconds())
 }

--- a/modules/caddyhttp/reverseproxy/metrics.go
+++ b/modules/caddyhttp/reverseproxy/metrics.go
@@ -40,14 +40,14 @@ func initReverseProxyMetrics(handler *Handler, registry *prometheus.Registry) {
 			Namespace: ns,
 			Subsystem: sub,
 			Name:      "upstream_requests_total",
-			Help:      "Counter of requests made to upstreams.",
+			Help:      "Counter of requests made to reverse proxy upstreams.",
 		}, upstreamRequestLabels)
 
 		reverseProxyMetrics.upstreamDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: ns,
 			Subsystem: sub,
 			Name:      "upstream_request_duration_seconds",
-			Help:      "Histogram of request durations to upstreams.",
+			Help:      "Histogram of request durations to reverse proxy upstreams.",
 			Buckets:   prometheus.DefBuckets,
 		}, upstreamRequestLabels)
 	})

--- a/modules/caddyhttp/reverseproxy/metrics.go
+++ b/modules/caddyhttp/reverseproxy/metrics.go
@@ -49,7 +49,7 @@ func initReverseProxyMetrics(handler *Handler, registry *prometheus.Registry) {
 			Name:      "upstream_request_duration_seconds",
 			Help:      "Histogram of request durations to upstreams.",
 			Buckets:   prometheus.DefBuckets,
-		}, upstreamsLabels)
+		}, upstreamRequestLabels)
 	})
 
 	// duplicate registration could happen if multiple sites with reverse proxy are configured; so ignore the error because
@@ -140,16 +140,12 @@ func recordUpstreamMetrics(upstream string, method string, statusCode int, durat
 		return
 	}
 
-	code := metrics.SanitizeCode(statusCode)
-	method = metrics.SanitizeMethod(method)
-
-	reverseProxyMetrics.upstreamRequests.With(prometheus.Labels{
+	labels := prometheus.Labels{
 		"upstream": upstream,
-		"code":     code,
-		"method":   method,
-	}).Inc()
+		"method":   metrics.SanitizeMethod(method),
+		"code":     metrics.SanitizeCode(statusCode),
+	}
 
-	reverseProxyMetrics.upstreamDuration.With(prometheus.Labels{
-		"upstream": upstream,
-	}).Observe(duration.Seconds())
+	reverseProxyMetrics.upstreamRequests.With(labels).Inc()
+	reverseProxyMetrics.upstreamDuration.With(labels).Observe(duration.Seconds())
 }

--- a/modules/caddyhttp/reverseproxy/metrics.go
+++ b/modules/caddyhttp/reverseproxy/metrics.go
@@ -15,11 +15,12 @@ import (
 )
 
 var reverseProxyMetrics = struct {
-	once             sync.Once
-	upstreamsHealthy *prometheus.GaugeVec
-	upstreamRequests *prometheus.CounterVec
-	upstreamDuration *prometheus.HistogramVec
-	logger           *zap.Logger
+	once                     sync.Once
+	upstreamsHealthy         *prometheus.GaugeVec
+	upstreamRequests         *prometheus.CounterVec
+	upstreamDuration         *prometheus.HistogramVec
+	upstreamRequestsInFlight *prometheus.GaugeVec
+	logger                   *zap.Logger
 }{}
 
 func initReverseProxyMetrics(handler *Handler, registry *prometheus.Registry) {
@@ -50,6 +51,13 @@ func initReverseProxyMetrics(handler *Handler, registry *prometheus.Registry) {
 			Help:      "Histogram of request durations to reverse proxy upstreams.",
 			Buckets:   prometheus.DefBuckets,
 		}, upstreamRequestLabels)
+
+		reverseProxyMetrics.upstreamRequestsInFlight = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Subsystem: sub,
+			Name:      "upstream_requests_in_flight",
+			Help:      "Gauge of requests currently in flight to upstreams.",
+		}, upstreamsLabels)
 	})
 
 	// duplicate registration could happen if multiple sites with reverse proxy are configured; so ignore the error because
@@ -75,6 +83,14 @@ func initReverseProxyMetrics(handler *Handler, registry *prometheus.Registry) {
 		!errors.Is(err, prometheus.AlreadyRegisteredError{
 			ExistingCollector: reverseProxyMetrics.upstreamDuration,
 			NewCollector:      reverseProxyMetrics.upstreamDuration,
+		}) {
+		panic(err)
+	}
+
+	if err := registry.Register(reverseProxyMetrics.upstreamRequestsInFlight); err != nil &&
+		!errors.Is(err, prometheus.AlreadyRegisteredError{
+			ExistingCollector: reverseProxyMetrics.upstreamRequestsInFlight,
+			NewCollector:      reverseProxyMetrics.upstreamRequestsInFlight,
 		}) {
 		panic(err)
 	}

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -1068,6 +1068,7 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, origRe
 		if c := logger.Check(zapcore.DebugLevel, logMessage); c != nil {
 			c.Write(zap.Error(err))
 		}
+		recordUpstreamMetrics(di.Upstream.String(), req.Method, http.StatusBadGateway, duration)
 		return err
 	}
 	if c := logger.Check(zapcore.DebugLevel, logMessage); c != nil {
@@ -1079,6 +1080,8 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, origRe
 			zap.Int("status", res.StatusCode),
 		)
 	}
+
+	recordUpstreamMetrics(di.Upstream.String(), req.Method, res.StatusCode, duration)
 
 	// duration until upstream wrote response headers (roundtrip duration)
 	repl.Set("http.reverse_proxy.upstream.latency", duration)

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -35,6 +35,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/net/http/httpguts"
@@ -993,12 +994,19 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, origRe
 
 	// Increment the in-flight request count
 	incInFlightRequest(di.Address)
+	requestLabels := prometheus.Labels{"upstream": di.Upstream.Dial}
+	if reverseProxyMetrics.upstreamRequestsInFlight != nil {
+		reverseProxyMetrics.upstreamRequestsInFlight.With(requestLabels).Inc()
+	}
 
 	//nolint:errcheck
 	defer func() {
 		di.Upstream.Host.countRequest(-1)
 		// Decrement the in-flight request count
 		decInFlightRequest(di.Address)
+		if reverseProxyMetrics.upstreamRequestsInFlight != nil {
+			reverseProxyMetrics.upstreamRequestsInFlight.With(requestLabels).Dec()
+		}
 	}()
 
 	// point the request to this upstream


### PR DESCRIPTION
This PR implements per-upstream metrics for `reverse_proxy`.

Fixes #4140

## Assistance Disclosure

The code was generated by OpenCode (GLM-5). I manually verified the correctness.
