### PR TITLE
logging: close file handle on permission errors when not rolling (#7833)

### DIFF
--- a/modules/logging/filewriter.go
+++ b/modules/logging/filewriter.go
@@ -232,11 +232,13 @@ func (fw FileWriter) OpenWriter() (io.WriteCloser, error) {
 	// Ensure already existing files have the right mode, since OpenFile will not set the mode in such case.
 	if configuredMode := os.FileMode(fw.Mode); configuredMode != 0 {
 		if err != nil {
+			file.Close()
 			return nil, fmt.Errorf("unable to stat log file to see if we need to set permissions: %v", err)
 		}
 		// only chmod if the configured mode is different
 		if info.Mode()&os.ModePerm != configuredMode&os.ModePerm {
 			if err = os.Chmod(fw.Filename, configuredMode); err != nil {
+				file.Close()
 				return nil, err
 			}
 		}


### PR DESCRIPTION
I'm not a native English speaker, so I used AI to help translate this PR description. The code and analysis are my own.

Fix resource leak in `OpenWriter`.
Fix for issue #7833.

**What**

In `FileWriter.OpenWriter` (`modules/logging/filewriter.go`), when `roll: false` and a custom `mode` is configured, the function could return early (on a `Stat` or `Chmod` error) without ever closing the previously opened `file`, leaking the descriptor. Added `file.Close()` on both error-return paths inside that block. The success path (returning the open file handle to the caller when `!roll`) is left untouched, since that handle is intentionally returned open to the caller.

**Testing**
`go build ./modules/logging/...`
`go vet ./modules/logging/...`