### PR TITLE
ci: bump Go toolchain to 1.26.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         # Set the minimum Go patch version for the given Go minor
         # Usable via ${{ matrix.GO_SEMVER }}
         - go: '1.26'
-          GO_SEMVER: '~1.26.0'
+          GO_SEMVER: '1.26.4'
 
         # Set some variables per OS, usable via ${{ matrix.VAR }}
         # OS_LABEL: the VM label from GitHub Actions (see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
@@ -235,7 +235,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "~1.26"
+          go-version: "1.26.4"
           check-latest: true
       - name: Install xcaddy
         run: |

--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -42,7 +42,7 @@ jobs:
         # Set the minimum Go patch version for the given Go minor
         # Usable via ${{ matrix.GO_SEMVER }}
         - go: '1.26'
-          GO_SEMVER: '~1.26.0'
+          GO_SEMVER: '1.26.4'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: '~1.26'
+          go-version: '1.26.4'
           check-latest: true
 
       - name: golangci-lint
@@ -80,7 +80,7 @@ jobs:
       - name: govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
-          go-version-input: '~1.26.0'
+          go-version-input: '1.26.4'
           check-latest: true
   
   dependency-review:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,7 +340,7 @@ jobs:
         # Set the minimum Go patch version for the given Go minor
         # Usable via ${{ matrix.GO_SEMVER }}
         - go: '1.26'
-          GO_SEMVER: '~1.26.0'
+          GO_SEMVER: '1.26.4'
 
     runs-on: ${{ matrix.os }}
     # https://github.com/sigstore/cosign/issues/1258#issuecomment-1002251233


### PR DESCRIPTION
Fixes GO-2026-5037 and GO-2026-5039. stdlib govulncheck findings for `crypto/x509` and `net/textproto`.
- pin CI, lint, cross-build and release workflow toolchains to Go `1.26.4`

## Assistance Disclosure
No AI was used.