### PR TITLE
[+] Allow enabling insecure TLS ciphersuites when an environment variable is set

### DIFF
--- a/modules/caddytls/values.go
+++ b/modules/caddytls/values.go
@@ -18,10 +18,26 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"os"
+	"strconv"
+	"sync"
 
 	"github.com/caddyserver/certmagic"
 	"github.com/klauspost/cpuid/v2"
 )
+
+// AllowInsecureCipherSuitesEnv, when set to a truthy value, lets the
+// cipher suites Go considers insecure (tls.InsecureCipherSuites, e.g. the
+// static-RSA suites) be configured by name. They are never used unless
+// named explicitly; this trades away forward secrecy for legacy clients
+// that offer no ECDHE suites.
+const AllowInsecureCipherSuitesEnv = "CADDY_TLS_ALLOW_INSECURE_CIPHER_SUITES"
+
+// evaluated once: a feature flag should not change during the process.
+var insecureCipherSuitesAllowed = sync.OnceValue(func() bool {
+	allowed, _ := strconv.ParseBool(os.Getenv(AllowInsecureCipherSuitesEnv))
+	return allowed
+})
 
 // CipherSuiteNameSupported returns true if name is
 // a supported cipher suite.
@@ -42,8 +58,17 @@ func CipherSuiteID(name string) uint16 {
 
 // SupportedCipherSuites returns a list of all the cipher suites
 // Caddy supports. The list is NOT ordered by security preference.
+//
+// This is Go's secure set (tls.CipherSuites), plus the insecure suites
+// when AllowInsecureCipherSuitesEnv is set. The insecure suites are never
+// in the defaults (see getOptimalDefaultCipherSuites); the flag only
+// permits configuring them by name.
 func SupportedCipherSuites() []*tls.CipherSuite {
-	return tls.CipherSuites()
+	suites := tls.CipherSuites()
+	if insecureCipherSuitesAllowed() {
+		suites = append(suites, tls.InsecureCipherSuites()...)
+	}
+	return suites
 }
 
 // defaultCipherSuites is the ordered list of all the cipher


### PR DESCRIPTION
I need to make caddy compatible with an old game. The game's client hello sends the following ciphersuites:

<img width="1907" height="1531" alt="image" src="https://github.com/user-attachments/assets/f2d33d20-b248-4d10-b8a2-373808d6f874" />

Caddy supports none of these. Even if I add them to the config, caddy would just crash on startup. After some digging, I find it's impossible to make caddy compatible without modifying the source code.

So I forked caddy to allow insecure TLS ciphersuites. To enable it:

1. `CADDY_TLS_ALLOW_INSECURE_CIPHER_SUITES=1`
2. Add `tls { ciphers ... }` block to caddy config
3. Verify with `openssl s_client -connect 127.0.0.1:443 -noservername -tls1_2 -cipher "DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA"`

Example caddy config:

```caddy
https://example.com {
    tls {
        key_type rsa2048
        ciphers TLS_RSA_WITH_AES_128_GCM_SHA256 TLS_RSA_WITH_AES_256_GCM_SHA384 TLS_RSA_WITH_AES_128_CBC_SHA TLS_RSA_WITH_AES_256_CBC_SHA
    }
}
```


## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

Claude edited the code, and I verified it is correct.
