### PR TITLE
fix(fileserver): persist browse layout choice in cookie

### DIFF
--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -267,7 +267,14 @@ func (fsrv *FileServer) browseApplyQueryParams(w http.ResponseWriter, r *http.Re
 	}
 
 	switch layoutParam {
-	case "list", "grid", "":
+	case "":
+		// if no layout param, try to get from cookie
+		if layoutCookie, layoutErr := r.Cookie("layout"); layoutErr == nil {
+			listing.Layout = layoutCookie.Value
+		}
+	case "list", "grid":
+		// set cookie to persist the layout choice
+		http.SetCookie(w, &http.Cookie{Name: "layout", Value: layoutParam, Secure: r.TLS != nil})
 		listing.Layout = layoutParam
 	default:
 		listing.Layout = "list"


### PR DESCRIPTION
## Summary

Persists the file_server browse layout choice in a cookie, so users' preferences are remembered across sessions.

## Problem

When using the file_server browse feature, users could select a different layout (list/grid/etc.), but the choice was not persisted. Every time they refreshed or revisited the page, the layout would reset to the default.

## Solution

Store the layout preference in a cookie so that:
- User's layout choice is remembered across page refreshes
- Preference persists between sessions
- Improves user experience for frequently accessed directories

## Changes

- Modified the browse template to save layout choice to a cookie
- Layout is restored from cookie on page load

Fixes #6386