### PR TITLE
core: preserve metrics registry in Context.WithValue

### DIFF
--- a/context.go
+++ b/context.go
@@ -676,6 +676,7 @@ func (ctx *Context) WithValue(key, value any) Context {
 		ancestry:        ctx.ancestry,
 		cleanupFuncs:    ctx.cleanupFuncs,
 		exitFuncs:       ctx.exitFuncs,
+		metricsRegistry: ctx.metricsRegistry,
 	}
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -15,9 +15,26 @@
 package caddy
 
 import (
+	"context"
 	"encoding/json"
 	"io"
+	"testing"
 )
+
+func TestContextWithValuePreservesMetricsRegistry(t *testing.T) {
+	ctx, cancel := NewContext(Context{Context: context.Background()})
+	t.Cleanup(cancel)
+
+	reg := ctx.GetMetricsRegistry()
+	if reg == nil {
+		t.Fatal("expected a metrics registry on the base context")
+	}
+
+	derived := ctx.WithValue("key", "value")
+	if got := derived.GetMetricsRegistry(); got != reg {
+		t.Fatalf("WithValue must preserve the metrics registry: got %p, want %p", got, reg)
+	}
+}
 
 func ExampleContext_LoadModule() {
 	// this whole first part is just setting up for the example;

--- a/context_test.go
+++ b/context_test.go
@@ -30,7 +30,8 @@ func TestContextWithValuePreservesMetricsRegistry(t *testing.T) {
 		t.Fatal("expected a metrics registry on the base context")
 	}
 
-	derived := ctx.WithValue("key", "value")
+	type testKey struct{}
+	derived := ctx.WithValue(testKey{}, "value")
 	if got := derived.GetMetricsRegistry(); got != reg {
 		t.Fatalf("WithValue must preserve the metrics registry: got %p, want %p", got, reg)
 	}


### PR DESCRIPTION
`Context.WithValue` rebuilt the `Context` struct but omitted the unexported `metricsRegistry` field, so any module provisioned under a context derived via `WithValue` received a `nil` registry from `GetMetricsRegistry()`.

This bites modules that set context values before loading child modules: the derived context loses the registry, and a child module calling `GetMetricsRegistry()` either gets `nil` metrics silently or panics when it passes the registry to something that dereferences it (e.g. an OpenTelemetry Prometheus exporter registering collectors).

The fix copies `metricsRegistry` alongside the other fields `WithValue` already preserves. Added a regression test asserting the registry pointer survives `WithValue`.

## Assistance Disclosure

Claude (via Claude Code) identified the root cause and wrote the regression test. I reviewed and verified the fix and the test against a real reproduction (a Caddy app whose transport is provisioned under a `WithValue`-derived context and bridges go-redis metrics into `GetMetricsRegistry()`).
