### PR TITLE
reverseproxy: Add ability to clear dynamic upstreams cache during retries

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -575,7 +575,9 @@ func (h *Handler) proxyLoopIteration(r *http.Request, origReq *http.Request, w h
 	upstreams := h.Upstreams
 	if h.DynamicUpstreams != nil {
 		if retries > 0 {
-			if cachingDynamicUpstreams, ok := h.DynamicUpstreams.(cachingUpstreamSource); ok {
+			// after a failure (and thus during a retry), give dynamic upstream modules an opportunity
+			// to purge their relevant cache entries so we don't keep retrying bad upstreams
+			if cachingDynamicUpstreams, ok := h.DynamicUpstreams.(CachingUpstreamSource); ok {
 				if err := cachingDynamicUpstreams.ResetCache(r); err != nil {
 					if c := h.logger.Check(zapcore.ErrorLevel, "failed clearing dynamic upstream source's cache"); c != nil {
 						c.Write(zap.Error(err))
@@ -1595,19 +1597,23 @@ type Selector interface {
 // may be called during each retry, multiple times per request, and as
 // such, needs to be instantaneous. The returned slice will not be
 // modified.
+//
+// For upstream sources that cache results, implement the
+// [CachingUpstreamSource] interface for optimal performance.
 type UpstreamSource interface {
 	GetUpstreams(*http.Request) ([]*Upstream, error)
 }
 
-// cachingUpstreamSource is an upstream source that caches its upstreams.
+// CachingUpstreamSource is an upstream source that caches its upstreams.
 // The relevant cache entry can be cleared/reset for a given request during
-// retries if a request fails. This can help ensure that down backends are
-// not retried.
+// retries if a request fails. This can help ensure that failing backends
+// are not retried.
+//
 // EXPERIMENTAL: Subject to change.
-type cachingUpstreamSource interface {
+type CachingUpstreamSource interface {
 	UpstreamSource
 
-	// ResetCache clears any cached entry related to the given request.
+	// ResetCache clears any cache entry related to the given request.
 	// The next time GetUpstreams is called, it should have new upstream
 	// information for the given request.
 	ResetCache(*http.Request) error

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -1600,9 +1600,16 @@ type UpstreamSource interface {
 }
 
 // cachingUpstreamSource is an upstream source that caches its upstreams.
+// The relevant cache entry can be cleared/reset for a given request during
+// retries if a request fails. This can help ensure that down backends are
+// not retried.
 // EXPERIMENTAL: Subject to change.
 type cachingUpstreamSource interface {
 	UpstreamSource
+
+	// ResetCache clears any cached entry related to the given request.
+	// The next time GetUpstreams is called, it should have new upstream
+	// information for the given request.
 	ResetCache(*http.Request) error
 }
 

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -574,6 +574,15 @@ func (h *Handler) proxyLoopIteration(r *http.Request, origReq *http.Request, w h
 	// get the updated list of upstreams
 	upstreams := h.Upstreams
 	if h.DynamicUpstreams != nil {
+		if retries > 0 {
+			if cachingDynamicUpstreams, ok := h.DynamicUpstreams.(cachingUpstreamSource); ok {
+				if err := cachingDynamicUpstreams.ResetCache(r); err != nil {
+					if c := h.logger.Check(zapcore.ErrorLevel, "failed clearing dynamic upstream source's cache"); c != nil {
+						c.Write(zap.Error(err))
+					}
+				}
+			}
+		}
 		dUpstreams, err := h.DynamicUpstreams.GetUpstreams(r)
 		if err != nil {
 			if c := h.logger.Check(zapcore.ErrorLevel, "failed getting dynamic upstreams; falling back to static upstreams"); c != nil {
@@ -1588,6 +1597,13 @@ type Selector interface {
 // modified.
 type UpstreamSource interface {
 	GetUpstreams(*http.Request) ([]*Upstream, error)
+}
+
+// cachingUpstreamSource is an upstream source that caches its upstreams.
+// EXPERIMENTAL: Subject to change.
+type cachingUpstreamSource interface {
+	UpstreamSource
+	ResetCache(*http.Request) error
 }
 
 // Hop-by-hop headers. These are removed when sent to the backend.

--- a/modules/caddyhttp/reverseproxy/upstreams.go
+++ b/modules/caddyhttp/reverseproxy/upstreams.go
@@ -568,7 +568,7 @@ var (
 var (
 	_ caddy.Provisioner     = (*SRVUpstreams)(nil)
 	_ UpstreamSource        = (*SRVUpstreams)(nil)
-	_ cachingUpstreamSource = (*SRVUpstreams)(nil)
+	_ CachingUpstreamSource = (*SRVUpstreams)(nil)
 	_ caddy.Provisioner     = (*AUpstreams)(nil)
 	_ UpstreamSource        = (*AUpstreams)(nil)
 )

--- a/modules/caddyhttp/reverseproxy/upstreams.go
+++ b/modules/caddyhttp/reverseproxy/upstreams.go
@@ -119,6 +119,18 @@ func (su *SRVUpstreams) Provision(ctx caddy.Context) error {
 	return nil
 }
 
+func (su *SRVUpstreams) ResetCache(r *http.Request) error {
+	srvsMu.Lock()
+	if r == nil {
+		srvs = make(map[string]srvLookup)
+	} else {
+		suAddr, _, _, _ := su.expandedAddr(r)
+		delete(srvs, suAddr)
+	}
+	srvsMu.Unlock()
+	return nil
+}
+
 func (su SRVUpstreams) GetUpstreams(r *http.Request) ([]*Upstream, error) {
 	suAddr, service, proto, name := su.expandedAddr(r)
 
@@ -554,8 +566,9 @@ var (
 
 // Interface guards
 var (
-	_ caddy.Provisioner = (*SRVUpstreams)(nil)
-	_ UpstreamSource    = (*SRVUpstreams)(nil)
-	_ caddy.Provisioner = (*AUpstreams)(nil)
-	_ UpstreamSource    = (*AUpstreams)(nil)
+	_ caddy.Provisioner     = (*SRVUpstreams)(nil)
+	_ UpstreamSource        = (*SRVUpstreams)(nil)
+	_ cachingUpstreamSource = (*SRVUpstreams)(nil)
+	_ caddy.Provisioner     = (*AUpstreams)(nil)
+	_ UpstreamSource        = (*AUpstreams)(nil)
 )


### PR DESCRIPTION
This is an optional interface for dynamic upstream modules to implement if they cache results. If one of the upstreams it returns fails, during retries we should make sure that entry in the cache is evicted so it is not retried.

## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

No AI used.