### PR TITLE
caddyfile: preserve implicit TLS issuer semantics

### DIFF
--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -1036,7 +1036,7 @@ outer:
 			// otherwise the one without any subjects (a catch-all) would be
 			// eaten up by the one with subjects; and if both have subjects, we
 			// need to combine their lists
-			if reflect.DeepEqual(aps[i].IssuersRaw, aps[j].IssuersRaw) &&
+			if automationPoliciesHaveSameIssuers(aps[i], aps[j]) &&
 				reflect.DeepEqual(aps[i].ManagersRaw, aps[j].ManagersRaw) &&
 				bytes.Equal(aps[i].StorageRaw, aps[j].StorageRaw) &&
 				aps[i].MustStaple == aps[j].MustStaple &&
@@ -1126,6 +1126,58 @@ func subjectQualifiesForPublicCert(ap *caddytls.AutomationPolicy, subj string) b
 	return !certmagic.SubjectIsIP(subj) &&
 		!certmagic.SubjectIsInternal(subj) &&
 		(strings.Count(subj, "*.") < 2 || ap.OnDemand)
+}
+
+func automationPoliciesHaveSameIssuers(a, b *caddytls.AutomationPolicy) bool {
+	if reflect.DeepEqual(a.IssuersRaw, b.IssuersRaw) {
+		return automationPoliciesHaveCompatibleImplicitIssuers(a, b)
+	}
+	return automationPolicyUsesDefaultInternalIssuer(a) && automationPolicyUsesDefaultInternalIssuer(b)
+}
+
+func automationPolicyUsesDefaultInternalIssuer(ap *caddytls.AutomationPolicy) bool {
+	if len(ap.IssuersRaw) == 0 && len(ap.Issuers) == 0 {
+		return automationPolicyImplicitIssuerClass(ap) == "internal"
+	}
+	return len(ap.IssuersRaw) == 1 &&
+		len(ap.Issuers) == 0 &&
+		string(bytes.TrimSpace(ap.IssuersRaw[0])) == `{"module":"internal"}`
+}
+
+// automationPoliciesHaveCompatibleImplicitIssuers returns whether two policies
+// without explicit issuers can be consolidated without changing default issuer
+// selection for their subjects.
+func automationPoliciesHaveCompatibleImplicitIssuers(a, b *caddytls.AutomationPolicy) bool {
+	if len(a.IssuersRaw) > 0 || len(a.Issuers) > 0 ||
+		len(b.IssuersRaw) > 0 || len(b.Issuers) > 0 {
+		return true
+	}
+
+	aClass := automationPolicyImplicitIssuerClass(a)
+	bClass := automationPolicyImplicitIssuerClass(b)
+	return aClass == "catch-all" || bClass == "catch-all" || aClass == bClass
+}
+
+func automationPolicyImplicitIssuerClass(ap *caddytls.AutomationPolicy) string {
+	if len(ap.SubjectsRaw) == 0 {
+		return "catch-all"
+	}
+
+	hasPublic := slices.ContainsFunc(ap.SubjectsRaw, func(subj string) bool {
+		return subjectQualifiesForPublicCert(ap, subj)
+	})
+	hasInternal := slices.ContainsFunc(ap.SubjectsRaw, func(subj string) bool {
+		return !subjectQualifiesForPublicCert(ap, subj)
+	})
+
+	switch {
+	case hasPublic && hasInternal:
+		return "mixed"
+	case hasPublic:
+		return "public"
+	default:
+		return "internal"
+	}
 }
 
 // automationPolicyHasAllPublicNames returns true if all the names on the policy

--- a/caddyconfig/httpcaddyfile/tlsapp_test.go
+++ b/caddyconfig/httpcaddyfile/tlsapp_test.go
@@ -3,6 +3,7 @@ package httpcaddyfile
 import (
 	"testing"
 
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
 )
 
@@ -52,5 +53,22 @@ func TestAutomationPolicyIsSubset(t *testing.T) {
 		if actual := automationPolicyIsSubset(apA, apB); actual != test.expect {
 			t.Errorf("Test %d: Expected %t but got %t (A: %v  B: %v)", i, test.expect, actual, test.a, test.b)
 		}
+	}
+}
+
+func TestAutomationPoliciesAllowSameHostOnDifferentPorts(t *testing.T) {
+	input := `https://example.com:5000 localhost:5000 {
+	respond "one"
+}
+
+https://example.net localhost:8080 {
+	respond "two"
+}
+`
+
+	adapter := caddyfile.Adapter{ServerType: ServerType{}}
+	_, _, err := adapter.Adapt([]byte(input), nil)
+	if err != nil {
+		t.Fatalf("adapting Caddyfile: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes #7738
- preserve implicit issuer semantics when consolidating Caddyfile-generated automation policies
- avoid merging implicit public and internal subject sets into one no-issuer policy
- treat implicit internal-only policies and explicit default internal issuer policies as equivalent for consolidation
- add regression coverage for repeated localhost subjects on different ports

## Assistance Disclosure
No AI was used.