### PR TITLE
caddytls: fix TLS state races and ECH rotation retry

### DIFF
--- a/modules/caddytls/sessiontickets.go
+++ b/modules/caddytls/sessiontickets.go
@@ -137,11 +137,10 @@ func (s *SessionTicketService) stayUpdated() {
 		case newKeys := <-keysChan:
 			s.mu.Lock()
 			s.currentKeys = newKeys
-			configs := s.configs
-			s.mu.Unlock()
-			for cfg := range configs {
+			for cfg := range s.configs {
 				cfg.SetSessionTicketKeys(newKeys)
 			}
+			s.mu.Unlock()
 		case <-s.stopChan:
 			return
 		}

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -879,6 +879,8 @@ func (t *TLS) getAutomationPolicyForName(name string) *AutomationPolicy {
 // AllMatchingCertificates returns the list of all certificates in
 // the cache which could be used to satisfy the given SAN.
 func AllMatchingCertificates(san string) []certmagic.Certificate {
+	certCacheMu.RLock()
+	defer certCacheMu.RUnlock()
 	return certCache.AllMatchingCertificates(san)
 }
 

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -440,7 +440,7 @@ func (t *TLS) Start() error {
 					t.EncryptedClientHello.configsMu.Unlock()
 					if err != nil {
 						echLogger.Error("rotating ECH configs failed", zap.Error(err))
-						return
+						continue
 					}
 					err := t.publishECHConfigs(echLogger)
 					if err != nil {


### PR DESCRIPTION
I'm working on a "Production Go" audit skill and ran it through Caddy.

I found these minor issues that have obvious fixes. They are in three commits but I figured they're so minor I'd send them in a single pull request. Let me know if they should be separated and apologies if I should have filed an issue first.

## Assistance Disclosure

<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

I'm working on a "Production Go" audit skill and ran it through Caddy.

The LLM suggested a maps.Clone but I think holding the mutex in `sessiontickets` is better.