### PR TITLE
fileserver: append repeated hide subdirectives instead of overwriting

### DIFF
--- a/caddytest/integration/caddyfile_adapt/file_server_hide_repeated.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/file_server_hide_repeated.caddyfiletest
@@ -1,0 +1,35 @@
+:80
+
+file_server {
+	hide first.txt
+	hide second.txt third.txt
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "file_server",
+									"hide": [
+										"first.txt",
+										"second.txt",
+										"third.txt",
+										"./Caddyfile"
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -91,10 +91,14 @@ func (fsrv *FileServer) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			fsrv.FileSystem = d.Val()
 
 		case "hide":
-			fsrv.Hide = d.RemainingArgs()
-			if len(fsrv.Hide) == 0 {
+			hide := d.RemainingArgs()
+			if len(hide) == 0 {
 				return d.ArgErr()
 			}
+			// Append so that repeated "hide" subdirectives accumulate
+			// instead of overwriting, which also lets imported snippets
+			// compose with site-specific hides.
+			fsrv.Hide = append(fsrv.Hide, hide...)
 
 		case "index":
 			fsrv.IndexNames = d.RemainingArgs()


### PR DESCRIPTION
Fixes #7815.

Repeated `hide` subdirectives in a `file_server` block were silently overwriting each other — only the last entry took effect. So `hide cobra*` followed by `hide main.go` would stop hiding `cobra*` files, which is surprising. This makes them append instead, so multiple `hide` lines accumulate and imported snippets compose with site-specific hides, as discussed in the issue.

I added an adapt regression test (`file_server_hide_repeated`) checking that repeated `hide` entries produce the combined list. Ran the fileserver package tests, the full adapt suite, `gofmt` and `go vet` locally — all green.

**Assistance Disclosure:** I used Claude (an AI assistant) to help locate the code, draft the one-line fix, and write the regression test. I reviewed it, confirmed it matches the behavior agreed in the issue, ran the tests/gofmt/vet myself, and I understand and stand behind the change.
