### PR TITLE
caddytls: Avoid ACME fallback for implicit Tailscale *.ts.net policies

### DIFF
--- a/modules/caddytls/automation.go
+++ b/modules/caddytls/automation.go
@@ -235,7 +235,7 @@ func (ap *AutomationPolicy) Provision(tlsApp *TLS) error {
 	}
 
 	issuers := ap.Issuers
-	if len(issuers) == 0 {
+	if len(issuers) == 0 && !ap.implicitTailscaleManagersOnly() {
 		var err error
 		issuers, err = DefaultIssuersProvisioned(tlsApp.ctx)
 		if err != nil {
@@ -427,6 +427,29 @@ func (ap *AutomationPolicy) AllInternalSubjects() bool {
 	return !slices.ContainsFunc(ap.subjects, func(s string) bool {
 		return !certmagic.SubjectIsInternal(s)
 	})
+}
+
+// implicitTailscaleManagersOnly returns true if this policy is configured to
+// serve only Tailscale names from the Tailscale manager at handshake-time.
+func (ap *AutomationPolicy) implicitTailscaleManagersOnly() bool {
+	if len(ap.subjects) == 0 {
+		return false
+	}
+
+	for _, subject := range ap.subjects {
+		if !strings.HasSuffix(strings.ToLower(subject), tailscaleDomainAliasEnding) {
+			return false
+		}
+	}
+
+	for _, manager := range ap.Managers {
+		switch manager.(type) {
+		case Tailscale, *Tailscale:
+			return true
+		}
+	}
+
+	return false
 }
 
 func (ap *AutomationPolicy) onlyInternalIssuer() bool {

--- a/modules/caddytls/automation_test.go
+++ b/modules/caddytls/automation_test.go
@@ -1,0 +1,37 @@
+package caddytls
+
+import (
+	"testing"
+
+	"github.com/caddyserver/certmagic"
+	"go.uber.org/zap"
+)
+
+func TestAutomationPolicyMakeCertMagicConfigImplicitTailscaleManagersOnly(t *testing.T) {
+	ap := AutomationPolicy{
+		Managers: []certmagic.Manager{Tailscale{}},
+		subjects: []string{"test-node.example.ts.net"},
+	}
+
+	cfg, err := ap.makeCertMagicConfig(&TLS{
+		logger: zap.NewNop(),
+	}, nil, &certmagic.FileStorage{Path: t.TempDir()})
+	if err != nil {
+		t.Fatalf("making certmagic config: %v", err)
+	}
+	if cfg.OnDemand == nil {
+		t.Fatal("expected on-demand config to be set")
+	}
+	if len(cfg.Issuers) != 0 {
+		t.Fatalf("expected no issuers for tailscale-managed ts.net policy, got %d", len(cfg.Issuers))
+	}
+}
+
+func TestAutomationPolicyImplicitTailscaleManagersOnlyCatchAll(t *testing.T) {
+	ap := AutomationPolicy{
+		Managers: []certmagic.Manager{Tailscale{}},
+	}
+	if ap.implicitTailscaleManagersOnly() {
+		t.Fatal("expected catch-all manager policy to remain outside tailscale-only special case")
+	}
+}


### PR DESCRIPTION
Fixes the implicit `*.ts.net` Tailscale policy shape so it does not inherit default ACME issuers.

Without this, a Tailscale-managed `*.ts.net` policy can fall through to normal ACME issuance if the Tailscale manager does not immediately return a certificate, which is the wrong path for these names.

This change:
- skips default issuer injection for Tailscale-only policies with explicit `*.ts.net` subjects
- adds a regression test for that policy shape
- documents that subjectless/catch-all manager policies are not changed by this patch

Should fix #7562.

## Assistance Disclosure
No AI was used.