### PR TITLE
caddytls: skip idna.ToASCII for pure ASCII SNI values

### DIFF
--- a/modules/caddytls/matchers.go
+++ b/modules/caddytls/matchers.go
@@ -85,7 +85,15 @@ func asciiServerNameForMatch(name string) string {
 		return name
 	}
 
-	// SNI is ASCII on the wire, but config can use Unicode IDNs.
+	// Fast path: if the name is pure ASCII, skip idna.ToASCII.
+	// SNI values on the wire are always ASCII (RFC 6066), and most
+	// config patterns are also ASCII. For pure ASCII input, idna.ToASCII
+	// only validates and lowercases, which is equivalent to our fallback.
+	if isPureASCII(name) {
+		return strings.ToLower(name)
+	}
+
+	// Config can use Unicode IDNs.
 	ascii, err := idna.ToASCII(name)
 	if err == nil {
 		return strings.ToLower(ascii)
@@ -107,6 +115,15 @@ func asciiServerNameForMatch(name string) string {
 		labels[i] = strings.ToLower(ascii)
 	}
 	return strings.Join(labels, ".")
+}
+
+func isPureASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
 }
 
 // UnmarshalCaddyfile sets up the MatchServerName from Caddyfile tokens. Syntax:


### PR DESCRIPTION
SNI is always ASCII on the wire (RFC 6066), and most config
patterns are also ASCII. For pure ASCII input, idna.ToASCII
only validates and lowercases, which is equivalent to a simple
strings.ToLower. Add a fast path to avoid the overhead of
idna.ToASCII in the common case.


## AI Assistance Disclosure
- AI tools used: Claude
- Usage scope: Vulnerability scanning and code optimization suggestions only
- Verification: All code changes in this PR were manually implemented, reviewed, and tested by me. I take full responsibility for the correctness and originality of the work.
