### PR TITLE
fix(file_server): persist browse layout setting using localStorage

### DIFF
--- a/modules/caddyhttp/fileserver/browse.html
+++ b/modules/caddyhttp/fileserver/browse.html
@@ -1202,6 +1202,15 @@ footer {
 						sizebar.style.width = `${size/largest * 100}%`;
 					}
 				});
+
+				// restore layout preference from localStorage if not in URL
+				const savedLayout = localStorage.getItem('browse-layout');
+				if (savedLayout) {
+					const currentLayout = new URL(window.location.href).searchParams.get('layout') || '';
+					if (savedLayout !== currentLayout) {
+						queryParam('layout', savedLayout);
+					}
+				}
 			}
 
 			function filter() {
@@ -1228,9 +1237,11 @@ footer {
 			}
 
 			document.getElementById("layout-list").addEventListener("click", function() {
+				localStorage.setItem('browse-layout', '');
 				queryParam('layout', '');
 			});
 			document.getElementById("layout-grid").addEventListener("click", function() {
+				localStorage.setItem('browse-layout', 'grid');
 				queryParam('layout', 'grid');
 			});
 


### PR DESCRIPTION
This PR fixes the issue where the file_server browse layout setting was not persisted.

Fixes #6386

**Changes:**
- The browse layout setting is now saved using localStorage
- Users will no longer lose their preferred layout setting when navigating between pages

**Testing:**
Test by changing the layout in file_server browse, then navigating to a different directory and back. The layout setting should persist.