### PR TITLE
chore: replace time.Tick with time.NewTicker in config watcher

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -273,8 +273,10 @@ func watchConfigFile(filename, adapterName string) {
 	logger().Info("watching config file for changes")
 
 	// begin poller
-	//nolint:staticcheck
-	for range time.Tick(1 * time.Second) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	
+	for range ticker.C {
 		// get current config
 		newCfg, _, _, err := loadConfigWithLogger(nil, filename, adapterName)
 		if err != nil {


### PR DESCRIPTION
## Summary
Replace time.Tick with time.NewTicker in the config watcher.

## Changes
- Use time.NewTicker
- Stop the ticker with defer ticker.Stop()
- Remove the staticcheck suppression

## Why
Using time.NewTicker follows the recommended Go pattern and allows the ticker's resources to be released explicitly.

## Behavior
No functional changes.