### PR TITLE
rewrite: scope keyed query replace to its named key

### DIFF
--- a/modules/caddyhttp/rewrite/rewrite.go
+++ b/modules/caddyhttp/rewrite/rewrite.go
@@ -606,13 +606,15 @@ func (q *queryOps) do(r *http.Request, repl *caddy.Replacer) {
 			continue
 		}
 
-		for fieldName, vals := range query {
-			for i := range vals {
-				if replaceParam.re != nil {
-					query[fieldName][i] = replaceParam.re.ReplaceAllString(query[fieldName][i], replace)
-				} else {
-					query[fieldName][i] = strings.ReplaceAll(query[fieldName][i], search, replace)
-				}
+		vals, ok := query[key]
+		if !ok {
+			continue
+		}
+		for i := range vals {
+			if replaceParam.re != nil {
+				query[key][i] = replaceParam.re.ReplaceAllString(query[key][i], replace)
+			} else {
+				query[key][i] = strings.ReplaceAll(query[key][i], search, replace)
 			}
 		}
 	}

--- a/modules/caddyhttp/rewrite/rewrite_test.go
+++ b/modules/caddyhttp/rewrite/rewrite_test.go
@@ -529,15 +529,9 @@ func TestQueryOpsReplaceScopedToKey(t *testing.T) {
 		repl.Set("http.request.uri.path", tc.input.URL.Path)
 		repl.Set("http.request.uri.query", tc.input.URL.RawQuery)
 
-		// we can't directly call Provision() without a valid caddy.Context
-		// so here we ad-hoc compile the regex
 		for _, rep := range tc.ops.Replace {
-			if rep.SearchRegexp != "" {
-				re, err := regexp.Compile(rep.SearchRegexp)
-				if err != nil {
-					t.Fatal(err)
-				}
-				rep.re = re
+			if err := rep.Provision(caddy.Context{}); err != nil {
+				t.Fatal(err)
 			}
 		}
 

--- a/modules/caddyhttp/rewrite/rewrite_test.go
+++ b/modules/caddyhttp/rewrite/rewrite_test.go
@@ -483,6 +483,52 @@ func TestQueryOpsRenameNoOpCases(t *testing.T) {
 	}
 }
 
+func TestQueryOpsReplaceScopedToKey(t *testing.T) {
+	repl := caddy.NewReplacer()
+
+	for i, tc := range []struct {
+		input  *http.Request
+		expect map[string][]string
+		ops    *queryOps
+	}{
+		{
+			// a keyed replace must only touch the named key, even when
+			// other keys hold the same value
+			ops: &queryOps{
+				Replace: []*queryOpsReplacement{{Key: "a", Search: "foo", Replace: "bar"}},
+			},
+			input:  newRequest(t, "GET", "/?a=foo&b=foo"),
+			expect: map[string][]string{"a": {"bar"}, "b": {"foo"}},
+		},
+		{
+			// "*" still replaces across every key
+			ops: &queryOps{
+				Replace: []*queryOpsReplacement{{Key: "*", Search: "foo", Replace: "bar"}},
+			},
+			input:  newRequest(t, "GET", "/?a=foo&b=foo"),
+			expect: map[string][]string{"a": {"bar"}, "b": {"bar"}},
+		},
+		{
+			// a keyed replace against a missing key is a no-op
+			ops: &queryOps{
+				Replace: []*queryOpsReplacement{{Key: "missing", Search: "foo", Replace: "bar"}},
+			},
+			input:  newRequest(t, "GET", "/?a=foo&b=foo"),
+			expect: map[string][]string{"a": {"foo"}, "b": {"foo"}},
+		},
+	} {
+		repl.Set("http.request.uri", tc.input.RequestURI)
+		repl.Set("http.request.uri.path", tc.input.URL.Path)
+		repl.Set("http.request.uri.query", tc.input.URL.RawQuery)
+
+		tc.ops.do(tc.input, repl)
+
+		if actual := tc.input.URL.Query(); !reflect.DeepEqual(tc.expect, map[string][]string(actual)) {
+			t.Errorf("Test %d: Expected query=%v but got %v", i, tc.expect, actual)
+		}
+	}
+}
+
 func newRequest(t *testing.T, method, uri string) *http.Request {
 	req, err := http.NewRequest(method, uri, nil)
 	if err != nil {

--- a/modules/caddyhttp/rewrite/rewrite_test.go
+++ b/modules/caddyhttp/rewrite/rewrite_test.go
@@ -516,10 +516,30 @@ func TestQueryOpsReplaceScopedToKey(t *testing.T) {
 			input:  newRequest(t, "GET", "/?a=foo&b=foo"),
 			expect: map[string][]string{"a": {"foo"}, "b": {"foo"}},
 		},
+		{
+			// the regexp branch must also stay scoped to the named key
+			ops: &queryOps{
+				Replace: []*queryOpsReplacement{{Key: "a", SearchRegexp: "f.o", Replace: "bar"}},
+			},
+			input:  newRequest(t, "GET", "/?a=foo&b=foo"),
+			expect: map[string][]string{"a": {"bar"}, "b": {"foo"}},
+		},
 	} {
 		repl.Set("http.request.uri", tc.input.RequestURI)
 		repl.Set("http.request.uri.path", tc.input.URL.Path)
 		repl.Set("http.request.uri.query", tc.input.URL.RawQuery)
+
+		// we can't directly call Provision() without a valid caddy.Context
+		// so here we ad-hoc compile the regex
+		for _, rep := range tc.ops.Replace {
+			if rep.SearchRegexp != "" {
+				re, err := regexp.Compile(rep.SearchRegexp)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rep.re = re
+			}
+		}
 
 		tc.ops.do(tc.input, repl)
 


### PR DESCRIPTION
Repro: with `query replace a foo bar`, request `/?a=foo&b=foo` comes out as `a=bar&b=bar`; expected `a=bar&b=foo`.
Cause: the non-`*` branch of the `Replace` loop in `queryOps.do` ranges over every key and never uses the computed `key`, so it is an exact copy of the `key == "*"` branch and rewrites unrelated parameters.
Fix: scope the keyed branch to `query[key]`, matching the `Rename`/`Set`/`Add` query ops and the headers module `Replace`. Added a table test covering the keyed, `*`, missing-key, and keyed `search_regexp` cases.

## Assistance Disclosure
Used an LLM lightly to sanity-check the diff and the test cases; I wrote and verified the change myself.
