### PR TITLE
chore: fix sabotage spelling in nolint comments

### DIFF
--- a/cmd/commandfuncs.go
+++ b/cmd/commandfuncs.go
@@ -836,7 +836,7 @@ func AdminAPIRequest(adminAddr, method, uri string, headers http.Header, body io
 		},
 	}
 
-	resp, err := client.Do(req) //nolint:gosec // the only SSRF here would be self-sabatoge I think
+	resp, err := client.Do(req) //nolint:gosec // the only SSRF here would be self-sabotage I think
 	if err != nil {
 		return nil, fmt.Errorf("performing request: %v", err)
 	}

--- a/modules/caddyhttp/staticresp.go
+++ b/modules/caddyhttp/staticresp.go
@@ -246,7 +246,7 @@ func (s StaticResponse) ServeHTTP(w http.ResponseWriter, r *http.Request, next H
 
 	// write response body
 	if statusCode != http.StatusEarlyHints && body != "" {
-		fmt.Fprint(w, body) //nolint:gosec // no XSS unless you sabatoge your own config
+		fmt.Fprint(w, body) //nolint:gosec // no XSS unless you sabotage your own config
 	}
 
 	// continue handling after Early Hints as they are not the final response


### PR DESCRIPTION


## Assistance Disclosure
<!--
Thank you for contributing! Please note:

The use of AI/LLM tools is allowed so long as it is disclosed, so
that we can provide better code review and maintain project quality.

If you used AI/LLM tooling in any way related to this PR, please
let us know to what extent it was utilized.

Examples:

"No AI was used."
"I wrote the code, but Claude generated the tests."
"I consulted ChatGPT for a solution, but I authored/coded it myself."
"Cody generated the code, and I verified it is correct."
"Copilot provided tab completion for code and comments."

We expect that you have vetted your contributions for correctness.
Additionally, signing our CLA certifies that you have the rights to
contribute this change.

Replace the text below with your disclosure:
-->

No AI was used.

Fix two occurrences of the misspelled word `sabatoge` in existing
`gosec` suppression comments.

This is a comment-only change and does not affect runtime behavior.