### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/modules/caddyhttp/reverseproxy/fastcgi/client_test.go
+++ b/modules/caddyhttp/reverseproxy/fastcgi/client_test.go
@@ -244,15 +244,15 @@ func DisabledTest(t *testing.T) {
 	sendFcgi(0, fcgiParams, []byte("c4ca4238a0b923820dcc509a6f75849b=1&7b8b965ad4bca0e41ab51de7b31363a1=n"), nil, nil)
 
 	log.Println("test:", "post data (more than 60KB)")
-	data := ""
+	var data strings.Builder
 	for i := 0x00; i < 0xff; i++ {
 		v0 := strings.Repeat(fmt.Sprint(i), 256)
 		h := md5.New()
 		_, _ = io.WriteString(h, v0)
 		k0 := fmt.Sprintf("%x", h.Sum(nil))
-		data += k0 + "=" + url.QueryEscape(v0) + "&"
+		data.WriteString(k0 + "=" + url.QueryEscape(v0) + "&")
 	}
-	sendFcgi(0, fcgiParams, []byte(data), nil, nil)
+	sendFcgi(0, fcgiParams, []byte(data.String()), nil, nil)
 
 	log.Println("test:", "post form (use url.Values)")
 	p0 := make(map[string]string, 1)


### PR DESCRIPTION


## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->


strings.Builder has fewer memory allocations and better performance.
More info: https://github.com/golang/go/issues/75190


Inspired by https://github.com/caddyserver/caddy/pull/7364 and replace all.
