### PR TITLE
caddyfile: Improve import/global options UX for imports before global options

### DIFF
--- a/caddyconfig/caddyfile/formatter.go
+++ b/caddyconfig/caddyfile/formatter.go
@@ -84,7 +84,7 @@ func Format(input []byte) []byte {
 		finishToken()
 		if currentLineFirstToken != "" {
 			previousLineWasTopLevelImport = nesting == 0 && currentLineFirstToken == "import"
-		} else if !(openBrace && openBraceOwnLine && !openBraceWritten) {
+		} else if !openBrace || !openBraceOwnLine || openBraceWritten {
 			previousLineWasTopLevelImport = false
 		}
 		currentLineFirstToken = ""

--- a/caddyconfig/caddyfile/formatter.go
+++ b/caddyconfig/caddyfile/formatter.go
@@ -63,7 +63,32 @@ func Format(input []byte) []byte {
 		heredocClosingMarker []rune
 
 		nesting int // indentation level
+
+		currentToken                  strings.Builder
+		currentLineFirstToken         string
+		previousLineWasTopLevelImport bool
+		openBraceOwnLine              bool
 	)
+
+	finishToken := func() {
+		if currentToken.Len() == 0 {
+			return
+		}
+		if currentLineFirstToken == "" {
+			currentLineFirstToken = currentToken.String()
+		}
+		currentToken.Reset()
+	}
+
+	finishLine := func() {
+		finishToken()
+		if currentLineFirstToken != "" {
+			previousLineWasTopLevelImport = nesting == 0 && currentLineFirstToken == "import"
+		} else if !(openBrace && openBraceOwnLine && !openBraceWritten) {
+			previousLineWasTopLevelImport = false
+		}
+		currentLineFirstToken = ""
+	}
 
 	write := func(ch rune) {
 		out.WriteRune(ch)
@@ -220,9 +245,11 @@ func Format(input []byte) []byte {
 		}
 
 		if unicode.IsSpace(ch) {
+			finishToken()
 			space = true
 			heredocEscaped = false
 			if ch == '\n' {
+				finishLine()
 				newLines++
 			}
 			continue
@@ -249,13 +276,19 @@ func Format(input []byte) []byte {
 			}
 
 			openBrace = false
-			if beginningOfLine {
+			if openBraceOwnLine && previousLineWasTopLevelImport {
+				if last != '\n' {
+					nextLine()
+				}
+				indent()
+			} else if beginningOfLine {
 				indent()
 			} else if !openBraceSpace || !unicode.IsSpace(last) {
 				write(' ')
 			}
 			write('{')
 			openBraceWritten = true
+			openBraceOwnLine = false
 			nextLine()
 			newLines = 0
 			// prevent infinite nesting from ridiculous inputs (issue #4169)
@@ -266,8 +299,10 @@ func Format(input []byte) []byte {
 
 		switch {
 		case ch == '{':
+			finishToken()
 			openBrace = true
 			openBraceSpace = spacePrior && !beginningOfLine
+			openBraceOwnLine = newLines > 0
 			if openBraceSpace && newLines == 0 {
 				write(' ')
 			}
@@ -275,11 +310,13 @@ func Format(input []byte) []byte {
 			if quotes == "`" {
 				write('{')
 				openBraceWritten = true
+				openBraceOwnLine = false
 				continue
 			}
 			continue
 
 		case ch == '}' && (spacePrior || !openBrace):
+			finishToken()
 			if quotes == "`" {
 				write('}')
 				continue
@@ -324,6 +361,7 @@ func Format(input []byte) []byte {
 			space = true
 		}
 
+		currentToken.WriteRune(ch)
 		write(ch)
 
 		beginningOfLine = false

--- a/caddyconfig/caddyfile/formatter_test.go
+++ b/caddyconfig/caddyfile/formatter_test.go
@@ -475,6 +475,21 @@ Hope this helps.` + "`" + `
 }`,
 			expect: "https://localhost:8953 {\n\trespond `Here are some random numbers:\n\n{{randNumeric 16}}\n\nHope this helps.`\n}",
 		},
+		{
+			description: "imports before global options block keep standalone brace",
+			input: `import ./conf.d/matcher_my_subnet.caddy
+import ./conf.d/matcher_not_my_subnet.caddy
+{
+	order crowdsec first
+	order appsec after crowdsec
+}`,
+			expect: `import ./conf.d/matcher_my_subnet.caddy
+import ./conf.d/matcher_not_my_subnet.caddy
+{
+	order crowdsec first
+	order appsec after crowdsec
+}`,
+		},
 	} {
 		// the formatter should output a trailing newline,
 		// even if the tests aren't written to expect that

--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -682,9 +682,26 @@ func (p *parser) directive() error {
 // a opening curly brace. It does NOT advance the token.
 func (p *parser) openCurlyBrace() error {
 	if p.Val() != "{" {
+		if p.valLooksLikeGlobalOptionsAfterImportedSnippets() {
+			return p.Err("global options block must appear before import directives; move the global options block to the top of the Caddyfile")
+		}
 		return p.SyntaxErr("{")
 	}
 	return nil
+}
+
+func (p *parser) valLooksLikeGlobalOptionsAfterImportedSnippets() bool {
+	if p.Val() != "import" || len(p.block.Keys) == 0 {
+		return false
+	}
+
+	for _, key := range p.block.Keys {
+		if !strings.HasPrefix(key.Text, "(") || !strings.HasSuffix(key.Text, ")") {
+			return false
+		}
+	}
+
+	return true
 }
 
 // closeCurlyBrace expects the current token to be

--- a/caddyconfig/caddyfile/parse_test.go
+++ b/caddyconfig/caddyfile/parse_test.go
@@ -930,6 +930,36 @@ func TestAcceptSiteImportWithBraces(t *testing.T) {
 	}
 }
 
+func TestGlobalOptionsAfterImportedSnippetsGivesHelpfulError(t *testing.T) {
+	tempDir := t.TempDir()
+	importFile1 := filepath.Join(tempDir, "matcher_snippet_1.caddy")
+	importFile2 := filepath.Join(tempDir, "matcher_snippet_2.caddy")
+
+	err := os.WriteFile(importFile1, []byte(`(matcher1)`), 0o644)
+	if err != nil {
+		t.Fatalf("writing first import file: %v", err)
+	}
+
+	err = os.WriteFile(importFile2, []byte(`(matcher2)`), 0o644)
+	if err != nil {
+		t.Fatalf("writing second import file: %v", err)
+	}
+
+	_, err = Parse("Testfile", []byte(`import `+importFile1+`
+import `+importFile2+`
+{
+	debug
+}`))
+	if err == nil {
+		t.Fatal("Expected an error, but got nil")
+	}
+
+	expected := "global options block must appear before import directives; move the global options block to the top of the Caddyfile"
+	if !strings.HasPrefix(err.Error(), expected) {
+		t.Errorf("Expected error to start with '%s' but got '%v'", expected, err)
+	}
+}
+
 func testParser(input string) parser {
 	return parser{Dispenser: NewTestDispenser(input)}
 }


### PR DESCRIPTION
 
Improves the UX around #7639.

## Summary
This fixes two parts of the issue when `import` directives appear before the global options block.

First, `caddy fmt` no longer rewrites:
```caddyfile
import ./conf.d/matcher_my_subnet.caddy
import ./conf.d/matcher_not_my_subnet.caddy
{
	order crowdsec first
	order appsec after crowdsec
}
```

into the more confusing shape:
```caddyfile
import ./conf.d/matcher_not_my_subnet.caddy {
```

Second, `caddy validate --adapter caddyfile` now gives a clearer error message for this unsupported layout.

## Behaviour
- `fmt` preserves the standalone top-level `{` after `import` lines instead of collapsing it into `import ... {`
- `validate` now reports:
  - `global options block must appear before import directives; move the global options block to the top of the Caddyfile`
- the layout remains unsupported, but the failure mode is now much clearer

## Tests
Added:
- formatter regression coverage for preserving the standalone global-options brace after `import` lines
- parser regression coverage for the clearer validation error when imports precede the global options block

Tested with:
```bash
go test ./caddyconfig/caddyfile -run "TestFormatter|TestGlobalOptionsAfterImportedSnippetsGivesHelpfulError" -count=1
```

Also verified directly with:
```bash
go run ./cmd/caddy validate --config tmp.Caddyfile --adapter caddyfile
```

Should close #7639

## Assistance Disclosure
No AI was used.
