### PR TITLE
fileserver: show symlink targets verbatim (#7476)

### DIFF
--- a/modules/caddyhttp/fileserver/browsetplcontext.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"path/filepath"
 	"slices"
 	"sort"
 	"strconv"
@@ -100,7 +99,7 @@ func (fsrv *FileServer) directoryListing(ctx context.Context, fileSystem fs.FS, 
 			}
 
 			if fsrv.Browse.RevealSymlinks {
-				symLinkTarget, err := filepath.EvalSymlinks(path)
+				symLinkTarget, err := os.Readlink(path)
 				if err == nil {
 					symlinkPath = symLinkTarget
 				}


### PR DESCRIPTION
Fixes #7476

`reveal_symlinks` was exposing symlink targets as fully resolved absolute paths, even if the target is a relative path. With this change the link target is shown as-is, without resolving anything.


## Example

`tree` output:
```
.
├── abs -> /home/maxtruxa/caddy-test-files/foo
├── foo
├── ind -> sub/rel
├── rel -> foo
└── sub
    └── rel -> ../foo
```


## Before

<img width="790" height="517" alt="caddy-before-1" src="https://github.com/user-attachments/assets/bc27d3de-fd41-44ca-85a0-272e44814232" />

<img width="789" height="343" alt="caddy-before-2" src="https://github.com/user-attachments/assets/4561eb42-1153-4aa2-9b86-1888321ad9cc" />


## After

<img width="790" height="516" alt="caddy-after-1" src="https://github.com/user-attachments/assets/54d6fc14-85ac-45cc-b7ab-27164c03c103" />

<img width="786" height="349" alt="caddy-after-2" src="https://github.com/user-attachments/assets/bcb7c958-0586-4256-b8ee-18555f107570" />


## Assistance Disclosure

No AI was used.