### PR TITLE
httpcaddyfile: error on duplicate named_routes

### DIFF
--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -523,7 +523,11 @@ func (ServerType) extractNamedRoutes(
 			route.HandlersRaw = []json.RawMessage{caddyconfig.JSONModuleObject(handler, "handler", subroute.CaddyModule().ID.Name(), h.warnings)}
 		}
 
-		namedRoutes[sb.block.GetKeysText()[0]] = &route
+		key := sb.block.GetKeysText()[0]
+		if _, exists := namedRoutes[key]; exists {
+			return nil, fmt.Errorf("cannot have duplicate named_routes: %s", key)
+		}
+		namedRoutes[key] = &route
 	}
 	options["named_routes"] = namedRoutes
 

--- a/caddytest/integration/caddyfile_adapt/duplicate_named_route_challenge.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/duplicate_named_route_challenge.caddyfiletest
@@ -1,0 +1,16 @@
+&(api) {
+	header X-Version v1
+	respond "API v1"
+}
+
+&(api) {
+	header X-Version v2
+	respond "API v2"
+}
+
+localhost {
+	invoke api
+}
+
+----------
+cannot have duplicate named_routes: api


### PR DESCRIPTION
Fixes issue #7798

Validate named route names before inserting them into the named route map.

This prevents later definitions from overwriting existing named routes and returns an error when a route name is defined more than once.

## Assistance Disclosure
No AI was used for this code.