### PR TITLE
admin: redact sensitive request headers in API logs

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -45,6 +45,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 )
 
 // testCertMagicStorageOverride is a package-level test hook. Tests may set
@@ -800,7 +802,7 @@ func (h adminHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		zap.String("uri", r.RequestURI),
 		zap.String("remote_ip", ip),
 		zap.String("remote_port", port),
-		zap.Reflect("headers", r.Header),
+		zap.Object("headers", caddyhttp.LoggableHTTPHeader{Header: r.Header}),
 	)
 	if r.TLS != nil {
 		log = log.With(


### PR DESCRIPTION
## Summary

The admin API handler was logging request headers using `zap.Reflect`, which serializes the raw header map without any redaction. This could expose sensitive headers like Cookie, Set-Cookie, Authorization, and Proxy-Authorization in logs.

## Problem

Before this fix, the admin API would log all request headers in plain text:
```go
zap.Reflect("headers", r.Header)
```

This could expose sensitive information in logs.

## Solution

Changed to use `LoggableHTTPHeader` which redacts sensitive headers:
```go
zap.Object("headers", caddyhttp.LoggableHTTPHeader{Header: r.Header})
```

This is consistent with how headers are logged everywhere else in the codebase. Sensitive headers (Cookie, Set-Cookie, Authorization, Proxy-Authorization) are redacted unless `ShouldLogCredentials` is explicitly enabled.

## Changes

- `admin.go` (2 lines: import + logging change)

Fixes #7566