### PR TITLE
reverseproxy: validate on weighted_round_robin loadbalancing policy

### DIFF
--- a/caddytest/integration/reverseproxy_test.go
+++ b/caddytest/integration/reverseproxy_test.go
@@ -199,7 +199,7 @@ func TestReverseProxyWithPlaceholderDialAddress(t *testing.T) {
 								],
 								"handle": [
 									{
-	
+
 										"handler": "reverse_proxy",
 										"upstreams": [
 											{
@@ -293,7 +293,7 @@ func TestReverseProxyWithPlaceholderTCPDialAddress(t *testing.T) {
 								],
 								"handle": [
 									{
-	
+
 										"handler": "reverse_proxy",
 										"upstreams": [
 											{
@@ -374,7 +374,7 @@ func TestReverseProxyHealthCheck(t *testing.T) {
 	http://localhost:9080 {
 		reverse_proxy {
 			to localhost:2020
-	
+
 			health_uri /health
 			health_port 2021
 			health_interval 10ms
@@ -495,7 +495,7 @@ func TestReverseProxyHealthCheckUnixSocket(t *testing.T) {
 	http://localhost:9080 {
 		reverse_proxy {
 			to unix/%s
-	
+
 			health_uri /health
 			health_port 2021
 			health_interval 2s
@@ -553,7 +553,7 @@ func TestReverseProxyHealthCheckUnixSocketWithoutPort(t *testing.T) {
 	http://localhost:9080 {
 		reverse_proxy {
 			to unix/%s
-	
+
 			health_uri /health
 			health_interval 2s
 			health_timeout 5s
@@ -829,5 +829,67 @@ func TestReverseProxySNIPlaceHolder(t *testing.T) {
 
 		req.Header.Set("X-SNI", "example.com")
 		tester.AssertResponse(req, 200, "example.com")
+	}
+}
+
+func TestWeightedRoundRobinSelectionValidation(t *testing.T) {
+	configTemplate := `
+	{
+		"apps": {
+			"http": {
+				"servers": {
+					"srv0": {
+						"listen": [":18080"],
+						"routes": [
+							{
+								"handle": [
+									{
+										"handler": "reverse_proxy",
+										"load_balancing": {
+											"selection_policy": {
+												"policy": "weighted_round_robin",
+												"weights": %s
+											}
+										},
+										"upstreams": [
+											{"dial": "localhost:18081"},
+											{"dial": "localhost:18082"}
+										]
+									}
+								]
+							}
+						]
+					}
+				}
+			}
+		}
+	}`
+
+	tests := []struct {
+		name    string
+		weights string
+		errMsg  string
+	}{
+		{
+			name:    "negative weight",
+			weights: "[-1, 2]",
+			errMsg:  "weight of an upstream cannot be negative",
+		},
+		{
+			name:    "zero total weight",
+			weights: "[0, 0]",
+			errMsg:  "requires at least one upstream with a positive weight",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			caddytest.AssertLoadError(
+				t,
+				fmt.Sprintf(configTemplate, tc.weights),
+				"json",
+				tc.errMsg,
+			)
+		})
 	}
 }

--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -129,7 +129,7 @@ func (r *WeightedRoundRobinSelection) Provision(ctx caddy.Context) error {
 
 // Validate ensures that r's configuration is valid
 func (r *WeightedRoundRobinSelection) Validate() error {
-	if r.totalWeight == 0 {
+	if r.totalWeight <= 0 {
 		return fmt.Errorf("weighted_round_robin requires at least one upstream with a positive weight")
 	}
 	return nil

--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -127,7 +127,7 @@ func (r *WeightedRoundRobinSelection) Provision(ctx caddy.Context) error {
 	return nil
 }
 
-// Validate ensures if r's configuration is valid
+// Validate ensures that r's configuration is valid
 func (r *WeightedRoundRobinSelection) Validate() error {
 	if r.totalWeight == 0 {
 		return fmt.Errorf("weighted_round_robin requires at least one upstream with a positive weight")

--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -132,6 +132,11 @@ func (r *WeightedRoundRobinSelection) Validate() error {
 	if r.totalWeight <= 0 {
 		return fmt.Errorf("weighted_round_robin requires at least one upstream with a positive weight")
 	}
+	for _, weight := range r.Weights {
+		if weight < 0 {
+			return fmt.Errorf("weight of an upstream cannot be negative")
+		}
+	}
 	return nil
 }
 

--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -127,6 +127,14 @@ func (r *WeightedRoundRobinSelection) Provision(ctx caddy.Context) error {
 	return nil
 }
 
+// Validate ensures if r's configuration is valid
+func (r *WeightedRoundRobinSelection) Validate() error {
+	if r.totalWeight == 0 {
+		return fmt.Errorf("weighted_round_robin requires at least one upstream with a positive weight.")
+	}
+	return nil
+}
+
 // Select returns an available host, if any.
 func (r *WeightedRoundRobinSelection) Select(pool UpstreamPool, _ *http.Request, _ http.ResponseWriter) *Upstream {
 	if len(pool) == 0 {
@@ -891,6 +899,7 @@ var (
 	_ Selector = (*CookieHashSelection)(nil)
 
 	_ caddy.Validator = (*RandomChoiceSelection)(nil)
+	_ caddy.Validator = (*WeightedRoundRobinSelection)(nil)
 
 	_ caddy.Provisioner = (*RandomChoiceSelection)(nil)
 	_ caddy.Provisioner = (*WeightedRoundRobinSelection)(nil)

--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -130,7 +130,7 @@ func (r *WeightedRoundRobinSelection) Provision(ctx caddy.Context) error {
 // Validate ensures if r's configuration is valid
 func (r *WeightedRoundRobinSelection) Validate() error {
 	if r.totalWeight == 0 {
-		return fmt.Errorf("weighted_round_robin requires at least one upstream with a positive weight.")
+		return fmt.Errorf("weighted_round_robin requires at least one upstream with a positive weight")
 	}
 	return nil
 }

--- a/modules/caddyhttp/reverseproxy/selectionpolicies_test.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies_test.go
@@ -131,6 +131,53 @@ func TestWeightedRoundRobinPolicy(t *testing.T) {
 	}
 }
 
+func TestWeightedRoundRobinSelection_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		weights     []int
+		totalWeight int
+		wantErr     bool
+	}{
+		{
+			name:        "Valid 0 2 1 case",
+			weights:     []int{0, 2, 1},
+			totalWeight: 3,
+			wantErr:     false,
+		},
+		{
+			name:        "Invalid 0 case (single)",
+			weights:     []int{0},
+			totalWeight: 0,
+			wantErr:     true,
+		},
+		{
+			name:        "Invalid 0 0 case (multiple)",
+			weights:     []int{0, 0},
+			totalWeight: 0,
+			wantErr:     true,
+		},
+		{
+			name:        "Valid weights",
+			weights:     []int{1, 1, 1},
+			totalWeight: 3,
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &WeightedRoundRobinSelection{
+				Weights:     tt.weights,
+				totalWeight: tt.totalWeight,
+			}
+			err := s.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestWeightedRoundRobinPolicyWithZeroWeight(t *testing.T) {
 	pool := testPool()
 	wrrPolicy := WeightedRoundRobinSelection{

--- a/modules/caddyhttp/reverseproxy/selectionpolicies_test.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies_test.go
@@ -135,31 +135,26 @@ func TestWeightedRoundRobinSelection_Validate(t *testing.T) {
 	tests := []struct {
 		name        string
 		weights     []int
-		totalWeight int
 		wantErr     bool
 	}{
 		{
 			name:        "Valid 0 2 1 case",
 			weights:     []int{0, 2, 1},
-			totalWeight: 3,
 			wantErr:     false,
 		},
 		{
 			name:        "Invalid 0 case (single)",
 			weights:     []int{0},
-			totalWeight: 0,
 			wantErr:     true,
 		},
 		{
 			name:        "Invalid 0 0 case (multiple)",
 			weights:     []int{0, 0},
-			totalWeight: 0,
 			wantErr:     true,
 		},
 		{
 			name:        "Valid weights",
 			weights:     []int{1, 1, 1},
-			totalWeight: 3,
 			wantErr:     false,
 		},
 	}
@@ -168,8 +163,8 @@ func TestWeightedRoundRobinSelection_Validate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &WeightedRoundRobinSelection{
 				Weights:     tt.weights,
-				totalWeight: tt.totalWeight,
 			}
+			_ = s.Provision(caddy.Context{})
 			err := s.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Fixes issue #7806

Validate that weighted_round_robin has a non-zero total weight.
This prevents configurations such as:
    weighted_round_robin 0 0
from being accepted and causing a divide-by-zero panic during request handling.

## Assistance Disclosure

The initial test template was generated using Gemini 3.1 and then manually edited.