### PR TITLE
fix: typo minor spelling fixes in acmeserver comment and redir test

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins_test.go
+++ b/caddyconfig/httpcaddyfile/builtins_test.go
@@ -189,7 +189,7 @@ func TestRedirDirectiveSyntax(t *testing.T) {
 		},
 		{
 			input: `:8080 {
-				redir /old.html /new.html htlm
+				redir /old.html /new.html html
 			}`,
 			expectError: true,
 		},

--- a/modules/caddypki/acmeserver/challenges.go
+++ b/modules/caddypki/acmeserver/challenges.go
@@ -28,7 +28,7 @@ func (c ACMEChallenge) validate() error {
 }
 
 // The unmarshaller first marshals the value into a string. Then it
-// trims any space around it and lowercase it for normaliztion. The
+// trims any space around it and lowercase it for normalization. The
 // method does not and should not validate the value within accepted enums.
 func (c *ACMEChallenge) UnmarshalJSON(b []byte) error {
 	var s string


### PR DESCRIPTION
Closes #7788

Fix two minor spelling typos:
- `normaliztion` → `normalization` in acmeserver comment
- `htlm` → `html` in redir test input