### PR TITLE
docs: clarify key_type applies to new certificates

### DIFF
--- a/modules/caddytls/automation.go
+++ b/modules/caddytls/automation.go
@@ -128,8 +128,10 @@ type AutomationPolicy struct {
 	// you may wish to increase the ratio to ~1/2.
 	RenewalWindowRatio float64 `json:"renewal_window_ratio,omitempty"`
 
-	// The type of key to generate for certificates.
+	// The type of key to generate for new certificates.
 	// Supported values: `ed25519`, `p256`, `p384`, `rsa2048`, `rsa4096`.
+	// Changing this setting does not affect existing certificates until they are
+	// renewed, because their private keys have already been generated.
 	KeyType string `json:"key_type,omitempty"`
 
 	// Optionally configure a separate storage module associated with this


### PR DESCRIPTION
## Summary

- Clarifies that `tls.automation.policies[].key_type` is used for newly generated certificates.
- Documents that changing `key_type` does not affect existing certificates until renewal, because their private keys already exist.

Closes #7444.

## Notes

The issue originally proposed an INFO log during reload. In the issue discussion, maintainers leaned toward documenting this behavior instead of adding an informational reload log, because logs that only say "in case you didn't know" add noise for users who already understand the behavior.

This updates the source comment used by Caddy's generated JSON config documentation for the `key_type` field.

## Testing

- `go test ./cmd`
- `go test ./modules/caddytls`
- `go test ./caddyconfig/httpcaddyfile`
- `git diff --check`
- Codex autoreview against the exact PR diff: CLEAN

I initially tried running the focused packages together, but this machine's filesystem ran out of space during Go linking. After cleaning Go build/test cache and stale `/tmp/go-build*` directories, the packages above passed one at a time.

## Assistance Disclosure

Hermes Agent, using GPT-5.5 via OpenAI Codex, inspected the issue discussion and repository conventions, made this documentation-only change, ran the verification commands above, ran a read-only Codex autoreview against the exact PR diff, and prepared this PR body. Max should review and confirm the final wording before marking the PR ready for review.
