### PR TITLE
fileserver: Improve 404 error detail and context

### DIFF
--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -121,7 +121,7 @@ func (fsrv *FileServer) serveBrowse(fileSystem fs.FS, root, dirPath string, w ht
 	case errors.Is(err, fs.ErrPermission):
 		return caddyhttp.Error(http.StatusForbidden, err)
 	case errors.Is(err, fs.ErrNotExist):
-		return fsrv.notFound(w, r, next)
+		return fsrv.notFound(w, r, next, err)
 	case err != nil:
 		return caddyhttp.Error(http.StatusInternalServerError, err)
 	}

--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -309,7 +309,7 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 	if err != nil {
 		err = fsrv.mapDirOpenError(fileSystem, err, filename)
 		if errors.Is(err, fs.ErrNotExist) {
-			return fsrv.notFound(w, r, next)
+			return fsrv.notFound(w, r, next, err)
 		} else if errors.Is(err, fs.ErrInvalid) {
 			return caddyhttp.Error(http.StatusBadRequest, err)
 		} else if errors.Is(err, fs.ErrPermission) {
@@ -371,7 +371,7 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 		if fsrv.Browse != nil && !fileHidden(filename, filesToHide) {
 			return fsrv.serveBrowse(fileSystem, root, filename, w, r, next)
 		}
-		return fsrv.notFound(w, r, next)
+		return fsrv.notFound(w, r, next, fmt.Errorf("directory without index file or browse enabled"))
 	}
 
 	// one last check to ensure the file isn't hidden (we might
@@ -383,7 +383,7 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 				zap.Strings("files_to_hide", filesToHide),
 			)
 		}
-		return fsrv.notFound(w, r, next)
+		return fsrv.notFound(w, r, next, fmt.Errorf("file is hidden"))
 	}
 
 	// if URL canonicalization is enabled, we need to enforce trailing
@@ -501,7 +501,7 @@ func (fsrv *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 		if err != nil {
 			if herr, ok := err.(caddyhttp.HandlerError); ok &&
 				herr.StatusCode == http.StatusNotFound {
-				return fsrv.notFound(w, r, next)
+				return fsrv.notFound(w, r, next, herr.Err)
 			}
 			return err // error is already structured
 		}
@@ -730,11 +730,11 @@ func fileHidden(filename string, hide []string) bool {
 
 // notFound returns a 404 error or, if pass-thru is enabled,
 // it calls the next handler in the chain.
-func (fsrv *FileServer) notFound(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
+func (fsrv *FileServer) notFound(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler, err error) error {
 	if fsrv.PassThru {
 		return next.ServeHTTP(w, r)
 	}
-	return caddyhttp.Error(http.StatusNotFound, nil)
+	return caddyhttp.Error(http.StatusNotFound, err)
 }
 
 // Indicates whether a file's modification time is useful for validator


### PR DESCRIPTION
🚀 **Improve error handling in file server middleware**

### Overview
This PR improves the error handling inside the `fileserver` middleware, specifically addressing the ambiguity of `404 Not Found` errors. 

Previously, when a file was not found, a directory lacked an index file, or a file was hidden, the `notFound` method would return a generic `caddyhttp.Error(http.StatusNotFound, nil)` without any context. This made debugging difficult for users trying to figure out exactly why a resource was returning a 404.

### 🛠️ What’s been fixed?
- **Updated `notFound` signature:** The internal `notFound` function now accepts an `err error` argument.
- **Contextual error propagation:** All calls to `notFound` in `staticfiles.go` and `browse.go` now pass specific errors to the response instead of `nil`.
- **Clearer Error Messages:**
  - `fmt.Errorf("directory without index file or browse enabled")` when an index is missing.
  - `fmt.Errorf("file is hidden")` when a file matches the `Hide` paths configuration.
  - Passes through the underlying `fs.ErrNotExist` for missing files.

### 💡 Impact
These changes ensure that logs and error responses now contain actionable context when a 404 is triggered, significantly improving the debuggability of the file server without breaking the `PassThru` logic.

---

🤖 **AI Disclosure:** *The logic updates, context propagation, and documentation in this Pull Request were developed with the assistance of AI, carefully reviewed and tested to ensure Caddy's high standards are met.*
