### PR TITLE
feat(fileserver): add allow_precompressed_without_base option

### DIFF
--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -52,13 +52,14 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 // the static file server and configures it with this syntax:
 //
 //	file_server [<matcher>] [browse] {
-//	    fs            <filesystem>
-//	    root          <path>
-//	    hide          <files...>
-//	    index         <files...>
-//	    browse        [<template_file>]
-//	    precompressed <formats...>
-//	    status        <status>
+//	    fs                         <filesystem>
+//	    root                       <path>
+//	    hide                       <files...>
+//	    index                      <files...>
+//	    browse                     [<template_file>]
+//	    precompressed              <formats...>
+//	    allow_precompressed_without_base
+//	    status                     <status>
 //	    disable_canonical_uris
 //	}
 //
@@ -193,6 +194,12 @@ func (fsrv *FileServer) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				return d.ArgErr()
 			}
 			fsrv.EtagFileExtensions = etagFileExtensions
+
+		case "allow_precompressed_without_base":
+			if d.NextArg() {
+				return d.ArgErr()
+			}
+			fsrv.AllowPrecompressedWithoutBase = true
 
 		default:
 			return d.Errf("unknown subdirective '%s'", d.Val())

--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -39,7 +39,7 @@ import (
 func init() {
 	caddycmd.RegisterCommand(caddycmd.Command{
 		Name:  "file-server",
-		Usage: "[--domain <example.com>] [--root <path>] [--listen <addr>] [--browse] [--reveal-symlinks] [--access-log] [--precompressed]",
+		Usage: "[--domain <example.com>] [--root <path>] [--listen <addr>] [--browse] [--reveal-symlinks] [--access-log] [--precompressed] [--allow-precompressed-without-base]",
 		Short: "Spins up a production-ready file server",
 		Long: `
 A simple but production-ready file server. Useful for quick deployments,
@@ -56,7 +56,12 @@ By default, Zstandard and Gzip compression are enabled. Use --no-compress
 to disable compression.
 
 If --browse is enabled, requests for folders without an index file will
-respond with a file listing.`,
+respond with a file listing.
+
+If --allow-precompressed-without-base is enabled along with --precompressed,
+the file server will serve precompressed files even when the uncompressed
+base file does not exist. This is useful for saving disk space by only
+keeping compressed versions of files.`,
 		CobraFunc: func(cmd *cobra.Command) {
 			cmd.Flags().StringP("domain", "d", "", "Domain name at which to serve the files")
 			cmd.Flags().StringP("root", "r", "", "The path to the root of the site")
@@ -69,6 +74,7 @@ respond with a file listing.`,
 			cmd.Flags().IntP("file-limit", "f", defaultDirEntryLimit, "Max directories to read")
 			cmd.Flags().BoolP("no-compress", "", false, "Disable Zstandard and Gzip compression")
 			cmd.Flags().StringSliceP("precompressed", "p", []string{}, "Specify precompression file extensions. Compression preference implied from flag order.")
+			cmd.Flags().BoolP("allow-precompressed-without-base", "", false, "Allow serving precompressed files without base files")
 			cmd.RunE = caddycmd.WrapCommandFuncForCobra(cmdFileServer)
 			cmd.AddCommand(&cobra.Command{
 				Use:     "export-template",
@@ -100,6 +106,7 @@ func cmdFileServer(fs caddycmd.Flags) (int, error) {
 	if err != nil {
 		return caddy.ExitCodeFailedStartup, fmt.Errorf("invalid precompressed flag: %v", err)
 	}
+	allowPrecompressedWithoutBase := fs.Bool("allow-precompressed-without-base")
 	var handlers []json.RawMessage
 
 	if compress {
@@ -150,6 +157,7 @@ func cmdFileServer(fs caddycmd.Flags) (int, error) {
 			order = append(order, compression)
 		}
 		handler.PrecompressedOrder = order
+		handler.AllowPrecompressedWithoutBase = allowPrecompressedWithoutBase
 	}
 
 	if browse {

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -168,6 +168,11 @@ type FileServer struct {
 	PrecompressedOrder []string `json:"precompressed_order,omitempty"`
 	precompressors     map[string]encode.Precompressed
 
+	// If true, allow serving precompressed files even when the base file does not exist.
+	// This is useful for space-saving scenarios where only compressed files are kept on disk.
+	// If a client does not support any of the available compression formats, a 404 is returned.
+	AllowPrecompressedWithoutBase bool `json:"allow_precompressed_without_base,omitempty"`
+
 	// List of file extensions to try to read Etags from.
 	// If set, file Etags will be read from sidecar files
 	// with any of these suffixes, instead of generating
@@ -308,6 +313,11 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 	if err != nil {
 		err = fsrv.mapDirOpenError(fileSystem, err, filename)
 		if errors.Is(err, fs.ErrNotExist) {
+			// if AllowPrecompressedWithoutBase is enabled, check for precompressed files
+			// even when the base file doesn't exist
+			if fsrv.AllowPrecompressedWithoutBase && len(fsrv.precompressors) > 0 {
+				return fsrv.servePrecompressedOnly(fileSystem, filename, w, r, next)
+			}
 			return fsrv.notFound(w, r, next)
 		} else if errors.Is(err, fs.ErrInvalid) {
 			return caddyhttp.Error(http.StatusBadRequest, err)
@@ -724,6 +734,148 @@ func (fsrv *FileServer) notFound(w http.ResponseWriter, r *http.Request, next ca
 		return next.ServeHTTP(w, r)
 	}
 	return caddyhttp.Error(http.StatusNotFound, nil)
+}
+
+// servePrecompressedOnly handles serving precompressed files when the base file
+// does not exist. This is used when AllowPrecompressedWithoutBase is enabled.
+// It iterates through the client's accepted encodings and serves the first
+// matching precompressed file found. If no matching file is found, it returns 404.
+func (fsrv *FileServer) servePrecompressedOnly(fileSystem fs.FS, filename string, w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
+	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+	filesToHide := fsrv.transformHidePaths(repl)
+
+	respHeader := w.Header()
+
+	// static file responses should contain "Vary: Accept-Encoding"
+	// so caches can craft a reliable key
+	respHeader.Add("Vary", "Accept-Encoding")
+
+	// Iterate through the client's accepted encodings in order of preference
+	for _, ae := range encode.AcceptedEncodings(r, fsrv.PrecompressedOrder) {
+		precompress, ok := fsrv.precompressors[ae]
+		if !ok {
+			continue
+		}
+
+		compressedFilename := filename + precompress.Suffix()
+
+		// Check if the compressed file is hidden
+		if fileHidden(compressedFilename, filesToHide) {
+			if c := fsrv.logger.Check(zapcore.DebugLevel, "hiding precompressed file"); c != nil {
+				c.Write(
+					zap.String("filename", compressedFilename),
+					zap.Strings("files_to_hide", filesToHide),
+				)
+			}
+			continue
+		}
+
+		// Check if the compressed file exists
+		compressedInfo, err := fs.Stat(fileSystem, compressedFilename)
+		if err != nil {
+			if c := fsrv.logger.Check(zapcore.DebugLevel, "precompressed file not accessible"); c != nil {
+				c.Write(zap.String("filename", compressedFilename), zap.Error(err))
+			}
+			continue
+		}
+
+		// Skip directories
+		if compressedInfo.IsDir() {
+			continue
+		}
+
+		if c := fsrv.logger.Check(zapcore.DebugLevel, "opening precompressed file without base"); c != nil {
+			c.Write(zap.String("filename", compressedFilename))
+		}
+
+		// Open the file
+		file, err := fsrv.openFile(fileSystem, compressedFilename, w)
+		if err != nil {
+			if caddyErr, ok := err.(caddyhttp.HandlerError); ok && caddyErr.StatusCode == http.StatusServiceUnavailable {
+				return err
+			}
+			if c := fsrv.logger.Check(zapcore.WarnLevel, "opening precompressed file failed"); c != nil {
+				c.Write(zap.String("filename", compressedFilename), zap.Error(err))
+			}
+			continue
+		}
+		defer file.Close()
+
+		// Set the Content-Encoding header
+		respHeader.Set("Content-Encoding", ae)
+
+		// Set Content-Length for non-range requests
+		if r.Header.Get("Range") == "" {
+			respHeader.Set("Content-Length", strconv.FormatInt(compressedInfo.Size(), 10))
+		}
+
+		// Calculate ETag
+		var etag string
+		if fsrv.EtagFileExtensions != nil {
+			etag, err = fsrv.getEtagFromFile(fileSystem, compressedFilename)
+			if err != nil {
+				return err
+			}
+		}
+		if etag == "" {
+			etag = calculateEtag(compressedInfo)
+		}
+		if etag != "" {
+			respHeader.Set("Etag", etag)
+		}
+
+		// Set Content-Type based on the base filename (not the compressed filename)
+		if respHeader.Get("Content-Type") == "" {
+			mtyp := mime.TypeByExtension(filepath.Ext(filename))
+			if mtyp == "" {
+				// do not allow Go to sniff the content-type
+				respHeader["Content-Type"] = nil
+			} else {
+				respHeader.Set("Content-Type", mtyp)
+			}
+		}
+
+		// Handle status code override if configured
+		var statusCodeOverride int
+		codeStr := fsrv.StatusCode.String()
+		if codeStr != "" {
+			statusCodeOverride, err = strconv.Atoi(repl.ReplaceAll(codeStr, ""))
+			if err != nil {
+				return caddyhttp.Error(http.StatusInternalServerError, err)
+			}
+		}
+
+		// Handle error context status code
+		if reqErr, ok := r.Context().Value(caddyhttp.ErrorCtxKey).(error); ok {
+			statusCodeOverride = http.StatusInternalServerError
+			if handlerErr, ok := reqErr.(caddyhttp.HandlerError); ok {
+				if handlerErr.StatusCode > 0 {
+					statusCodeOverride = handlerErr.StatusCode
+				}
+			}
+		}
+
+		// Wrap response writer if status code override is needed
+		if statusCodeOverride > 0 {
+			w = statusOverrideResponseWriter{ResponseWriter: w, code: statusCodeOverride}
+		}
+
+		// Reject methods other than GET and HEAD
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			if _, ok := r.Context().Value(caddyhttp.ErrorCtxKey).(error); !ok {
+				respHeader.Add("Allow", "GET, HEAD")
+				return caddyhttp.Error(http.StatusMethodNotAllowed, nil)
+			}
+		}
+
+		// Serve the file
+		http.ServeContent(w, r, compressedInfo.Name(), compressedInfo.ModTime(), file.(io.ReadSeeker))
+
+		return nil
+	}
+
+	// No precompressed file found for any accepted encoding
+	return fsrv.notFound(w, r, next)
 }
 
 // calculateEtag computes an entity tag using a strong validator


### PR DESCRIPTION
This PR adds support for serving precompressed files without requiring the base file to exist.

Fixes #5116

**Changes:**
- Added new option `allow_precompressed_without_base` to the file server configuration
- When enabled, precompressed files (e.g., .gz, .br) can be served directly even if the uncompressed version does not exist

**Testing:**
Please test with file_server browse configuration that has precompressed files but no base files.