### PR TITLE
rewrite: escape file matcher paths before rewriting

### DIFF
--- a/modules/caddyhttp/fileserver/matcher_test.go
+++ b/modules/caddyhttp/fileserver/matcher_test.go
@@ -196,6 +196,7 @@ func TestTryFilesRewriteEscapesMatchedPath(t *testing.T) {
 		name           string
 		requestTarget  string
 		filename       string
+		extraFiles     []string
 		wantPath       string
 		wantRequestURI string
 		skipWindows    bool
@@ -230,6 +231,14 @@ func TestTryFilesRewriteEscapesMatchedPath(t *testing.T) {
 			wantRequestURI: "/nested/%3F.html",
 			skipWindows:    true,
 		},
+		{
+			name:           "encoded slash in filename does not conflict with nesting",
+			requestTarget:  "/nested%252Ffile.html",
+			filename:       "nested%2Ffile.html",
+			extraFiles:     []string{filepath.Join("nested", "file.html")},
+			wantPath:       "/nested%2Ffile.html",
+			wantRequestURI: "/nested%252Ffile.html",
+		},
 	}
 
 	for _, tc := range tests {
@@ -238,12 +247,14 @@ func TestTryFilesRewriteEscapesMatchedPath(t *testing.T) {
 				t.Skip("Windows file names cannot contain question marks")
 			}
 
-			filename := filepath.Join(root, tc.filename)
-			if err := os.MkdirAll(filepath.Dir(filename), 0o700); err != nil {
-				t.Fatalf("creating test file parent directory: %v", err)
-			}
-			if err := os.WriteFile(filename, []byte(tc.filename), 0o600); err != nil {
-				t.Fatalf("writing test file: %v", err)
+			for _, name := range append([]string{tc.filename}, tc.extraFiles...) {
+				filename := filepath.Join(root, name)
+				if err := os.MkdirAll(filepath.Dir(filename), 0o700); err != nil {
+					t.Fatalf("creating test file parent directory: %v", err)
+				}
+				if err := os.WriteFile(filename, []byte(name), 0o600); err != nil {
+					t.Fatalf("writing test file: %v", err)
+				}
 			}
 
 			m := &MatchFile{

--- a/modules/caddyhttp/fileserver/matcher_test.go
+++ b/modules/caddyhttp/fileserver/matcher_test.go
@@ -222,6 +222,14 @@ func TestTryFilesRewriteEscapesMatchedPath(t *testing.T) {
 			wantPath:       "/%3F.html",
 			wantRequestURI: "/%253F.html",
 		},
+		{
+			name:           "question mark in nested path",
+			requestTarget:  "/nested/%3F.html",
+			filename:       filepath.Join("nested", "?.html"),
+			wantPath:       "/nested/?.html",
+			wantRequestURI: "/nested/%3F.html",
+			skipWindows:    true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -230,7 +238,11 @@ func TestTryFilesRewriteEscapesMatchedPath(t *testing.T) {
 				t.Skip("Windows file names cannot contain question marks")
 			}
 
-			if err := os.WriteFile(filepath.Join(root, tc.filename), []byte(tc.filename), 0o600); err != nil {
+			filename := filepath.Join(root, tc.filename)
+			if err := os.MkdirAll(filepath.Dir(filename), 0o700); err != nil {
+				t.Fatalf("creating test file parent directory: %v", err)
+			}
+			if err := os.WriteFile(filename, []byte(tc.filename), 0o600); err != nil {
 				t.Fatalf("writing test file: %v", err)
 			}
 

--- a/modules/caddyhttp/fileserver/matcher_test.go
+++ b/modules/caddyhttp/fileserver/matcher_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/internal/filesystems"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp/rewrite"
 )
 
 type testCase struct {
@@ -185,6 +186,82 @@ func fileMatcherTest(t *testing.T, i int, tc testCase) {
 	fileType, _ := repl.Get("http.matchers.file.type")
 	if fileType != tc.expectedType {
 		t.Errorf("Test %d: actual file type: %v, expected: %v", i, fileType, tc.expectedType)
+	}
+}
+
+func TestTryFilesRewriteEscapesMatchedPath(t *testing.T) {
+	root := t.TempDir()
+
+	tests := []struct {
+		name           string
+		requestTarget  string
+		filename       string
+		wantPath       string
+		wantRequestURI string
+		skipWindows    bool
+	}{
+		{
+			name:           "question mark in path",
+			requestTarget:  "/%3F.html",
+			filename:       "?.html",
+			wantPath:       "/?.html",
+			wantRequestURI: "/%3F.html",
+			skipWindows:    true,
+		},
+		{
+			name:           "percent in path",
+			requestTarget:  "/%25.html",
+			filename:       "%.html",
+			wantPath:       "/%.html",
+			wantRequestURI: "/%25.html",
+		},
+		{
+			name:           "encoded question mark remains percent-encoded",
+			requestTarget:  "/%253F.html",
+			filename:       "%3F.html",
+			wantPath:       "/%3F.html",
+			wantRequestURI: "/%253F.html",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.skipWindows && runtime.GOOS == "windows" {
+				t.Skip("Windows file names cannot contain question marks")
+			}
+
+			if err := os.WriteFile(filepath.Join(root, tc.filename), []byte(tc.filename), 0o600); err != nil {
+				t.Fatalf("writing test file: %v", err)
+			}
+
+			m := &MatchFile{
+				fsmap:    &filesystems.FileSystemMap{},
+				Root:     root,
+				TryFiles: []string{"{http.request.uri.path}"},
+			}
+			req := httptest.NewRequest(http.MethodGet, "http://example.com"+tc.requestTarget, nil)
+			repl := caddyhttp.NewTestReplacer(req)
+
+			matched, err := m.MatchWithError(req)
+			if err != nil {
+				t.Fatalf("matching file: %v", err)
+			}
+			if !matched {
+				t.Fatalf("expected request %s to match %s", tc.requestTarget, tc.filename)
+			}
+
+			rewrite.Rewrite{URI: "{http.matchers.file.relative}"}.Rewrite(req, repl)
+
+			if req.URL.Path != tc.wantPath {
+				t.Errorf("rewritten path = %q, want %q", req.URL.Path, tc.wantPath)
+			}
+			if req.RequestURI != tc.wantRequestURI {
+				t.Errorf("rewritten request URI = %q, want %q", req.RequestURI, tc.wantRequestURI)
+			}
+			if req.URL.RawQuery != "" {
+				t.Errorf("rewritten raw query = %q, want empty", req.URL.RawQuery)
+			}
+		})
 	}
 }
 

--- a/modules/caddyhttp/rewrite/rewrite.go
+++ b/modules/caddyhttp/rewrite/rewrite.go
@@ -211,12 +211,7 @@ func (rewr Rewrite) Rewrite(r *http.Request, repl *caddy.Replacer) bool {
 		var newPath, newQuery, newFrag string
 
 		if path != "" {
-			// replace the `path` placeholder to escaped path
-			pathPlaceholder := "{http.request.uri.path}"
-			if strings.Contains(path, pathPlaceholder) {
-				path = strings.ReplaceAll(path, pathPlaceholder, r.URL.EscapedPath())
-			}
-
+			path = escapePathPlaceholders(path, r, repl)
 			newPath = repl.ReplaceAll(path, "")
 		}
 
@@ -298,6 +293,29 @@ func (rewr Rewrite) Rewrite(r *http.Request, repl *caddy.Replacer) bool {
 
 	// return true if anything changed
 	return r.Method != oldMethod || r.RequestURI != oldURI
+}
+
+func escapePathPlaceholders(path string, r *http.Request, repl *caddy.Replacer) string {
+	// Replace path-valued placeholders in escaped form before the URI is parsed,
+	// otherwise literal '?' and '%' bytes from the path can be interpreted as URI
+	// delimiters or percent-escape sequences during the rewrite.
+	pathPlaceholder := "{http.request.uri.path}"
+	if strings.Contains(path, pathPlaceholder) {
+		path = strings.ReplaceAll(path, pathPlaceholder, r.URL.EscapedPath())
+	}
+
+	fileMatchRelativePlaceholder := "{http.matchers.file.relative}"
+	if strings.Contains(path, fileMatchRelativePlaceholder) {
+		if val, ok := repl.Get("http.matchers.file.relative"); ok {
+			path = strings.ReplaceAll(path, fileMatchRelativePlaceholder, escapePathPreservingSlashes(fmt.Sprint(val)))
+		}
+	}
+
+	return path
+}
+
+func escapePathPreservingSlashes(path string) string {
+	return strings.ReplaceAll(url.PathEscape(path), "%2F", "/")
 }
 
 // buildQueryString takes an input query string and

--- a/modules/caddyhttp/rewrite/rewrite.go
+++ b/modules/caddyhttp/rewrite/rewrite.go
@@ -307,7 +307,9 @@ func escapePathPlaceholders(path string, r *http.Request, repl *caddy.Replacer) 
 	fileMatchRelativePlaceholder := "{http.matchers.file.relative}"
 	if strings.Contains(path, fileMatchRelativePlaceholder) {
 		if val, ok := repl.Get("http.matchers.file.relative"); ok {
-			path = strings.ReplaceAll(path, fileMatchRelativePlaceholder, escapePathPreservingSlashes(fmt.Sprint(val)))
+			if relativePath, ok := val.(string); ok {
+				path = strings.ReplaceAll(path, fileMatchRelativePlaceholder, escapePathPreservingSlashes(relativePath))
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Preserve matched file paths containing literal `?` and `%` when `try_files` rewrites to `{http.matchers.file.relative}`.
- Keep file-matcher path placeholders escaped while rewrite parses the target URI, so matched paths are not mistaken for query delimiters or decoded twice.

Fixes #7678

## Tests

- `go test ./modules/caddyhttp/fileserver -run TestTryFilesRewriteEscapesMatchedPath -count=1`
- `go test ./modules/caddyhttp/rewrite ./modules/caddyhttp/fileserver -count=1`

## Assistance Disclosure

AI assistance was used for investigation, implementation, and tests. I used Hermes Agent (OpenAI GPT-5.5) and verified the generated changes with the tests above.
