### PR TITLE
caddyfile: reset wildcard client auth for exact hosts

### DIFF
--- a/BOT_PR_REQUEST_NOTICE.txt
+++ b/BOT_PR_REQUEST_NOTICE.txt
@@ -1,1 +1,0 @@
-I am just a bot. You are interacting with a bot.

--- a/BOT_PR_REQUEST_NOTICE.txt
+++ b/BOT_PR_REQUEST_NOTICE.txt
@@ -1,0 +1,1 @@
+I am just a bot. You are interacting with a bot.

--- a/caddyconfig/httpcaddyfile/httptype.go
+++ b/caddyconfig/httpcaddyfile/httptype.go
@@ -16,6 +16,7 @@ package httpcaddyfile
 
 import (
 	"cmp"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -967,6 +968,8 @@ func (st *ServerType) serversFromPairings(
 			return nil, err
 		}
 
+		srv.TLSConnPolicies = addExactHostTLSConnPolicies(srv.TLSConnPolicies, p.serverBlocks, httpPort, warnings)
+
 		// a catch-all TLS conn policy is necessary to ensure TLS can
 		// be offered to all hostnames of the server; even though only
 		// one policy is needed to enable TLS for the server, that
@@ -1061,6 +1064,84 @@ func detectConflictingSchemes(srv *caddyhttp.Server, serverBlocks []serverBlock,
 	}
 
 	return nil
+}
+
+func addExactHostTLSConnPolicies(cps caddytls.ConnectionPolicies, serverBlocks []serverBlock, httpPort string, warnings *[]caddyconfig.Warning) caddytls.ConnectionPolicies {
+	exactHosts := make(map[string]struct{})
+	for _, sblock := range serverBlocks {
+		for _, addr := range sblock.parsedKeys {
+			if addr.Host == "" || strings.Contains(addr.Host, "*") {
+				continue
+			}
+			if addr.Scheme == "http" || addr.Port == httpPort {
+				continue
+			}
+			exactHosts[addr.Host] = struct{}{}
+		}
+	}
+
+	if len(exactHosts) == 0 {
+		return cps
+	}
+
+	for _, cp := range cps {
+		for _, name := range sniConnPolicyMatcherNames(cp) {
+			if !strings.Contains(name, "*") {
+				delete(exactHosts, name)
+			}
+		}
+	}
+
+	sortedExactHosts := make([]string, 0, len(exactHosts))
+	for host := range exactHosts {
+		sortedExactHosts = append(sortedExactHosts, host)
+	}
+	slices.Sort(sortedExactHosts)
+
+	for _, host := range sortedExactHosts {
+		insertAt := -1
+		for i, cp := range cps {
+			if cp.ClientAuthentication == nil {
+				continue
+			}
+			for _, name := range sniConnPolicyMatcherNames(cp) {
+				if strings.Contains(name, "*") && (caddytls.MatchServerName{name}).Match(&tls.ClientHelloInfo{ServerName: host}) {
+					insertAt = i
+					break
+				}
+			}
+			if insertAt >= 0 {
+				break
+			}
+		}
+		if insertAt < 0 {
+			continue
+		}
+
+		exactHostCP := &caddytls.ConnectionPolicy{
+			MatchersRaw: caddy.ModuleMap{
+				"sni": caddyconfig.JSON([]string{host}, warnings),
+			},
+		}
+		cps = append(cps[:insertAt], append(caddytls.ConnectionPolicies{exactHostCP}, cps[insertAt:]...)...)
+	}
+
+	return cps
+}
+
+func sniConnPolicyMatcherNames(cp *caddytls.ConnectionPolicy) caddytls.MatchServerName {
+	if cp == nil || len(cp.MatchersRaw) != 1 {
+		return nil
+	}
+	sniMatcherJSON, ok := cp.MatchersRaw["sni"]
+	if !ok {
+		return nil
+	}
+	var sniMatcher caddytls.MatchServerName
+	if err := json.Unmarshal(sniMatcherJSON, &sniMatcher); err != nil {
+		return nil
+	}
+	return sniMatcher
 }
 
 // consolidateConnPolicies sorts any catch-all policy to the end, removes empty TLS connection

--- a/caddytest/integration/caddyfile_adapt/tls_wildcard_exact_host_resets_client_auth.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/tls_wildcard_exact_host_resets_client_auth.caddyfiletest
@@ -1,0 +1,99 @@
+*.example.com {
+	tls {
+		client_auth {
+			mode require
+		}
+	}
+
+	respond "wildcard"
+}
+
+public.example.com {
+	respond "public"
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"public.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "public",
+													"handler": "static_response"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						},
+						{
+							"match": [
+								{
+									"host": [
+										"*.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"body": "wildcard",
+													"handler": "static_response"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					],
+					"tls_connection_policies": [
+						{
+							"match": {
+								"sni": [
+									"public.example.com"
+								]
+							}
+						},
+						{
+							"match": {
+								"sni": [
+									"*.example.com"
+								]
+							},
+							"client_authentication": {
+								"mode": "require"
+							}
+						},
+						{}
+					]
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION


## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

_AI/LLM assistance was used via OpenAI Codex to help draft the adapter change, fixture, and test workflow. I reviewed the diff, understand the code being submitted, and verified it with the tests listed above._


## Summary
- Add a Caddyfile adapter fixture for wildcard TLS client auth shadowing an exact hostname.
- Emit an exact-host SNI TLS connection policy before matching wildcard client-auth policies.
- Preserve wildcard client authentication while letting explicitly configured exact hosts use default TLS behavior.

## Tests
- go test ./caddytest/integration -run 'TestCaddyfileAdaptToJSON/tls_wildcard_exact_host_resets_client_auth'
- go test ./caddyconfig/httpcaddyfile ./caddytest/integration
- go test -race -short ./caddyconfig/httpcaddyfile ./caddytest/integration

## Assistance Disclosure
OpenAI Codex generated the initial fixture and adapter implementation. I submitted the initial diff before reviewing it thoroughly. I have since reviewed every changed line, verified the behavior, and rerun the listed tests.