### PR TITLE
caddyhttp: use canonical header key casing to avoid re-canonicalization

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - canonicalheader
     - decorder
     - dogsled
     - dupl
@@ -96,6 +97,9 @@ linters:
         path: modules/caddyhttp/vars.go
       - linters:
           - errcheck
+        path: _test\.go
+      - linters:
+          - canonicalheader
         path: _test\.go
     paths:
       - third_party$

--- a/modules/caddyhttp/caddyauth/basicauth.go
+++ b/modules/caddyhttp/caddyauth/basicauth.go
@@ -212,7 +212,7 @@ func (hba HTTPBasicAuth) promptForCredentials(w http.ResponseWriter, err error) 
 	if realm == "" {
 		realm = "restricted"
 	}
-	w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Basic realm="%s"`, realm))
+	w.Header().Set("Www-Authenticate", fmt.Sprintf(`Basic realm="%s"`, realm))
 	return User{}, false, err
 }
 

--- a/modules/caddyhttp/encode/encode.go
+++ b/modules/caddyhttp/encode/encode.go
@@ -499,10 +499,10 @@ func hasVaryValue(hdr http.Header, target string) bool {
 // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html.
 func AcceptedEncodings(r *http.Request, preferredOrder []string) []string {
 	acceptEncHeader := r.Header.Get("Accept-Encoding")
-	websocketKey := r.Header.Get("Sec-WebSocket-Key")
 	if acceptEncHeader == "" {
 		return []string{}
 	}
+	websocketKey := r.Header.Get("Sec-Websocket-Key")
 
 	prefs := []encodingPreference{}
 

--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -1368,7 +1368,7 @@ func (m MatchProtocol) Match(r *http.Request) bool {
 func (m MatchProtocol) MatchWithError(r *http.Request) (bool, error) {
 	switch string(m) {
 	case "grpc":
-		return strings.HasPrefix(r.Header.Get("content-type"), "application/grpc"), nil
+		return strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc"), nil
 	case "https":
 		return r.TLS != nil, nil
 	case "http":


### PR DESCRIPTION
## Summary
http.Header.Get/Set re-canonicalize the passed key and allocate a new
string whenever it isn't already in canonical MIME header form. Three
call sites in the codebase were passing non-canonical keys, forcing
this avoidable work on every call:

- modules/caddyhttp/encode/encode.go: "Sec-WebSocket-Key" -> "Sec-Websocket-Key"
- modules/caddyhttp/caddyauth/basicauth.go: "WWW-Authenticate" -> "Www-Authenticate"
- modules/caddyhttp/matchers.go: "content-type" -> "Content-Type"

The encode.go lookup also moved after the Accept-Encoding empty check,
so it's skipped entirely when there's nothing to negotiate.

Also enables the canonicalheader golangci-lint linter to catch this
class of issue going forward, excluded in test files since several
already use non-canonical casing without a perf-sensitive path behind
them.

## Benchmark
Header.Get on a small header set, same machine, -benchtime=300000x:

| literal                | ns/op | allocs  |
|-------------------------|-------|---------|
| Sec-WebSocket-Key        | 47.6  | 1 (24B) |
| Sec-Websocket-Key        | 19.6  | 0       |
| WWW-Authenticate         | 47.5  | 1 (16B) |
| Www-Authenticate         | 26.4  | 0       |
| content-type             | 31.4  | 0       |
| Content-Type             | 20.3  | 0       |

encode.go's check runs on every request through the encode handler;
matchers.go's on every request evaluated by a protocol grpc matcher;
basicauth.go's on every failed Basic Auth attempt.

## Assistance Disclosure
Code has been updated by Claude under my supervision.