### PR TITLE
fix: Propagate ECH keys to the QUIC listener

### DIFF
--- a/listeners.go
+++ b/listeners.go
@@ -462,7 +462,10 @@ func (na NetworkAddress) ListenQUIC(ctx context.Context, portOffset uint, config
 		sqs := newSharedQUICState(tlsConf)
 		// http3.ConfigureTLSConfig only uses this field and tls App sets this field as well
 		//nolint:gosec
-		quicTlsConfig := &tls.Config{GetConfigForClient: sqs.getConfigForClient}
+		quicTlsConfig := &tls.Config{
+			GetConfigForClient:          sqs.getConfigForClient,
+			GetEncryptedClientHelloKeys: sqs.getEncryptedClientHelloKeys,
+		}
 		// Require clients to verify their source address when we're handling more than 1000 handshakes per second.
 		// TODO: make tunable?
 		limiter := rate.NewLimiter(1000, 1000)
@@ -538,6 +541,16 @@ func (sqs *sharedQUICState) getConfigForClient(ch *tls.ClientHelloInfo) (*tls.Co
 	sqs.rmu.RLock()
 	defer sqs.rmu.RUnlock()
 	return sqs.activeTlsConf.GetConfigForClient(ch)
+}
+
+// getEncryptedClientHelloKeys is used as tls.Config's GetEncryptedClientHelloKeys field.
+func (sqs *sharedQUICState) getEncryptedClientHelloKeys(ch *tls.ClientHelloInfo) ([]tls.EncryptedClientHelloKey, error) {
+	sqs.rmu.RLock()
+	defer sqs.rmu.RUnlock()
+	if sqs.activeTlsConf.GetEncryptedClientHelloKeys == nil {
+		return nil, nil
+	}
+	return sqs.activeTlsConf.GetEncryptedClientHelloKeys(ch)
 }
 
 // addState adds tls.Config and activeRequests to the map if not present and returns the corresponding context and its cancelFunc

--- a/listeners_test.go
+++ b/listeners_test.go
@@ -15,6 +15,7 @@
 package caddy
 
 import (
+	"crypto/tls"
 	"reflect"
 	"testing"
 
@@ -172,6 +173,63 @@ func TestJoinNetworkAddress(t *testing.T) {
 		if actual != tc.expect {
 			t.Errorf("Test %d: Expected '%s' but got '%s'", i, tc.expect, actual)
 		}
+	}
+}
+
+func TestSharedQUICStateGetEncryptedClientHelloKeys(t *testing.T) {
+	hello := &tls.ClientHelloInfo{ServerName: "example.com"}
+	initialKeys := []tls.EncryptedClientHelloKey{{Config: []byte("initial"), PrivateKey: []byte("initial-key")}}
+	updatedKeys := []tls.EncryptedClientHelloKey{{Config: []byte("updated"), PrivateKey: []byte("updated-key")}}
+
+	initialConfig := &tls.Config{
+		GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
+			return nil, nil
+		},
+		GetEncryptedClientHelloKeys: func(*tls.ClientHelloInfo) ([]tls.EncryptedClientHelloKey, error) {
+			return initialKeys, nil
+		},
+	}
+
+	sqs := newSharedQUICState(initialConfig)
+
+	keys, err := sqs.getEncryptedClientHelloKeys(hello)
+	if err != nil {
+		t.Fatalf("getting initial ECH keys: %v", err)
+	}
+	if !reflect.DeepEqual(keys, initialKeys) {
+		t.Fatalf("unexpected initial ECH keys: got %#v, want %#v", keys, initialKeys)
+	}
+
+	updatedConfig := &tls.Config{
+		GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
+			return nil, nil
+		},
+		GetEncryptedClientHelloKeys: func(*tls.ClientHelloInfo) ([]tls.EncryptedClientHelloKey, error) {
+			return updatedKeys, nil
+		},
+	}
+
+	_, cancel := sqs.addState(updatedConfig)
+	sqs.rmu.Lock()
+	sqs.activeTlsConf = updatedConfig
+	sqs.rmu.Unlock()
+
+	keys, err = sqs.getEncryptedClientHelloKeys(hello)
+	if err != nil {
+		t.Fatalf("getting updated ECH keys: %v", err)
+	}
+	if !reflect.DeepEqual(keys, updatedKeys) {
+		t.Fatalf("unexpected updated ECH keys: got %#v, want %#v", keys, updatedKeys)
+	}
+
+	cancel(nil)
+
+	keys, err = sqs.getEncryptedClientHelloKeys(hello)
+	if err != nil {
+		t.Fatalf("getting restored ECH keys: %v", err)
+	}
+	if !reflect.DeepEqual(keys, initialKeys) {
+		t.Fatalf("unexpected restored ECH keys: got %#v, want %#v", keys, initialKeys)
 	}
 }
 


### PR DESCRIPTION
Touches a small follow-up to #7653.

## Summary
This preserves ECH handling on the QUIC / HTTP/3 path by forwarding `GetEncryptedClientHelloKeys` through Caddy's shared QUIC TLS config.

#7653 fixes the HTTPS RR `alpn` omission but that was only part of the problem. Found in #7667, QUIC was still rebuilding a minimal TLS config with `GetConfigForClient` only which meant the HTTP/3 listener could not process ECH even though the normal TLS path could.

This change keeps the existing shared-config model for QUIC listeners and adds the missing ECH key callback so the QUIC path sees the same ECH-capable behaviour as the TCP TLS path.

## Tests
Added a listener regression test to verify:
- shared QUIC state exposes the active config's ECH keys
- ECH key lookup follows active config changes

```bash
go test . -run TestSharedQUICStateGetEncryptedClientHelloKeys -v
go test . -run "Test(SplitNetworkAddress|JoinNetworkAddress|ParseNetworkAddress|SharedQUICStateGetEncryptedClientHelloKeys)$" -count=1
```

Should close #7667.

## Assistance Disclosure
No AI was used.