### PR TITLE
caddytls: Expand placeholders in dns_challenge override_domain tls parameter

### DIFF
--- a/modules/caddytls/acmeissuer.go
+++ b/modules/caddytls/acmeissuer.go
@@ -149,6 +149,15 @@ func (iss *ACMEIssuer) Provision(ctx caddy.Context) error {
 		iss.AccountKey = accountKey
 	}
 
+	// expand DNS override domain, if non-empty
+	if iss.Challenges != nil && iss.Challenges.DNS != nil && iss.Challenges.DNS.OverrideDomain != "" {
+		overrideDomain, err := repl.ReplaceOrErr(iss.Challenges.DNS.OverrideDomain, true, true)
+		if err != nil {
+			return fmt.Errorf("expanding DNS override domain '%s': %v", iss.Challenges.DNS.OverrideDomain, err)
+		}
+		iss.Challenges.DNS.OverrideDomain = overrideDomain
+	}
+
 	// DNS challenge provider, if not already established
 	if iss.Challenges != nil && iss.Challenges.DNS != nil && iss.Challenges.DNS.solver == nil {
 		var prov certmagic.DNSProvider


### PR DESCRIPTION
This PR simply adds placeholder expansion support to the "dns_challenge override_domain" tls parameter.

## Assistance Disclosure

I consulted Claude to determine where the code should be located, but I authored it myself.
