### PR TITLE
caddyhttp: normalize method names to uppercase in MatchMethod.Provision

### DIFF
--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -785,6 +785,15 @@ func (MatchMethod) CaddyModule() caddy.ModuleInfo {
 	}
 }
 
+// Provision uppercases all configured methods to ensure case-insensitive
+// matching against incoming requests, whose methods are always uppercase.
+func (m MatchMethod) Provision(_ caddy.Context) error {
+	for i := range m {
+		m[i] = strings.ToUpper(m[i])
+	}
+	return nil
+}
+
 // UnmarshalCaddyfile implements caddyfile.Unmarshaler.
 func (m *MatchMethod) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	// iterate to merge multiple matchers into one
@@ -1645,9 +1654,11 @@ var (
 	_ RequestMatcherWithError = (*MatchHost)(nil)
 	_ caddy.Provisioner       = (*MatchHost)(nil)
 	_ RequestMatcherWithError = (*MatchPath)(nil)
+	_ caddy.Provisioner       = (*MatchPath)(nil)
 	_ RequestMatcherWithError = (*MatchPathRE)(nil)
 	_ caddy.Provisioner       = (*MatchPathRE)(nil)
 	_ RequestMatcherWithError = (*MatchMethod)(nil)
+	_ caddy.Provisioner       = (*MatchMethod)(nil)
 	_ RequestMatcherWithError = (*MatchQuery)(nil)
 	_ RequestMatcherWithError = (*MatchHeader)(nil)
 	_ RequestMatcherWithError = (*MatchHeaderRE)(nil)

--- a/modules/caddyhttp/matchers_test.go
+++ b/modules/caddyhttp/matchers_test.go
@@ -1218,6 +1218,59 @@ func TestNotMatcher(t *testing.T) {
 	}
 }
 
+func TestMethodMatcher(t *testing.T) {
+	for i, tc := range []struct {
+		scenario string
+		match    MatchMethod
+		input    string
+		expect   bool
+	}{
+		{
+			scenario: "match uppercase GET",
+			match:    MatchMethod{"GET"},
+			input:    http.MethodGet,
+			expect:   true,
+		},
+		{
+			scenario: "match lowercase get after Provision uppercases it",
+			match:    MatchMethod{"get"},
+			input:    http.MethodGet,
+			expect:   true,
+		},
+		{
+			scenario: "match mixed case Post after Provision uppercases it",
+			match:    MatchMethod{"Post"},
+			input:    http.MethodPost,
+			expect:   true,
+		},
+		{
+			scenario: "no match for wrong method",
+			match:    MatchMethod{"GET"},
+			input:    http.MethodPost,
+			expect:   false,
+		},
+		{
+			scenario: "match one of multiple methods",
+			match:    MatchMethod{"get", "post"},
+			input:    http.MethodPost,
+			expect:   true,
+		},
+	} {
+		req := &http.Request{Method: tc.input}
+		if err := tc.match.Provision(caddy.Context{}); err != nil {
+			t.Errorf("Test %d %v: provisioning failed: %v", i, tc.scenario, err)
+		}
+		actual, err := tc.match.MatchWithError(req)
+		if err != nil {
+			t.Errorf("Test %d %v: matching failed: %v", i, tc.scenario, err)
+		}
+		if actual != tc.expect {
+			t.Errorf("Test %d %v: Expected %t, got %t for method=%s", i, tc.scenario, tc.expect, actual, tc.input)
+			continue
+		}
+	}
+}
+
 func BenchmarkLargeHostMatcher(b *testing.B) {
 	// this benchmark simulates a large host matcher (thousands of entries) where each
 	// value is an exact hostname (not a placeholder or wildcard) - compare the results


### PR DESCRIPTION


## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

HTTP method names are case-sensitive and must be uppercase per RFC 7230.
However, MatchMethod had no Provision step to normalize configured method
names, meaning a JSON config like {"method": ["get", "post"]} or a
Caddyfile snippet like `method get post` would silently never match any
request, since net/http always sets r.Method to uppercase.

This commit adds a Provision method to MatchMethod that uppercases all
configured method names at config load time, consistent with the pattern
used by MatchPath (which lowercases paths) and MatchHost (which normalizes
hostnames). This makes method matchers resilient to case variations in user
configs, avoiding silent mismatches.

Additionally, this commit adds the missing compile-time interface guards:
- _ caddy.Provisioner = (*MatchMethod)(nil)
- _ caddy.Provisioner = (*MatchPath)(nil)  (MatchPath.Provision already
  existed but lacked a corresponding guard)

A table-driven TestMethodMatcher test is added to cover uppercase,
lowercase, mixed-case, single, and multi-method scenarios.
