### PR TITLE
caddytls: Do not pass fd/ descriptors to ACME listener (fixes #7525)

### DIFF
--- a/modules/caddytls/acmeissuer.go
+++ b/modules/caddytls/acmeissuer.go
@@ -253,7 +253,11 @@ func (iss *ACMEIssuer) makeIssuerTemplate(ctx caddy.Context) (certmagic.ACMEIssu
 		if iss.Challenges.DNS != nil {
 			template.DNS01Solver = iss.Challenges.DNS.solver
 		}
-		template.ListenHost = iss.Challenges.BindHost
+		if strings.HasPrefix(iss.Challenges.BindHost, "fd/") {
+			template.ListenHost = ""
+		} else {
+			template.ListenHost = iss.Challenges.BindHost
+		}
 		if iss.Challenges.Distributed != nil {
 			template.DisableDistributedSolvers = !*iss.Challenges.Distributed
 		}


### PR DESCRIPTION
This PR fixes a bug where configuring a systemd file descriptor in `bind` or `default_bind` causes the ACME challenge solver to crash with a `no such host` error. 

Fixes #7525 

Currently, if a user configures `bind fd/3`, Caddy passes `"fd/3"` directly to CertMagic via `iss.Challenges.BindHost`. It attempts a DNS lookup on the literal string `"fd/3"`. This fails immediately, preventing ACME certificates from being issued or renewed. 

This PR intercepts the `BindHost` before it is passed to CertMagic. If it detects a file descriptor, it leaves the CertMagic `ListenHost` template blank. 

This safely forces CertMagic to fall back to its default behavior (binding to standard ports `:80` or `:443`), bypassing the DNS lookup crash while still allowing the main Caddy server to intercept the challenge traffic via the file descriptor.

I compiled a custom build and ran it locally using `systemd-socket-activate` to simulate the environment:

**Test Caddyfile:**
```caddyfile
{
    servers {
        protocols h1 h2
    }
}
fake-domain-for-testing.com {
    bind fd/3
    tls {
        ca [https://acme-staging-v02.api.letsencrypt.org/directory](https://acme-staging-v02.api.letsencrypt.org/directory)
    }
    respond "Hello World"
}
```

## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

I consulted Gemini to help analyze the root cause of the socket activation bug and generate the code for this fix. I have reviewed the code and verified it is correct.
