### PR TITLE
reverseproxy: re-normalize WebSocket header casing after header op rebuild

### DIFF
--- a/modules/caddyhttp/reverseproxy/headers_test.go
+++ b/modules/caddyhttp/reverseproxy/headers_test.go
@@ -2,10 +2,13 @@ package reverseproxy
 
 import (
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp/headers"
 )
 
 func TestAddForwardedHeadersNonIP(t *testing.T) {
@@ -123,5 +126,98 @@ func TestAddForwardedHeaders_UnixSocketTrustedNoExistingHeaders(t *testing.T) {
 	}
 	if got := req.Header.Get("X-Forwarded-Host"); got != "example.com" {
 		t.Errorf("X-Forwarded-Host = %q, want %q", got, "example.com")
+	}
+}
+
+// TestRebuildRequestHeadersPreservesWebsocketCasing is a regression test for
+// https://github.com/caddyserver/caddy/issues/7784. The header-rebuild path in
+// proxyLoopIteration runs whenever a request header op is configured, or
+// whenever the HTTPS transport auto-injects its Host op. copyHeader uses
+// http.Header.Add, which canonicalizes the keys (Sec-WebSocket-Key ->
+// Sec-Websocket-Key). Upstreams that compare these header names
+// case-sensitively reject the WebSocket handshake. rebuildRequestHeaders must
+// re-normalize the casing after the rebuild.
+func TestRebuildRequestHeadersPreservesWebsocketCasing(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		handler Handler
+	}{
+		{
+			name: "user header_ops only",
+			handler: Handler{
+				Headers: &headers.Handler{
+					Request: &headers.HeaderOps{
+						Add: http.Header{"X-Custom": []string{"v"}},
+					},
+				},
+			},
+		},
+		{
+			name: "transport-injected Host op only (HTTPS upstream)",
+			handler: Handler{
+				transportHeaderOps: &headers.HeaderOps{
+					Set: http.Header{"Host": []string{"upstream.example.com"}},
+				},
+			},
+		},
+		{
+			name: "transport and user ops together",
+			handler: Handler{
+				transportHeaderOps: &headers.HeaderOps{
+					Set: http.Header{"Host": []string{"upstream.example.com"}},
+				},
+				Headers: &headers.Handler{
+					Request: &headers.HeaderOps{
+						Add: http.Header{"X-Custom": []string{"v"}},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reqHeader := http.Header{}
+			reqHeader["Sec-WebSocket-Key"] = []string{"dGhlIHNhbXBsZSBub25jZQ=="}
+			reqHeader["Sec-WebSocket-Version"] = []string{"13"}
+			reqHeader.Set("Upgrade", "websocket")
+			reqHeader.Set("Connection", "Upgrade")
+
+			req := httptest.NewRequest("GET", "http://example.com/", nil)
+			// HeaderOps.ApplyToRequest reads the Replacer from the request context.
+			ctx := context.WithValue(req.Context(), caddy.ReplacerCtxKey, caddy.NewReplacer())
+			req = req.WithContext(ctx)
+			tc.handler.rebuildRequestHeaders(req, reqHeader, "upstream.example.com")
+
+			for _, key := range []string{"Sec-WebSocket-Key", "Sec-WebSocket-Version"} {
+				if _, ok := req.Header[key]; !ok {
+					t.Errorf("%q (RFC 6455 casing) missing; header = %v", key, req.Header)
+				}
+				canonical := http.CanonicalHeaderKey(key)
+				if canonical != key {
+					if _, ok := req.Header[canonical]; ok {
+						t.Errorf("%q (Go-canonical) leaked to upstream; header = %v", canonical, req.Header)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestRebuildRequestHeadersIsNoOpWithoutOps verifies that when neither
+// transport- nor user-configured header ops are present, the request header
+// is left untouched (preserving the prior behavior of the inline rebuild
+// block this helper replaced).
+func TestRebuildRequestHeadersIsNoOpWithoutOps(t *testing.T) {
+	h := Handler{}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Original", "stays")
+	otherHeader := http.Header{"Different": []string{"should-not-appear"}}
+
+	h.rebuildRequestHeaders(req, otherHeader, "ignored")
+
+	if got := req.Header.Get("Original"); got != "stays" {
+		t.Errorf("header rebuilt despite no ops; Original = %q, want %q", got, "stays")
+	}
+	if got := req.Header.Get("Different"); got != "" {
+		t.Errorf("reqHeader leaked despite no ops; Different = %q, want empty", got)
 	}
 }

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -677,25 +677,8 @@ func (h *Handler) proxyLoopIteration(r *http.Request, origReq *http.Request, w h
 	// mutate request headers according to this upstream;
 	// because we're in a retry loop, we have to copy headers
 	// (and the r.Host value) from the original so that each
-	// retry is identical to the first. If either transport or
-	// user ops exist, apply them in order (transport first,
-	// then user, so user's config wins).
-	var userOps *headers.HeaderOps
-	if h.Headers != nil {
-		userOps = h.Headers.Request
-	}
-	transportOps := h.transportHeaderOps
-	if transportOps != nil || userOps != nil {
-		r.Header = make(http.Header)
-		copyHeader(r.Header, reqHeader)
-		r.Host = reqHost
-		if transportOps != nil {
-			transportOps.ApplyToRequest(r)
-		}
-		if userOps != nil {
-			userOps.ApplyToRequest(r)
-		}
-	}
+	// retry is identical to the first.
+	h.rebuildRequestHeaders(r, reqHeader, reqHost)
 
 	// proxy the request to that upstream
 	proxyErr = h.reverseProxy(w, r, origReq, repl, dialInfo, next)
@@ -726,6 +709,40 @@ func (h *Handler) proxyLoopIteration(r *http.Request, origReq *http.Request, w h
 	}
 
 	return false, proxyErr
+}
+
+// rebuildRequestHeaders rebuilds r.Header from reqHeader and applies any
+// transport- and user-configured request header operations, so that each
+// iteration of the proxy loop starts from the same base. If neither set
+// of operations is configured, r.Header is left unchanged. Transport ops
+// are applied before user ops, so user config wins.
+//
+// WebSocket header casing (per RFC 6455) is re-normalized at the end
+// because copyHeader uses http.Header.Add, which canonicalizes the keys
+// to Go's textproto form (e.g. Sec-WebSocket-Key -> Sec-Websocket-Key).
+// Without this, upstreams that compare WebSocket header names
+// case-sensitively reject the handshake whenever any header op is
+// configured (or when the HTTPS transport injects its own Host op).
+// See https://github.com/caddyserver/caddy/issues/7784.
+func (h *Handler) rebuildRequestHeaders(r *http.Request, reqHeader http.Header, reqHost string) {
+	var userOps *headers.HeaderOps
+	if h.Headers != nil {
+		userOps = h.Headers.Request
+	}
+	transportOps := h.transportHeaderOps
+	if transportOps == nil && userOps == nil {
+		return
+	}
+	r.Header = make(http.Header)
+	copyHeader(r.Header, reqHeader)
+	r.Host = reqHost
+	if transportOps != nil {
+		transportOps.ApplyToRequest(r)
+	}
+	if userOps != nil {
+		userOps.ApplyToRequest(r)
+	}
+	normalizeWebsocketHeaders(r.Header)
 }
 
 // Mapping of the canonical form of the headers, to the RFC 6455 form,


### PR DESCRIPTION
## Summary

Fixes #7784. WebSocket header casing (RFC 6455 `Sec-WebSocket-*`) was being silently reverted to Go's canonical form (`Sec-Websocket-*`) on the request path whenever any `header_up` was configured, or whenever the upstream was HTTPS (the HTTP transport auto-injects a `Host` op for HTTPS upstreams, which triggers the same rebuild block). Upstreams that compare these header names case-sensitively then rejected the WebSocket handshake. The response-side path in `streaming.go` was already correct; this brings the request-side path to parity.

## Problem

`prepareRequest` normalizes WebSocket header casing at the end of header preparation. But `proxyLoopIteration` rebuilds `r.Header` on every iteration (so retries don't accumulate header ops) by calling `copyHeader`, which uses `http.Header.Add` — and `Add` runs `textproto.CanonicalMIMEHeaderKey`, turning `Sec-WebSocket-Key` back into `Sec-Websocket-Key`. Nothing re-normalized afterwards.

Repro from the issue:

```
GET / HTTP/1.1
Connection: Upgrade
Upgrade: websocket
Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
Sec-WebSocket-Version: 13
```

through `reverse_proxy 127.0.0.1:9081 { header_up X-Repro-Trigger rebuild }`.

**Wire bytes the upstream sees, pre-fix:**

```
Connection: Upgrade
Sec-Websocket-Key: dGhlIHNhbXBsZSBub25jZQ==
Sec-Websocket-Version: 13
Upgrade: websocket
```

**Wire bytes the upstream sees, post-fix:**

```
Connection: Upgrade
Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
Sec-WebSocket-Version: 13
Upgrade: websocket
```

(Captured with a raw `net.Listen` upstream so the bytes aren't canonicalized by Go's `net/http` server on receive.)

## Solution

Extracted the inline header-rebuild block from `proxyLoopIteration` into a small private `rebuildRequestHeaders` helper. The helper preserves the exact prior behavior (same early-out condition, same op-application order) and additionally calls `normalizeWebsocketHeaders(r.Header)` at the end, mirroring the response-side normalization at `streaming.go:91`. Extracting the helper was necessary to write a regression test that fails if the normalization is later removed.

## Changes

- `modules/caddyhttp/reverseproxy/reverseproxy.go` — extract `rebuildRequestHeaders` helper; add `normalizeWebsocketHeaders` call after both transport- and user-ops are applied.
- `modules/caddyhttp/reverseproxy/headers_test.go` — add `TestRebuildRequestHeadersPreservesWebsocketCasing` (table-driven: user `header_up` only, HTTPS transport-injected Host op only, and both together) and `TestRebuildRequestHeadersIsNoOpWithoutOps`.

## Testing

Quality gates run locally on macOS arm64 / Go 1.25.5:

```
go test -race -short ./modules/caddyhttp/reverseproxy/...   # ok 2.5s
go test -race -short ./modules/caddyhttp/headers/...        # ok 2.5s
go build ./...                                              # exit 0
gofmt -l <changed-files>                                    # clean
go vet ./modules/caddyhttp/reverseproxy/...                 # clean
golangci-lint run --timeout 5m ./modules/caddyhttp/reverseproxy/...  # 0 issues
```

I also verified the regression test does its job: with the new `normalizeWebsocketHeaders` call commented out, all three sub-tests of `TestRebuildRequestHeadersPreservesWebsocketCasing` fail with the exact `Sec-Websocket-*` leak shown in the issue; restoring the call makes them pass.

Manual end-to-end repro (raw `net.Listen` upstream + `reverse_proxy` with `header_up`) showed the wire-level header casing transition documented under **Problem** above.

Closes #7784

---

## Assistance Disclosure

I authored and tested the change, and I am able to explain every line. I used Claude (Opus 4.7) for limited assistance: comparing two implementation shapes I had drafted (a one-line inline fix vs. extracting the rebuild block into a small helper) and selecting the shape that gives a clean regression-test seam, plus drafting the doc comment on `rebuildRequestHeaders`. The fix logic, test cases, and manual repro were verified by me end-to-end.
