### PR TITLE
intercept: fix replace_status being silently dropped

### DIFF
--- a/caddytest/integration/intercept_test.go
+++ b/caddytest/integration/intercept_test.go
@@ -38,3 +38,72 @@ func TestIntercept(t *testing.T) {
 
 	tester.AssertGetResponse("http://localhost:9080/no-intercept", 200, "I'm not a teapot")
 }
+
+func TestInterceptReplaceStatusWithMatcher(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`{
+		skip_install_trust
+		admin localhost:2999
+		http_port     9080
+		https_port    9443
+		grace_period  1ns
+	}
+
+	localhost:9080 {
+		respond /error "boom" 500
+
+		intercept {
+			@err status 5xx
+			replace_status @err 200
+		}
+	}
+	`, "caddyfile")
+
+	tester.AssertGetResponse("http://localhost:9080/error", 200, "boom")
+}
+
+func TestInterceptReplaceStatusWithoutMatcher(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`{
+		skip_install_trust
+		admin localhost:2999
+		http_port     9080
+		https_port    9443
+		grace_period  1ns
+	}
+
+	localhost:9080 {
+		respond /forbidden "denied" 403
+
+		intercept {
+			replace_status 200
+		}
+	}
+	`, "caddyfile")
+
+	tester.AssertGetResponse("http://localhost:9080/forbidden", 200, "denied")
+}
+
+func TestInterceptReplaceStatusNotMatched(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`{
+		skip_install_trust
+		admin localhost:2999
+		http_port     9080
+		https_port    9443
+		grace_period  1ns
+	}
+
+	localhost:9080 {
+		respond /ok "all good" 200
+
+		intercept {
+			@err status 5xx
+			replace_status @err 503
+		}
+	}
+	`, "caddyfile")
+
+	// 200 does not match @err (5xx), so status should pass through unchanged
+	tester.AssertGetResponse("http://localhost:9080/ok", 200, "all good")
+}

--- a/modules/caddyhttp/intercept/intercept.go
+++ b/modules/caddyhttp/intercept/intercept.go
@@ -137,6 +137,7 @@ func (ir Intercept) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 				} else {
 					rec.statusCode = sc
 				}
+
 				return true
 			}
 
@@ -166,15 +167,18 @@ func (ir Intercept) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 
 	// replace_status only: no routes to execute, just substitute status and write body
 	if rec.handler.Routes == nil {
-		if rec.statusCode != 0 {
-			w.WriteHeader(rec.statusCode)
-		} else {
+		if rec.statusCode == 0 {
 			w.WriteHeader(rec.Status())
+		} else {
+			w.WriteHeader(rec.statusCode)
 		}
+
 		if buf.Len() > 0 {
 			_, err := io.Copy(w, buf)
+
 			return err
 		}
+
 		return nil
 	}
 

--- a/modules/caddyhttp/intercept/intercept.go
+++ b/modules/caddyhttp/intercept/intercept.go
@@ -97,8 +97,6 @@ var bufPool = sync.Pool{
 	},
 }
 
-// TODO: handle status code replacement
-//
 // EXPERIMENTAL: Subject to change or removal.
 type interceptedResponseHandler struct {
 	caddyhttp.ResponseRecorder
@@ -106,17 +104,6 @@ type interceptedResponseHandler struct {
 	handler      caddyhttp.ResponseHandler
 	handlerIndex int
 	statusCode   int
-}
-
-// EXPERIMENTAL: Subject to change or removal.
-func (irh interceptedResponseHandler) WriteHeader(statusCode int) {
-	if irh.statusCode != 0 && (statusCode < 100 || statusCode >= 200) {
-		irh.ResponseRecorder.WriteHeader(irh.statusCode)
-
-		return
-	}
-
-	irh.ResponseRecorder.WriteHeader(statusCode)
 }
 
 // EXPERIMENTAL: Subject to change or removal.

--- a/modules/caddyhttp/intercept/intercept.go
+++ b/modules/caddyhttp/intercept/intercept.go
@@ -142,7 +142,7 @@ func (ir Intercept) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 			rec.handlerIndex = i
 
 			// if configured to only change the status code,
-			// do that then stream
+			// buffer the response so we can substitute the status
 			if statusCodeStr := rh.StatusCode.String(); statusCodeStr != "" {
 				sc, err := strconv.Atoi(repl.ReplaceAll(statusCodeStr, ""))
 				if err != nil {
@@ -150,6 +150,7 @@ func (ir Intercept) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 				} else {
 					rec.statusCode = sc
 				}
+				return true
 			}
 
 			return rec.statusCode == 0
@@ -174,6 +175,20 @@ func (ir Intercept) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 
 	if c := ir.logger.Check(zapcore.DebugLevel, "handling response"); c != nil {
 		c.Write(zap.Int("handler", rec.handlerIndex))
+	}
+
+	// replace_status only: no routes to execute, just substitute status and write body
+	if rec.handler.Routes == nil {
+		if rec.statusCode != 0 {
+			w.WriteHeader(rec.statusCode)
+		} else {
+			w.WriteHeader(rec.Status())
+		}
+		if buf.Len() > 0 {
+			_, err := io.Copy(w, buf)
+			return err
+		}
+		return nil
 	}
 
 	// response recorder doesn't create a new copy of the original headers, they're


### PR DESCRIPTION
Fixes #7805

## Problem

`replace_status` in `intercept` has no effect. The status code replacement never reaches the client — it has been silently a no-op since the directive was introduced.

The `shouldBuffer` closure correctly identifies the matching response and records the replacement status, but then returns `false`. This puts the response into stream mode, which writes the original status to the wire immediately. There is no second chance to substitute it.

On top of that, the `WriteHeader` method that was supposed to apply the substitution uses a value receiver, so it operates on a stale copy of the struct that never sees the replacement status set by the closure.

## Fix

- `shouldBuffer` now returns `true` when `replace_status` matches, so the response gets buffered.
- After `next.ServeHTTP` returns, a new branch handles the `replace_status`-only case (no routes): it writes the replacement status code and flushes the buffered body to the client.
- Removed the dead `WriteHeader` method and resolved `TODO` comment since the substitution now happens post-ServeHTTP.

## Tests

Integration tests added:

- `TestInterceptReplaceStatusWithMatcher` — upstream 500, expect client sees 200
- `TestInterceptReplaceStatusWithoutMatcher` — upstream 403, expect 200
- `TestInterceptReplaceStatusNotMatched` — upstream 200 with a 5xx matcher, passes through unchanged

Manual verification using the exact config from the issue:

```
$ curl -sk -o /tmp/body -w "status=%{http_code}\n" https://localhost:9443/
```

Before (master): `status=500`. After (this branch): `status=200`. Body `boom` unchanged in both cases.

Existing `TestIntercept` (handle_response path) passes. Full `./modules/caddyhttp/...` suite passes.

## Notes

- `replace_status` now buffers the full body. This is the same trade-off `handle_response` makes, and is required because HTTP needs the status line before the body. Typical use case is small error pages so this should be fine in practice.
- 1xx responses (including WebSocket 101) are unaffected — they bypass shouldBuffer and go directly to the wire.
- If `replace_status` and `handle_response` share the same matcher, `replace_status` wins due to parse ordering. This was pre-existing behavior.

## Assistance Disclosure

AI (Claude) was used to help analyze the root cause and draft the initial test cases. I reviewed the fix, verified every code path, and confirmed the before/after behavior manually against master and the patched binary.