### PR TITLE
reverseproxy: set Secure and SameSite=None on sticky cookies

### DIFF
--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -656,11 +656,12 @@ func (s CookieHashSelection) Select(pool UpstreamPool, req *http.Request, w http
 			return upstream
 		}
 		http.SetCookie(w, &http.Cookie{
-			Name:   s.Name,
-			Value:  sha,
-			Path:   "/",
-			Secure: false,
-		})
+				Name:     s.Name,
+				Value:    sha,
+				Path:     "/",
+				Secure:   req.TLS != nil,
+				SameSite: http.SameSiteNoneMode,
+			})
 		return upstream
 	}
 


### PR DESCRIPTION
When the reverse_proxy directive uses `lb_policy cookie`, the sticky session cookie should be Secure and SameSite=None by default so that users arriving from third-party links (e.g., email, social media) can still be properly sticky-routed to their upstream.

**Changes:**
- Set `SameSite` to `None` so the browser sends the cookie on cross-site requests
- Set `Secure` only when the connection is TLS (`req.TLS != nil`) to avoid issues with non-TLS deployments

**Impact on existing users:**

For an HTTPS site, this is not a breaking change:

1. Fresh user → receives new cookie with Secure and SameSite=None
2. Existing user with old cookie (same-site) → old cookie continues to be sent to Caddy
3. Existing user with old cookie (third-party) → old cookie not sent by browser, so Caddy sets a new cookie with Secure and SameSite=None

The existing tests continue to pass.