### PR TITLE
http: make zstd checksum configurable

### DIFF
--- a/caddytest/integration/caddyfile_adapt/encode_options.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/encode_options.caddyfiletest
@@ -19,7 +19,7 @@ encode gzip zstd {
 # Long way with a block for each encoding
 encode {
 	zstd {
-		checksum false
+		disable_checksum
 	}
 	gzip 5
 }

--- a/modules/caddyhttp/encode/caddyfile.go
+++ b/modules/caddyhttp/encode/caddyfile.go
@@ -43,7 +43,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 //	    gzip           [<level>]
 //	    zstd           [<level>] {
 //	        level           <level>
-//	        checksum        [<true|false>]
+//	        disable_checksum
 //	    }
 //	    minimum_length <length>
 //	    # response matcher block

--- a/modules/caddyhttp/encode/zstd/zstd.go
+++ b/modules/caddyhttp/encode/zstd/zstd.go
@@ -16,7 +16,6 @@ package caddyzstd
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/klauspost/compress/zstd"
 
@@ -80,23 +79,15 @@ func (z *Zstd) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			}
 			z.Level = args[0]
 
-		case "checksum":
-			args := d.RemainingArgs()
-			if len(args) > 1 {
+		case "disable_checksum":
+			if d.NextArg() {
 				return d.ArgErr()
 			}
 			if z.Checksum != nil {
 				return d.Err("checksum already specified")
 			}
-			enabled := true
-			if len(args) == 1 {
-				parsed, err := strconv.ParseBool(args[0])
-				if err != nil {
-					return d.Errf("parsing checksum: invalid boolean value %q", args[0])
-				}
-				enabled = parsed
-			}
-			z.Checksum = &enabled
+			disabled := false
+			z.Checksum = &disabled
 
 		default:
 			return d.Errf("unknown subdirective '%s'", d.Val())


### PR DESCRIPTION
Fixes #7585 

## Benchmarks

Local gzhttp zstd benchmarks with SpeedBetterCompression show a small but consistent throughput win when the checksum is disabled. 

S2K = single-threaded 2kb responses
P100k = multi-threaded 100kb responses

  | Benchmark | Checksum On | Checksum Off | Delta |
  | --- | ---: | ---: | ---: |
  | S2k | 184.97 MB/s | 193.09 MB/s | +4.4% |
  | S20k | 304.39 MB/s | 313.58 MB/s | +3.0% |
  | S100k | 270.95 MB/s | 274.40 MB/s | +1.3% |
  | P2k | 2814.30 MB/s | 2863.82 MB/s | +1.8% |
  | P20k | 4357.71 MB/s | 4447.01 MB/s | +2.0% |
  | P100k | 3526.51 MB/s | 3598.24 MB/s | +2.0% |


## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

Plan was written by hand and executed by codex CLI with GPT-5.4-xhigh and refined to continue with existing behavior (instead of disabling checksums) and better config behavior (reuse encoder-level parsing text)