### PR TITLE
vars: Don't expand placeholders in values

### DIFF
--- a/modules/caddyhttp/vars.go
+++ b/modules/caddyhttp/vars.go
@@ -181,18 +181,15 @@ func (m VarsMatcher) MatchWithError(r *http.Request) (bool, error) {
 	vars := r.Context().Value(VarsCtxKey).(map[string]any)
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 
-	var fromPlaceholder bool
-	var matcherValExpanded, valExpanded, varStr, v string
+	var matcherValExpanded, varStr, v string
 	var varValue any
 	for key, vals := range m {
 		if strings.HasPrefix(key, "{") &&
 			strings.HasSuffix(key, "}") &&
 			strings.Count(key, "{") == 1 {
 			varValue, _ = repl.Get(strings.Trim(key, "{}"))
-			fromPlaceholder = true
 		} else {
 			varValue = vars[key]
-			fromPlaceholder = false
 		}
 
 		switch vv := varValue.(type) {
@@ -208,19 +205,15 @@ func (m VarsMatcher) MatchWithError(r *http.Request) (bool, error) {
 			varStr = fmt.Sprintf("%v", vv)
 		}
 
-		// Only expand placeholders in values from literal variable names
-		// (e.g. map outputs). Values resolved from placeholder keys are
+		// Don't expand placeholders in values from literal variable names
+		// (e.g. map outputs) or other placeholders. These values are
 		// already final and must not be re-expanded, as that would allow
 		// user input like {env.SECRET} to be evaluated.
-		valExpanded = varStr
-		if !fromPlaceholder {
-			valExpanded = repl.ReplaceAll(varStr, "")
-		}
 
 		// see if any of the values given in the matcher match the actual value
 		for _, v = range vals {
 			matcherValExpanded = repl.ReplaceAll(v, "")
-			if valExpanded == matcherValExpanded {
+			if varStr == matcherValExpanded {
 				return true, nil
 			}
 		}
@@ -324,18 +317,16 @@ func (m MatchVarsRE) MatchWithError(r *http.Request) (bool, error) {
 	vars := r.Context().Value(VarsCtxKey).(map[string]any)
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 
-	var fromPlaceholder, match bool
-	var valExpanded, varStr string
+	var match bool
+	var varStr string
 	var varValue any
 	for key, val := range m {
 		if strings.HasPrefix(key, "{") &&
 			strings.HasSuffix(key, "}") &&
 			strings.Count(key, "{") == 1 {
 			varValue, _ = repl.Get(strings.Trim(key, "{}"))
-			fromPlaceholder = true
 		} else {
 			varValue = vars[key]
-			fromPlaceholder = false
 		}
 
 		switch vv := varValue.(type) {
@@ -351,15 +342,12 @@ func (m MatchVarsRE) MatchWithError(r *http.Request) (bool, error) {
 			varStr = fmt.Sprintf("%v", vv)
 		}
 
-		// Only expand placeholders in values from literal variable names
-		// (e.g. map outputs). Values resolved from placeholder keys are
+		// Don't expand placeholders in values from literal variable names
+		// (e.g. map outputs) or other placeholders. These values are
 		// already final and must not be re-expanded, as that would allow
 		// user input like {env.SECRET} to be evaluated.
-		valExpanded = varStr
-		if !fromPlaceholder {
-			valExpanded = repl.ReplaceAll(varStr, "")
-		}
-		if match = val.Match(valExpanded, repl); match {
+
+		if match = val.Match(varStr, repl); match {
 			return match, nil
 		}
 	}


### PR DESCRIPTION
This PR prevents a potential leakage of sensitive information because of expanding placeholders in values of custom variables via `vars_regexp`. For consistency, both `vars` and `vars_regexp` matchers now treat values of placeholders and custom variables as final, i.e. don't expand them before matching.

A config example of how it could have been exploited:
```caddyfile
:8080 {
	# assign the value of `http.request.uri.query` to `q`
	vars q {http.request.uri.query}
	# before this PR: expand the value of `q`, match it against the pattern
	# after this PR: match the value of `q` against the pattern
	@has_q vars_regexp qre q "(.+)"
	handle @has_q {
		respond "Query value {re.qre.1}" 200
	}
	respond "Missing query" 400
}

# navigate to http://127.0.0.1:8080/?{env.SECRET}:
# before this PR: it returns `Query value` and anything `env.SECRET` contains
# after this PR: it returns `Query value {env.SECRET}` without expansion
```

No AI has been involved.