### PR TITLE
httpcaddyfile: accept duration strings for log sampling interval

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -1053,7 +1053,7 @@ func parseLogHelper(h Helper, globalLogNames map[string]struct{}) ([]ConfigValue
 					if !d.NextArg() {
 						return nil, d.ArgErr()
 					}
-					interval, err := time.ParseDuration(d.Val() + "ns")
+					interval, err := caddy.ParseDuration(d.Val())
 					if err != nil {
 						return nil, d.Errf("failed to parse interval: %v", err)
 					}

--- a/caddyconfig/httpcaddyfile/builtins_test.go
+++ b/caddyconfig/httpcaddyfile/builtins_test.go
@@ -66,14 +66,14 @@ func TestLogDirectiveSyntax(t *testing.T) {
 			input: `:8080 {
 				log {
 					sampling {
-						interval 2
+						interval 2s
 						first 3
 						thereafter 4
 					}
 				}
 			}
 			`,
-			output:      `{"logging":{"logs":{"default":{"exclude":["http.log.access.log0"]},"log0":{"sampling":{"interval":2,"first":3,"thereafter":4},"include":["http.log.access.log0"]}}},"apps":{"http":{"servers":{"srv0":{"listen":[":8080"],"logs":{"default_logger_name":"log0"}}}}}}`,
+			output:      `{"logging":{"logs":{"default":{"exclude":["http.log.access.log0"]},"log0":{"sampling":{"interval":2000000000,"first":3,"thereafter":4},"include":["http.log.access.log0"]}}},"apps":{"http":{"servers":{"srv0":{"listen":[":8080"],"logs":{"default_logger_name":"log0"}}}}}}`,
 			expectError: false,
 		},
 	} {

--- a/caddytest/integration/caddyfile_adapt/global_options_log_sampling.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/global_options_log_sampling.caddyfiletest
@@ -1,7 +1,7 @@
 {
 	log {
 		sampling {
-			interval 300
+			interval 5m
 			first 50
 			thereafter 40
 		}
@@ -13,7 +13,7 @@
 		"logs": {
 			"default": {
 				"sampling": {
-					"interval": 300,
+					"interval": 300000000000,
 					"first": 50,
 					"thereafter": 40
 				}

--- a/caddytest/integration/caddyfile_adapt/log_sampling.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/log_sampling.caddyfiletest
@@ -1,7 +1,7 @@
 :80 {
 	log {
 		sampling {
-			interval 300
+			interval 5m
 			first 50
 			thereafter 40
 		}
@@ -18,7 +18,7 @@
 			},
 			"log0": {
 				"sampling": {
-					"interval": 300,
+					"interval": 300000000000,
 					"first": 50,
 					"thereafter": 40
 				},


### PR DESCRIPTION
## Summary

The Caddyfile adapter for `log { sampling { interval ... } }` rejects the
duration-string syntax shown in the docs. `interval 1s` (the example on the
[`log` directive page](https://caddyserver.com/docs/caddyfile/directives/log))
currently fails with `failed to parse interval: time: unknown unit "sns" in
duration "1sns"` because `parseLogHelper` appends `"ns"` to the literal token
before passing it to `time.ParseDuration`.

In practice the adapter only accepts bare integers (interpreted as
nanoseconds) — what the existing fixtures cover — but a sub-microsecond
sampling window isn't a useful configuration and isn't documented anywhere
user-facing. The result is a directive whose docs and implementation
disagree on every example.

**Projected impact is small.** A GitHub code search for non-fork Caddyfiles
that contain a `sampling { ... interval ... first ... thereafter ... }`
block returns zero hits outside `caddyserver/caddy` itself and its forks
(test fixtures, mirrors, fuzzing clones). Francis Lavoie [noted in the
forum thread that motivated #6682](https://caddy.community/t/how-to-configure-access-logs-sampling/26213)
that sampling "is just not a very popular feature so I guess it just got
forgotten" — consistent with the docs/impl mismatch sitting unnoticed
since the directive shipped. Anyone who *did* configure a bare-integer
interval can append `ns` and get bit-identical output; the new error
message points them there.

> **⚠️ Breaking change.** Configs that use bare integers for `interval`
> (e.g. `interval 100`) will fail to parse after this change. They were
> never documented and only made sense at nanosecond resolution. The fix
> is to add a unit (`100ns`, `5m`, etc.) — the error message now points
> the user at this directly.

## Changes

- `caddyconfig/httpcaddyfile/builtins.go` — switch `interval` from
  `time.ParseDuration(d.Val() + "ns")` to `caddy.ParseDuration(d.Val())`.
  This matches the three other duration fields parsed in the same file
  (`acme_dns` propagation delay/timeout, ACME `dns_ttl`) and accepts the
  units documented for `caddy.ParseDuration`.
- `caddytest/integration/caddyfile_adapt/log_sampling.caddyfiletest` and
  `global_options_log_sampling.caddyfiletest` — exercise the documented
  syntax (`interval 5m` → `"interval": 300000000000`).
- `caddyconfig/httpcaddyfile/builtins_test.go` — `TestLogDirectiveSyntax`
  asserts a duration string (`interval 2s` → `"interval": 2000000000`).

## Compatibility

| Before | After |
|---|---|
| `interval 1s` → ❌ parse error | `interval 1s` → ✅ `1_000_000_000` ns |
| `interval 100` → ✅ `100` ns (undocumented) | `interval 100` → ❌ parse error w/ guidance |
| `interval 100ns` → ❌ parse error | `interval 100ns` → ✅ `100` ns |

## Motivation

I hit this trying to use `interval 1s` per the docs and traced it to the
`"ns"`-appending parser. Original feature work was #6682 / #6680.

## Assistance Disclosure

Claude assisted with research, the code change, and the test updates; I
reviewed every diff, ran the build and tests against a freshly built
binary, and pushed back where appropriate.

---

<details>
<summary><b>Appendix: reproduce build + verify steps</b></summary>

### What it verifies

- The fork builds cleanly.
- `TestLogDirectiveSyntax` (`builtins_test.go`) and the two `*log_sampling.caddyfiletest` adapt fixtures pass under the new duration-string syntax.
- A locally built Caddy binary adapts the documented `interval 1s` form to `"interval": 1000000000` (positive case).
- The same binary rejects `interval 100` with `time: missing unit in duration "100"` (negative case — confirms the breaking-change migration path is mechanical).

### Reproduction steps

```bash
# 1. Check out the branch
git fetch origin pull/7694/head:pr-7694
git checkout pr-7694

# 2. Build
go build ./...

# 3. Targeted unit + adapt tests
go test -run TestLogDirectiveSyntax ./caddyconfig/httpcaddyfile/...
go test -run 'TestCaddyfileAdaptToJSON/(global_options_)?log_sampling' ./caddytest/integration/

# 4. End-to-end positive case — documented duration string
cat > /tmp/dur-str.caddy <<'EOF_CFG'
{
  log {
    sampling {
      interval 1s
      first 5
      thereafter 10
    }
  }
}
EOF_CFG
go run ./cmd/caddy adapt --config /tmp/dur-str.caddy --adapter caddyfile

# 5. End-to-end negative case — bare integer must now error with guidance
cat > /tmp/bare-int.caddy <<'EOF_CFG'
{
  log {
    sampling {
      interval 100
      first 1
      thereafter 200
    }
  }
}
EOF_CFG
go run ./cmd/caddy adapt --config /tmp/bare-int.caddy --adapter caddyfile
```

### Observed result

```
$ go build ./...
(exit 0)

$ go test -run TestLogDirectiveSyntax ./caddyconfig/httpcaddyfile/...
ok  	github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile  0.627s

$ go test -run 'TestCaddyfileAdaptToJSON/(global_options_)?log_sampling' ./caddytest/integration/
=== RUN   TestCaddyfileAdaptToJSON/global_options_log_sampling.caddyfiletest
=== RUN   TestCaddyfileAdaptToJSON/log_sampling.caddyfiletest
PASS

$ go run ./cmd/caddy adapt --config /tmp/dur-str.caddy --adapter caddyfile
{"logging":{"logs":{"default":{"sampling":{"interval":1000000000,"first":5,"thereafter":10}}}}}

$ go run ./cmd/caddy adapt --config /tmp/bare-int.caddy --adapter caddyfile
Error: parsing caddyfile tokens for 'log': failed to parse interval: time: missing unit in duration "100", at /tmp/bare-int.caddy:4
```

</details>