### PR TITLE
reverseproxy: add option to omit Via header in proxied responses

### DIFF
--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -100,6 +100,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 //	    stream_timeout     <duration>
 //	    stream_close_delay <duration>
 //	    verbose_logs
+//	    omit_via_header
 //
 //	    # request manipulation
 //	    trusted_proxies [private_ranges] <ranges...>
@@ -862,6 +863,12 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				return d.Err("verbose_logs already specified")
 			}
 			h.VerboseLogs = true
+
+		case "omit_via_header":
+			if h.OmitViaHeader {
+				return d.Err("omit_via_header already specified")
+			}
+			h.OmitViaHeader = true
 
 		default:
 			return d.Errf("unrecognized subdirective %s", d.Val())

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -220,6 +220,13 @@ type Handler struct {
 	// EXPERIMENTAL: This feature is subject to change or removal.
 	VerboseLogs bool `json:"verbose_logs,omitempty"`
 
+	// If true, omit the Via header on proxied responses sent to the client.
+	//
+	// Per RFC 9110, proxies MUST add Via to forwarded messages.
+	// However, an HTTP-to-HTTP gateway MAY omit Via on response messages.
+	// This option controls that response behavior.
+	OmitViaHeader bool `json:"omit_via_header,omitempty"`
+
 	Transport        http.RoundTripper `json:"-"`
 	CB               CircuitBreaker    `json:"-"`
 	DynamicUpstreams UpstreamSource    `json:"-"`
@@ -1153,11 +1160,13 @@ func (h *Handler) finalizeResponse(
 
 	// delete our Server header and use Via instead (see #6275)
 	rw.Header().Del("Server")
-	var protoPrefix string
-	if !strings.HasPrefix(strings.ToUpper(res.Proto), "HTTP/") {
-		protoPrefix = res.Proto[:strings.Index(res.Proto, "/")+1]
+	if !h.OmitViaHeader {
+		var protoPrefix string
+		if !strings.HasPrefix(strings.ToUpper(res.Proto), "HTTP/") {
+			protoPrefix = res.Proto[:strings.Index(res.Proto, "/")+1]
+		}
+		rw.Header().Add("Via", fmt.Sprintf("%s%d.%d Caddy", protoPrefix, res.ProtoMajor, res.ProtoMinor))
 	}
-	rw.Header().Add("Via", fmt.Sprintf("%s%d.%d Caddy", protoPrefix, res.ProtoMajor, res.ProtoMinor))
 
 	// apply any response header operations
 	if h.Headers != nil && h.Headers.Response != nil {


### PR DESCRIPTION

Related Issue: #7643

## Summary

This PR adds an optional `omit_via_header` setting to `reverse_proxy` to suppress the `Via` header on proxied responses.

## Background

Currently, `reverse_proxy` always adds a `Via` header to responses sent back to the client, with no option to disable this.

According to RFC 9110 §7.6.3 [(https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.3)](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.3):

- A proxy MUST send `Via` on forwarded messages
- An HTTP-to-HTTP gateway MUST send `Via` on inbound requests
- An HTTP-to-HTTP gateway MAY send `Via` on forwarded responses

This means that adding `Via` to responses is optional, not mandatory.

## Implementation

This change adds a new optional `omit_via_header` setting to the `reverse_proxy` configuration.

When enabled:

- the `Via` header is omitted from responses sent back to the client
- the `Via` header is still added to outbound requests sent to the upstream, as required by the RFC

## Example

### Caddyfile

```caddyfile
test.local:80 {
    reverse_proxy localhost:3000 {
        omit_via_header
    }
}
```

### JSON

```json
{
  "apps": {
    "http": {
      "servers": {
        "srv0": {
          "listen": [":80"],
          "routes": [
            {
              "match": [
                {
                  "host": ["test.local"]
                }
              ],
              "handle": [
                {
                  "handler": "reverse_proxy",
                  "omit_via_header": true,
                  "upstreams": [
                    {
                      "dial": "localhost:3000"
                    }
                  ]
                }
              ]
            }
          ]
        }
      }
    }
  }
}
```

## Notes

This change preserves the default behavior and maintains RFC-compliant request forwarding, while providing an explicit option to omit the `Via` header on responses.

## Assistance Disclosure
Copilot provided tab completion for code and comments.
