### PR TITLE
logging: hash query parameter values in QueryFilter

### DIFF
--- a/modules/logging/filters.go
+++ b/modules/logging/filters.go
@@ -421,7 +421,7 @@ func (m QueryFilter) processQueryString(s string) string {
 
 		case hashAction:
 			for i := range q[a.Parameter] {
-				q[a.Parameter][i] = hash(a.Value)
+				q[a.Parameter][i] = hash(q[a.Parameter][i])
 			}
 
 		case deleteAction:

--- a/modules/logging/filters_test.go
+++ b/modules/logging/filters_test.go
@@ -100,7 +100,7 @@ func TestQueryFilterSingleValue(t *testing.T) {
 	}
 
 	out := f.Filter(zapcore.Field{String: "/path?foo=a&foo=b&bar=c&bar=d&baz=e&hash=hashed"})
-	if out.String != "/path?baz=e&foo=REDACTED&foo=REDACTED&hash=e3b0c442" {
+	if out.String != "/path?baz=e&foo=REDACTED&foo=REDACTED&hash=1a06df82" {
 		t.Fatalf("query parameters have not been filtered: %s", out.String)
 	}
 }
@@ -121,16 +121,16 @@ func TestQueryFilterMultiValue(t *testing.T) {
 	}
 
 	out := f.Filter(zapcore.Field{Interface: internal.LoggableStringArray{
-		"/path1?foo=a&foo=b&bar=c&bar=d&baz=e&hash=hashed",
-		"/path2?foo=c&foo=d&bar=e&bar=f&baz=g&hash=hashed",
+		"/path1?foo=a&foo=b&bar=c&bar=d&baz=e&hash=alpha",
+		"/path2?foo=c&foo=d&bar=e&bar=f&baz=g&hash=beta",
 	}})
 	arr, ok := out.Interface.(internal.LoggableStringArray)
 	if !ok {
 		t.Fatalf("field is wrong type: %T", out.Interface)
 	}
 
-	expected1 := "/path1?baz=e&foo=REDACTED&foo=REDACTED&hash=e3b0c442"
-	expected2 := "/path2?baz=g&foo=REDACTED&foo=REDACTED&hash=e3b0c442"
+	expected1 := "/path1?baz=e&foo=REDACTED&foo=REDACTED&hash=8ed3f6ad"
+	expected2 := "/path2?baz=g&foo=REDACTED&foo=REDACTED&hash=f44e64e7"
 	if arr[0] != expected1 {
 		t.Fatalf("query parameters in entry 0 have not been filtered correctly: got %s, expected %s", arr[0], expected1)
 	}


### PR DESCRIPTION
Fixes #7883.

## Summary

The query log filter currently passes the hash action's `Value` field to `hash`. Because a hash action does not populate that field, every query parameter value is replaced with the hash of an empty string (`e3b0c442`).

This change:

- hashes each actual query parameter value;
- updates the existing single-value test to expect the hash of its input;
- uses distinct inputs in the multi-value test to verify that different values produce different hashes.

The behavior is now consistent with the query filter documentation and with the cookie filter, which already hashes the actual cookie value.

## Testing

The updated tests failed against the original implementation with `e3b0c442`, then passed after the production-code change.

The following commands completed successfully:

```console
go test ./modules/logging \
  -run 'TestQueryFilter(SingleValue|MultiValue)$' \
  -count=1

go test ./modules/logging -count=1

go test -race ./modules/logging -count=1

go test \
  -coverprofile=/tmp/caddy-cover-profile.out \
  -short \
  -race \
  ./... \
  -count=1
```

## Assistance Disclosure

AI-assisted using OpenAI Codex (GPT-5).

The issue was initially identified with AI assistance while reviewing a downstream Caddy configuration. I independently reproduced the behavior against unmodified v2.11.4 and current `master` checkouts, inspected and understood the relevant implementation, verified the SHA-256 results, and performed a red-green regression-test workflow.

AI assisted with the initial analysis, test planning, and wording. I reviewed and understand the code and tests in this pull request.