### PR TITLE
fix: using variable interpolation `${{ in release-proposal.yml...

### DIFF
--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -38,10 +38,13 @@ jobs:
 
       - name: Trim and validate inputs
         id: inputs
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_COMMIT_HASH: ${{ inputs.commit_hash }}
         run: |
           # Trim whitespace from inputs
-          VERSION=$(echo "${{ inputs.version }}" | xargs)
-          COMMIT_HASH=$(echo "${{ inputs.commit_hash }}" | xargs)
+          VERSION=$(echo "$INPUT_VERSION" | xargs)
+          COMMIT_HASH=$(echo "$INPUT_COMMIT_HASH" | xargs)
           
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
@@ -65,9 +68,11 @@ jobs:
           fi
 
       - name: Check if tag already exists
+        env:
+          VERSION: ${{ steps.inputs.outputs.version }}
         run: |
-          if git rev-parse "${{ steps.inputs.outputs.version }}" >/dev/null 2>&1; then
-            echo "Error: Tag ${{ steps.inputs.outputs.version }} already exists"
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Error: Tag $VERSION already exists"
             exit 1
           fi
 
@@ -128,9 +133,10 @@ jobs:
 
       - name: Generate changelog and create branch
         id: setup
+        env:
+          VERSION: ${{ steps.inputs.outputs.version }}
+          COMMIT_HASH: ${{ steps.inputs.outputs.commit_hash }}
         run: |
-          VERSION="${{ steps.inputs.outputs.version }}"
-          COMMIT_HASH="${{ steps.inputs.outputs.commit_hash }}"
           
           # Create a new branch for the release proposal
           BRANCH_NAME="release_proposal-$VERSION"
@@ -239,11 +245,16 @@ jobs:
           result-encoding: json
 
       - name: Post summary
+        env:
+          VERSION: ${{ steps.inputs.outputs.version }}
+          COMMIT_HASH: ${{ steps.inputs.outputs.commit_hash }}
+          BEHIND_INFO: ${{ steps.setup.outputs.behind_info }}
+          PR_URL: ${{ fromJson(steps.create_pr.outputs.result).url }}
         run: |
           echo "## Release Proposal PR Created! 🚀" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Version: **${{ steps.inputs.outputs.version }}**" >> $GITHUB_STEP_SUMMARY
-          echo "Commit: **${{ steps.inputs.outputs.commit_hash }}**" >> $GITHUB_STEP_SUMMARY
-          echo "Status: ${{ steps.setup.outputs.behind_info }}" >> $GITHUB_STEP_SUMMARY
+          echo "Version: **$VERSION**" >> $GITHUB_STEP_SUMMARY
+          echo "Commit: **$COMMIT_HASH**" >> $GITHUB_STEP_SUMMARY
+          echo "Status: $BEHIND_INFO" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "PR: ${{ fromJson(steps.create_pr.outputs.result).url }}" >> $GITHUB_STEP_SUMMARY
+          echo "PR: $PR_URL" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
Fix medium severity security issue in `.github/workflows/release-proposal.yml`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | yaml.github-actions.security.run-shell-injection.run-shell-injection |
| **Severity** | MEDIUM |
| **Scanner** | semgrep |
| **Rule** | `yaml.github-actions.security.run-shell-injection.run-shell-injection` |
| **File** | `.github/workflows/release-proposal.yml:41` |

**Description**: Using variable interpolation `${{...}}` with `github` context data in a `run:` step could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. `github` context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with `env:` to store the data and use the environment variable in the `run:` script. Be sure to use double-quotes the environment variable, like this: "$ENVVAR".

## Changes
- `.github/workflows/release-proposal.yml`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
