### PR TITLE
Fix minor typos in comments and strings

### DIFF
--- a/caddyconfig/caddyfile/lexer.go
+++ b/caddyconfig/caddyfile/lexer.go
@@ -155,7 +155,7 @@ func (l *lexer) next() (bool, error) {
 			// want to keep.
 			if ch == '\n' {
 				if len(val) == 2 {
-					return false, fmt.Errorf("missing opening heredoc marker on line #%d; must contain only alpha-numeric characters, dashes and underscores; got empty string", l.line)
+					return false, fmt.Errorf("missing opening heredoc marker on line #%d; must contain only alphanumeric characters, dashes and underscores; got empty string", l.line)
 				}
 
 				// check if there's too many <
@@ -165,7 +165,7 @@ func (l *lexer) next() (bool, error) {
 
 				heredocMarker = string(val[2:])
 				if !heredocMarkerRegexp.Match([]byte(heredocMarker)) {
-					return false, fmt.Errorf("heredoc marker on line #%d must contain only alpha-numeric characters, dashes and underscores; got '%s'", l.line, heredocMarker)
+					return false, fmt.Errorf("heredoc marker on line #%d must contain only alphanumeric characters, dashes and underscores; got '%s'", l.line, heredocMarker)
 				}
 
 				inHeredoc = true

--- a/caddyconfig/caddyfile/lexer_test.go
+++ b/caddyconfig/caddyfile/lexer_test.go
@@ -424,7 +424,7 @@ EOF
 		{
 			input:        []byte("not-a-heredoc <<\n"),
 			expectErr:    true,
-			errorMessage: "missing opening heredoc marker on line #1; must contain only alpha-numeric characters, dashes and underscores; got empty string",
+			errorMessage: "missing opening heredoc marker on line #1; must contain only alphanumeric characters, dashes and underscores; got empty string",
 		},
 		{
 			input: []byte(`heredoc <<<EOF

--- a/caddytest/integration/caddyfile_adapt/heredoc_invalid_marker.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/heredoc_invalid_marker.caddyfiletest
@@ -6,4 +6,4 @@ handle {
     END!
 }
 ----------
-heredoc marker on line #4 must contain only alpha-numeric characters, dashes and underscores; got 'END!'
+heredoc marker on line #4 must contain only alphanumeric characters, dashes and underscores; got 'END!'

--- a/modules/caddyhttp/http2listener.go
+++ b/modules/caddyhttp/http2listener.go
@@ -15,7 +15,7 @@ type connectionStater interface {
 
 // http2Listener wraps the listener to solve the following problems:
 // 1. prevent genuine h2c connections from succeeding if h2c is not enabled
-// and the connection doesn't implment connectionStater or the resulting NegotiatedProtocol
+// and the connection doesn't implement connectionStater or the resulting NegotiatedProtocol
 // isn't http2.
 // This does allow a connection to pass as tls enabled even if it's not, listener wrappers
 // can do this.

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -522,7 +522,7 @@ func (h *Handler) doActiveHealthCheck(dialInfo DialInfo, hostAddr string, networ
 		body = io.LimitReader(body, h.HealthChecks.Active.MaxSize)
 	}
 	defer func() {
-		// drain any remaining body so connection could be re-used
+		// drain any remaining body so connection could be reused
 		_, _ = io.Copy(io.Discard, body)
 		resp.Body.Close()
 	}()

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -460,7 +460,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 	}
 
 	// websocket over http2 or http3 if extended connect is enabled, assuming backend doesn't support this, the request will be modified to http1.1 upgrade
-	// Both use the same upgrade mechanism: server advertizes extended connect support, and client sends the pseudo header :protocol in a CONNECT request
+	// Both use the same upgrade mechanism: server advertises extended connect support, and client sends the pseudo header :protocol in a CONNECT request
 	// The quic-go http3 implementation also puts :protocol in r.Proto for CONNECT requests (quic-go/http3/headers.go@70-72,185,203)
 	// TODO: once we can reliably detect backend support this, it can be removed for those backends
 	if (r.ProtoMajor == 2 && r.Method == http.MethodConnect && r.Header.Get(":protocol") == "websocket") ||


### PR DESCRIPTION
This PR fixes some minor typos found in the codebase:
- `implment` -> `implement`
- `advertizes` -> `advertises`
- `re-used` -> `reused`
- `alpha-numeric` -> `alphanumeric`

These changes apply mostly to comments and a few internal test / error messages.