### PR TITLE
fix: trusted_leaf_cert_file now works correctly

### DIFF
--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -853,10 +853,10 @@ func (clientauth *ClientAuthentication) ConfigureTLSConfig(cfg *tls.Config) erro
 		}
 	} else {
 		// otherwise, set a safe default mode
-		if len(clientauth.TrustedCACerts) > 0 ||
+		hasCACerts := len(clientauth.TrustedCACerts) > 0 ||
 			len(clientauth.TrustedCACertPEMFiles) > 0 ||
-			len(clientauth.TrustedLeafCerts) > 0 ||
-			clientauth.CARaw != nil || clientauth.ca != nil {
+			clientauth.CARaw != nil || clientauth.ca != nil
+		if hasCACerts {
 			cfg.ClientAuth = tls.RequireAndVerifyClientCert
 		} else {
 			cfg.ClientAuth = tls.RequireAnyClientCert
@@ -907,7 +907,7 @@ func (clientauth *ClientAuthentication) verifyConnection(cs tls.ConnectionState)
 		}
 	}
 	for _, verifier := range clientauth.verifiers {
-		if err := verifier.VerifyClientCertificate(nil, cs.VerifiedChains); err != nil {
+		if err := verifier.VerifyClientCertificate(cs.PeerCertificatesRaw, cs.VerifiedChains); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #4518: `trusted_leaf_cert_file` now works correctly as documented.

## Root Cause

The issue had two root causes:

1. In `verifyConnection()`, verifiers were called with `nil` as `rawCerts` instead of the actual peer certificates. This caused `LeafCertClientAuth.VerifyClientCertificate` to fail immediately with "no client certificate provided".

2. When only `TrustedLeafCerts` were specified (no CA certs), the default mode was set to `RequireAndVerifyClientCert`, which requires CA verification. Since no CA certs were provided, CA verification would fail before `VerifyConnection` was called.

## Changes

- Pass `cs.PeerCertificatesRaw` to verifiers in `verifyConnection()`
- Only default to `RequireAndVerifyClientCert` when CA certs are actually provided, not when only `TrustedLeafCerts` are specified

## Files Changed

- `modules/caddytls/connpolicy.go`: Fixed the two issues above

Closes #4518