### PR TITLE
perf(replacer): optimize memory allocation for file placeholders

### DIFF
--- a/replacer.go
+++ b/replacer.go
@@ -427,14 +427,10 @@ func readFileIntoBuffer(filename string, size int) ([]byte, error) {
 	}
 	defer file.Close()
 
-	buffer := make([]byte, size)
-	n, err := file.Read(buffer)
-	if err != nil && err != io.EOF {
-		return nil, err
-	}
-
-	// slice the buffer to the actual size
-	return buffer[:n], nil
+	// io.LimitReader ensures we never read more than 'size' bytes.
+	// io.ReadAll starts with a small buffer and grows it as needed,
+	// preventing a massive 1MB allocation for small files.
+	return io.ReadAll(io.LimitReader(file, int64(size)))
 }
 
 // ReplacementFunc is a function that is called when a


### PR DESCRIPTION
## What does this PR do?

Resolves #7771.

This PR optimizes memory allocation in Caddy's `replacer` module specifically for the `{file.*}` placeholder. Previously, Caddy blindly allocated a fixed 1MB (`1024 * 1024`) buffer on *every single replacement request*, regardless of the actual file size. 

For small files (e.g., Kubernetes service account tokens which are typically ~800 bytes), this hardcoded allocation resulted in a devastating **99.92% memory waste per request**, leading to massive Garbage Collection (GC) overhead and throughput bottlenecks under high load.

## Why is this important? (The Impact)

By replacing the fixed 1MB buffer allocation with a dynamic, size-aware `io.ReadAll` combined with `io.LimitReader`, this PR achieves:
* **Massive RAM Savings:** For small files (like secrets or tokens), memory allocation is reduced by over **1,300x per request**.
* **Increased Throughput:** By virtually eliminating the unnecessary GC pressure, Caddy can handle significantly more requests per second when `{file.*}` is in the hot path.
* **OOM Prevention:** Protects containerized deployments (like Kubernetes pods with strict 256MB memory limits) from experiencing `cgroup max` throttle events or Out-Of-Memory crashes under high concurrency.
* **Security Maintained:** The `io.LimitReader` ensures the reading process is still strictly capped at the defined maximum size, preventing malicious actors from exhausting memory by pointing the placeholder to massive or infinite files (e.g. `/dev/zero`).

## Implementation Details
Replaced `buffer := make([]byte, size)` and `file.Read(buffer)` with a one-liner:
`return io.ReadAll(io.LimitReader(file, int64(size)))`

This idiomatic Go approach leverages `io.ReadAll`'s internal capability to start with a minimal 512-byte buffer and dynamically `append()` as needed, while guaranteeing it never surpasses the capped `size` from the LimitReader. This safely and elegantly handles both regular files and special pseudo-files (like `/proc/*` which might report a 0-byte stat size).
