### PR TITLE
caddyfile: differentiate repeated snippet imports for parser (fix #7774)

### DIFF
--- a/caddyconfig/caddyfile/parse.go
+++ b/caddyconfig/caddyfile/parse.go
@@ -117,6 +117,7 @@ type parser struct {
 	definedSnippets map[string][]Token
 	nesting         int
 	importGraph     importGraph
+	importCount     int
 }
 
 func (p *parser) parseAll() ([]ServerBlock, error) {
@@ -495,12 +496,13 @@ func (p *parser) doImport(nesting int) error {
 	// run the argument replacer on the tokens
 	// golang for range slice return a copy of value
 	// similarly, append also copy value
+	p.importCount++
 	for i, token := range importedTokens {
 		// update the token's imports to refer to import directive filename, line number and snippet name if there is one
 		if token.snippetName != "" {
-			token.imports = append(token.imports, fmt.Sprintf("%s:%d (import %s)", p.File(), p.Line(), token.snippetName))
+			token.imports = append(token.imports, fmt.Sprintf("%s:%d (import %s #%d)", p.File(), p.Line(), token.snippetName, p.importCount))
 		} else {
-			token.imports = append(token.imports, fmt.Sprintf("%s:%d (import)", p.File(), p.Line()))
+			token.imports = append(token.imports, fmt.Sprintf("%s:%d (import #%d)", p.File(), p.Line(), p.importCount))
 		}
 
 		// naive way of determine snippets, as snippets definition can only follow name + block

--- a/caddyconfig/httpcaddyfile/builtins_test.go
+++ b/caddyconfig/httpcaddyfile/builtins_test.go
@@ -246,7 +246,7 @@ func TestImportErrorLine(t *testing.T) {
 					import t1 true
 				}`,
 			errorFunc: func(err error) bool {
-				return err != nil && strings.Contains(err.Error(), "Caddyfile:6 (import t1)")
+				return err != nil && strings.Contains(err.Error(), "Caddyfile:6 (import t1 #2)")
 			},
 		},
 		{
@@ -257,7 +257,7 @@ func TestImportErrorLine(t *testing.T) {
 					import t1 true
 				}`,
 			errorFunc: func(err error) bool {
-				return err != nil && strings.Contains(err.Error(), "Caddyfile:5 (import t1)")
+				return err != nil && strings.Contains(err.Error(), "Caddyfile:5 (import t1 #1)")
 			},
 		},
 		{


### PR DESCRIPTION
**Before:**
When a snippet containing a named matcher (e.g., `@{args[0]}_{args[1]}`) was imported multiple times within the same site block, Caddy would fail with a confusing error:
`Error: getting matcher module '@html_br': module not registered: http.matchers.@html_br`

This happened because the parser's `isNextOnNewLine` logic compared token line numbers relative to the original snippet definition. Since the tokens from repeated imports had identical line numbers and import chain strings, the parser mistakenly coalesced them into a single segment, misinterpreting the second matcher definition as a module name for the first matcher.

**After:**
This PR introduces an `importCount` to the `parser` struct. Every time an `import` is resolved, the counter is incremented and its value is appended to the tokens' import chain (e.g., `... (import #1)`, `... (import #2)`).

This ensures that tokens from distinct import invocations are always seen as being on different "lines" by the parser. Now, instead of a cryptic "module not registered" error, Caddy correctly identifies the duplicate definition and reports:
`Error: matcher is defined more than once: @html_br`

Closes #7774

## Assistance Disclosure

The root cause analysis and the `importCount` fix were performed with the assistance of an AI coding agent. I have verified the fix using reproduction Caddyfiles and ensured that all existing Caddyfile tests pass.
