### PR TITLE
reverseproxy: fix misleading handle_response error for extra matcher args

### DIFF
--- a/caddytest/integration/caddyfile_adapt/reverse_proxy_handle_response_too_many_args.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/reverse_proxy_handle_response_too_many_args.caddyfiletest
@@ -1,0 +1,10 @@
+localhost:8884 {
+	reverse_proxy localhost:8000 {
+		handle_response header Foo {
+			respond "handled"
+		}
+	}
+}
+
+----------
+parsing caddyfile tokens for 'reverse_proxy': too many arguments for 'handle_response': only a single response matcher name is allowed, but got: [header Foo]

--- a/modules/caddyhttp/reverseproxy/caddyfile.go
+++ b/modules/caddyhttp/reverseproxy/caddyfile.go
@@ -923,13 +923,8 @@ func (h *Handler) FinalizeUnmarshalCaddyfile(helper httpcaddyfile.Helper) error 
 		d.Next()
 		args := d.RemainingArgs()
 
-		// TODO: Remove this check at some point in the future
-		if len(args) == 2 {
-			return d.Errf("configuring 'handle_response' for status code replacement is no longer supported. Use 'replace_status' instead.")
-		}
-
 		if len(args) > 1 {
-			return d.Errf("too many arguments for 'handle_response': %s", args)
+			return d.Errf("too many arguments for 'handle_response': only a single response matcher name is allowed, but got: %s", args)
 		}
 
 		var matcher *caddyhttp.ResponseMatcher


### PR DESCRIPTION
Fixes #6529

Per @steadytao's go-ahead on the issue, this implements exactly the fix @francislavoie specced in his review of #7709: reject more than a single argument to `handle_response`, and stop referencing `replace_status` in the error message, stating instead that only a single response matcher name token is allowed.

Previously, `handle_response header Foo { ... }` tripped an obsolete two-argument check (left over from the long-removed inline status-code-replacement syntax, marked `// TODO: Remove this check at some point in the future`) and confusingly told the user to use `replace_status` even though no status replacement was involved.

Changes:
- Remove the obsolete `len(args) == 2` special case and its `replace_status` explanation.
- The existing `len(args) > 1` check now covers all excess-argument cases with an accurate message: `too many arguments for 'handle_response': only a single response matcher name is allowed, but got: [header Foo]`.
- Add a Caddyfile adapt test (`reverse_proxy_handle_response_too_many_args.caddyfiletest`) for the exact case reported in #6529, following the existing error-asserting adapt test convention. It fails on current master (old misleading message) and passes with this change.

This intentionally supersedes #7709, which has been idle and took a different direction than the reviewed suggestion — thanks to @suryaanshah for the earlier effort there. Note the same obsolete check also exists in the `intercept` directive (`modules/caddyhttp/intercept/intercept.go`); left untouched here to keep this PR focused on the reported case, happy to follow up separately if desired.

`go test ./caddytest/integration/ -run TestCaddyfileAdaptToJSON` and `go test ./modules/caddyhttp/reverseproxy/` both pass; gofmt clean.

## Assistance Disclosure

This change was implemented with the assistance of Claude (Anthropic's LLM) via Claude Code: it drafted the code change and the adapt test under my direction, following the exact approach specified by the maintainers in #6529 / the #7709 review. I have read, fully understand, and take responsibility for every line, and verified the fix with a fail-before/pass-after test run.
