### PR TITLE
httpcaddyfile/matchers: optimize CIDR blocklist matching latency using bitwise Radix Trie

### DIFF
--- a/modules/caddyhttp/ip_matchers.go
+++ b/modules/caddyhttp/ip_matchers.go
@@ -42,6 +42,7 @@ type MatchRemoteIP struct {
 	// length and indexes for matching later
 	cidrs  []*netip.Prefix
 	zones  []string
+	trie   *IPTrie
 	logger *zap.Logger
 }
 
@@ -55,6 +56,7 @@ type MatchClientIP struct {
 	// length and indexes for matching later
 	cidrs  []*netip.Prefix
 	zones  []string
+	trie   *IPTrie
 	logger *zap.Logger
 }
 
@@ -138,6 +140,9 @@ func (m *MatchRemoteIP) Provision(ctx caddy.Context) error {
 	}
 	m.cidrs = cidrs
 	m.zones = zones
+	if len(cidrs) >= 8 {
+		m.trie = NewIPTrie(cidrs, zones)
+	}
 
 	return nil
 }
@@ -170,7 +175,12 @@ func (m MatchRemoteIP) MatchWithError(r *http.Request) (bool, error) {
 
 		return false, nil
 	}
-	matches, zoneFilter := matchIPByCidrZones(clientIP, zoneID, m.cidrs, m.zones)
+	var matches, zoneFilter bool
+	if m.trie != nil {
+		matches, zoneFilter = m.trie.Contains(clientIP, zoneID)
+	} else {
+		matches, zoneFilter = matchIPByCidrZones(clientIP, zoneID, m.cidrs, m.zones)
+	}
 	if !matches && !zoneFilter {
 		if c := m.logger.Check(zapcore.DebugLevel, "zone ID from remote IP did not match"); c != nil {
 			c.Write(zap.String("zone", zoneID))
@@ -246,6 +256,9 @@ func (m *MatchClientIP) Provision(ctx caddy.Context) error {
 	}
 	m.cidrs = cidrs
 	m.zones = zones
+	if len(cidrs) >= 8 {
+		m.trie = NewIPTrie(cidrs, zones)
+	}
 	return nil
 }
 
@@ -274,7 +287,12 @@ func (m MatchClientIP) MatchWithError(r *http.Request) (bool, error) {
 		m.logger.Error("getting client IP", zap.Error(err))
 		return false, nil
 	}
-	matches, zoneFilter := matchIPByCidrZones(clientIP, zoneID, m.cidrs, m.zones)
+	var matches, zoneFilter bool
+	if m.trie != nil {
+		matches, zoneFilter = m.trie.Contains(clientIP, zoneID)
+	} else {
+		matches, zoneFilter = matchIPByCidrZones(clientIP, zoneID, m.cidrs, m.zones)
+	}
 	if !matches && !zoneFilter {
 		m.logger.Debug("zone ID from client IP did not match", zap.String("zone", zoneID))
 	}

--- a/modules/caddyhttp/ip_matchers.go
+++ b/modules/caddyhttp/ip_matchers.go
@@ -356,9 +356,13 @@ func parseIPZoneFromString(address string) (netip.Addr, string, error) {
 }
 
 func matchIPByCidrZones(clientIP netip.Addr, zoneID string, cidrs []*netip.Prefix, zones []string) (bool, bool) {
+	unmappedClientIP := clientIP.Unmap()
 	zoneFilter := true
 	for i, ipRange := range cidrs {
-		if ipRange.Contains(clientIP) {
+		if ipRange == nil {
+			continue
+		}
+		if prefixContainsAddr(*ipRange, clientIP, unmappedClientIP) {
 			// Check if there are zone filters assigned and if they match.
 			if zones[i] == "" || zoneID == zones[i] {
 				return true, false
@@ -367,6 +371,19 @@ func matchIPByCidrZones(clientIP netip.Addr, zoneID string, cidrs []*netip.Prefi
 		}
 	}
 	return false, zoneFilter
+}
+
+func prefixContainsAddr(prefix netip.Prefix, clientIP netip.Addr, unmappedClientIP netip.Addr) bool {
+	if prefix.Contains(clientIP) || prefix.Contains(unmappedClientIP) {
+		return true
+	}
+	if prefix.Addr().Is4In6() && prefix.Bits() >= 96 {
+		unmappedPrefix := netip.PrefixFrom(prefix.Addr().Unmap(), prefix.Bits()-96)
+		if unmappedPrefix.Contains(unmappedClientIP) {
+			return true
+		}
+	}
+	return false
 }
 
 // Interface guards

--- a/modules/caddyhttp/ip_matchers.go
+++ b/modules/caddyhttp/ip_matchers.go
@@ -42,7 +42,7 @@ type MatchRemoteIP struct {
 	// length and indexes for matching later
 	cidrs  []*netip.Prefix
 	zones  []string
-	trie   *IPTrie
+	trie   *ipTrie
 	logger *zap.Logger
 }
 
@@ -56,7 +56,7 @@ type MatchClientIP struct {
 	// length and indexes for matching later
 	cidrs  []*netip.Prefix
 	zones  []string
-	trie   *IPTrie
+	trie   *ipTrie
 	logger *zap.Logger
 }
 
@@ -140,8 +140,9 @@ func (m *MatchRemoteIP) Provision(ctx caddy.Context) error {
 	}
 	m.cidrs = cidrs
 	m.zones = zones
+	m.trie = nil
 	if len(cidrs) >= 8 {
-		m.trie = NewIPTrie(cidrs, zones)
+		m.trie = newIPTrie(cidrs, zones)
 	}
 
 	return nil
@@ -177,7 +178,7 @@ func (m MatchRemoteIP) MatchWithError(r *http.Request) (bool, error) {
 	}
 	var matches, zoneFilter bool
 	if m.trie != nil {
-		matches, zoneFilter = m.trie.Contains(clientIP, zoneID)
+		matches, zoneFilter = m.trie.contains(clientIP, zoneID)
 	} else {
 		matches, zoneFilter = matchIPByCidrZones(clientIP, zoneID, m.cidrs, m.zones)
 	}
@@ -256,8 +257,9 @@ func (m *MatchClientIP) Provision(ctx caddy.Context) error {
 	}
 	m.cidrs = cidrs
 	m.zones = zones
+	m.trie = nil
 	if len(cidrs) >= 8 {
-		m.trie = NewIPTrie(cidrs, zones)
+		m.trie = newIPTrie(cidrs, zones)
 	}
 	return nil
 }
@@ -289,7 +291,7 @@ func (m MatchClientIP) MatchWithError(r *http.Request) (bool, error) {
 	}
 	var matches, zoneFilter bool
 	if m.trie != nil {
-		matches, zoneFilter = m.trie.Contains(clientIP, zoneID)
+		matches, zoneFilter = m.trie.contains(clientIP, zoneID)
 	} else {
 		matches, zoneFilter = matchIPByCidrZones(clientIP, zoneID, m.cidrs, m.zones)
 	}
@@ -356,13 +358,9 @@ func parseIPZoneFromString(address string) (netip.Addr, string, error) {
 }
 
 func matchIPByCidrZones(clientIP netip.Addr, zoneID string, cidrs []*netip.Prefix, zones []string) (bool, bool) {
-	unmappedClientIP := clientIP.Unmap()
 	zoneFilter := true
 	for i, ipRange := range cidrs {
-		if ipRange == nil {
-			continue
-		}
-		if prefixContainsAddr(*ipRange, clientIP, unmappedClientIP) {
+		if ipRange.Contains(clientIP) {
 			// Check if there are zone filters assigned and if they match.
 			if zones[i] == "" || zoneID == zones[i] {
 				return true, false
@@ -371,19 +369,6 @@ func matchIPByCidrZones(clientIP netip.Addr, zoneID string, cidrs []*netip.Prefi
 		}
 	}
 	return false, zoneFilter
-}
-
-func prefixContainsAddr(prefix netip.Prefix, clientIP netip.Addr, unmappedClientIP netip.Addr) bool {
-	if prefix.Contains(clientIP) || prefix.Contains(unmappedClientIP) {
-		return true
-	}
-	if prefix.Addr().Is4In6() && prefix.Bits() >= 96 {
-		unmappedPrefix := netip.PrefixFrom(prefix.Addr().Unmap(), prefix.Bits()-96)
-		if unmappedPrefix.Contains(unmappedClientIP) {
-			return true
-		}
-	}
-	return false
 }
 
 // Interface guards

--- a/modules/caddyhttp/iptrie.go
+++ b/modules/caddyhttp/iptrie.go
@@ -1,0 +1,182 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddyhttp
+
+import (
+	"net/netip"
+)
+
+// iptrieNode represents a node in the bitwise Radix Trie.
+type iptrieNode struct {
+	children [2]*iptrieNode
+	// isEnd is true if a CIDR prefix ends at this node depth.
+	isEnd bool
+	// zones holds zone identifiers associated with CIDRs ending at this node.
+	// An empty string in zones means any zone (or no zone required) matches.
+	zones []string
+}
+
+// IPTrie is a bitwise Radix Trie (PATRICIA trie) for fast O(W) IP and CIDR prefix lookups.
+// It provides sub-50ns lookup speed regardless of the number of registered CIDRs.
+type IPTrie struct {
+	v4Root *iptrieNode
+	v6Root *iptrieNode
+	count  int
+}
+
+// NewIPTrie constructs a new IPTrie from a list of netip.Prefix and corresponding zone strings.
+func NewIPTrie(cidrs []*netip.Prefix, zones []string) *IPTrie {
+	t := &IPTrie{
+		v4Root: &iptrieNode{},
+		v6Root: &iptrieNode{},
+		count:  len(cidrs),
+	}
+
+	for i, prefix := range cidrs {
+		if prefix == nil {
+			continue
+		}
+		zone := ""
+		if i < len(zones) {
+			zone = zones[i]
+		}
+		t.Insert(*prefix, zone)
+	}
+
+	return t
+}
+
+// Insert adds a prefix and associated zone string into the trie.
+func (t *IPTrie) Insert(prefix netip.Prefix, zone string) {
+	addr := prefix.Addr().Unmap()
+	bits := prefix.Bits()
+
+	var root *iptrieNode
+	var bytes []byte
+
+	if addr.Is4() {
+		root = t.v4Root
+		b4 := addr.As4()
+		bytes = b4[:]
+	} else if addr.Is6() {
+		root = t.v6Root
+		b16 := addr.As16()
+		bytes = b16[:]
+	} else {
+		return
+	}
+
+	if bits < 0 {
+		bits = len(bytes) * 8
+	}
+
+	curr := root
+	for bitIdx := 0; bitIdx < bits; bitIdx++ {
+		byteIdx := bitIdx / 8
+		bitOffset := 7 - (bitIdx % 8)
+		bitVal := (bytes[byteIdx] >> bitOffset) & 1
+
+		if curr.children[bitVal] == nil {
+			curr.children[bitVal] = &iptrieNode{}
+		}
+		curr = curr.children[bitVal]
+	}
+
+	curr.isEnd = true
+	// Check if zone already exists to avoid duplicate entries
+	for _, z := range curr.zones {
+		if z == zone {
+			return
+		}
+	}
+	curr.zones = append(curr.zones, zone)
+}
+
+// Contains tests whether clientIP matches any CIDR prefix stored in the trie.
+// It returns (matches, zoneFilterPassed):
+// - matches = true if clientIP is in a matching prefix and zone matches.
+// - zoneFilterPassed = true if either no CIDR matched, or a CIDR matched with a valid zone.
+//   zoneFilterPassed = false if a CIDR matched but the zone ID failed to match.
+func (t *IPTrie) Contains(clientIP netip.Addr, zoneID string) (bool, bool) {
+	addr := clientIP.Unmap()
+
+	var curr *iptrieNode
+	var bytes []byte
+	var maxBits int
+
+	if addr.Is4() {
+		curr = t.v4Root
+		b4 := addr.As4()
+		bytes = b4[:]
+		maxBits = 32
+	} else if addr.Is6() {
+		curr = t.v6Root
+		b16 := addr.As16()
+		bytes = b16[:]
+		maxBits = 128
+	} else {
+		return false, true
+	}
+
+	foundZoneMismatch := false
+
+	// Check root node first (in case 0.0.0.0/0 or ::/0 was inserted)
+	if curr.isEnd {
+		m, zm := checkZoneMatch(curr.zones, zoneID)
+		if m {
+			return true, true
+		}
+		if zm {
+			foundZoneMismatch = true
+		}
+	}
+
+	for bitIdx := 0; bitIdx < maxBits; bitIdx++ {
+		byteIdx := bitIdx / 8
+		bitOffset := 7 - (bitIdx % 8)
+		bitVal := (bytes[byteIdx] >> bitOffset) & 1
+
+		curr = curr.children[bitVal]
+		if curr == nil {
+			break
+		}
+
+		if curr.isEnd {
+			m, zm := checkZoneMatch(curr.zones, zoneID)
+			if m {
+				return true, true
+			}
+			if zm {
+				foundZoneMismatch = true
+			}
+		}
+	}
+
+	if foundZoneMismatch {
+		return false, false
+	}
+	return false, true
+}
+
+func checkZoneMatch(nodeZones []string, requestZoneID string) (bool, bool) {
+	hasMismatch := false
+	for _, z := range nodeZones {
+		if z == "" || z == requestZoneID {
+			return true, false
+		}
+		hasMismatch = true
+	}
+	return false, hasMismatch
+}

--- a/modules/caddyhttp/iptrie.go
+++ b/modules/caddyhttp/iptrie.go
@@ -18,7 +18,7 @@ import (
 	"net/netip"
 )
 
-// iptrieNode represents a node in the bitwise Radix Trie.
+// iptrieNode represents a node in the bitwise binary prefix trie.
 type iptrieNode struct {
 	children [2]*iptrieNode
 	// isEnd is true if a CIDR prefix ends at this node depth.
@@ -28,17 +28,16 @@ type iptrieNode struct {
 	zones []string
 }
 
-// IPTrie is a bitwise Radix Trie (PATRICIA trie) for fast O(W) IP and CIDR prefix lookups.
-// It provides sub-50ns lookup speed regardless of the number of registered CIDRs.
-type IPTrie struct {
+// ipTrie is an internal bitwise binary prefix trie for fast O(W) IP and CIDR prefix lookups.
+type ipTrie struct {
 	v4Root *iptrieNode
 	v6Root *iptrieNode
 	count  int
 }
 
-// NewIPTrie constructs a new IPTrie from a list of netip.Prefix and corresponding zone strings.
-func NewIPTrie(cidrs []*netip.Prefix, zones []string) *IPTrie {
-	t := &IPTrie{
+// newIPTrie constructs a new ipTrie from a list of netip.Prefix and corresponding zone strings.
+func newIPTrie(cidrs []*netip.Prefix, zones []string) *ipTrie {
+	t := &ipTrie{
 		v4Root: &iptrieNode{},
 		v6Root: &iptrieNode{},
 		count:  len(cidrs),
@@ -52,32 +51,16 @@ func NewIPTrie(cidrs []*netip.Prefix, zones []string) *IPTrie {
 		if i < len(zones) {
 			zone = zones[i]
 		}
-		t.Insert(*prefix, zone)
+		t.insert(*prefix, zone)
 	}
 
 	return t
 }
 
-// normalizePrefix converts an IPv4-mapped IPv6 prefix with prefix length >= 96
-// into a standard IPv4 prefix (e.g. ::ffff:192.0.2.0/120 -> 192.0.2.0/24).
-// For pure IPv4 or pure IPv6 prefixes, it unmaps the address representation.
-func normalizePrefix(prefix netip.Prefix) (netip.Addr, int) {
+// insert adds a prefix and associated zone string into the trie.
+func (t *ipTrie) insert(prefix netip.Prefix, zone string) {
 	addr := prefix.Addr()
 	bits := prefix.Bits()
-
-	if addr.Is4In6() {
-		if bits >= 96 {
-			return addr.Unmap(), bits - 96
-		}
-		return addr, bits
-	}
-
-	return addr.Unmap(), bits
-}
-
-// Insert adds a prefix and associated zone string into the trie.
-func (t *IPTrie) Insert(prefix netip.Prefix, zone string) {
-	addr, bits := normalizePrefix(prefix)
 
 	var root *iptrieNode
 	var bytes []byte
@@ -123,26 +106,21 @@ func (t *IPTrie) Insert(prefix netip.Prefix, zone string) {
 	curr.zones = append(curr.zones, zone)
 }
 
-// Contains tests whether clientIP matches any CIDR prefix stored in the trie.
-// It returns (matches, zoneFilterPassed):
-// - matches = true if clientIP is in a matching prefix and zone matches.
-// - zoneFilterPassed = true if either no CIDR matched, or a CIDR matched with a valid zone.
-//   zoneFilterPassed = false if a CIDR matched but the zone ID failed to match.
-func (t *IPTrie) Contains(clientIP netip.Addr, zoneID string) (bool, bool) {
-	addr := clientIP.Unmap()
-
+// contains tests whether clientIP matches any CIDR prefix stored in the trie.
+// It returns (matches, zoneFilterPassed) matching the exact return tuple contract of matchIPByCidrZones.
+func (t *ipTrie) contains(clientIP netip.Addr, zoneID string) (bool, bool) {
 	var curr *iptrieNode
 	var bytes []byte
 	var maxBits int
 
-	if addr.Is4() {
+	if clientIP.Is4() {
 		curr = t.v4Root
-		b4 := addr.As4()
+		b4 := clientIP.As4()
 		bytes = b4[:]
 		maxBits = 32
-	} else if addr.Is6() {
+	} else if clientIP.Is6() {
 		curr = t.v6Root
-		b16 := addr.As16()
+		b16 := clientIP.As16()
 		bytes = b16[:]
 		maxBits = 128
 	} else {
@@ -155,7 +133,7 @@ func (t *IPTrie) Contains(clientIP netip.Addr, zoneID string) (bool, bool) {
 	if curr.isEnd {
 		m, zm := checkZoneMatch(curr.zones, zoneID)
 		if m {
-			return true, true
+			return true, false
 		}
 		if zm {
 			foundZoneMismatch = true
@@ -175,7 +153,7 @@ func (t *IPTrie) Contains(clientIP netip.Addr, zoneID string) (bool, bool) {
 		if curr.isEnd {
 			m, zm := checkZoneMatch(curr.zones, zoneID)
 			if m {
-				return true, true
+				return true, false
 			}
 			if zm {
 				foundZoneMismatch = true

--- a/modules/caddyhttp/iptrie.go
+++ b/modules/caddyhttp/iptrie.go
@@ -58,10 +58,26 @@ func NewIPTrie(cidrs []*netip.Prefix, zones []string) *IPTrie {
 	return t
 }
 
+// normalizePrefix converts an IPv4-mapped IPv6 prefix with prefix length >= 96
+// into a standard IPv4 prefix (e.g. ::ffff:192.0.2.0/120 -> 192.0.2.0/24).
+// For pure IPv4 or pure IPv6 prefixes, it unmaps the address representation.
+func normalizePrefix(prefix netip.Prefix) (netip.Addr, int) {
+	addr := prefix.Addr()
+	bits := prefix.Bits()
+
+	if addr.Is4In6() {
+		if bits >= 96 {
+			return addr.Unmap(), bits - 96
+		}
+		return addr, bits
+	}
+
+	return addr.Unmap(), bits
+}
+
 // Insert adds a prefix and associated zone string into the trie.
 func (t *IPTrie) Insert(prefix netip.Prefix, zone string) {
-	addr := prefix.Addr().Unmap()
-	bits := prefix.Bits()
+	addr, bits := normalizePrefix(prefix)
 
 	var root *iptrieNode
 	var bytes []byte
@@ -79,6 +95,9 @@ func (t *IPTrie) Insert(prefix netip.Prefix, zone string) {
 	}
 
 	if bits < 0 {
+		bits = len(bytes) * 8
+	}
+	if bits > len(bytes)*8 {
 		bits = len(bytes) * 8
 	}
 

--- a/modules/caddyhttp/iptrie_test.go
+++ b/modules/caddyhttp/iptrie_test.go
@@ -1,0 +1,170 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddyhttp
+
+import (
+	"fmt"
+	"net/netip"
+	"testing"
+)
+
+func TestIPTrie(t *testing.T) {
+	tests := []struct {
+		name          string
+		cidrs         []string
+		zones         []string
+		queryIP       string
+		queryZone     string
+		wantMatch     bool
+		wantZonePass  bool
+	}{
+		{
+			name:         "IPv4 exact match",
+			cidrs:        []string{"192.168.1.1/32"},
+			zones:        []string{""},
+			queryIP:      "192.168.1.1",
+			wantMatch:    true,
+			wantZonePass: true,
+		},
+		{
+			name:         "IPv4 subnet match",
+			cidrs:        []string{"10.0.0.0/16"},
+			zones:        []string{""},
+			queryIP:      "10.0.4.20",
+			wantMatch:    true,
+			wantZonePass: true,
+		},
+		{
+			name:         "IPv4 no match",
+			cidrs:        []string{"10.0.0.0/16"},
+			zones:        []string{""},
+			queryIP:      "10.1.0.1",
+			wantMatch:    false,
+			wantZonePass: true,
+		},
+		{
+			name:         "IPv6 subnet match",
+			cidrs:        []string{"2001:db8::/32"},
+			zones:        []string{""},
+			queryIP:      "2001:db8:1234:5678::1",
+			wantMatch:    true,
+			wantZonePass: true,
+		},
+		{
+			name:         "IPv4-mapped IPv6 match",
+			cidrs:        []string{"192.168.1.0/24"},
+			zones:        []string{""},
+			queryIP:      "::ffff:192.168.1.42",
+			wantMatch:    true,
+			wantZonePass: true,
+		},
+		{
+			name:         "Zone ID match success",
+			cidrs:        []string{"fe80::/10"},
+			zones:        []string{"eth0"},
+			queryIP:      "fe80::1",
+			queryZone:    "eth0",
+			wantMatch:    true,
+			wantZonePass: true,
+		},
+		{
+			name:         "Zone ID mismatch",
+			cidrs:        []string{"fe80::/10"},
+			zones:        []string{"eth0"},
+			queryIP:      "fe80::1",
+			queryZone:    "eth1",
+			wantMatch:    false,
+			wantZonePass: false,
+		},
+		{
+			name:         "Catch-all 0.0.0.0/0",
+			cidrs:        []string{"0.0.0.0/0"},
+			zones:        []string{""},
+			queryIP:      "1.2.3.4",
+			wantMatch:    true,
+			wantZonePass: true,
+		},
+		{
+			name:         "Overlapping subnets broader allows",
+			cidrs:        []string{"10.0.0.0/8", "10.1.0.0/16"},
+			zones:        []string{"", "eth0"},
+			queryIP:      "10.1.2.3",
+			queryZone:    "eth1",
+			wantMatch:    true, // 10.0.0.0/8 has no zone requirement, so it matches
+			wantZonePass: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var prefixes []*netip.Prefix
+			for _, c := range tt.cidrs {
+				p := netip.MustParsePrefix(c)
+				prefixes = append(prefixes, &p)
+			}
+
+			trie := NewIPTrie(prefixes, tt.zones)
+			addr := netip.MustParseAddr(tt.queryIP)
+
+			gotMatch, gotZonePass := trie.Contains(addr, tt.queryZone)
+
+			if gotMatch != tt.wantMatch {
+				t.Errorf("IPTrie.Contains() match = %v, want %v", gotMatch, tt.wantMatch)
+			}
+			if gotZonePass != tt.wantZonePass {
+				t.Errorf("IPTrie.Contains() zonePass = %v, want %v", gotZonePass, tt.wantZonePass)
+			}
+		})
+	}
+}
+
+// Micro-benchmarks comparing Linear Slice iteration vs Radix Trie lookup
+func benchmarkIPLookups(b *testing.B, numCIDRs int) {
+	cidrs := make([]*netip.Prefix, 0, numCIDRs)
+	zones := make([]string, numCIDRs)
+
+	for i := 0; i < numCIDRs; i++ {
+		a := (i >> 16) & 0xFF
+		bByte := (i >> 8) & 0xFF
+		c := i & 0xFF
+		cidrStr := fmt.Sprintf("10.%d.%d.%d/32", a, bByte, c)
+		p := netip.MustParsePrefix(cidrStr)
+		cidrs = append(cidrs, &p)
+	}
+
+	trie := NewIPTrie(cidrs, zones)
+	targetIP := netip.MustParseAddr(fmt.Sprintf("10.%d.%d.%d", (numCIDRs-1)>>16, ((numCIDRs-1)>>8)&0xFF, (numCIDRs-1)&0xFF))
+
+	b.Run(fmt.Sprintf("Linear_%d", numCIDRs), func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = matchIPByCidrZones(targetIP, "", cidrs, zones)
+		}
+	})
+
+	b.Run(fmt.Sprintf("RadixTrie_%d", numCIDRs), func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = trie.Contains(targetIP, "")
+		}
+	})
+}
+
+func BenchmarkIPLookup_10(b *testing.B)    { benchmarkIPLookups(b, 10) }
+func BenchmarkIPLookup_100(b *testing.B)   { benchmarkIPLookups(b, 100) }
+func BenchmarkIPLookup_1000(b *testing.B)  { benchmarkIPLookups(b, 1000) }
+func BenchmarkIPLookup_10000(b *testing.B) { benchmarkIPLookups(b, 10000) }

--- a/modules/caddyhttp/iptrie_test.go
+++ b/modules/caddyhttp/iptrie_test.go
@@ -22,13 +22,13 @@ import (
 
 func TestIPTrie(t *testing.T) {
 	tests := []struct {
-		name          string
-		cidrs         []string
-		zones         []string
-		queryIP       string
-		queryZone     string
-		wantMatch     bool
-		wantZonePass  bool
+		name         string
+		cidrs        []string
+		zones        []string
+		queryIP      string
+		queryZone    string
+		wantMatch    bool
+		wantZonePass bool
 	}{
 		{
 			name:         "IPv4 exact match",
@@ -36,7 +36,7 @@ func TestIPTrie(t *testing.T) {
 			zones:        []string{""},
 			queryIP:      "192.168.1.1",
 			wantMatch:    true,
-			wantZonePass: true,
+			wantZonePass: false,
 		},
 		{
 			name:         "IPv4 subnet match",
@@ -44,7 +44,7 @@ func TestIPTrie(t *testing.T) {
 			zones:        []string{""},
 			queryIP:      "10.0.4.20",
 			wantMatch:    true,
-			wantZonePass: true,
+			wantZonePass: false,
 		},
 		{
 			name:         "IPv4 no match",
@@ -60,15 +60,15 @@ func TestIPTrie(t *testing.T) {
 			zones:        []string{""},
 			queryIP:      "2001:db8:1234:5678::1",
 			wantMatch:    true,
-			wantZonePass: true,
+			wantZonePass: false,
 		},
 		{
 			name:         "IPv4-mapped IPv6 match",
-			cidrs:        []string{"192.168.1.0/24"},
+			cidrs:        []string{"::ffff:192.168.1.0/120"},
 			zones:        []string{""},
 			queryIP:      "::ffff:192.168.1.42",
 			wantMatch:    true,
-			wantZonePass: true,
+			wantZonePass: false,
 		},
 		{
 			name:         "Zone ID match success",
@@ -77,7 +77,7 @@ func TestIPTrie(t *testing.T) {
 			queryIP:      "fe80::1",
 			queryZone:    "eth0",
 			wantMatch:    true,
-			wantZonePass: true,
+			wantZonePass: false,
 		},
 		{
 			name:         "Zone ID mismatch",
@@ -94,7 +94,15 @@ func TestIPTrie(t *testing.T) {
 			zones:        []string{""},
 			queryIP:      "1.2.3.4",
 			wantMatch:    true,
-			wantZonePass: true,
+			wantZonePass: false,
+		},
+		{
+			name:         "Catch-all ::/0",
+			cidrs:        []string{"::/0"},
+			zones:        []string{""},
+			queryIP:      "2001:db8::1",
+			wantMatch:    true,
+			wantZonePass: false,
 		},
 		{
 			name:         "Overlapping subnets broader allows",
@@ -102,32 +110,8 @@ func TestIPTrie(t *testing.T) {
 			zones:        []string{"", "eth0"},
 			queryIP:      "10.1.2.3",
 			queryZone:    "eth1",
-			wantMatch:    true, // 10.0.0.0/8 has no zone requirement, so it matches
-			wantZonePass: true,
-		},
-		{
-			name:         "IPv4-mapped IPv6 prefix with IPv4 query",
-			cidrs:        []string{"::ffff:192.0.2.0/120"},
-			zones:        []string{""},
-			queryIP:      "192.0.2.1",
 			wantMatch:    true,
-			wantZonePass: true,
-		},
-		{
-			name:         "IPv4-mapped IPv6 prefix with IPv4-mapped IPv6 query",
-			cidrs:        []string{"::ffff:192.0.2.0/120"},
-			zones:        []string{""},
-			queryIP:      "::ffff:192.0.2.1",
-			wantMatch:    true,
-			wantZonePass: true,
-		},
-		{
-			name:         "IPv4-mapped IPv6 prefix out of range no match",
-			cidrs:        []string{"::ffff:192.0.2.0/120"},
-			zones:        []string{""},
-			queryIP:      "192.0.3.1",
-			wantMatch:    false,
-			wantZonePass: true,
+			wantZonePass: false,
 		},
 	}
 
@@ -139,16 +123,16 @@ func TestIPTrie(t *testing.T) {
 				prefixes = append(prefixes, &p)
 			}
 
-			trie := NewIPTrie(prefixes, tt.zones)
+			trie := newIPTrie(prefixes, tt.zones)
 			addr := netip.MustParseAddr(tt.queryIP)
 
-			gotMatch, gotZonePass := trie.Contains(addr, tt.queryZone)
+			gotMatch, gotZonePass := trie.contains(addr, tt.queryZone)
 
 			if gotMatch != tt.wantMatch {
-				t.Errorf("IPTrie.Contains() match = %v, want %v", gotMatch, tt.wantMatch)
+				t.Errorf("ipTrie.contains() match = %v, want %v", gotMatch, tt.wantMatch)
 			}
 			if gotZonePass != tt.wantZonePass {
-				t.Errorf("IPTrie.Contains() zonePass = %v, want %v", gotZonePass, tt.wantZonePass)
+				t.Errorf("ipTrie.contains() zonePass = %v, want %v", gotZonePass, tt.wantZonePass)
 			}
 
 			// Parity check against linear matcher (matchIPByCidrZones)
@@ -161,7 +145,7 @@ func TestIPTrie(t *testing.T) {
 	}
 }
 
-// Micro-benchmarks comparing Linear Slice iteration vs Radix Trie lookup
+// Micro-benchmarks comparing Linear Slice iteration vs Trie lookup across First, Middle, Last, and Miss cases
 func benchmarkIPLookups(b *testing.B, numCIDRs int) {
 	cidrs := make([]*netip.Prefix, 0, numCIDRs)
 	zones := make([]string, numCIDRs)
@@ -175,24 +159,42 @@ func benchmarkIPLookups(b *testing.B, numCIDRs int) {
 		cidrs = append(cidrs, &p)
 	}
 
-	trie := NewIPTrie(cidrs, zones)
-	targetIP := netip.MustParseAddr(fmt.Sprintf("10.%d.%d.%d", (numCIDRs-1)>>16, ((numCIDRs-1)>>8)&0xFF, (numCIDRs-1)&0xFF))
+	trie := newIPTrie(cidrs, zones)
 
-	b.Run(fmt.Sprintf("Linear_%d", numCIDRs), func(b *testing.B) {
-		b.ReportAllocs()
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			_, _ = matchIPByCidrZones(targetIP, "", cidrs, zones)
-		}
-	})
+	firstIP := netip.MustParseAddr("10.0.0.0")
+	midIdx := numCIDRs / 2
+	midIP := netip.MustParseAddr(fmt.Sprintf("10.%d.%d.%d", midIdx>>16, (midIdx>>8)&0xFF, midIdx&0xFF))
+	lastIdx := numCIDRs - 1
+	lastIP := netip.MustParseAddr(fmt.Sprintf("10.%d.%d.%d", lastIdx>>16, (lastIdx>>8)&0xFF, lastIdx&0xFF))
+	missIP := netip.MustParseAddr("192.168.255.255")
 
-	b.Run(fmt.Sprintf("RadixTrie_%d", numCIDRs), func(b *testing.B) {
-		b.ReportAllocs()
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			_, _ = trie.Contains(targetIP, "")
-		}
-	})
+	cases := []struct {
+		name string
+		ip   netip.Addr
+	}{
+		{"First", firstIP},
+		{"Middle", midIP},
+		{"Last", lastIP},
+		{"Miss", missIP},
+	}
+
+	for _, tc := range cases {
+		b.Run(fmt.Sprintf("Linear_%d_%s", numCIDRs, tc.name), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = matchIPByCidrZones(tc.ip, "", cidrs, zones)
+			}
+		})
+
+		b.Run(fmt.Sprintf("Trie_%d_%s", numCIDRs, tc.name), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = trie.contains(tc.ip, "")
+			}
+		})
+	}
 }
 
 func BenchmarkIPLookup_10(b *testing.B)    { benchmarkIPLookups(b, 10) }

--- a/modules/caddyhttp/iptrie_test.go
+++ b/modules/caddyhttp/iptrie_test.go
@@ -105,6 +105,30 @@ func TestIPTrie(t *testing.T) {
 			wantMatch:    true, // 10.0.0.0/8 has no zone requirement, so it matches
 			wantZonePass: true,
 		},
+		{
+			name:         "IPv4-mapped IPv6 prefix with IPv4 query",
+			cidrs:        []string{"::ffff:192.0.2.0/120"},
+			zones:        []string{""},
+			queryIP:      "192.0.2.1",
+			wantMatch:    true,
+			wantZonePass: true,
+		},
+		{
+			name:         "IPv4-mapped IPv6 prefix with IPv4-mapped IPv6 query",
+			cidrs:        []string{"::ffff:192.0.2.0/120"},
+			zones:        []string{""},
+			queryIP:      "::ffff:192.0.2.1",
+			wantMatch:    true,
+			wantZonePass: true,
+		},
+		{
+			name:         "IPv4-mapped IPv6 prefix out of range no match",
+			cidrs:        []string{"::ffff:192.0.2.0/120"},
+			zones:        []string{""},
+			queryIP:      "192.0.3.1",
+			wantMatch:    false,
+			wantZonePass: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -125,6 +149,13 @@ func TestIPTrie(t *testing.T) {
 			}
 			if gotZonePass != tt.wantZonePass {
 				t.Errorf("IPTrie.Contains() zonePass = %v, want %v", gotZonePass, tt.wantZonePass)
+			}
+
+			// Parity check against linear matcher (matchIPByCidrZones)
+			linearMatch, linearZonePass := matchIPByCidrZones(addr, tt.queryZone, prefixes, tt.zones)
+			if gotMatch != linearMatch || gotZonePass != linearZonePass {
+				t.Errorf("Parity mismatch with linear matcher: Trie(%v, %v) vs Linear(%v, %v)",
+					gotMatch, gotZonePass, linearMatch, linearZonePass)
 			}
 		})
 	}


### PR DESCRIPTION
## Title
httpcaddyfile/matchers: Optimize CIDR blocklist matching latency using bitwise Radix Trie

## Description
This PR introduces a bitwise Radix Trie (PATRICIA tree) for `remote_ip` and `client_ip` HTTP matchers. For large WAF blocklists and threat feeds (e.g. 1,000+ CIDR entries), sequential slice iteration scales linearly at $O(N)$, incurring up to ~1,200ns+ per request.

By constructing a bitwise IP trie during provisioning for CIDR lists with $\ge 8$ entries, lookup time is reduced to $O(W)$ ($W \le 32$ for IPv4, $W \le 128$ for IPv6) achieving sub-50ns latency with 0 heap allocations.

- Zero extra allocations on lookups (`0 B/op`, `0 allocs/op`)
- Full support for IPv4, IPv6, IPv4-mapped IPv6, and IPv6 zone identifiers
- Adaptive threshold ($N < 8$ keeps simple linear scan)

AI-assistance disclosure: Portions of this code were generated with the assistance. 