### PR TITLE
admin: reject non-canonical config array indices

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -1154,7 +1154,6 @@ func parseCanonicalArrayIndex(idx string) (int, error) {
 	if strconv.Itoa(i) != idx {
 		return 0, fmt.Errorf("non-canonical array index")
 	}
-
 	return i, nil
 }
 

--- a/admin.go
+++ b/admin.go
@@ -1146,7 +1146,6 @@ func parseCanonicalArrayIndex(idx string) (int, error) {
 	if idx == "" {
 		return 0, fmt.Errorf("empty index")
 	}
-
 	i, err := strconv.Atoi(idx)
 	if err != nil {
 		return 0, err

--- a/admin.go
+++ b/admin.go
@@ -1142,6 +1142,22 @@ func handleStop(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
+func parseCanonicalArrayIndex(idx string) (int, error) {
+	if idx == "" {
+		return 0, fmt.Errorf("empty index")
+	}
+
+	i, err := strconv.Atoi(idx)
+	if err != nil {
+		return 0, err
+	}
+	if strconv.Itoa(i) != idx {
+		return 0, fmt.Errorf("non-canonical array index")
+	}
+
+	return i, nil
+}
+
 // unsyncedConfigAccess traverses into the current config and performs
 // the operation at path according to method, using body and out as
 // needed. This is a low-level, unsynchronized function; most callers
@@ -1203,11 +1219,12 @@ traverseLoop:
 				var idx int
 				if method != http.MethodPost {
 					idxStr := parts[len(parts)-1]
-					idx, err = strconv.Atoi(idxStr)
+					idx, err = parseCanonicalArrayIndex(idxStr)
 					if err != nil {
 						return fmt.Errorf("[%s] invalid array index '%s': %v",
 							path, idxStr, err)
 					}
+
 					if idx < 0 || (method != http.MethodPut && idx >= len(arr)) || idx > len(arr) {
 						return fmt.Errorf("[%s] array index out of bounds: %s", path, idxStr)
 					}
@@ -1307,7 +1324,7 @@ traverseLoop:
 			}
 
 		case []any:
-			partInt, err := strconv.Atoi(part)
+			partInt, err := parseCanonicalArrayIndex(part)
 			if err != nil {
 				return fmt.Errorf("[/%s] invalid array index '%s': %v",
 					strings.Join(parts[:i+1], "/"), part, err)

--- a/admin_test.go
+++ b/admin_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io"
 	"maps"
 	"net/http"
 	"net/http/httptest"
@@ -954,5 +955,18 @@ MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDRS0LmTwUT0iwP
 				test.checkState(t, test.cfg)
 			}
 		})
+	}
+}
+
+func TestUnsyncedConfigAccessRejectsNonCanonicalArrayIndices(t *testing.T) {
+	rawCfg = map[string]any{
+		rawConfigKey: map[string]any{
+			"list": []any{"zero", "one"},
+		},
+	}
+
+	err := unsyncedConfigAccess(http.MethodGet, "/"+rawConfigKey+"/list/01", nil, io.Discard)
+	if err == nil {
+		t.Fatal("expected non-canonical array index to be rejected")
 	}
 }

--- a/admin_test.go
+++ b/admin_test.go
@@ -15,11 +15,11 @@
 package caddy
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io"
 	"maps"
 	"net/http"
 	"net/http/httptest"
@@ -966,27 +966,37 @@ func TestUnsyncedConfigAccessCanonicalArrayIndices(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		path    string
-		wantErr bool
+		name       string
+		path       string
+		wantOutput string
+		wantErr    bool
 	}{
-		{name: "allow zero", path: "/" + rawConfigKey + "/list/0"},
-		{name: "allow one", path: "/" + rawConfigKey + "/list/1"},
-		{name: "allow ten", path: "/" + rawConfigKey + "/list/10"},
+		{name: "allow zero", path: "/" + rawConfigKey + "/list/0", wantOutput: "\"zero\"\n"},
+		{name: "allow one", path: "/" + rawConfigKey + "/list/1", wantOutput: "\"one\"\n"},
+		{name: "allow ten", path: "/" + rawConfigKey + "/list/10", wantOutput: "\"ten\"\n"},
 		{name: "reject leading zero", path: "/" + rawConfigKey + "/list/01", wantErr: true},
 		{name: "reject multiple leading zeros", path: "/" + rawConfigKey + "/list/002", wantErr: true},
 		{name: "reject plus sign", path: "/" + rawConfigKey + "/list/+1", wantErr: true},
 		{name: "reject negative zero", path: "/" + rawConfigKey + "/list/-0", wantErr: true},
 	}
 
-	for _, tc := range tests {
+	for i, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := unsyncedConfigAccess(http.MethodGet, tc.path, nil, io.Discard)
-			if tc.wantErr && err == nil {
-				t.Fatal("expected error, got nil")
+			var gotOutput bytes.Buffer
+			err := unsyncedConfigAccess(http.MethodGet, tc.path, nil, &gotOutput)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("test %d (%s): input path %q: expected error, got nil with output %q", i, tc.name, tc.path, gotOutput.String())
+				}
+				return
 			}
-			if !tc.wantErr && err != nil {
-				t.Fatalf("expected no error, got %v", err)
+
+			if err != nil {
+				t.Errorf("test %d (%s): input path %q: expected no error with output %q, got error %v with output %q", i, tc.name, tc.path, tc.wantOutput, err, gotOutput.String())
+			}
+			if gotOutput.String() != tc.wantOutput {
+				t.Errorf("test %d (%s): input path %q: expected output %q, got %q", i, tc.name, tc.path, tc.wantOutput, gotOutput.String())
 			}
 		})
 	}

--- a/admin_test.go
+++ b/admin_test.go
@@ -958,15 +958,36 @@ MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDRS0LmTwUT0iwP
 	}
 }
 
-func TestUnsyncedConfigAccessRejectsNonCanonicalArrayIndices(t *testing.T) {
+func TestUnsyncedConfigAccessCanonicalArrayIndices(t *testing.T) {
 	rawCfg = map[string]any{
 		rawConfigKey: map[string]any{
-			"list": []any{"zero", "one"},
+			"list": []any{"zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"},
 		},
 	}
 
-	err := unsyncedConfigAccess(http.MethodGet, "/"+rawConfigKey+"/list/01", nil, io.Discard)
-	if err == nil {
-		t.Fatal("expected non-canonical array index to be rejected")
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{name: "allow zero", path: "/" + rawConfigKey + "/list/0"},
+		{name: "allow one", path: "/" + rawConfigKey + "/list/1"},
+		{name: "allow ten", path: "/" + rawConfigKey + "/list/10"},
+		{name: "reject leading zero", path: "/" + rawConfigKey + "/list/01", wantErr: true},
+		{name: "reject multiple leading zeros", path: "/" + rawConfigKey + "/list/002", wantErr: true},
+		{name: "reject plus sign", path: "/" + rawConfigKey + "/list/+1", wantErr: true},
+		{name: "reject negative zero", path: "/" + rawConfigKey + "/list/-0", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := unsyncedConfigAccess(http.MethodGet, tc.path, nil, io.Discard)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
  This rejects non-canonical numeric array indices in `/config` traversal.

  Previously, array path components were parsed with `strconv.Atoi`, which meant paths like `01` were accepted and normalized to `1`. That could cause the authorization layer to accept one textual path while config traversal resolved a
  different array element.

  This change introduces canonical index parsing so that only normalized decimal forms are accepted:
  - allowed: `0`, `1`, `10`
  - rejected: `01`, `002`, `+1`, `-0`

  Validation:
  - `go test ./... -run TestUnsyncedConfigAccessRejectsNonCanonicalArrayIndices`
  - `go test ./... -run TestUnsyncedConfigAccess`

  I also ran `go test ./...`, but the run hit an unrelated integration timeout/failure in `caddytest/integration` (`TestACMEServerWithDefaults`).


  Assistance disclosure:
  I used an LLM to help review the code, reason about the behavior, and help draft the original report and parts of the patch/PR text. I manually reproduced the issue, validated the fix, and ran the relevant tests myself.