### PR TITLE
vars: Add matcher placeholder handling tests

### DIFF
--- a/modules/caddyhttp/vars_test.go
+++ b/modules/caddyhttp/vars_test.go
@@ -1,0 +1,141 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddyhttp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+)
+
+func newVarsTestRequest(t *testing.T, headers http.Header, vars map[string]any) (*http.Request, *caddy.Replacer) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/test", nil)
+	req.Header = headers
+
+	repl := caddy.NewReplacer()
+	ctx := context.WithValue(req.Context(), caddy.ReplacerCtxKey, repl)
+	if vars == nil {
+		vars = make(map[string]any)
+	}
+	// Inject vars directly so these tests exercise matcher-side handling of
+	// already-resolved values, not VarsMiddleware placeholder expansion.
+	ctx = context.WithValue(ctx, VarsCtxKey, vars)
+	req = req.WithContext(ctx)
+
+	addHTTPVarsToReplacer(repl, req, httptest.NewRecorder())
+
+	return req, repl
+}
+
+func TestVarsMatcherDoesNotExpandResolvedValues(t *testing.T) {
+	t.Setenv("CADDY_VARS_TEST_SECRET", "topsecret")
+
+	for _, tc := range []struct {
+		name    string
+		match   VarsMatcher
+		headers http.Header
+		vars    map[string]any
+		expect  bool
+	}{
+		{
+			name:   "literal variable value containing placeholder syntax is not re-expanded",
+			match:  VarsMatcher{"secret": []string{"topsecret"}},
+			vars:   map[string]any{"secret": "{env.CADDY_VARS_TEST_SECRET}"},
+			expect: false,
+		},
+		{
+			name:    "placeholder key value containing placeholder syntax is not re-expanded",
+			match:   VarsMatcher{"{http.request.header.X-Input}": []string{"topsecret"}},
+			headers: http.Header{"X-Input": []string{"{env.CADDY_VARS_TEST_SECRET}"}},
+			expect:  false,
+		},
+		{
+			name:   "matcher values still expand placeholders",
+			match:  VarsMatcher{"secret": []string{"{env.CADDY_VARS_TEST_SECRET}"}},
+			vars:   map[string]any{"secret": "topsecret"},
+			expect: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, _ := newVarsTestRequest(t, tc.headers, tc.vars)
+
+			actual, err := tc.match.MatchWithError(req)
+			if err != nil {
+				t.Fatalf("MatchWithError() error = %v", err)
+			}
+
+			if actual != tc.expect {
+				t.Fatalf("MatchWithError() = %t, want %t", actual, tc.expect)
+			}
+		})
+	}
+}
+
+func TestMatchVarsREDoesNotExpandResolvedValues(t *testing.T) {
+	t.Setenv("CADDY_VARS_TEST_SECRET", "topsecret")
+
+	for _, tc := range []struct {
+		name    string
+		match   MatchVarsRE
+		headers http.Header
+		vars    map[string]any
+		expect  bool
+	}{
+		{
+			name:   "literal variable value containing placeholder syntax is not re-expanded",
+			match:  MatchVarsRE{"secret": &MatchRegexp{Pattern: "^topsecret$"}},
+			vars:   map[string]any{"secret": "{env.CADDY_VARS_TEST_SECRET}"},
+			expect: false,
+		},
+		{
+			name:    "placeholder key value containing placeholder syntax is not re-expanded",
+			match:   MatchVarsRE{"{http.request.header.X-Input}": &MatchRegexp{Pattern: "^topsecret$"}},
+			headers: http.Header{"X-Input": []string{"{env.CADDY_VARS_TEST_SECRET}"}},
+			expect:  false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.match.Provision(caddy.Context{})
+			if err != nil {
+				t.Fatalf("Provision() error = %v", err)
+			}
+
+			err = tc.match.Validate()
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+
+			req, _ := newVarsTestRequest(t, tc.headers, tc.vars)
+
+			actual, err := tc.match.MatchWithError(req)
+			if err != nil {
+				t.Fatalf("MatchWithError() error = %v", err)
+			}
+
+			if actual != tc.expect {
+				t.Fatalf("MatchWithError() = %t, want %t", actual, tc.expect)
+			}
+		})
+	}
+}

--- a/modules/caddyhttp/vars_test.go
+++ b/modules/caddyhttp/vars_test.go
@@ -23,10 +23,14 @@ import (
 	"github.com/caddyserver/caddy/v2"
 )
 
-func newVarsTestRequest(t *testing.T, headers http.Header, vars map[string]any) (*http.Request, *caddy.Replacer) {
+func newVarsTestRequest(t *testing.T, target string, headers http.Header, vars map[string]any) (*http.Request, *caddy.Replacer) {
 	t.Helper()
 
-	req := httptest.NewRequest(http.MethodGet, "https://example.com/test", nil)
+	if target == "" {
+		target = "https://example.com/test"
+	}
+
+	req := httptest.NewRequest(http.MethodGet, target, nil)
 	req.Header = headers
 
 	repl := caddy.NewReplacer()
@@ -49,6 +53,7 @@ func TestVarsMatcherDoesNotExpandResolvedValues(t *testing.T) {
 
 	for _, tc := range []struct {
 		name    string
+		target  string
 		match   VarsMatcher
 		headers http.Header
 		vars    map[string]any
@@ -67,6 +72,12 @@ func TestVarsMatcherDoesNotExpandResolvedValues(t *testing.T) {
 			expect:  false,
 		},
 		{
+			name:   "query placeholder value containing placeholder syntax is not re-expanded",
+			target: "https://example.com/test?foo=%7Benv.CADDY_VARS_TEST_SECRET%7D",
+			match:  VarsMatcher{"{http.request.uri.query.foo}": []string{"topsecret"}},
+			expect: false,
+		},
+		{
 			name:   "matcher values still expand placeholders",
 			match:  VarsMatcher{"secret": []string{"{env.CADDY_VARS_TEST_SECRET}"}},
 			vars:   map[string]any{"secret": "topsecret"},
@@ -76,7 +87,7 @@ func TestVarsMatcherDoesNotExpandResolvedValues(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			req, _ := newVarsTestRequest(t, tc.headers, tc.vars)
+			req, _ := newVarsTestRequest(t, tc.target, tc.headers, tc.vars)
 
 			actual, err := tc.match.MatchWithError(req)
 			if err != nil {
@@ -95,6 +106,7 @@ func TestMatchVarsREDoesNotExpandResolvedValues(t *testing.T) {
 
 	for _, tc := range []struct {
 		name    string
+		target  string
 		match   MatchVarsRE
 		headers http.Header
 		vars    map[string]any
@@ -112,6 +124,12 @@ func TestMatchVarsREDoesNotExpandResolvedValues(t *testing.T) {
 			headers: http.Header{"X-Input": []string{"{env.CADDY_VARS_TEST_SECRET}"}},
 			expect:  false,
 		},
+		{
+			name:   "query placeholder value containing placeholder syntax is not re-expanded",
+			target: "https://example.com/test?foo=%7Benv.CADDY_VARS_TEST_SECRET%7D",
+			match:  MatchVarsRE{"{http.request.uri.query.foo}": &MatchRegexp{Pattern: "^topsecret$"}},
+			expect: false,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -126,7 +144,7 @@ func TestMatchVarsREDoesNotExpandResolvedValues(t *testing.T) {
 				t.Fatalf("Validate() error = %v", err)
 			}
 
-			req, _ := newVarsTestRequest(t, tc.headers, tc.vars)
+			req, _ := newVarsTestRequest(t, tc.target, tc.headers, tc.vars)
 
 			actual, err := tc.match.MatchWithError(req)
 			if err != nil {


### PR DESCRIPTION
Adds focused regression coverage for #7629.

## Summary
This adds table-driven tests for matcher-side placeholder handling in `vars` and `vars_regexp`.

The main goal is to cover the case where already-resolved values contain placeholder syntax such as `{env.SECRET}` and must not be re-expanded by the matcher. It also adds a compatibility case to make sure matcher-side values still expand placeholders as before.

## Behaviour
Added coverage to verify that:
- `VarsMatcher` does not re-expand resolved values from literal vars
- `VarsMatcher` does not re-expand resolved values from placeholder-key lookups
- matcher values in `VarsMatcher` still expand placeholders
- `MatchVarsRE` does not re-expand resolved values from literal vars
- `MatchVarsRE` does not re-expand resolved values from placeholder-key lookups

These tests exercise the matcher boundary directly by injecting already-resolved values into `VarsCtxKey` which matches the behavior changed in #7629.

## Assistance Disclosure
No AI was used.