### PR TITLE
caddyhttp: normalize Windows backslashes in path matcher

### DIFF
--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -435,12 +435,12 @@ func (m MatchPath) MatchWithError(r *http.Request) (bool, error) {
 	// can be used instead.
 	reqPath := strings.ToLower(r.URL.Path)
 
-	// See #2917; Windows ignores trailing dots and spaces
-	// when accessing files (sigh), potentially causing a
-	// security risk (cry) if PHP files end up being served
-	// as static files, exposing the source code, instead of
-	// being matched by *.php to be treated as PHP scripts.
 	if runtime.GOOS == "windows" { // issue #5613
+		// Windows treats backslashes as path separators and
+		// ignores trailing dots and spaces when accessing files
+		// (sigh), potentially causing a security risk (cry) if
+		// protected files are not matched as intended.
+		reqPath = strings.ReplaceAll(reqPath, `\`, "/")
 		reqPath = strings.TrimRight(reqPath, ". ")
 	}
 
@@ -478,7 +478,12 @@ func (m MatchPath) MatchWithError(r *http.Request) (bool, error) {
 		// the intent is to compare that part of the path in raw/escaped
 		// space; i.e. "%40"=="%40", not "@", and "%2F"=="%2F", not "/"
 		if strings.Contains(matchPattern, "%") {
-			reqPathForPattern := CleanPath(r.URL.EscapedPath(), mergeSlashes)
+			escapedPath := r.URL.EscapedPath()
+			if runtime.GOOS == "windows" {
+				escapedPath = windowsEscapedPathSeparatorRepl.Replace(escapedPath)
+				matchPattern = windowsEscapedPathSeparatorRepl.Replace(matchPattern)
+			}
+			reqPathForPattern := CleanPath(escapedPath, mergeSlashes)
 			if m.matchPatternWithEscapeSequence(reqPathForPattern, matchPattern) {
 				return true, nil
 			}
@@ -642,6 +647,14 @@ func (MatchPath) matchPatternWithEscapeSequence(escapedPath, matchPath string) b
 	matches, _ := path.Match(matchPath, strings.ToLower(sb.String()))
 	return matches
 }
+
+// windowsEscapedPathSeparatorRepl normalizes Windows backslash separators
+// while preserving escaped-path matching semantics.
+var windowsEscapedPathSeparatorRepl = strings.NewReplacer(
+	`\`, "%2f",
+	"%5c", "%2f",
+	"%5C", "%2f",
+)
 
 // CELLibrary produces options that expose this matcher for use in CEL
 // expression matchers.

--- a/modules/caddyhttp/matchers_test.go
+++ b/modules/caddyhttp/matchers_test.go
@@ -461,18 +461,61 @@ func TestPathMatcherWindows(t *testing.T) {
 		return
 	}
 
-	req := &http.Request{URL: &url.URL{Path: "/index.php . . .."}}
 	repl := caddy.NewReplacer()
-	ctx := context.WithValue(req.Context(), caddy.ReplacerCtxKey, repl)
-	req = req.WithContext(ctx)
 
-	match := MatchPath{"*.php"}
-	matched, err := match.MatchWithError(req)
-	if err != nil {
-		t.Errorf("Expected no error, but got: %v", err)
-	}
-	if !matched {
-		t.Errorf("Expected to match; should ignore trailing dots and spaces")
+	for _, tc := range []struct {
+		name          string
+		path          string
+		requestTarget string
+		match         MatchPath
+	}{
+		{
+			name:  "trailing dots and spaces",
+			path:  "/index.php . . ..",
+			match: MatchPath{"*.php"},
+		},
+		{
+			name:          "encoded backslash path separator",
+			requestTarget: `/private%5csecret.txt`,
+			match:         MatchPath{"/private/*"},
+		},
+		{
+			name:          "encoded backslash path separator with escaped wildcard",
+			requestTarget: `/private%5csecret.txt`,
+			match:         MatchPath{"/private/%*"},
+		},
+		{
+			name:          "uppercase encoded backslash path separator with escaped wildcard",
+			requestTarget: `/private%5Csecret.txt`,
+			match:         MatchPath{"/private/%*"},
+		},
+		{
+			name:          "encoded backslash in escaped pattern",
+			requestTarget: `/private%5csecret.txt`,
+			match:         MatchPath{"/private%5c%*"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			u := &url.URL{Path: tc.path}
+			if tc.requestTarget != "" {
+				var err error
+				u, err = url.ParseRequestURI(tc.requestTarget)
+				if err != nil {
+					t.Fatalf("Parsing request target: %v", err)
+				}
+			}
+			req := &http.Request{URL: u}
+			ctx := context.WithValue(req.Context(), caddy.ReplacerCtxKey, repl)
+			req = req.WithContext(ctx)
+
+			matched, err := tc.match.MatchWithError(req)
+			if err != nil {
+				t.Errorf("Expected no error, but got: %v", err)
+			}
+			if !matched {
+				t.Errorf("Expected %q to match %v", req.URL.Path, tc.match)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Normalize Windows backslash path separators before `MatchPath` evaluates request paths.

On Windows, `file_server` resolves `\` as a filesystem path separator, but `MatchPath` previously evaluated request paths with URL path semantics only. This meant a request like `/private%5csecret.txt` could miss a matcher such as `/private/*`, while `file_server` later resolved it as `private\secret.txt`.

This patch applies the same Windows separator handling to both:

- normal path matcher patterns, e.g. `/private/*`
- escaped/raw path matcher patterns containing `%`, e.g. `/private/%*`

## Tests

Added Windows-only regression coverage for:

- trailing dot/space behavior already covered by the existing Windows test
- `/private%5csecret.txt` matching `/private/*`
- `/private%5csecret.txt` matching `/private/%*`
- uppercase `%5C`
- matcher patterns containing `%5c`

Local verification:

```text
go test ./modules/caddyhttp -run TestPathMatcher -count=1
GOOS=windows GOARCH=amd64 go test -c ./modules/caddyhttp -o /tmp/caddyhttp-matchers.test.exe
wine /tmp/caddyhttp-matchers.test.exe -test.run TestPathMatcherWindows -test.v
go test ./modules/caddyhttp -count=1
git diff --check
```