### PR TITLE
fileserver: reuse static hide-path list across requests

### DIFF
--- a/modules/caddyhttp/fileserver/staticfiles.go
+++ b/modules/caddyhttp/fileserver/staticfiles.go
@@ -179,6 +179,11 @@ type FileServer struct {
 
 	fsmap caddy.FileSystems
 
+	// set during provisioning: true when no Hide entry contains a
+	// placeholder, meaning the transformed hide list is constant and
+	// can be reused for every request instead of being rebuilt.
+	hideStatic bool
+
 	logger *zap.Logger
 }
 
@@ -209,9 +214,16 @@ func (fsrv *FileServer) Provision(ctx caddy.Context) error {
 	}
 
 	// for hide paths that are static (i.e. no placeholders), we can transform them into
-	// absolute paths before the server starts for very slight performance improvement
+	// absolute paths before the server starts for very slight performance improvement; if
+	// every hide path is static, the fully transformed list is constant and can be reused
+	// for every request without rebuilding it (see transformHidePaths)
+	fsrv.hideStatic = true
 	for i, h := range fsrv.Hide {
-		if !strings.Contains(h, "{") && strings.Contains(h, separator) {
+		if strings.Contains(h, "{") {
+			fsrv.hideStatic = false
+			continue
+		}
+		if strings.Contains(h, separator) {
 			if abs, err := caddy.FastAbs(h); err == nil {
 				fsrv.Hide[i] = abs
 			}
@@ -664,6 +676,12 @@ func (fsrv *FileServer) mapDirOpenError(fileSystem fs.FS, originalErr error, nam
 // makes them absolute paths (if they contain a path separator), then returns a
 // new list of the transformed values.
 func (fsrv *FileServer) transformHidePaths(repl *caddy.Replacer) []string {
+	// when no hide path contains a placeholder, the list was already fully
+	// transformed during provisioning and is identical for every request,
+	// so we avoid re-allocating and re-resolving it here
+	if fsrv.hideStatic {
+		return fsrv.Hide
+	}
 	hide := make([]string, len(fsrv.Hide))
 	for i := range fsrv.Hide {
 		hide[i] = repl.ReplaceAll(fsrv.Hide[i], "")

--- a/modules/caddyhttp/fileserver/transform_hide_paths_bench_test.go
+++ b/modules/caddyhttp/fileserver/transform_hide_paths_bench_test.go
@@ -1,0 +1,19 @@
+package fileserver
+
+import (
+	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+)
+
+func BenchmarkTransformHidePaths(b *testing.B) {
+	repl := caddy.NewReplacer()
+	fsrv := &FileServer{
+		Hide:       []string{"/etc/caddy/Caddyfile", ".git", "/var/www/secret"},
+		hideStatic: true, // all entries static; set during Provision in real use
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = fsrv.transformHidePaths(repl)
+	}
+}


### PR DESCRIPTION
transformHidePaths rebuilt the hide list on every request, allocating a new []string and re-running ReplaceAll and FastAbs on each entry, even though Provision already resolves static (placeholder-free) hide paths to absolute form ahead of time. file_server is a popular handler I think, and the common case (including the default that hides the Caddyfile) has a fully static hide list, so this is pure per-request garbage. While removing a single allocation isn't much, it's still helping reducing GC work.

Track during provisioning whether every Hide entry is static (no "{"), and when so, return the already-transformed fsrv.Hide directly. Entries containing placeholders still take the per-request resolution path. The returned slice is only read (fileHidden and logging), so sharing it is safe.

Adds a benchmark as per policy, with 3 static hide entries:

TransformHidePaths
- sec/op  264.2n -> 2.5n  (-99.05%)
- B/op 48 -> 0  (-100%)
- allocs/op 1 -> 0  (-100%)




## Assistance Disclosure
"No AI was used."