### PR TITLE
fix(reverseproxy): defer response body close to prevent buffer pool memory leaks on early exit paths

### DIFF
--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -1108,6 +1108,13 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, origRe
 		res.Body, _ = h.bufferedBody(res.Body, h.ResponseBuffers)
 	}
 
+	var bodyReleased bool
+	defer func() {
+		if !bodyReleased && res != nil && res.Body != nil {
+			res.Body.Close()
+		}
+	}()
+
 	// set response placeholders so they can be used in retry match
 	// expressions and handle_response routes; clear stale header
 	// placeholders from a previous attempt first so they don't
@@ -1139,6 +1146,7 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, origRe
 			}
 			if match {
 				res.Body.Close()
+				bodyReleased = true
 				return retryableResponseError{
 					error:      fmt.Errorf("upstream response matched retry_match (status %d)", res.StatusCode),
 					statusCode: res.StatusCode,
@@ -1196,6 +1204,7 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, origRe
 		if !hrc.isFinalized {
 			res.Body.Close()
 		}
+		bodyReleased = true
 
 		// wrap any route error in roundtripSucceededError so caller knows that
 		// the roundtrip was successful and to not retry
@@ -1209,6 +1218,7 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, origRe
 	}
 
 	// copy the response body and headers back to the upstream client
+	bodyReleased = true
 	return h.finalizeResponse(rw, req, res, repl, start, logger)
 }
 


### PR DESCRIPTION
## Assistance Disclosure
I used an AI assistant to collaborate on the architectural discovery, trace early exit paths, and construct the defensive deferred cleanup pattern used in this patch. I verified the code compilation locally.

---

### Description
This PR introduces a defensive `defer` cleanup envelope around the upstream response body tracking loop inside the reverse proxy module (`reverseproxy.go`). This guarantees the release of pooled internal buffers under unexpected upstream errors or early termination paths.

### Technical Root Cause
When `h.bufferedBody()` pulls a dynamic byte buffer from `bufPool`, it encapsulates it into a standard `bodyReadCloser`. Safely recycling that memory requires explicitly calling `.Close()` on the response body down the execution line. 

However, several critical error branches (such as status code parsing failures or downstream connection faults) execute an immediate return before reaching `finalizeResponse()`. Because these intermediate exit routes bypass the non-deferred closure tracking, the wrapped `bodyReadCloser` is discarded, permanently leaking the underlying buffer from the core `sync.Pool`.

### Resolution Strategy
* **Defensive Defer Envelope:** Implemented an explicit `defer` wrapper tracking `res.Body` closure right after the upstream request completes and assigns the response payload.
* **Ownership Transfer Flag:** Added a state variable (`bodyReleased`) that toggles to true once the stream safely passes into the final handoff pipeline, preventing premature closure during an un-interrupted lifecycle.
* **Idempotent Leak Mitigation:** Ensures any premature return routes cleanly invoke `.Close()`, safely returning the allocation directly to the buffer pool under high-concurrency client failures.