### PR TITLE
logging: Preserve ts for journald-wrapped JSON logs

### DIFF
--- a/modules/logging/journaldencoder.go
+++ b/modules/logging/journaldencoder.go
@@ -81,7 +81,7 @@ func (je *JournaldEncoder) Provision(ctx caddy.Context) error {
 		je.Encoder = val.(zapcore.Encoder)
 	}
 
-	suppressEncoderTimestamp(je.Encoder)
+	suppressConsoleEncoderTimestamp(je.Encoder)
 
 	return nil
 }
@@ -106,7 +106,7 @@ func (je *JournaldEncoder) ConfigureDefaultFormat(wo caddy.WriterOpener) error {
 		}
 	}
 
-	suppressEncoderTimestamp(je.Encoder)
+	suppressConsoleEncoderTimestamp(je.Encoder)
 
 	return nil
 }
@@ -194,22 +194,19 @@ func journaldPriorityPrefix(level zapcore.Level) string {
 	}
 }
 
-func suppressEncoderTimestamp(enc zapcore.Encoder) {
+func suppressConsoleEncoderTimestamp(enc zapcore.Encoder) {
 	empty := ""
 
 	switch e := enc.(type) {
 	case *ConsoleEncoder:
 		e.TimeKey = &empty
 		_ = e.Provision(caddy.Context{})
-	case *JSONEncoder:
-		e.TimeKey = &empty
-		_ = e.Provision(caddy.Context{})
 	case *AppendEncoder:
-		suppressEncoderTimestamp(e.wrapped)
+		suppressConsoleEncoderTimestamp(e.wrapped)
 	case *FilterEncoder:
-		suppressEncoderTimestamp(e.wrapped)
+		suppressConsoleEncoderTimestamp(e.wrapped)
 	case *JournaldEncoder:
-		suppressEncoderTimestamp(e.Encoder)
+		suppressConsoleEncoderTimestamp(e.Encoder)
 	}
 }
 

--- a/modules/logging/journaldencoder_test.go
+++ b/modules/logging/journaldencoder_test.go
@@ -89,7 +89,7 @@ journald {
 	}
 }
 
-func TestJournaldEncoderSuppressesJSONTimestamp(t *testing.T) {
+func TestJournaldEncoderPreservesJSONTimestamp(t *testing.T) {
 	enc := &JournaldEncoder{
 		Encoder: &JSONEncoder{},
 	}
@@ -108,8 +108,8 @@ func TestJournaldEncoderSuppressesJSONTimestamp(t *testing.T) {
 	defer buf.Free()
 
 	got := buf.String()
-	if strings.Contains(got, `"ts"`) {
-		t.Fatalf("got JSON output with ts field: %q", got)
+	if !strings.Contains(got, `"ts"`) {
+		t.Fatalf("got JSON output without ts field: %q", got)
 	}
 }
 


### PR DESCRIPTION
Fixes a small follow-up in #7623.

## Summary
This preserves `ts` for journald-wrapped JSON logs while continuing to suppress the duplicated inline timestamp for journald-wrapped console logs.

That keeps `wrap console` optimised for `journalctl` readability while letting `wrap json` retain the normal structured shape for workflows such as `journalctl | jq`.

## Tests
Updated journald encoder tests to verify:
- `wrap json` preserves `ts`
- `wrap console` still suppresses the inline timestamp

```bash
go test ./modules/logging -run "TestJournald" -count=1
```

## Assistance Disclosure
No AI was used.