### PR TITLE
Patch for GHSA-vcc4-2c75-vc9v

### DIFF
--- a/modules/caddyhttp/templates/tplcontext.go
+++ b/modules/caddyhttp/templates/tplcontext.go
@@ -312,35 +312,32 @@ func (c TemplateContext) Host() (string, error) {
 	return host, nil
 }
 
-// funcStripHTML returns s without HTML tags. It is fairly naive
-// but works with most valid HTML inputs.
+// funcStripHTML returns s without HTML tags. Similar to PHP's strip_tags()
 func (TemplateContext) funcStripHTML(s string) string {
 	var buf bytes.Buffer
-	var inTag, inQuotes bool
-	var tagStart int
-	for i, ch := range s {
-		if inTag {
-			if ch == '>' && !inQuotes {
-				inTag = false
-			} else if ch == '<' && !inQuotes {
-				// false start
-				buf.WriteString(s[tagStart:i])
-				tagStart = i
-			} else if ch == '"' {
-				inQuotes = !inQuotes
+	depth := 0
+	var quoteChar rune
+	for _, ch := range s {
+		switch {
+		case depth > 0 && quoteChar == 0 && (ch == '"' || ch == '\''):
+			// entering a quoted attribute value
+			quoteChar = ch
+		case depth > 0 && ch == quoteChar:
+			// leaving a quoted attribute value
+			quoteChar = 0
+		case ch == '<' && quoteChar == 0:
+			depth++
+		case ch == '>' && quoteChar == 0:
+			if depth > 0 {
+				depth--
+			} else {
+				buf.WriteRune(ch) // stray '>' with no opening '<', keep it
 			}
-			continue
+		default:
+			if depth == 0 {
+				buf.WriteRune(ch)
+			}
 		}
-		if ch == '<' {
-			inTag = true
-			tagStart = i
-			continue
-		}
-		buf.WriteRune(ch)
-	}
-	if inTag {
-		// false start
-		buf.WriteString(s[tagStart:])
 	}
 	return buf.String()
 }

--- a/modules/caddyhttp/templates/tplcontext_test.go
+++ b/modules/caddyhttp/templates/tplcontext_test.go
@@ -419,14 +419,44 @@ func TestStripHTML(t *testing.T) {
 			expect: `h1`,
 		},
 		{
-			// tags not closed
+			// unclosed tag — trailing text must be stripped, not emitted
 			input:  `<h1`,
-			expect: `<h1`,
+			expect: ``,
 		},
 		{
-			// false start
-			input:  `<h1<b>hi`,
-			expect: `<h1hi`,
+		    // false start — second '<' increments depth, single '>' only closes one level
+		    input:  `<h1<b>hi`,
+		    expect: ``,
+		},
+		{
+			// XSS bypass via double opening bracket
+			input:  `<<>img src=x onerror=alert('XSS')>`,
+			expect: ``,
+		},
+		{
+			// stacked angle brackets (PHP strip_tags parity)
+			input:  `<<<<<>>>>><b>hello</b>`,
+			expect: `hello`,
+		},
+		{
+			// unclosed tag strips trailing text
+			input:  `hello <world`,
+			expect: `hello `,
+		},
+		{
+			// '>' inside double-quoted attribute must not close tag early
+			input:  `<a href="foo>bar">text</a>`,
+			expect: `text`,
+		},
+		{
+			// '>' inside single-quoted attribute must not close tag early
+			input:  `<a href='foo>bar'>text</a>`,
+			expect: `text`,
+		},
+		{
+			// stray '>' with no opening '<' is preserved
+			input:  `stray > bracket`,
+			expect: `stray > bracket`,
 		},
 	} {
 		actual := tplContext.funcStripHTML(test.input)


### PR DESCRIPTION
### Summary
Caddy’s `stripHTML` template function cannot reliably remove all HTML tags from input strings. Certain malformed HTML, such as `<<>img src=x onerror=alert()>`, can bypass the tag-stripping logic, potentially leaving dangerous content in the output if it is later rendered as HTML. This may allow client-side XSS in cases where untrusted strings are rendered unsafely.

---

### Details
The vulnerability originates from `funcStripHTML` in:

[caddy/caddy/caddyhttp/templates/tplcontext.go](https://github.com/caddyserver/caddy/blob/77e9ce7404c4a76853e101a9f5687a929ee56654/modules/caddyhttp/templates/tplcontext.go)

```go
func (TemplateContext) funcStripHTML(s string) string {
    var buf bytes.Buffer
    var inTag, inQuotes bool
    var tagStart int
    for i, ch := range s {
        if inTag {
            if ch == '>' && !inQuotes {
                inTag = false
            } else if ch == '<' && !inQuotes {
                // false start
                buf.WriteString(s[tagStart:i])
                tagStart = i
            } else if ch == '"' {
                inQuotes = !inQuotes
            }
            continue
        }
        if ch == '<' {
            inTag = true
            tagStart = i
            continue
        }
        buf.WriteRune(ch)
    }
    if inTag {
        // false start
        buf.WriteString(s[tagStart:])
    }
    return buf.String()
}
```

### POC

Caddyfile setup

```
:8080 {
    root * ./site
    file_server
    templates
}
```

Template file (index.html)

```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <title>StripHTML Bypass Test</title>
</head>
<body>
    <p>{{ stripHTML "<<>img src=x onerror=alert('XSS')>" }}</p>
</body>
</html>
```

The payload exploits the false start branch to smuggle a literal < back into the output, then uses the following > to terminate the parser’s tag state, leaving a valid <img ...> tag behind.

Tested in v2.11.3

### Impact

Malformed HTML can bypass stripHTML, potentially allowing arbitrary HTML or JavaScript to be rendered if the output is used unsafely, leading to client-side XSS.

### AI Disclosure

AI assisted in writing the report description; however, the discovery of the issue has been done manually. Claude generated the code, and I verified it is correct.