### PR TITLE
caddyhttp: lower default max header bytes

### DIFF
--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -845,8 +845,10 @@ const (
 
 	// defaultMaxHeaderBytes is the default maximum size of HTTP headers.
 	// net/http uses 1MB as default, which is historically very lenient.
-	// 64 KB is a more reasonable default for modern web traffic.
-	// this mainly hardens the server against header-based DOS.
+	// this mainly hardens the server against header-based DOS (like H2 Bombs).
+	// see also: 
+	// https://github.com/caddyserver/caddy/pull/7811
+	// https://github.com/php/frankenphp/issues/2459
 	defaultMaxHeaderBytes = 64 * 1024 // 64KB
 )
 

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -846,7 +846,7 @@ const (
 	// defaultMaxHeaderBytes is the default maximum size of HTTP headers.
 	// net/http uses 1MB as default, which is historically very lenient.
 	// this mainly hardens the server against header-based DOS (like H2 Bombs).
-	// see also: 
+	// see also:
 	// https://github.com/caddyserver/caddy/pull/7811
 	// https://github.com/php/frankenphp/issues/2459
 	defaultMaxHeaderBytes = 64 * 1024 // 64KB

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -384,6 +384,10 @@ func (app *App) Provision(ctx caddy.Context) error {
 		if srv.ReadHeaderTimeout == 0 {
 			srv.ReadHeaderTimeout = defaultReadHeaderTimeout // see #6663
 		}
+
+		if srv.MaxHeaderBytes == 0 {
+			srv.MaxHeaderBytes = defaultMaxHeaderBytes
+		}
 	}
 	ctx.Context = oldContext
 	return nil
@@ -838,6 +842,12 @@ const (
 	// long time even on legitimately slow connections or
 	// busy servers to read it.
 	defaultReadHeaderTimeout = caddy.Duration(time.Minute)
+
+	// defaultMaxHeaderBytes is the default maximum size of HTTP headers.
+	// net/http uses 1MB as default, which is historically very lenient.
+	// 64 KB is a more reasonable default for modern web traffic.
+	// this mainly hardens the server against header-based DOS.
+	defaultMaxHeaderBytes = 64 * 1024 // 64KB
 )
 
 // Interface guards


### PR DESCRIPTION
This PR is a follow-up of https://github.com/php/frankenphp/issues/2459.

64KB is probably a more sane default for the `MaxHeaderByte` setting, but feel free to disagree or close this. This would be a BC break for people expecting very large headers. Realistically, headers are never that large in standard web traffic.


Some other defaults for comparison (table copy-pasted from LLM output):
| Server / Service | Per-header limit | Total headers limit | 
|---|---|---|
| nginx | 8 KB | 32 KB (4×8 KB pool) | 
| Apache httpd | 8,190 bytes | 
| HAProxy | ~15 KB effective | 
| Tomcat | 8 KB | 8 KB | 
| IIS / http.sys | 16 KB | 16 KB |
| Node.js | — | 16 KB | 
| Spring Boot (Tomcat/Jetty) | — | 8 KB | 
| AWS ALB | 16 KB | 64 KB | 
| AWS CloudFront | — | ~20 KB (headers + URL combined)
| Cloudflare CDN | 128 KB | 128 KB | 
| Go `net/http` | — | 1 MB | 