### PR TITLE
notify: Always send "READY=1" even after an error

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -127,10 +127,9 @@ func Load(cfgJSON []byte, forceReload bool) error {
 					zap.Error(notifyErr),
 					zap.String("reload_err", err.Error()))
 			}
-			return
 		}
-		if err := notify.Ready(); err != nil {
-			Log().Error("unable to notify to service manager of ready state", zap.Error(err))
+		if notifyErr := notify.Ready(); notifyErr != nil {
+			Log().Error("unable to notify to service manager of ready state", zap.Error(notifyErr))
 		}
 	}()
 


### PR DESCRIPTION
Fixes https://github.com/caddyserver/caddy/issues/7385

## Assistance Disclosure
Used GitHub Copilot to investigate and fix, and it produced this report:

---

## Problem Summary
When `systemctl reload caddy` fails (e.g., due to invalid TLS certificates or config errors), the reload command hangs forever. Even after fixing the configuration issue, the reload continues to hang until Caddy is manually restarted.

Example from issue logs:
```
Dec 04 19:37:29 docker-test systemd[1]: caddy.service: Reload operation timed out. Killing reload process.
```

## Root Cause Analysis
The issue occurs in the systemd service notification protocol implementation in `Load()` function (caddy.go, lines 115-140).

According to systemd documentation (https://www.freedesktop.org/software/systemd/man/sd_notify.html), when a reload is initiated:
1. Service sends `RELOADING=1` to notify systemd that reload is starting
2. Service must send `READY=1` when reload completes (success or failure)
3. systemd waits for `READY=1` to mark the reload as complete

**The Bug:** The original code had an early return in the error path:
```go
defer func() {
	if err != nil {
		if notifyErr := notify.Error(err, 0); notifyErr != nil {
			Log().Error(...)
		}
		return  // <-- PROBLEM: Never calls notify.Ready()
	}
	if err := notify.Ready(); err != nil {
		Log().Error(...)
	}
}()
```

When a reload failed, `notify.Ready()` was never called, leaving systemd in a waiting state. Eventually, systemd would timeout and kill the process.

## Solution
Remove the early `return` statement and ensure `notify.Ready()` is **always** called after attempting a reload, whether it succeeds or fails:

```go
defer func() {
	if err != nil {
		if notifyErr := notify.Error(err, 0); notifyErr != nil {
			Log().Error(...)
		}
		// DO NOT RETURN - let execution continue to notify.Ready()
	}
	if notifyErr := notify.Ready(); notifyErr != nil {
		Log().Error(...)
	}
}()
```

This follows the systemd protocol requirement:
- `RELOADING=1` signals the start of reload
- Either `READY=1` (if successful) or an error status is sent
- `READY=1` **must** be sent to complete the cycle, even on failure

## Changes Made
**File:** `caddy.go`
**Function:** `Load()` (lines 115-140)
**Modification:** Removed the early `return` statement in the error handling path of the defer block

### Diff
```diff
  defer func() {
      if err != nil {
          if notifyErr := notify.Error(err, 0); notifyErr != nil {
              Log().Error(...)
          }
-         return
      }
      if notifyErr := notify.Ready(); notifyErr != nil {
          Log().Error(...)
      }
  }()
```

## Impact
- ✅ Fixes systemd reload hangs on configuration errors
- ✅ systemd can now properly detect reload failures and complete the reload cycle
- ✅ Users can retry `systemctl reload caddy` after fixing configuration issues
- ✅ No breaking changes - systemd still receives error information via `STATUS=` message
- ✅ All existing tests pass
- ✅ Backward compatible - non-systemd environments unaffected

## Testing
- All existing unit tests pass
- `TestLoadConcurrent` passes (100 concurrent load operations)
- No behavioral changes in normal operation (success case)
- Error information still properly communicated to systemd

## SystemD Protocol Compliance
This fix ensures Caddy properly implements the systemd notification protocol as documented in `sd_notify(3)`:
- ✅ RELOADING=1 signals reload start
- ✅ STATUS=<error> communicates error details on failure
- ✅ READY=1 signals reload completion (required for both success and failure)
