### PR TITLE
http: use `sync.Map` for request-scoped vars

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -935,10 +935,10 @@ func PrepareRequest(r *http.Request, repl *caddy.Replacer, w http.ResponseWriter
 	ctx = context.WithValue(ctx, ServerCtxKey, s)
 
 	trusted, clientIP := determineTrustedProxy(r, s)
-	ctx = context.WithValue(ctx, VarsCtxKey, map[string]any{
-		TrustedProxyVarKey: trusted,
-		ClientIPVarKey:     clientIP,
-	})
+	varsMap := &sync.Map{}
+	varsMap.Store(TrustedProxyVarKey, trusted)
+	varsMap.Store(ClientIPVarKey, clientIP)
+	ctx = context.WithValue(ctx, VarsCtxKey, varsMap)
 
 	ctx = context.WithValue(ctx, routeGroupCtxKey, make(map[string]struct{}))
 

--- a/modules/caddyhttp/vars.go
+++ b/modules/caddyhttp/vars.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"sync"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types/ref"
@@ -443,11 +444,12 @@ func (m MatchVarsRE) Validate() error {
 // GetVar gets a value out of the context's variable table by key.
 // If the key does not exist, the return value will be nil.
 func GetVar(ctx context.Context, key string) any {
-	varMap, ok := ctx.Value(VarsCtxKey).(map[string]any)
+	varMap, ok := ctx.Value(VarsCtxKey).(*sync.Map)
 	if !ok {
 		return nil
 	}
-	return varMap[key]
+	val, _ := varMap.Load(key)
+	return val
 }
 
 // SetVar sets a value in the context's variable table with
@@ -458,17 +460,15 @@ func GetVar(ctx context.Context, key string) any {
 // underlying value does not count) and the key exists in
 // the table, the key+value will be deleted from the table.
 func SetVar(ctx context.Context, key string, value any) {
-	varMap, ok := ctx.Value(VarsCtxKey).(map[string]any)
+	varMap, ok := ctx.Value(VarsCtxKey).(*sync.Map)
 	if !ok {
 		return
 	}
 	if value == nil {
-		if _, ok := varMap[key]; ok {
-			delete(varMap, key)
-			return
-		}
+		varMap.Delete(key)
+		return
 	}
-	varMap[key] = value
+	varMap.Store(key, value)
 }
 
 // Interface guards


### PR DESCRIPTION
I received a report of a `concurrent map read and map write` failure at this line

https://github.com/caddyserver/caddy/blob/ffb6ab0644f24c5ee6542aca6bd59b7a1b0a8f91/modules/caddyhttp/marshalers.go#L43-L45

The only conceivable reason for it is due to how the cache handler creates data race between cache and upstream on the same `http.Request` object. I cannot think of any other scenario. Whether it's truly the culprit or not, we can resolve it for all cases by using `sync.Map`. I contemplated creating our own opaque map struct with a mutex, but the one of use cases listed in `sync.Map` [documentation](https://pkg.go.dev/sync#Map) seems to apply to our scenario:

> The Map type is optimized for two common use cases: (1) when the entry for a given key is only ever written once but read many times, as in caches that only grow, or (2) when multiple goroutines read, write, and overwrite entries for disjoint sets of keys. In these two cases, use of a Map may significantly reduce lock contention compared to a Go map paired with a separate [Mutex](https://pkg.go.dev/sync#Mutex) or [RWMutex](https://pkg.go.dev/sync#RWMutex).

Namely, the entry for a given key is written once and read many times. I searched the code base for `SetVar` and `GetVar`. I don't see cases of overwrite, but there are a couple multiple `GetVar` for the same key.

## Assistance Disclosure

No AI was used.