### PR TITLE
intercept: fix misleading handle_response error for extra matcher args

### DIFF
--- a/caddytest/integration/caddyfile_adapt/intercept_handle_response_too_many_args.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/intercept_handle_response_too_many_args.caddyfiletest
@@ -1,0 +1,11 @@
+localhost:8884 {
+	intercept {
+		handle_response header Foo {
+			respond "handled"
+		}
+	}
+	respond "hello"
+}
+
+----------
+parsing caddyfile tokens for 'intercept': too many arguments for 'handle_response': only a single response matcher name is allowed, but got: [header Foo]

--- a/modules/caddyhttp/intercept/intercept.go
+++ b/modules/caddyhttp/intercept/intercept.go
@@ -303,13 +303,8 @@ func (i *Intercept) FinalizeUnmarshalCaddyfile(helper httpcaddyfile.Helper) erro
 		d.Next()
 		args := d.RemainingArgs()
 
-		// TODO: Remove this check at some point in the future
-		if len(args) == 2 {
-			return d.Errf("configuring 'handle_response' for status code replacement is no longer supported. Use 'replace_status' instead.")
-		}
-
 		if len(args) > 1 {
-			return d.Errf("too many arguments for 'handle_response': %s", args)
+			return d.Errf("too many arguments for 'handle_response': only a single response matcher name is allowed, but got: %s", args)
 		}
 
 		var matcher *caddyhttp.ResponseMatcher


### PR DESCRIPTION
Follow-up to #7869, which fixed this for `reverse_proxy` — the `intercept` directive carries the identical obsolete two-argument check (the `// TODO: Remove this check` leftover from the removed inline status-code-replacement syntax), so `handle_response header Foo { ... }` inside `intercept` still told users to use `replace_status`. Same change as #7869: drop the special case, let the generic `len(args) > 1` check reject all excess-argument cases with the accurate single-matcher message, plus the matching adapt test (fails on master with the old message, passes here).

`go test ./caddytest/integration/ -run TestCaddyfileAdaptToJSON` and `go build ./modules/caddyhttp/intercept/` pass; gofmt clean.

## Assistance Disclosure

Implemented with the assistance of Claude (Anthropic's LLM) via Claude Code, mirroring the reviewed and merged #7869. I have read, fully understand, and take responsibility for every line, and verified fail-before/pass-after.