### PR TITLE
fix: prevent downgrade on 'caddy upgrade' by clearing pinned versions

### DIFF
--- a/cmd/packagesfuncs.go
+++ b/cmd/packagesfuncs.go
@@ -43,6 +43,12 @@ func cmdUpgrade(fl Flags) (int, error) {
 		return caddy.ExitCodeFailedStartup, err
 	}
 
+	// for upgrade, we want to get the latest versions, so clear any pinned versions
+	for path, pkg := range pluginPkgs {
+		pkg.Version = ""
+		pluginPkgs[path] = pkg
+	}
+
 	return upgradeBuild(pluginPkgs, fl)
 }
 


### PR DESCRIPTION
## Summary

The `caddy upgrade` command could accidentally downgrade packages when it preserved the current installed version numbers when querying the download API.

## Problem

When calling the download API, `caddy upgrade` was sending the current installed version numbers for plugin packages. This caused the API to return those specific versions instead of the latest versions, potentially resulting in a downgrade.

## Solution

Clear the `Version` field of all plugin packages before calling `upgradeBuild`. This ensures the download API returns the latest versions for all packages.

## Changes

- Clear `pkg.Version` for all plugin packages in `cmdUpgrade` before calling `upgradeBuild`

## Testing

- All cmd tests pass
- Full test suite passes

Fixes #4057