### PR TITLE
caddytls: Fix client auth (fix #7724)

### DIFF
--- a/modules/caddytls/connpolicy.go
+++ b/modules/caddytls/connpolicy.go
@@ -896,18 +896,19 @@ func (clientauth *ClientAuthentication) ConfigureTLSConfig(cfg *tls.Config) erro
 // Unlike VerifyPeerCertificate, VerifyConnection is called on every
 // connection including resumed sessions, preventing session-resumption bypass.
 func (clientauth *ClientAuthentication) verifyConnection(cs tls.ConnectionState) error {
+	rawCerts := make([][]byte, len(cs.PeerCertificates))
+	for i, cert := range cs.PeerCertificates {
+		rawCerts[i] = cert.Raw
+	}
+
 	// first use any pre-existing custom verification function
 	if clientauth.existingVerifyPeerCert != nil {
-		rawCerts := make([][]byte, len(cs.PeerCertificates))
-		for i, cert := range cs.PeerCertificates {
-			rawCerts[i] = cert.Raw
-		}
 		if err := clientauth.existingVerifyPeerCert(rawCerts, cs.VerifiedChains); err != nil {
 			return err
 		}
 	}
 	for _, verifier := range clientauth.verifiers {
-		if err := verifier.VerifyClientCertificate(nil, cs.VerifiedChains); err != nil {
+		if err := verifier.VerifyClientCertificate(rawCerts, cs.VerifiedChains); err != nil {
 			return err
 		}
 	}

--- a/modules/caddytls/connpolicy_verifyconnection_test.go
+++ b/modules/caddytls/connpolicy_verifyconnection_test.go
@@ -1,0 +1,59 @@
+package caddytls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type testClientCertificateVerifier struct {
+	rawCerts       [][]byte
+	verifiedChains [][]*x509.Certificate
+	err            error
+}
+
+func (v *testClientCertificateVerifier) VerifyClientCertificate(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+	v.rawCerts = rawCerts
+	v.verifiedChains = verifiedChains
+	return v.err
+}
+
+func TestClientAuthenticationVerifyConnectionPassesRawCertsToVerifiers(t *testing.T) {
+	verifier := &testClientCertificateVerifier{}
+	clientauth := &ClientAuthentication{
+		verifiers: []ClientCertificateVerifier{verifier},
+	}
+
+	peerCert := &x509.Certificate{Raw: []byte("peer-cert-raw")}
+	verifiedChains := [][]*x509.Certificate{{peerCert}}
+	connState := tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{peerCert},
+		VerifiedChains:   verifiedChains,
+	}
+
+	if err := clientauth.verifyConnection(connState); err != nil {
+		t.Fatalf("verifyConnection failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(verifier.rawCerts, [][]byte{[]byte("peer-cert-raw")}) {
+		t.Fatalf("unexpected raw certs: got %#v", verifier.rawCerts)
+	}
+	if !reflect.DeepEqual(verifier.verifiedChains, verifiedChains) {
+		t.Fatalf("unexpected verified chains: got %#v", verifier.verifiedChains)
+	}
+}
+
+func TestClientAuthenticationVerifyConnectionReturnsVerifierError(t *testing.T) {
+	wantErr := errors.New("verify failed")
+	verifier := &testClientCertificateVerifier{err: wantErr}
+	clientauth := &ClientAuthentication{
+		verifiers: []ClientCertificateVerifier{verifier},
+	}
+
+	err := clientauth.verifyConnection(tls.ConnectionState{})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
+	}
+}


### PR DESCRIPTION
The peer certificates should be loaded even if `existingVerifyPeerCert` is nil.

Patched with the assistance of Copilot, as an experiment.

Do you think we need to return an error in the default case (i.e. neither branch gets entered)?