### PR TITLE
Emit network address in health events

### DIFF
--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -476,7 +476,7 @@ func (h *Handler) doActiveHealthCheck(dialInfo DialInfo, hostAddr string, networ
 		if upstream.Host.activeHealthFails() >= h.HealthChecks.Active.Fails {
 			// dispatch an event that the host newly became unhealthy
 			if upstream.setHealthy(false) {
-				h.events.Emit(h.ctx, "unhealthy", map[string]any{"host": hostAddr})
+				h.events.Emit(h.ctx, "unhealthy", map[string]any{"host": hostAddr, "addr": networkAddr})
 				upstream.Host.resetHealth()
 			}
 		}
@@ -499,7 +499,7 @@ func (h *Handler) doActiveHealthCheck(dialInfo DialInfo, hostAddr string, networ
 				if c := h.HealthChecks.Active.logger.Check(zapcore.InfoLevel, "host is up"); c != nil {
 					c.Write(zap.String("host", hostAddr))
 				}
-				h.events.Emit(h.ctx, "healthy", map[string]any{"host": hostAddr})
+				h.events.Emit(h.ctx, "healthy", map[string]any{"host": hostAddr, "addr": networkAddr})
 				upstream.Host.resetHealth()
 			}
 		}

--- a/modules/caddyhttp/reverseproxy/healthchecks.go
+++ b/modules/caddyhttp/reverseproxy/healthchecks.go
@@ -474,7 +474,7 @@ func (h *Handler) doActiveHealthCheck(dialInfo DialInfo, hostAddr string, networ
 		if upstream.activeHealthFails() >= h.HealthChecks.Active.Fails {
 			// dispatch an event that the host newly became unhealthy
 			if upstream.setHealthy(false) {
-				h.events.Emit(h.ctx, "unhealthy", map[string]any{"host": hostAddr})
+				h.events.Emit(h.ctx, "unhealthy", map[string]any{"host": hostAddr, "addr": networkAddr})
 				upstream.resetHealth()
 			}
 		}
@@ -497,7 +497,7 @@ func (h *Handler) doActiveHealthCheck(dialInfo DialInfo, hostAddr string, networ
 				if c := h.HealthChecks.Active.logger.Check(zapcore.InfoLevel, "host is up"); c != nil {
 					c.Write(zap.String("host", hostAddr))
 				}
-				h.events.Emit(h.ctx, "healthy", map[string]any{"host": hostAddr})
+				h.events.Emit(h.ctx, "healthy", map[string]any{"host": hostAddr, "addr": networkAddr})
 				upstream.resetHealth()
 			}
 		}


### PR DESCRIPTION
This event is effectively useless currently for local upstreams, since these will always show up as `localhost` with no additional disambiguation.

To minimise compatibility issues, the `host` field of the event is left as-is, but an additional `addr` field is emitted as part of the event which includes the network address of the upstream. This will include ports and also name unix sockets verbatim.

## Assistance Disclosure
This is the tool of the enemy. We do not use it. [ltdk.xyz/slop](https://ltdk.xyz/slop)