### PR TITLE
listeners: clean up stale Unix socket files on Windows

### DIFF
--- a/listen.go
+++ b/listen.go
@@ -30,10 +30,6 @@ import (
 	"go.uber.org/zap"
 )
 
-func reuseUnixSocket(_, _ string) (any, error) {
-	return nil, nil
-}
-
 func listenReusable(ctx context.Context, lnKey string, network, address string, config net.ListenConfig) (any, error) {
 	var socketFile *os.File
 

--- a/listen_reuseUnixSocket.go
+++ b/listen_reuseUnixSocket.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build (!unix || solaris) && !windows
 
 package caddy

--- a/listen_reuseUnixSocket.go
+++ b/listen_reuseUnixSocket.go
@@ -1,0 +1,7 @@
+//go:build (!unix || solaris) && !windows
+
+package caddy
+
+func reuseUnixSocket(_, _ string) (any, error) {
+	return nil, nil
+}

--- a/listen_reuseUnixSocket_windows.go
+++ b/listen_reuseUnixSocket_windows.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+package caddy
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"strings"
+)
+
+func reuseUnixSocket(network, addr string) (any, error) {
+	if !IsUnixNetwork(network) {
+		return nil, nil
+	}
+
+	//Note: This is here mainly for proper compatibility, because Unix sockets with abstract names are in an interesting limbo state on Windows:
+	//Golang already translates `@` characters to `\0` for Windows: https://github.com/golang/go/blob/65d5c5f6dd8aa7b221cff6ec3f5101ea2e5f3efa/src/syscall/syscall_windows.go#L910
+	//...but there still is an open issue about the fact that this is not properly supported: https://github.com/microsoft/WSL/issues/4240#issuecomment-620805115
+	//The main issue is that the original announcement proclaimed support for this feature, but it was (apparently) never implemented: https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
+	isAbstractUnixSocket := strings.HasPrefix(addr, "@")
+
+	if isAbstractUnixSocket {
+		//Abstract Unix sockets do not require us to remove stale socket files.
+		return nil, nil
+	}
+
+	//On Windows, we're using the `fakeCloseListener` wrappers around a single, ever-living listener.
+	//So, if there's an active listener entry in the pool, we're the current owner of the Unix socket file.
+	_, socketBelongsToCurrentProcess := listenerPool.References(listenerKey(network, addr))
+
+	if socketBelongsToCurrentProcess {
+		//Reuse/cleanup is entirely handled by the refcounting mechanism in `listenerPool`.
+		return nil, nil
+	}
+
+	//Another process created this socket file; try to delete it so we can bind to it later.
+	//This allows us to start up even after a crash (that left an orphaned socket file behind).
+	err := os.Remove(addr)
+
+	if err == nil {
+		return nil, nil
+	} else if errors.Is(err, fs.ErrNotExist) {
+		//Either the file didn't exist in the first place, or it was deleted before we were able to.
+		return nil, nil
+	} else {
+		//We failed to delete the file. Likely, it belongs to another (active) process.
+		return nil, err
+	}
+}

--- a/listen_reuseUnixSocket_windows.go
+++ b/listen_reuseUnixSocket_windows.go
@@ -4,10 +4,16 @@ package caddy
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
+	"net"
 	"os"
 	"strings"
+	"syscall"
+	"time"
 )
+
+var ErrUnixSocketAlreadyInUse = errors.New("unix socket is already in use by another process")
 
 func reuseUnixSocket(network, addr string) (any, error) {
 	if !IsUnixNetwork(network) {
@@ -34,9 +40,28 @@ func reuseUnixSocket(network, addr string) (any, error) {
 		return nil, nil
 	}
 
-	//Another process created this socket file; try to delete it so we can bind to it later.
-	//This allows us to start up even after a crash (that left an orphaned socket file behind).
-	err := os.Remove(addr)
+	//If the socket file does not exist or has no backing server process, this will fail instantly.
+	connection, err := net.DialTimeout("unix", addr, 10*time.Millisecond)
+
+	if err == nil {
+		connection.Close()
+		return nil, fmt.Errorf("cannot reuse socket %v: %w", addr, ErrUnixSocketAlreadyInUse)
+	}
+
+	//Windows returns this error code both if the socket file does not exist and if it isn't backed by a server process anymore.
+	//See: https://learn.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2#wsaeconnrefused
+	const WSAECONNREFUSED syscall.Errno = 10061
+
+	var errno syscall.Errno
+	hasNoListeningServerProcess := errors.As(err, &errno) && errno == WSAECONNREFUSED
+
+	if !hasNoListeningServerProcess {
+		return nil, fmt.Errorf("cannot reuse socket %v: %w", addr, ErrUnixSocketAlreadyInUse)
+	}
+
+	//If the socket file exists, it hasn't been created by our process, and it seemingly
+	//isn't backed by a server process anymore. Try to delete it so we can bind to it later.
+	err = os.Remove(addr)
 
 	if err == nil {
 		return nil, nil

--- a/listen_reuseUnixSocket_windows.go
+++ b/listen_reuseUnixSocket_windows.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build windows
 
 package caddy
@@ -13,63 +27,63 @@ import (
 	"time"
 )
 
-var ErrUnixSocketAlreadyInUse = errors.New("unix socket is already in use by another process")
+var errUnixSocketAlreadyInUse = errors.New("unix socket is already in use by another process")
 
 func reuseUnixSocket(network, addr string) (any, error) {
 	if !IsUnixNetwork(network) {
 		return nil, nil
 	}
 
-	//Note: This is here mainly for proper compatibility, because Unix sockets with abstract names are in an interesting limbo state on Windows:
-	//Golang already translates `@` characters to `\0` for Windows: https://github.com/golang/go/blob/65d5c5f6dd8aa7b221cff6ec3f5101ea2e5f3efa/src/syscall/syscall_windows.go#L910
-	//...but there still is an open issue about the fact that this is not properly supported: https://github.com/microsoft/WSL/issues/4240#issuecomment-620805115
-	//The main issue is that the original announcement proclaimed support for this feature, but it was (apparently) never implemented: https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
+	// Note: This is here mainly for proper compatibility, because Unix sockets with abstract names are in an interesting limbo state on Windows:
+	// Go already translates `@` characters to `\0` for Windows: https://github.com/golang/go/blob/65d5c5f6dd8aa7b221cff6ec3f5101ea2e5f3efa/src/syscall/syscall_windows.go#L910
+	// ...but there still is an open issue about the fact that this is not properly supported: https://github.com/microsoft/WSL/issues/4240#issuecomment-620805115
+	// The main issue is that the original announcement proclaimed support for this feature, but it was (apparently) never implemented: https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
 	isAbstractUnixSocket := strings.HasPrefix(addr, "@")
 
 	if isAbstractUnixSocket {
-		//Abstract Unix sockets do not require us to remove stale socket files.
+		// Abstract Unix sockets do not require us to remove stale socket files.
 		return nil, nil
 	}
 
-	//On Windows, we're using the `fakeCloseListener` wrappers around a single, ever-living listener.
-	//So, if there's an active listener entry in the pool, we're the current owner of the Unix socket file.
+	// On Windows, we're using the `fakeCloseListener` wrappers around a single, ever-living listener.
+	// So, if there's an active listener entry in the pool, we're the current owner of the Unix socket file.
 	_, socketBelongsToCurrentProcess := listenerPool.References(listenerKey(network, addr))
 
 	if socketBelongsToCurrentProcess {
-		//Reuse/cleanup is entirely handled by the refcounting mechanism in `listenerPool`.
+		// Reuse/cleanup is entirely handled by the refcounting mechanism in `listenerPool`.
 		return nil, nil
 	}
 
-	//If the socket file does not exist or has no backing server process, this will fail instantly.
+	// If the socket file does not exist or has no backing server process, this will fail instantly.
 	connection, err := net.DialTimeout("unix", addr, 10*time.Millisecond)
 
 	if err == nil {
 		connection.Close()
-		return nil, fmt.Errorf("cannot reuse socket %v: %w", addr, ErrUnixSocketAlreadyInUse)
+		return nil, fmt.Errorf("cannot reuse socket %v: %w", addr, errUnixSocketAlreadyInUse)
 	}
 
-	//Windows returns this error code both if the socket file does not exist and if it isn't backed by a server process anymore.
-	//See: https://learn.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2#wsaeconnrefused
+	// Windows returns this error code both if the socket file does not exist and if it isn't backed by a server process anymore.
+	// See: https://learn.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2#wsaeconnrefused
 	const WSAECONNREFUSED syscall.Errno = 10061
 
 	var errno syscall.Errno
 	hasNoListeningServerProcess := errors.As(err, &errno) && errno == WSAECONNREFUSED
 
 	if !hasNoListeningServerProcess {
-		return nil, fmt.Errorf("cannot reuse socket %v: %w", addr, ErrUnixSocketAlreadyInUse)
+		return nil, fmt.Errorf("cannot reuse socket %v: %w", addr, errUnixSocketAlreadyInUse)
 	}
 
-	//If the socket file exists, it hasn't been created by our process, and it seemingly
-	//isn't backed by a server process anymore. Try to delete it so we can bind to it later.
+	// If the socket file exists, it hasn't been created by our process, and it seemingly
+	// isn't backed by a server process anymore. Try to delete it so we can bind to it later.
 	err = os.Remove(addr)
 
 	if err == nil {
 		return nil, nil
 	} else if errors.Is(err, fs.ErrNotExist) {
-		//Either the file didn't exist in the first place, or it was deleted before we were able to.
+		// Either the file didn't exist in the first place, or it was deleted before we were able to.
 		return nil, nil
 	} else {
-		//We failed to delete the file. Likely, it belongs to another (active) process.
+		// We failed to delete the file. Likely, it belongs to another (active) process.
 		return nil, err
 	}
 }


### PR DESCRIPTION
The current [non-unix implementation of `reuseUnixSocket`](https://github.com/caddyserver/caddy/blob/master/listen.go#L33) is essentially a no-op, and the reuse mechanism is entirely centered around [fakeCloseListener](https://github.com/caddyserver/caddy/blob/4d6945769d205f2a60acf13eefb5af0a2eb428fc/listen.go#L122) wrappers and a refcounting mechanism in [listenerPool](https://github.com/caddyserver/caddy/blob/4d6945769d205f2a60acf13eefb5af0a2eb428fc/listeners.go#L736).

The [unix implementation of `reuseUnixSocket`](https://github.com/caddyserver/caddy/blob/4d6945769d205f2a60acf13eefb5af0a2eb428fc/listen_unix.go#L43), on the other hand, [also performs an `unlink()`](https://github.com/caddyserver/caddy/blob/4d6945769d205f2a60acf13eefb5af0a2eb428fc/listen_unix.go#L86) on any orphaned unix domain socket files that might have been left behind by earlier processes, which is not covered by the non-unix implementation.

This makes it rather painful to operate Caddy as a Windows service if it is configured to use a `unix/` socket for its admin interface: In practice, it isn't all that rare that a Caddy instance fails to clean up its socket file, which breaks all subsequent startup attempts (meaning someone will have to manually delete the file in question). Caddy will fail to start with the following error in such cases:

```
Error: loading initial config: loading new config: starting caddy administration endpoint: listen unix C:\path\to\admin.sock: bind: Only one usage of each socket address (protocol/network address/port) is normally permitted.
```

This change introduces a separate `reuseUnixSocket` implementation for Windows that will try to delete such socket files if they don't already belong to the current Caddy process. I've left the function as a no-op for other platforms (i.e. non-unix, non-windows + solaris) since I'm not certain they provide the same failure modes as Windows.

## Testing

As this change relates to socket state management, I've only tested this manually. An easy way to do so looks like this:

Caddyfile:
```Caddyfile
{
    admin unix/C:\path\to\admin.sock
}
```

In a shell (assuming `pwsh`):
```pwsh
caddy run

# In another pwsh:
taskkill /f /im caddy.exe

# After that, there's an orphaned socket file in C:\path\to\admin.sock
# Restarting caddy will fail from now on (but succeed with this PR's change):
caddy run
...
Error: loading initial config: loading new config: starting caddy administration endpoint: listen unix C:\path\to\admin.sock: bind: Only one usage of each socket address (protocol/network address/port) is normally permitted.

# With the change applied, repeatedly reloading the config keeps working:
Invoke-WebRequest `
    -SkipHttpErrorCheck `
    -Method Post `
    -ContentType "text/caddyfile" `
    -InFile Caddyfile `
    -UnixSocket C:\path\to\admin.sock `
    -Uri http://caddy/load
...
StatusCode        : 200
StatusDescription : OK
...

# Specifying a different UNIX domain socket as the admin socket and reloading the config
# also reliably causes caddy to switch sockets.

Invoke-WebRequest `
    -SkipHttpErrorCheck `
    -UnixSocket C:\path\to\admin.sock `
    -Method Post `
    -ContentType "application/json" `
    -Body ("unix/C:\path\to\admin2.sock" | ConvertTo-Json) `
    -Uri http://caddy/config/admin/listen
...
StatusCode        : 200
StatusDescription : OK
...


[System.IO.File]::Exists("C:\path\to\admin.sock")
False

[System.IO.File]::Exists("C:\path\to\admin2.sock")
True
```

## On the `isAbstractUnixSocket` if statement

I've tried to figure out if the Windows implementation also supports abstract names for unix domain sockets and found that the current state is somewhat contradictory (as stated in the comment). From what I can tell, [this _isn't_ implemented in Windows](https://github.com/microsoft/WSL/issues/4240#issuecomment-620805115) (although the [announcement stated otherwise](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/#:~:text=Windows%20implementation%20of%20AF_UNIX%20socket%20can%20also%20accept%20abstract%20addresses)), but the [Go standard library also implements the `@` -> `\0` mapping for Windows](https://github.com/golang/go/blob/65d5c5f6dd8aa7b221cff6ec3f5101ea2e5f3efa/src/syscall/syscall_windows.go#L910), meaning that specifying something akin to `admin @some-abstract-socket` will nevertheless result in an _attempt_ to listen to an abstract socket (which, strangely, also doesn't fail, leading to an inoperable admin socket but a running Caddy process).

Because of that, I figured it'd be better to have the correct behavior anyway, even if abstract unix sockets don't work. Essentially, avoiding to delete a socket file that won't be created (because of the mapping done by Go) won't hurt, and having the comment with references present will at least document the issue.


## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->
I've made this change in Cursor and used its tab-completion feature to do so.
