### PR TITLE
pki: Handle error immediately after reading root from disk

### DIFF
--- a/modules/caddypki/ca.go
+++ b/modules/caddypki/ca.go
@@ -152,6 +152,9 @@ func (ca *CA) Provision(ctx caddy.Context, id string, log *zap.Logger) error {
 			ca.rootCertPath = ca.Root.Certificate
 		}
 		rootCertChain, rootKey, err = ca.Root.Load()
+		if err != nil {
+			return err
+		}
 		rootCert = rootCertChain[0]
 	} else {
 		ca.rootCertPath = "storage:" + ca.storageKeyRootCert()


### PR DESCRIPTION
In https://github.com/caddyserver/caddy/pull/7057, the behavior of `KeyPair.Load` was changed to return a certificate chain. While the change was primarily meant for intermediates, it also affected how a root (or roots) were loaded. The existing error handling logic relied on a shared `err != nil` check, but with the new behavior there's no guarantee that there's actually a root in the PEM file on disk.

This commit handles the error immediately after reading the PEM from disk.

Fixes: #7895

