### PR TITLE
cmd: close response body on download error (#7833)

### DIFF
--- a/cmd/packagesfuncs.go
+++ b/cmd/packagesfuncs.go
@@ -288,6 +288,7 @@ func downloadBuild(qs url.Values) (*http.Response, error) {
 		return nil, fmt.Errorf("secure request failed: %v", err)
 	}
 	if resp.StatusCode >= 400 {
+		defer resp.Body.Close()
 		var details struct {
 			StatusCode int `json:"status_code"`
 			Error      struct {


### PR DESCRIPTION
 I'm not a native English speaker, so I used AI to help translate this PR description. The code and analysis are my own.

**What**
Fix resource leak in `downloadBuild`.
Fix for issue #7833.

`downloadBuild` in `cmd/packagesfuncs.go` returned early on HTTP error responses (`resp.StatusCode >= 400`) without closing `resp.Body`, leaking the underlying connection instead of returning it to the pool. Added `defer resp.Body.Close()` right after the status check, so the body is closed on both error-decoding paths. The success path (`return resp, nil`) is untouched the caller still owns and closes that body.

**Testing**
go build ./cmd/...
go vet ./cmd/...