### PR TITLE
fileserver: Support precompressed files w/o base.

### DIFF
--- a/caddytest/integration/caddyfile_adapt/file_server_prefer_precompressed.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/file_server_prefer_precompressed.caddyfiletest
@@ -1,0 +1,43 @@
+:80
+
+file_server {
+	precompressed zstd br gzip
+	prefer_precompressed
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "file_server",
+									"hide": [
+										"./Caddyfile"
+									],
+									"precompressed": {
+										"br": {},
+										"gzip": {},
+										"zstd": {}
+									},
+									"precompressed_order": [
+										"zstd",
+										"br",
+										"gzip"
+									],
+									"prefer_precompressed": true
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -58,6 +58,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 //	    index         <files...>
 //	    browse        [<template_file>]
 //	    precompressed <formats...>
+//	    prefer_precompressed
 //	    status        <status>
 //	    disable_canonical_uris
 //	}
@@ -167,6 +168,12 @@ func (fsrv *FileServer) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				}
 				fsrv.PrecompressedRaw[format] = caddyconfig.JSON(precompress, nil)
 			}
+
+		case "prefer_precompressed":
+			if d.NextArg() {
+				return d.ArgErr()
+			}
+			fsrv.PreferPrecompressed = true
 
 		case "status":
 			if !d.NextArg() {

--- a/modules/caddyhttp/fileserver/command.go
+++ b/modules/caddyhttp/fileserver/command.go
@@ -39,7 +39,7 @@ import (
 func init() {
 	caddycmd.RegisterCommand(caddycmd.Command{
 		Name:  "file-server",
-		Usage: "[--domain <example.com>] [--root <path>] [--listen <addr>] [--browse] [--reveal-symlinks] [--access-log] [--precompressed]",
+		Usage: "[--domain <example.com>] [--root <path>] [--listen <addr>] [--browse] [--reveal-symlinks] [--access-log] [--precompressed] [--prefer-precompressed]",
 		Short: "Spins up a production-ready file server",
 		Long: `
 A simple but production-ready file server. Useful for quick deployments,
@@ -69,6 +69,7 @@ respond with a file listing.`,
 			cmd.Flags().IntP("file-limit", "f", defaultDirEntryLimit, "Max directories to read")
 			cmd.Flags().BoolP("no-compress", "", false, "Disable Zstandard and Gzip compression")
 			cmd.Flags().StringSliceP("precompressed", "p", []string{}, "Specify precompression file extensions. Compression preference implied from flag order.")
+			cmd.Flags().BoolP("prefer-precompressed", "", false, "Serve precompressed files even without the uncompressed base file")
 			cmd.RunE = caddycmd.WrapCommandFuncForCobra(cmdFileServer)
 			cmd.AddCommand(&cobra.Command{
 				Use:     "export-template",
@@ -96,6 +97,7 @@ func cmdFileServer(fs caddycmd.Flags) (int, error) {
 	debug := fs.Bool("debug")
 	revealSymlinks := fs.Bool("reveal-symlinks")
 	compress := !fs.Bool("no-compress")
+	preferPrecompressed := fs.Bool("prefer-precompressed")
 	precompressed, err := fs.GetStringSlice("precompressed")
 	if err != nil {
 		return caddy.ExitCodeFailedStartup, fmt.Errorf("invalid precompressed flag: %v", err)
@@ -151,6 +153,8 @@ func cmdFileServer(fs caddycmd.Flags) (int, error) {
 		}
 		handler.PrecompressedOrder = order
 	}
+
+	handler.PreferPrecompressed = preferPrecompressed
 
 	if browse {
 		handler.Browse = &Browse{RevealSymlinks: revealSymlinks, FileLimit: fileLimit}

--- a/modules/caddyhttp/fileserver/precompressed_test.go
+++ b/modules/caddyhttp/fileserver/precompressed_test.go
@@ -1,0 +1,724 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/internal/filesystems"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp/encode"
+)
+
+// testPrecompressed implements encode.Precompressed for testing.
+type testPrecompressed struct {
+	encoding string
+	suffix   string
+}
+
+func (t testPrecompressed) AcceptEncoding() string { return t.encoding }
+func (t testPrecompressed) Suffix() string         { return t.suffix }
+
+// newTestFileServer creates a FileServer configured for testing with the
+// given root directory and precompressors.
+func newTestFileServer(root string, precompressors map[string]encode.Precompressed, preferPrecompressed bool, precompressedOrder []string) *FileServer {
+	fsrv := &FileServer{
+		Root:                root,
+		FileSystem:          "",
+		PreferPrecompressed: preferPrecompressed,
+		precompressors:      precompressors,
+		PrecompressedOrder:  precompressedOrder,
+		fsmap:               &filesystems.FileSystemMap{},
+		logger:              zap.NewNop(),
+	}
+	return fsrv
+}
+
+// newTestRequest creates an http.Request with the necessary context values
+// for the file server to work (replacer and original request).
+func newTestRequest(method, path string) *http.Request {
+	req := httptest.NewRequest(method, path, nil)
+	repl := caddy.NewReplacer()
+	ctx := context.WithValue(req.Context(), caddy.ReplacerCtxKey, repl)
+	ctx = context.WithValue(ctx, caddyhttp.OriginalRequestCtxKey, *req)
+	req = req.WithContext(ctx)
+	return req
+}
+
+// statusNextHandler is a caddyhttp.Handler that records whether it was called.
+type statusNextHandler struct {
+	called     bool
+	statusCode int
+}
+
+func (h *statusNextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+	h.called = true
+	w.WriteHeader(h.statusCode)
+	return nil
+}
+
+func TestPreferPrecompressedServesCompressedFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create only the precompressed file, no base file
+	gzContent := []byte("fake gzip content")
+	if err := os.WriteFile(filepath.Join(tmpDir, "style.css.gz"), gzContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	precompressors := map[string]encode.Precompressed{
+		"gzip": testPrecompressed{encoding: "gzip", suffix: ".gz"},
+	}
+	fsrv := newTestFileServer(tmpDir, precompressors, true, []string{"gzip"})
+
+	req := newTestRequest("GET", "/style.css")
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 404}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if next.called {
+		t.Fatal("next handler should not have been called")
+	}
+	if w.Code != 200 {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+	if ce := w.Header().Get("Content-Encoding"); ce != "gzip" {
+		t.Errorf("expected Content-Encoding gzip, got %q", ce)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/css; charset=utf-8" {
+		t.Errorf("expected Content-Type text/css, got %q", ct)
+	}
+	if w.Body.String() != string(gzContent) {
+		t.Errorf("unexpected body: %q", w.Body.String())
+	}
+}
+
+func TestPreferPrecompressedReturns404WhenNoCompressedVariant(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// No files at all - neither base nor precompressed
+	precompressors := map[string]encode.Precompressed{
+		"gzip": testPrecompressed{encoding: "gzip", suffix: ".gz"},
+	}
+	fsrv := newTestFileServer(tmpDir, precompressors, true, []string{"gzip"})
+
+	req := newTestRequest("GET", "/missing.css")
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 200}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	httpErr, ok := err.(caddyhttp.HandlerError)
+	if !ok {
+		t.Fatalf("expected caddyhttp.HandlerError, got %T", err)
+	}
+	if httpErr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 status, got %d", httpErr.StatusCode)
+	}
+}
+
+func TestPreferPrecompressedReturns404WhenClientDoesNotAcceptEncoding(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create only the precompressed file
+	if err := os.WriteFile(filepath.Join(tmpDir, "style.css.gz"), []byte("gzip"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	precompressors := map[string]encode.Precompressed{
+		"gzip": testPrecompressed{encoding: "gzip", suffix: ".gz"},
+	}
+	fsrv := newTestFileServer(tmpDir, precompressors, true, []string{"gzip"})
+
+	// No Accept-Encoding header
+	req := newTestRequest("GET", "/style.css")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 200}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err == nil {
+		t.Fatal("expected error for unsupported encoding")
+	}
+	httpErr, ok := err.(caddyhttp.HandlerError)
+	if !ok {
+		t.Fatalf("expected caddyhttp.HandlerError, got %T", err)
+	}
+	if httpErr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 status, got %d", httpErr.StatusCode)
+	}
+}
+
+func TestPreferPrecompressedDisabledReturns404ForMissingBase(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create only the precompressed file, but PreferPrecompressed is false
+	if err := os.WriteFile(filepath.Join(tmpDir, "style.css.gz"), []byte("gzip"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	precompressors := map[string]encode.Precompressed{
+		"gzip": testPrecompressed{encoding: "gzip", suffix: ".gz"},
+	}
+	fsrv := newTestFileServer(tmpDir, precompressors, false, []string{"gzip"})
+
+	req := newTestRequest("GET", "/style.css")
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 200}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err == nil {
+		t.Fatal("expected error when base file missing and prefer_precompressed disabled")
+	}
+	httpErr, ok := err.(caddyhttp.HandlerError)
+	if !ok {
+		t.Fatalf("expected caddyhttp.HandlerError, got %T", err)
+	}
+	if httpErr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 status, got %d", httpErr.StatusCode)
+	}
+}
+
+func TestPreferPrecompressedWithBaseFileStillWorks(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Both base and precompressed files exist
+	baseContent := []byte("body { color: red; }")
+	gzContent := []byte("fake gzip content")
+	if err := os.WriteFile(filepath.Join(tmpDir, "style.css"), baseContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "style.css.gz"), gzContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	precompressors := map[string]encode.Precompressed{
+		"gzip": testPrecompressed{encoding: "gzip", suffix: ".gz"},
+	}
+	fsrv := newTestFileServer(tmpDir, precompressors, true, []string{"gzip"})
+
+	req := newTestRequest("GET", "/style.css")
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 404}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if w.Code != 200 {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+	if ce := w.Header().Get("Content-Encoding"); ce != "gzip" {
+		t.Errorf("expected Content-Encoding gzip, got %q", ce)
+	}
+}
+
+func TestPreferPrecompressedSelectsBestEncoding(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create only precompressed files with multiple encodings
+	if err := os.WriteFile(filepath.Join(tmpDir, "app.js.br"), []byte("brotli content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "app.js.gz"), []byte("gzip content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	precompressors := map[string]encode.Precompressed{
+		"gzip": testPrecompressed{encoding: "gzip", suffix: ".gz"},
+		"br":   testPrecompressed{encoding: "br", suffix: ".br"},
+	}
+	// Prefer brotli over gzip
+	fsrv := newTestFileServer(tmpDir, precompressors, true, []string{"br", "gzip"})
+
+	req := newTestRequest("GET", "/app.js")
+	req.Header.Set("Accept-Encoding", "gzip, br")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 404}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if ce := w.Header().Get("Content-Encoding"); ce != "br" {
+		t.Errorf("expected Content-Encoding br (preferred), got %q", ce)
+	}
+}
+
+func TestPreferPrecompressedPassThru(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// No files exist, pass_thru enabled
+	precompressors := map[string]encode.Precompressed{
+		"gzip": testPrecompressed{encoding: "gzip", suffix: ".gz"},
+	}
+	fsrv := newTestFileServer(tmpDir, precompressors, true, []string{"gzip"})
+	fsrv.PassThru = true
+
+	req := newTestRequest("GET", "/missing.css")
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 200}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("expected no error with pass_thru, got: %v", err)
+	}
+	if !next.called {
+		t.Error("expected next handler to be called with pass_thru")
+	}
+}
+
+func TestPreferPrecompressedNoPrecompressors(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// PreferPrecompressed is true but no precompressors configured
+	// Should behave as if PreferPrecompressed is false
+	fsrv := newTestFileServer(tmpDir, nil, true, nil)
+
+	req := newTestRequest("GET", "/missing.css")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 200}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	httpErr, ok := err.(caddyhttp.HandlerError)
+	if !ok {
+		t.Fatalf("expected caddyhttp.HandlerError, got %T", err)
+	}
+	if httpErr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 status, got %d", httpErr.StatusCode)
+	}
+}
+
+func TestPreferPrecompressedHiddenFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a precompressed file for a hidden path
+	if err := os.WriteFile(filepath.Join(tmpDir, ".secret.gz"), []byte("secret gzip"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	precompressors := map[string]encode.Precompressed{
+		"gzip": testPrecompressed{encoding: "gzip", suffix: ".gz"},
+	}
+	fsrv := newTestFileServer(tmpDir, precompressors, true, []string{"gzip"})
+	fsrv.Hide = []string{".secret"}
+
+	req := newTestRequest("GET", "/.secret")
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 200}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err == nil {
+		t.Fatal("expected error for hidden file")
+	}
+	httpErr, ok := err.(caddyhttp.HandlerError)
+	if !ok {
+		t.Fatalf("expected caddyhttp.HandlerError, got %T", err)
+	}
+	if httpErr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 status, got %d", httpErr.StatusCode)
+	}
+}
+
+func TestPreferPrecompressedHiddenCompressedFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create only the precompressed file, and hide the compressed path itself
+	if err := os.WriteFile(filepath.Join(tmpDir, "style.css.gz"), []byte("gzip"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	precompressors := map[string]encode.Precompressed{
+		"gzip": testPrecompressed{encoding: "gzip", suffix: ".gz"},
+	}
+	fsrv := newTestFileServer(tmpDir, precompressors, true, []string{"gzip"})
+	fsrv.Hide = []string{filepath.Join(tmpDir, "*.gz")}
+
+	req := newTestRequest("GET", "/style.css")
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 200}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err == nil {
+		t.Fatal("expected error when compressed file is hidden")
+	}
+	httpErr, ok := err.(caddyhttp.HandlerError)
+	if !ok {
+		t.Fatalf("expected caddyhttp.HandlerError, got %T", err)
+	}
+	if httpErr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 status, got %d", httpErr.StatusCode)
+	}
+}
+
+func TestPreferPrecompressedSubdirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create subdirectory with only precompressed file
+	subDir := filepath.Join(tmpDir, "assets")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	gzContent := []byte("fake gzip css")
+	if err := os.WriteFile(filepath.Join(subDir, "main.css.gz"), gzContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	precompressors := map[string]encode.Precompressed{
+		"gzip": testPrecompressed{encoding: "gzip", suffix: ".gz"},
+	}
+	fsrv := newTestFileServer(tmpDir, precompressors, true, []string{"gzip"})
+
+	req := newTestRequest("GET", "/assets/main.css")
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 404}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if w.Code != 200 {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+	if ce := w.Header().Get("Content-Encoding"); ce != "gzip" {
+		t.Errorf("expected Content-Encoding gzip, got %q", ce)
+	}
+	if w.Body.String() != string(gzContent) {
+		t.Errorf("unexpected body: %q", w.Body.String())
+	}
+}
+
+// Verify that fs.FS-based test works with the filesystem map
+// by confirming the default filesystem reads from the right root.
+func TestPrecompressedWithExistingBaseFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Only base file exists, no precompressed - should serve base file
+	baseContent := []byte("body { color: blue; }")
+	if err := os.WriteFile(filepath.Join(tmpDir, "style.css"), baseContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	precompressors := map[string]encode.Precompressed{
+		"gzip": testPrecompressed{encoding: "gzip", suffix: ".gz"},
+	}
+	fsrv := newTestFileServer(tmpDir, precompressors, true, []string{"gzip"})
+
+	req := newTestRequest("GET", "/style.css")
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 404}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if w.Code != 200 {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+	// No precompressed file exists, so no Content-Encoding should be set
+	if ce := w.Header().Get("Content-Encoding"); ce != "" {
+		t.Errorf("expected no Content-Encoding, got %q", ce)
+	}
+}
+
+// Verify the Vary: Accept-Encoding header is present even in
+// prefer_precompressed mode.
+func TestPreferPrecompressedVaryHeader(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "style.css.gz"), []byte("gzip"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	precompressors := map[string]encode.Precompressed{
+		"gzip": testPrecompressed{encoding: "gzip", suffix: ".gz"},
+	}
+	fsrv := newTestFileServer(tmpDir, precompressors, true, []string{"gzip"})
+
+	req := newTestRequest("GET", "/style.css")
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 404}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if vary := w.Header().Get("Vary"); vary != "Accept-Encoding" {
+		t.Errorf("expected Vary: Accept-Encoding, got %q", vary)
+	}
+}
+
+// Ensure the warning is logged when prefer_precompressed is set without
+// precompressors. We use a zap observer to capture the log output.
+func TestPreferPrecompressedProvisionWarning(t *testing.T) {
+	// We can't easily test the Provision method directly without a full
+	// caddy.Context, but we can verify the runtime behavior: that
+	// PreferPrecompressed with no precompressors falls through to 404
+	// immediately (the same code path the warning is for).
+	tmpDir := t.TempDir()
+
+	// Create only precompressed file
+	if err := os.WriteFile(filepath.Join(tmpDir, "style.css.gz"), []byte("gzip"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// No precompressors configured - should return 404 even though
+	// the .gz file exists, because we can't serve it
+	fsrv := newTestFileServer(tmpDir, nil, true, nil)
+
+	req := newTestRequest("GET", "/style.css")
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 200}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	httpErr, ok := err.(caddyhttp.HandlerError)
+	if !ok {
+		t.Fatalf("expected caddyhttp.HandlerError, got %T", err)
+	}
+	if httpErr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", httpErr.StatusCode)
+	}
+}
+
+func TestPreferPrecompressedDirectoryIndex(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a subdirectory with only a precompressed index file
+	subDir := filepath.Join(tmpDir, "mydir")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	gzContent := []byte("compressed index")
+	if err := os.WriteFile(filepath.Join(subDir, "index.html.gz"), gzContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	precompressors := map[string]encode.Precompressed{
+		"gzip": testPrecompressed{encoding: "gzip", suffix: ".gz"},
+	}
+	fsrv := newTestFileServer(tmpDir, precompressors, true, []string{"gzip"})
+	fsrv.IndexNames = []string{"index.html"}
+
+	req := newTestRequest("GET", "/mydir/")
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 404}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if next.called {
+		t.Fatal("next handler should not have been called")
+	}
+	if w.Code != 200 {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+	if ce := w.Header().Get("Content-Encoding"); ce != "gzip" {
+		t.Errorf("expected Content-Encoding gzip, got %q", ce)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
+		t.Errorf("expected Content-Type text/html, got %q", ct)
+	}
+	if w.Body.String() != string(gzContent) {
+		t.Errorf("unexpected body: %q", w.Body.String())
+	}
+}
+
+func TestPreferPrecompressedDirectoryIndexRedirect(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a subdirectory with only a precompressed index file
+	subDir := filepath.Join(tmpDir, "mydir")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "index.html.gz"), []byte("gzip"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	precompressors := map[string]encode.Precompressed{
+		"gzip": testPrecompressed{encoding: "gzip", suffix: ".gz"},
+	}
+	fsrv := newTestFileServer(tmpDir, precompressors, true, []string{"gzip"})
+	fsrv.IndexNames = []string{"index.html"}
+
+	// Request without trailing slash should redirect
+	req := newTestRequest("GET", "/mydir")
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 404}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if w.Code != http.StatusPermanentRedirect {
+		t.Errorf("expected redirect status %d, got %d", http.StatusPermanentRedirect, w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "/mydir/" {
+		t.Errorf("expected Location /mydir/, got %q", loc)
+	}
+}
+
+func TestPreferPrecompressedDirectoryIndexDisabled(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a subdirectory with only a precompressed index file,
+	// but PreferPrecompressed is false
+	subDir := filepath.Join(tmpDir, "mydir")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "index.html.gz"), []byte("gzip"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	precompressors := map[string]encode.Precompressed{
+		"gzip": testPrecompressed{encoding: "gzip", suffix: ".gz"},
+	}
+	fsrv := newTestFileServer(tmpDir, precompressors, false, []string{"gzip"})
+	fsrv.IndexNames = []string{"index.html"}
+
+	req := newTestRequest("GET", "/mydir/")
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 200}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err == nil {
+		t.Fatal("expected error when prefer_precompressed is disabled")
+	}
+	httpErr, ok := err.(caddyhttp.HandlerError)
+	if !ok {
+		t.Fatalf("expected caddyhttp.HandlerError, got %T", err)
+	}
+	if httpErr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", httpErr.StatusCode)
+	}
+}
+
+func TestPreferPrecompressedDirectoryIndexFallbackToSecondIndex(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a subdirectory with only a precompressed variant of the
+	// second index name - the first index name has no variants at all.
+	subDir := filepath.Join(tmpDir, "mydir")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	gzContent := []byte("compressed default")
+	if err := os.WriteFile(filepath.Join(subDir, "default.html.gz"), gzContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	precompressors := map[string]encode.Precompressed{
+		"gzip": testPrecompressed{encoding: "gzip", suffix: ".gz"},
+	}
+	fsrv := newTestFileServer(tmpDir, precompressors, true, []string{"gzip"})
+	fsrv.IndexNames = []string{"index.html", "default.html"}
+
+	req := newTestRequest("GET", "/mydir/")
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 404}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if next.called {
+		t.Fatal("next handler should not have been called")
+	}
+	if w.Code != 200 {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+	if ce := w.Header().Get("Content-Encoding"); ce != "gzip" {
+		t.Errorf("expected Content-Encoding gzip, got %q", ce)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
+		t.Errorf("expected Content-Type text/html, got %q", ct)
+	}
+	if w.Body.String() != string(gzContent) {
+		t.Errorf("unexpected body: %q", w.Body.String())
+	}
+}
+
+func TestPreferPrecompressedDirectoryIndexEncodingMismatch(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a subdirectory with only a .gz precompressed index file,
+	// but the client only accepts br - should fall through to not found
+	subDir := filepath.Join(tmpDir, "mydir")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "index.html.gz"), []byte("gzip"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	precompressors := map[string]encode.Precompressed{
+		"gzip": testPrecompressed{encoding: "gzip", suffix: ".gz"},
+		"br":   testPrecompressed{encoding: "br", suffix: ".br"},
+	}
+	fsrv := newTestFileServer(tmpDir, precompressors, true, []string{"gzip", "br"})
+	fsrv.IndexNames = []string{"index.html"}
+
+	req := newTestRequest("GET", "/mydir/")
+	req.Header.Set("Accept-Encoding", "br")
+	w := httptest.NewRecorder()
+	next := &statusNextHandler{statusCode: 200}
+
+	err := fsrv.ServeHTTP(w, req, next)
+	if err == nil {
+		t.Fatal("expected error when no matching precompressed variant exists")
+	}
+	httpErr, ok := err.(caddyhttp.HandlerError)
+	if !ok {
+		t.Fatalf("expected caddyhttp.HandlerError, got %T", err)
+	}
+	if httpErr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", httpErr.StatusCode)
+	}
+}

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -168,6 +168,14 @@ type FileServer struct {
 	PrecompressedOrder []string `json:"precompressed_order,omitempty"`
 	precompressors     map[string]encode.Precompressed
 
+	// If true, the file server will look for precompressed sidecar files
+	// on disk even when the original uncompressed file does not exist.
+	// This allows serving only precompressed files without keeping the
+	// original uncompressed versions on disk. If the client does not
+	// support any of the available compressed encodings, a 404 is returned.
+	// Requires precompressed encoders to be configured.
+	PreferPrecompressed bool `json:"prefer_precompressed,omitempty"`
+
 	// List of file extensions to try to read Etags from.
 	// If set, file Etags will be read from sidecar files
 	// with any of these suffixes, instead of generating
@@ -244,6 +252,10 @@ func (fsrv *FileServer) Provision(ctx caddy.Context) error {
 		fsrv.precompressors[ae] = p
 	}
 
+	if fsrv.PreferPrecompressed && len(fsrv.precompressors) == 0 {
+		fsrv.logger.Warn("prefer_precompressed is enabled but no precompressed encoders are configured; option will have no effect")
+	}
+
 	if fsrv.Browse != nil {
 		// check sort options
 		for idx, sortOption := range fsrv.Browse.SortOptions {
@@ -308,19 +320,27 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 	if err != nil {
 		err = fsrv.mapDirOpenError(fileSystem, err, filename)
 		if errors.Is(err, fs.ErrNotExist) {
-			return fsrv.notFound(w, r, next)
+			if !fsrv.PreferPrecompressed || len(fsrv.precompressors) == 0 {
+				return fsrv.notFound(w, r, next)
+			}
+			// info stays nil; we'll try precompressed files below
+			if c := fsrv.logger.Check(zapcore.DebugLevel, "base file not found, trying precompressed variants"); c != nil {
+				c.Write(zap.String("filename", filename))
+			}
 		} else if errors.Is(err, fs.ErrInvalid) {
 			return caddyhttp.Error(http.StatusBadRequest, err)
 		} else if errors.Is(err, fs.ErrPermission) {
 			return caddyhttp.Error(http.StatusForbidden, err)
+		} else {
+			return caddyhttp.Error(http.StatusInternalServerError, err)
 		}
-		return caddyhttp.Error(http.StatusInternalServerError, err)
 	}
 
 	// if the request mapped to a directory, see if
 	// there is an index file we can serve
 	var implicitIndexFile bool
-	if info.IsDir() && len(fsrv.IndexNames) > 0 {
+	var precompressedIndexOnly bool
+	if info != nil && info.IsDir() && len(fsrv.IndexNames) > 0 {
 		for _, indexPage := range fsrv.IndexNames {
 			indexPage := repl.ReplaceAll(indexPage, "")
 			indexPath := caddyhttp.SanitizedPathJoin(filename, indexPage)
@@ -337,6 +357,19 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 
 			indexInfo, err := fs.Stat(fileSystem, indexPath)
 			if err != nil {
+				// if prefer_precompressed, check if a precompressed
+				// variant of the index file exists on disk
+				if fsrv.PreferPrecompressed && len(fsrv.precompressors) > 0 {
+					if fsrv.hasPrecompressedVariant(fileSystem, indexPath, filesToHide, r) {
+						filename = indexPath
+						implicitIndexFile = true
+						precompressedIndexOnly = true
+						if c := fsrv.logger.Check(zapcore.DebugLevel, "located precompressed index file"); c != nil {
+							c.Write(zap.String("filename", filename))
+						}
+						break
+					}
+				}
 				continue
 			}
 
@@ -360,7 +393,7 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 
 	// if still referencing a directory, delegate
 	// to browse or return an error
-	if info.IsDir() {
+	if info != nil && info.IsDir() && !precompressedIndexOnly {
 		if c := fsrv.logger.Check(zapcore.DebugLevel, "no index file in directory"); c != nil {
 			c.Write(
 				zap.String("path", filename),
@@ -374,7 +407,9 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 	}
 
 	// one last check to ensure the file isn't hidden (we might
-	// have changed the filename from when we last checked)
+	// have changed the filename from when we last checked);
+	// this also applies in prefer_precompressed mode: if the
+	// base path is hidden, we don't attempt precompressed variants
 	if fileHidden(filename, filesToHide) {
 		if c := fsrv.logger.Check(zapcore.DebugLevel, "hiding file"); c != nil {
 			c.Write(
@@ -389,7 +424,7 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 	// slash convention: if a directory, trailing slash; if a file, no
 	// trailing slash - not enforcing this can break relative hrefs
 	// in HTML (see https://github.com/caddyserver/caddy/issues/2741)
-	if fsrv.CanonicalURIs == nil || *fsrv.CanonicalURIs {
+	if info != nil && (fsrv.CanonicalURIs == nil || *fsrv.CanonicalURIs) {
 		// Only redirect if the last element of the path (the filename) was not
 		// rewritten; if the admin wanted to rewrite to the canonical path, they
 		// would have, and we have to be very careful not to introduce unwanted
@@ -419,6 +454,13 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 		}
 	}
 
+	// if we matched a precompressed index but no base index file exists,
+	// set info to nil so the precompressed loop below handles serving;
+	// this is done after canonical URI redirect so the redirect still works
+	if precompressedIndexOnly {
+		info = nil
+	}
+
 	var file fs.File
 	respHeader := w.Header()
 
@@ -439,6 +481,9 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 			continue
 		}
 		compressedFilename := filename + precompress.Suffix()
+		if fileHidden(compressedFilename, filesToHide) {
+			continue
+		}
 		compressedInfo, err := fs.Stat(fileSystem, compressedFilename)
 		if err != nil || compressedInfo.IsDir() {
 			if c := fsrv.logger.Check(zapcore.DebugLevel, "precompressed file not accessible"); c != nil {
@@ -480,10 +525,17 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 		}
 
 		// don't assign info = compressedInfo because sidecars are kind
-		// of transparent; however we do need to set the Etag:
+		// of transparent (unless the base file doesn't exist, handled
+		// below); however we do need to set the Etag:
 		// https://caddy.community/t/gzipped-sidecar-file-wrong-same-etag/16793
 		if etag == "" {
 			etag = calculateEtag(compressedInfo)
+		}
+
+		// if there's no base file (prefer_precompressed mode), use the
+		// compressed file's info for modtime in ServeContent
+		if info == nil {
+			info = compressedInfo
 		}
 
 		break
@@ -491,6 +543,12 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 
 	// no precompressed file found, use the actual file
 	if file == nil {
+		// if the base file doesn't exist (prefer_precompressed mode) and no
+		// precompressed variant was found, return 404
+		if info == nil {
+			return fsrv.notFound(w, r, next)
+		}
+
 		if c := fsrv.logger.Check(zapcore.DebugLevel, "opening file"); c != nil {
 			c.Write(zap.String("filename", filename))
 		}
@@ -582,6 +640,26 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 	http.ServeContent(w, r, info.Name(), info.ModTime(), file.(io.ReadSeeker))
 
 	return nil
+}
+
+// hasPrecompressedVariant checks whether any precompressed sidecar file
+// exists for the given filename (e.g. filename.gz, filename.br) that is
+// also accepted by the client's Accept-Encoding header.
+func (fsrv *FileServer) hasPrecompressedVariant(fileSystem fs.FS, filename string, filesToHide []string, r *http.Request) bool {
+	for _, ae := range encode.AcceptedEncodings(r, fsrv.PrecompressedOrder) {
+		precompress, ok := fsrv.precompressors[ae]
+		if !ok {
+			continue
+		}
+		compressedPath := filename + precompress.Suffix()
+		if fileHidden(compressedPath, filesToHide) {
+			continue
+		}
+		if info, err := fs.Stat(fileSystem, compressedPath); err == nil && !info.IsDir() {
+			return true
+		}
+	}
+	return false
 }
 
 // openFile opens the file at the given filename. If there was an error,


### PR DESCRIPTION
Add prefer_precompressed option that allows serving precompressed sidecar files (.gz, .br, .zst) even when the original uncompressed file does not exist on disk. If the client does not support any of the available encodings, a 404 is returned.

"This PR was developed with AI assistance (Claude)."

closes #5116