### PR TITLE
docs: add documentation for fileExists and fileStat template functions

### DIFF
--- a/modules/caddyhttp/templates/templates.go
+++ b/modules/caddyhttp/templates/templates.go
@@ -162,6 +162,25 @@ func init() {
 // {{listFiles "/mydir"}}
 // ```
 //
+// ##### `fileExists`
+//
+// Returns true if the given file name, relative to the template context's file root,
+// can be opened successfully.
+//
+// ```
+// {{fileExists "path/to/file.html"}}
+// ```
+//
+// ##### `fileStat`
+//
+// Returns [FileInfo](https://pkg.go.dev/io/fs#FileInfo) using [Stat](https://pkg.go.dev/io/fs#Stat)
+// on the given file name, relative to the template context's file root.
+//
+// ```
+// {{$css := fileStat "css/style.css" -}}
+// <link rel="stylesheet" href="/css/style.css?v={{ $css.ModTime.Unix }}">
+// ```
+//
 // ##### `markdown`
 //
 // Renders the given Markdown text as HTML and returns it. This uses the


### PR DESCRIPTION
Added documentation for the `fileExists` and `fileStats` template function so that they appear in the module reference:
https://caddyserver.com/docs/modules/http.handlers.templates#docs

See also https://github.com/caddyserver/website/issues/538

## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

Asked ChatGPT whether I, as a non-native English speaker, should use "file name" or "filename" in the documentation.
