### PR TITLE
chore: Fix golangci-lint 2.12.1 findings

### DIFF
--- a/cmd/packagesfuncs.go
+++ b/cmd/packagesfuncs.go
@@ -234,7 +234,7 @@ func getModules() (standard, nonstandard, unknown []moduleInfo, err error) {
 		// not sure why), and since New() should return a pointer
 		// value, we need to dereference it first
 		iface := any(modInfo.New())
-		if rv := reflect.ValueOf(iface); rv.Kind() == reflect.Ptr {
+		if rv := reflect.ValueOf(iface); rv.Kind() == reflect.Pointer {
 			iface = reflect.New(reflect.TypeOf(iface).Elem()).Elem().Interface()
 		}
 		modPkgPath := reflect.TypeOf(iface).PkgPath()

--- a/context.go
+++ b/context.go
@@ -378,7 +378,7 @@ func (ctx Context) LoadModuleByID(id string, rawMsg json.RawMessage) (any, error
 	// value must be a pointer for unmarshaling into concrete type, even if
 	// the module's concrete type is a slice or map; New() *should* return
 	// a pointer, otherwise unmarshaling errors or panics will occur
-	if rv := reflect.ValueOf(val); rv.Kind() != reflect.Ptr {
+	if rv := reflect.ValueOf(val); rv.Kind() != reflect.Pointer {
 		log.Printf("[WARNING] ModuleInfo.New() for module '%s' did not return a pointer,"+
 			" so we are using reflection to make a pointer instead; please fix this by"+
 			" using new(Type) or &Type notation in your module's New() function.", id)

--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -281,7 +281,7 @@ func (fsrv *FileServer) browseApplyQueryParams(w http.ResponseWriter, r *http.Re
 			sortParam = sortCookie.Value
 		}
 	case sortByName, sortByNameDirFirst, sortBySize, sortByTime:
-		http.SetCookie(w, &http.Cookie{
+		http.SetCookie(w, &http.Cookie{ //nolint:gosec // Secure depends on whether the request itself used TLS
 			Name:     "sort",
 			Value:    sortParam,
 			Secure:   r.TLS != nil,
@@ -298,7 +298,7 @@ func (fsrv *FileServer) browseApplyQueryParams(w http.ResponseWriter, r *http.Re
 			orderParam = orderCookie.Value
 		}
 	case sortOrderAsc, sortOrderDesc:
-		http.SetCookie(w, &http.Cookie{
+		http.SetCookie(w, &http.Cookie{ //nolint:gosec // Secure depends on whether the request itself used TLS
 			Name:     "order",
 			Value:    orderParam,
 			Secure:   r.TLS != nil,

--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -281,7 +281,13 @@ func (fsrv *FileServer) browseApplyQueryParams(w http.ResponseWriter, r *http.Re
 			sortParam = sortCookie.Value
 		}
 	case sortByName, sortByNameDirFirst, sortBySize, sortByTime:
-		http.SetCookie(w, &http.Cookie{Name: "sort", Value: sortParam, Secure: r.TLS != nil})
+		http.SetCookie(w, &http.Cookie{
+			Name:     "sort",
+			Value:    sortParam,
+			Secure:   r.TLS != nil,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+		})
 	}
 
 	// then figure out the order
@@ -292,7 +298,13 @@ func (fsrv *FileServer) browseApplyQueryParams(w http.ResponseWriter, r *http.Re
 			orderParam = orderCookie.Value
 		}
 	case sortOrderAsc, sortOrderDesc:
-		http.SetCookie(w, &http.Cookie{Name: "order", Value: orderParam, Secure: r.TLS != nil})
+		http.SetCookie(w, &http.Cookie{
+			Name:     "order",
+			Value:    orderParam,
+			Secure:   r.TLS != nil,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+		})
 	}
 
 	// finally, apply the sorting and limiting

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -785,7 +785,7 @@ func redirect(w http.ResponseWriter, r *http.Request, toPath string) error {
 	if r.URL.RawQuery != "" {
 		toPath += "?" + r.URL.RawQuery
 	}
-	http.Redirect(w, r, toPath, http.StatusPermanentRedirect)
+	http.Redirect(w, r, toPath, http.StatusPermanentRedirect) //nolint:gosec // toPath is a same-origin path and leading // is stripped above
 	return nil
 }
 

--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -664,10 +664,12 @@ func (s CookieHashSelection) Select(pool UpstreamPool, req *http.Request, w http
 			return upstream
 		}
 		cookie := &http.Cookie{
-			Name:   s.Name,
-			Value:  sha,
-			Path:   "/",
-			Secure: false,
+			Name:     s.Name,
+			Value:    sha,
+			Path:     "/",
+			Secure:   false,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
 		}
 		isProxyHttps := false
 		if trusted, ok := caddyhttp.GetVar(req.Context(), caddyhttp.TrustedProxyVarKey).(bool); ok && trusted {

--- a/modules/caddyhttp/routes.go
+++ b/modules/caddyhttp/routes.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/caddyserver/caddy/v2"
@@ -241,8 +242,8 @@ func (routes RouteList) Compile(next Handler) Handler {
 		mid = append(mid, wrapRoute(route))
 	}
 	stack := next
-	for i := len(mid) - 1; i >= 0; i-- {
-		stack = mid[i](stack)
+	for _, middleware := range slices.Backward(mid) {
+		stack = middleware(stack)
 	}
 	return stack
 }
@@ -305,8 +306,8 @@ func wrapRoute(route Route) Middleware {
 			}
 
 			// compile this route's handler stack
-			for i := len(route.middleware) - 1; i >= 0; i-- {
-				nextCopy = route.middleware[i](nextCopy)
+			for _, middleware := range slices.Backward(route.middleware) {
+				nextCopy = middleware(nextCopy)
 			}
 
 			// Apply metrics instrumentation once for the entire route,

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -1085,11 +1085,11 @@ func strictUntrustedClientIp(r *http.Request, headers []string, trusted []netip.
 	for _, headerName := range headers {
 		parts := strings.Split(strings.Join(r.Header.Values(headerName), ","), ",")
 
-		for i := len(parts) - 1; i >= 0; i-- {
+		for _, part := range slices.Backward(parts) {
 			// Some proxies may retain the port number, so split if possible
-			host, _, err := net.SplitHostPort(parts[i])
+			host, _, err := net.SplitHostPort(part)
 			if err != nil {
-				host = parts[i]
+				host = part
 			}
 
 			// Remove any zone identifier from the IP address


### PR DESCRIPTION
A few small changes due to recent lint findings:
- add explicit cookie security attributes for file-server browse cookies and reverse proxy sticky cookies
- modernise reverse slice iteration with `slices.Backward`
- use `reflect.Pointer` for the newer vet rule
- document the existing same-origin redirect path as a gosec false positive

Fixes #7686

## Assistance Disclosure
No AI was used.