### PR TITLE
caddyhttp: mitigate slowloris via idle read/write deadlines

### DIFF
--- a/caddyconfig/httpcaddyfile/directives.go
+++ b/caddyconfig/httpcaddyfile/directives.go
@@ -60,6 +60,7 @@ var defaultDirectiveOrder = []string{
 	"header",
 	"copy_response_headers", // only in reverse_proxy's handle_response
 	"request_body",
+	"timeouts", // wraps the response writer, so keep it close to the real writer, ahead of encode/push/etc.
 
 	"redir",
 

--- a/caddyconfig/httpcaddyfile/serveroptions.go
+++ b/caddyconfig/httpcaddyfile/serveroptions.go
@@ -41,7 +41,9 @@ type serverOptions struct {
 	PacketConnWrappersRaw     []json.RawMessage
 	ReadTimeout               caddy.Duration
 	ReadHeaderTimeout         caddy.Duration
+	ReadIdleTimeout           caddy.Duration
 	WriteTimeout              caddy.Duration
+	WriteIdleTimeout          caddy.Duration
 	IdleTimeout               caddy.Duration
 	KeepAliveInterval         caddy.Duration
 	KeepAliveIdle             caddy.Duration
@@ -137,6 +139,16 @@ func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (any, error) {
 					}
 					serverOpts.ReadTimeout = caddy.Duration(dur)
 
+				case "read_body_idle":
+					if !d.NextArg() {
+						return nil, d.ArgErr()
+					}
+					dur, err := caddy.ParseDuration(d.Val())
+					if err != nil {
+						return nil, d.Errf("parsing read_body_idle timeout duration: %v", err)
+					}
+					serverOpts.ReadIdleTimeout = caddy.Duration(dur)
+
 				case "read_header":
 					if !d.NextArg() {
 						return nil, d.ArgErr()
@@ -156,6 +168,16 @@ func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (any, error) {
 						return nil, d.Errf("parsing write timeout duration: %v", err)
 					}
 					serverOpts.WriteTimeout = caddy.Duration(dur)
+
+				case "write_idle":
+					if !d.NextArg() {
+						return nil, d.ArgErr()
+					}
+					dur, err := caddy.ParseDuration(d.Val())
+					if err != nil {
+						return nil, d.Errf("parsing write_idle timeout duration: %v", err)
+					}
+					serverOpts.WriteIdleTimeout = caddy.Duration(dur)
 
 				case "idle":
 					if !d.NextArg() {
@@ -381,7 +403,9 @@ func applyServerOptions(
 		server.PacketConnWrappersRaw = opts.PacketConnWrappersRaw
 		server.ReadTimeout = opts.ReadTimeout
 		server.ReadHeaderTimeout = opts.ReadHeaderTimeout
+		server.ReadIdleTimeout = opts.ReadIdleTimeout
 		server.WriteTimeout = opts.WriteTimeout
+		server.WriteIdleTimeout = opts.WriteIdleTimeout
 		server.IdleTimeout = opts.IdleTimeout
 		server.KeepAliveInterval = opts.KeepAliveInterval
 		server.KeepAliveIdle = opts.KeepAliveIdle

--- a/caddyconfig/httpcaddyfile/serveroptions.go
+++ b/caddyconfig/httpcaddyfile/serveroptions.go
@@ -46,6 +46,7 @@ type serverOptions struct {
 	WriteTimeout              caddy.Duration
 	WriteIdleTimeout          caddy.Duration
 	WriteMinRate              int64
+	MaxWriteChunk             int
 	IdleTimeout               caddy.Duration
 	KeepAliveInterval         caddy.Duration
 	KeepAliveIdle             caddy.Duration
@@ -200,6 +201,17 @@ func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (any, error) {
 						return nil, d.Errf("parsing write_min_rate bytes/second: %v", err)
 					}
 					serverOpts.WriteMinRate = rate
+
+				case "write_max_chunk":
+					var sizeStr string
+					if !d.AllArgs(&sizeStr) {
+						return nil, d.ArgErr()
+					}
+					size, err := humanize.ParseBytes(sizeStr)
+					if err != nil {
+						return nil, d.Errf("parsing write_max_chunk: %v", err)
+					}
+					serverOpts.MaxWriteChunk = int(size)
 
 				case "idle":
 					if !d.NextArg() {
@@ -430,6 +442,7 @@ func applyServerOptions(
 		server.WriteTimeout = opts.WriteTimeout
 		server.WriteIdleTimeout = opts.WriteIdleTimeout
 		server.WriteMinRate = opts.WriteMinRate
+		server.MaxWriteChunk = opts.MaxWriteChunk
 		server.IdleTimeout = opts.IdleTimeout
 		server.KeepAliveInterval = opts.KeepAliveInterval
 		server.KeepAliveIdle = opts.KeepAliveIdle

--- a/caddyconfig/httpcaddyfile/serveroptions.go
+++ b/caddyconfig/httpcaddyfile/serveroptions.go
@@ -143,24 +143,22 @@ func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (any, error) {
 					serverOpts.ReadTimeout = caddy.Duration(dur)
 
 				case "read_body_idle":
-					if !d.NextArg() {
+					args := d.RemainingArgs()
+					if len(args) < 1 || len(args) > 2 {
 						return nil, d.ArgErr()
 					}
-					dur, err := caddy.ParseDuration(d.Val())
+					dur, err := caddy.ParseDuration(args[0])
 					if err != nil {
 						return nil, d.Errf("parsing read_body_idle timeout duration: %v", err)
 					}
 					serverOpts.ReadIdleTimeout = caddy.Duration(dur)
-
-				case "read_body_min_rate":
-					if !d.NextArg() {
-						return nil, d.ArgErr()
+					if len(args) == 2 {
+						rate, err := strconv.ParseInt(args[1], 10, 64)
+						if err != nil {
+							return nil, d.Errf("parsing read_body_idle min_rate bytes/second: %v", err)
+						}
+						serverOpts.ReadMinRate = rate
 					}
-					rate, err := strconv.ParseInt(d.Val(), 10, 64)
-					if err != nil {
-						return nil, d.Errf("parsing read_body_min_rate bytes/second: %v", err)
-					}
-					serverOpts.ReadMinRate = rate
 
 				case "read_header":
 					if !d.NextArg() {
@@ -183,24 +181,22 @@ func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (any, error) {
 					serverOpts.WriteTimeout = caddy.Duration(dur)
 
 				case "write_idle":
-					if !d.NextArg() {
+					args := d.RemainingArgs()
+					if len(args) < 1 || len(args) > 2 {
 						return nil, d.ArgErr()
 					}
-					dur, err := caddy.ParseDuration(d.Val())
+					dur, err := caddy.ParseDuration(args[0])
 					if err != nil {
 						return nil, d.Errf("parsing write_idle timeout duration: %v", err)
 					}
 					serverOpts.WriteIdleTimeout = caddy.Duration(dur)
-
-				case "write_min_rate":
-					if !d.NextArg() {
-						return nil, d.ArgErr()
+					if len(args) == 2 {
+						rate, err := strconv.ParseInt(args[1], 10, 64)
+						if err != nil {
+							return nil, d.Errf("parsing write_idle min_rate bytes/second: %v", err)
+						}
+						serverOpts.WriteMinRate = rate
 					}
-					rate, err := strconv.ParseInt(d.Val(), 10, 64)
-					if err != nil {
-						return nil, d.Errf("parsing write_min_rate bytes/second: %v", err)
-					}
-					serverOpts.WriteMinRate = rate
 
 				case "write_max_chunk":
 					var sizeStr string

--- a/caddyconfig/httpcaddyfile/serveroptions.go
+++ b/caddyconfig/httpcaddyfile/serveroptions.go
@@ -42,8 +42,10 @@ type serverOptions struct {
 	ReadTimeout               caddy.Duration
 	ReadHeaderTimeout         caddy.Duration
 	ReadIdleTimeout           caddy.Duration
+	ReadMinRate               int64
 	WriteTimeout              caddy.Duration
 	WriteIdleTimeout          caddy.Duration
+	WriteMinRate              int64
 	IdleTimeout               caddy.Duration
 	KeepAliveInterval         caddy.Duration
 	KeepAliveIdle             caddy.Duration
@@ -149,6 +151,16 @@ func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (any, error) {
 					}
 					serverOpts.ReadIdleTimeout = caddy.Duration(dur)
 
+				case "read_body_min_rate":
+					if !d.NextArg() {
+						return nil, d.ArgErr()
+					}
+					rate, err := strconv.ParseInt(d.Val(), 10, 64)
+					if err != nil {
+						return nil, d.Errf("parsing read_body_min_rate bytes/second: %v", err)
+					}
+					serverOpts.ReadMinRate = rate
+
 				case "read_header":
 					if !d.NextArg() {
 						return nil, d.ArgErr()
@@ -178,6 +190,16 @@ func unmarshalCaddyfileServerOptions(d *caddyfile.Dispenser) (any, error) {
 						return nil, d.Errf("parsing write_idle timeout duration: %v", err)
 					}
 					serverOpts.WriteIdleTimeout = caddy.Duration(dur)
+
+				case "write_min_rate":
+					if !d.NextArg() {
+						return nil, d.ArgErr()
+					}
+					rate, err := strconv.ParseInt(d.Val(), 10, 64)
+					if err != nil {
+						return nil, d.Errf("parsing write_min_rate bytes/second: %v", err)
+					}
+					serverOpts.WriteMinRate = rate
 
 				case "idle":
 					if !d.NextArg() {
@@ -404,8 +426,10 @@ func applyServerOptions(
 		server.ReadTimeout = opts.ReadTimeout
 		server.ReadHeaderTimeout = opts.ReadHeaderTimeout
 		server.ReadIdleTimeout = opts.ReadIdleTimeout
+		server.ReadMinRate = opts.ReadMinRate
 		server.WriteTimeout = opts.WriteTimeout
 		server.WriteIdleTimeout = opts.WriteIdleTimeout
+		server.WriteMinRate = opts.WriteMinRate
 		server.IdleTimeout = opts.IdleTimeout
 		server.KeepAliveInterval = opts.KeepAliveInterval
 		server.KeepAliveIdle = opts.KeepAliveIdle

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -402,6 +402,12 @@ func (app *App) Provision(ctx caddy.Context) error {
 		if srv.ReadHeaderTimeout == 0 {
 			srv.ReadHeaderTimeout = defaultReadHeaderTimeout // see #6663
 		}
+		if srv.ReadTimeout == 0 {
+			srv.ReadTimeout = defaultReadTimeout
+		}
+		if srv.WriteTimeout == 0 {
+			srv.WriteTimeout = defaultWriteTimeout
+		}
 	}
 	ctx.Context = oldContext
 	return nil
@@ -471,9 +477,12 @@ func (app *App) Start() error {
 
 	for srvName, srv := range app.Servers {
 		srv.server = &http.Server{
-			ReadTimeout:       time.Duration(srv.ReadTimeout),
+			// ReadTimeout and WriteTimeout are deliberately not passed
+			// through here: Server.ReadTimeout/WriteTimeout enforce a
+			// single hard deadline over the whole body/response, which
+			// would defeat the idle-reset deadlines ServeHTTP applies
+			// per read/write (see idleTimeoutReader/idleTimeoutWriter).
 			ReadHeaderTimeout: time.Duration(srv.ReadHeaderTimeout),
-			WriteTimeout:      time.Duration(srv.WriteTimeout),
 			IdleTimeout:       time.Duration(srv.IdleTimeout),
 			MaxHeaderBytes:    srv.MaxHeaderBytes,
 			Handler:           srv,
@@ -856,6 +865,14 @@ const (
 	// long time even on legitimately slow connections or
 	// busy servers to read it.
 	defaultReadHeaderTimeout = caddy.Duration(time.Minute)
+
+	// defaultReadTimeout and defaultWriteTimeout mitigate slowloris-style
+	// attacks on the request body and response write. Unlike a hard
+	// deadline, these are safe defaults even for large payloads because
+	// Server.ReadTimeout/WriteTimeout deadlines are reset on every
+	// successful read/write; only a stalled connection is affected.
+	defaultReadTimeout  = caddy.Duration(time.Minute)
+	defaultWriteTimeout = caddy.Duration(time.Minute)
 )
 
 // Interface guards

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -408,6 +408,9 @@ func (app *App) Provision(ctx caddy.Context) error {
 		if srv.WriteIdleTimeout == 0 {
 			srv.WriteIdleTimeout = defaultWriteIdleTimeout
 		}
+		if srv.MaxWriteChunk == 0 {
+			srv.MaxWriteChunk = DefaultMaxWriteChunk
+		}
 	}
 	ctx.Context = oldContext
 	return nil

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -402,11 +402,11 @@ func (app *App) Provision(ctx caddy.Context) error {
 		if srv.ReadHeaderTimeout == 0 {
 			srv.ReadHeaderTimeout = defaultReadHeaderTimeout // see #6663
 		}
-		if srv.ReadTimeout == 0 {
-			srv.ReadTimeout = defaultReadTimeout
+		if srv.ReadIdleTimeout == 0 {
+			srv.ReadIdleTimeout = defaultReadIdleTimeout
 		}
-		if srv.WriteTimeout == 0 {
-			srv.WriteTimeout = defaultWriteTimeout
+		if srv.WriteIdleTimeout == 0 {
+			srv.WriteIdleTimeout = defaultWriteIdleTimeout
 		}
 	}
 	ctx.Context = oldContext
@@ -477,12 +477,9 @@ func (app *App) Start() error {
 
 	for srvName, srv := range app.Servers {
 		srv.server = &http.Server{
-			// ReadTimeout and WriteTimeout are deliberately not passed
-			// through here: Server.ReadTimeout/WriteTimeout enforce a
-			// single hard deadline over the whole body/response, which
-			// would defeat the idle-reset deadlines ServeHTTP applies
-			// per read/write (see idleTimeoutReader/idleTimeoutWriter).
+			ReadTimeout:       time.Duration(srv.ReadTimeout),
 			ReadHeaderTimeout: time.Duration(srv.ReadHeaderTimeout),
+			WriteTimeout:      time.Duration(srv.WriteTimeout),
 			IdleTimeout:       time.Duration(srv.IdleTimeout),
 			MaxHeaderBytes:    srv.MaxHeaderBytes,
 			Handler:           srv,
@@ -866,13 +863,13 @@ const (
 	// busy servers to read it.
 	defaultReadHeaderTimeout = caddy.Duration(time.Minute)
 
-	// defaultReadTimeout and defaultWriteTimeout mitigate slowloris-style
-	// attacks on the request body and response write. Unlike a hard
-	// deadline, these are safe defaults even for large payloads because
-	// Server.ReadTimeout/WriteTimeout deadlines are reset on every
-	// successful read/write; only a stalled connection is affected.
-	defaultReadTimeout  = caddy.Duration(time.Minute)
-	defaultWriteTimeout = caddy.Duration(time.Minute)
+	// defaultReadIdleTimeout and defaultWriteIdleTimeout mitigate
+	// slowloris-style attacks on the request body and response write.
+	// Unlike a hard deadline, these are safe defaults even for large
+	// payloads because the deadline is reset on every successful
+	// read/write; only a stalled connection is affected.
+	defaultReadIdleTimeout  = caddy.Duration(time.Minute)
+	defaultWriteIdleTimeout = caddy.Duration(time.Minute)
 )
 
 // Interface guards

--- a/modules/caddyhttp/idletimeout.go
+++ b/modules/caddyhttp/idletimeout.go
@@ -49,8 +49,7 @@ type idleDeadline struct {
 	transferred  int64
 }
 
-func (d *idleDeadline) next() time.Time {
-	var deadline time.Time
+func (d *idleDeadline) next() (deadline time.Time) {
 	if d.minRate > 0 {
 		credit := time.Duration(d.transferred) * time.Second / time.Duration(d.minRate)
 		deadline = d.start.Add(d.timeout + credit)
@@ -60,7 +59,8 @@ func (d *idleDeadline) next() time.Time {
 	if !d.hardDeadline.IsZero() && deadline.After(d.hardDeadline) {
 		deadline = d.hardDeadline
 	}
-	return deadline
+
+	return
 }
 
 // idleTimeoutReader wraps a request body with idleDeadline, resetting
@@ -86,6 +86,7 @@ func (r *idleTimeoutReader) Read(p []byte) (int, error) {
 
 	n, err := r.ReadCloser.Read(p)
 	r.deadline.transferred += int64(n)
+
 	return n, err
 }
 
@@ -120,6 +121,7 @@ func (w *idleTimeoutWriter) Write(p []byte) (int, error) {
 
 	n, err := w.ResponseWriterWrapper.Write(p)
 	w.deadline.transferred += int64(n)
+
 	return n, err
 }
 
@@ -128,6 +130,7 @@ func (w *idleTimeoutWriter) ReadFrom(r io.Reader) (int64, error) {
 
 	n, err := w.ResponseWriterWrapper.ReadFrom(r)
 	w.deadline.transferred += n
+
 	return n, err
 }
 

--- a/modules/caddyhttp/idletimeout.go
+++ b/modules/caddyhttp/idletimeout.go
@@ -23,29 +23,60 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// idleTimeoutReader wraps a request body so that the read deadline is
-// pushed forward before every Read call, instead of bounding the whole
-// body transfer with a single hard deadline. This way, a slow but
-// steadily-progressing upload is never killed, while a connection that
-// stalls (no bytes for the duration of timeout) is. hardDeadline, if
-// non-zero, caps how far the deadline can be pushed forward, so it
-// doesn't silently defeat an explicitly configured ReadTimeout ceiling.
+// idleDeadline computes the next read/write deadline for the idle-reset
+// mechanism shared by idleTimeoutReader and idleTimeoutWriter.
+//
+// With minRate == 0, the deadline is simply pushed forward on every
+// call (now+timeout): a slow but steadily-progressing transfer is never
+// killed, while a connection that stalls (no bytes for the duration of
+// timeout) is. This alone doesn't bound a transfer that trickles just
+// enough data to never go idle.
+//
+// With minRate > 0, the allowance instead grows from a fixed start
+// based on bytes transferred so far (1/minRate seconds of extra
+// allowance per byte), matching Apache mod_reqtimeout's MinRate: a
+// trickle that doesn't sustain minRate bytes/sec falls behind real
+// time and gets cut, even though no single call ever stalls.
+//
+// hardDeadline, if non-zero, caps the result either way, so this can't
+// silently defeat an explicitly configured ReadTimeout/WriteTimeout
+// ceiling.
+type idleDeadline struct {
+	start        time.Time
+	timeout      time.Duration
+	minRate      int64
+	hardDeadline time.Time
+	transferred  int64
+}
+
+func (d *idleDeadline) next() time.Time {
+	var deadline time.Time
+	if d.minRate > 0 {
+		credit := time.Duration(d.transferred) * time.Second / time.Duration(d.minRate)
+		deadline = d.start.Add(d.timeout + credit)
+	} else {
+		deadline = time.Now().Add(d.timeout)
+	}
+	if !d.hardDeadline.IsZero() && deadline.After(d.hardDeadline) {
+		deadline = d.hardDeadline
+	}
+	return deadline
+}
+
+// idleTimeoutReader wraps a request body with idleDeadline, resetting
+// the read deadline before every Read call instead of bounding the
+// whole body transfer with a single hard deadline.
 type idleTimeoutReader struct {
 	io.ReadCloser
-	ctrl         *http.ResponseController
-	timeout      time.Duration
-	hardDeadline time.Time
-	unsupported  bool
-	logger       *zap.Logger
+	ctrl        *http.ResponseController
+	deadline    idleDeadline
+	unsupported bool
+	logger      *zap.Logger
 }
 
 func (r *idleTimeoutReader) Read(p []byte) (int, error) {
 	if !r.unsupported {
-		deadline := time.Now().Add(r.timeout)
-		if !r.hardDeadline.IsZero() && deadline.After(r.hardDeadline) {
-			deadline = r.hardDeadline
-		}
-		if err := r.ctrl.SetReadDeadline(deadline); err != nil {
+		if err := r.ctrl.SetReadDeadline(r.deadline.next()); err != nil {
 			r.unsupported = true
 			if c := r.logger.Check(zapcore.DebugLevel, "could not set read deadline"); c != nil {
 				c.Write(zap.Error(err))
@@ -53,22 +84,22 @@ func (r *idleTimeoutReader) Read(p []byte) (int, error) {
 		}
 	}
 
-	return r.ReadCloser.Read(p)
+	n, err := r.ReadCloser.Read(p)
+	r.deadline.transferred += int64(n)
+	return n, err
 }
 
-// idleTimeoutWriter wraps a ResponseWriter so that the write deadline is
-// pushed forward before every Write call, the same way idleTimeoutReader
-// does for reads. A handler that pauses between writes (e.g. streaming
-// or SSE) is unaffected, since the deadline only bounds the duration of
-// the write operation actually in flight. hardDeadline caps it the same
-// way it does for idleTimeoutReader.
+// idleTimeoutWriter wraps a ResponseWriter with idleDeadline, resetting
+// the write deadline before every Write call, the same way
+// idleTimeoutReader does for reads. A handler that pauses between
+// writes (e.g. streaming or SSE) is unaffected, since with minRate == 0
+// the deadline only bounds the duration of the write actually in flight.
 type idleTimeoutWriter struct {
 	*ResponseWriterWrapper
-	ctrl         *http.ResponseController
-	timeout      time.Duration
-	hardDeadline time.Time
-	unsupported  bool
-	logger       *zap.Logger
+	ctrl        *http.ResponseController
+	deadline    idleDeadline
+	unsupported bool
+	logger      *zap.Logger
 }
 
 func (w *idleTimeoutWriter) resetDeadline() {
@@ -76,11 +107,7 @@ func (w *idleTimeoutWriter) resetDeadline() {
 		return
 	}
 
-	deadline := time.Now().Add(w.timeout)
-	if !w.hardDeadline.IsZero() && deadline.After(w.hardDeadline) {
-		deadline = w.hardDeadline
-	}
-	if err := w.ctrl.SetWriteDeadline(deadline); err != nil {
+	if err := w.ctrl.SetWriteDeadline(w.deadline.next()); err != nil {
 		w.unsupported = true
 		if c := w.logger.Check(zapcore.DebugLevel, "could not set write deadline"); c != nil {
 			c.Write(zap.Error(err))
@@ -91,13 +118,17 @@ func (w *idleTimeoutWriter) resetDeadline() {
 func (w *idleTimeoutWriter) Write(p []byte) (int, error) {
 	w.resetDeadline()
 
-	return w.ResponseWriterWrapper.Write(p)
+	n, err := w.ResponseWriterWrapper.Write(p)
+	w.deadline.transferred += int64(n)
+	return n, err
 }
 
 func (w *idleTimeoutWriter) ReadFrom(r io.Reader) (int64, error) {
 	w.resetDeadline()
 
-	return w.ResponseWriterWrapper.ReadFrom(r)
+	n, err := w.ResponseWriterWrapper.ReadFrom(r)
+	w.deadline.transferred += n
+	return n, err
 }
 
 // Interface guards

--- a/modules/caddyhttp/idletimeout.go
+++ b/modules/caddyhttp/idletimeout.go
@@ -1,0 +1,95 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddyhttp
+
+import (
+	"io"
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// idleTimeoutReader wraps a request body so that the read deadline is
+// pushed forward before every Read call, instead of bounding the whole
+// body transfer with a single hard deadline. This way, a slow but
+// steadily-progressing upload is never killed, while a connection that
+// stalls (no bytes for the duration of timeout) is.
+type idleTimeoutReader struct {
+	io.ReadCloser
+	ctrl        *http.ResponseController
+	timeout     time.Duration
+	unsupported bool
+	logger      *zap.Logger
+}
+
+func (r *idleTimeoutReader) Read(p []byte) (int, error) {
+	if !r.unsupported {
+		if err := r.ctrl.SetReadDeadline(time.Now().Add(r.timeout)); err != nil {
+			r.unsupported = true
+			if c := r.logger.Check(zapcore.DebugLevel, "could not set read deadline"); c != nil {
+				c.Write(zap.Error(err))
+			}
+		}
+	}
+
+	return r.ReadCloser.Read(p)
+}
+
+// idleTimeoutWriter wraps a ResponseWriter so that the write deadline is
+// pushed forward before every Write call, the same way idleTimeoutReader
+// does for reads. A handler that pauses between writes (e.g. streaming
+// or SSE) is unaffected, since the deadline only bounds the duration of
+// the write operation actually in flight.
+type idleTimeoutWriter struct {
+	*ResponseWriterWrapper
+	ctrl        *http.ResponseController
+	timeout     time.Duration
+	unsupported bool
+	logger      *zap.Logger
+}
+
+func (w *idleTimeoutWriter) resetDeadline() {
+	if w.unsupported {
+		return
+	}
+
+	if err := w.ctrl.SetWriteDeadline(time.Now().Add(w.timeout)); err != nil {
+		w.unsupported = true
+		if c := w.logger.Check(zapcore.DebugLevel, "could not set write deadline"); c != nil {
+			c.Write(zap.Error(err))
+		}
+	}
+}
+
+func (w *idleTimeoutWriter) Write(p []byte) (int, error) {
+	w.resetDeadline()
+
+	return w.ResponseWriterWrapper.Write(p)
+}
+
+func (w *idleTimeoutWriter) ReadFrom(r io.Reader) (int64, error) {
+	w.resetDeadline()
+
+	return w.ResponseWriterWrapper.ReadFrom(r)
+}
+
+// Interface guards
+var (
+	_ io.ReadCloser       = (*idleTimeoutReader)(nil)
+	_ http.ResponseWriter = (*idleTimeoutWriter)(nil)
+	_ io.ReaderFrom       = (*idleTimeoutWriter)(nil)
+)

--- a/modules/caddyhttp/idletimeout.go
+++ b/modules/caddyhttp/idletimeout.go
@@ -27,18 +27,25 @@ import (
 // pushed forward before every Read call, instead of bounding the whole
 // body transfer with a single hard deadline. This way, a slow but
 // steadily-progressing upload is never killed, while a connection that
-// stalls (no bytes for the duration of timeout) is.
+// stalls (no bytes for the duration of timeout) is. hardDeadline, if
+// non-zero, caps how far the deadline can be pushed forward, so it
+// doesn't silently defeat an explicitly configured ReadTimeout ceiling.
 type idleTimeoutReader struct {
 	io.ReadCloser
-	ctrl        *http.ResponseController
-	timeout     time.Duration
-	unsupported bool
-	logger      *zap.Logger
+	ctrl         *http.ResponseController
+	timeout      time.Duration
+	hardDeadline time.Time
+	unsupported  bool
+	logger       *zap.Logger
 }
 
 func (r *idleTimeoutReader) Read(p []byte) (int, error) {
 	if !r.unsupported {
-		if err := r.ctrl.SetReadDeadline(time.Now().Add(r.timeout)); err != nil {
+		deadline := time.Now().Add(r.timeout)
+		if !r.hardDeadline.IsZero() && deadline.After(r.hardDeadline) {
+			deadline = r.hardDeadline
+		}
+		if err := r.ctrl.SetReadDeadline(deadline); err != nil {
 			r.unsupported = true
 			if c := r.logger.Check(zapcore.DebugLevel, "could not set read deadline"); c != nil {
 				c.Write(zap.Error(err))
@@ -53,13 +60,15 @@ func (r *idleTimeoutReader) Read(p []byte) (int, error) {
 // pushed forward before every Write call, the same way idleTimeoutReader
 // does for reads. A handler that pauses between writes (e.g. streaming
 // or SSE) is unaffected, since the deadline only bounds the duration of
-// the write operation actually in flight.
+// the write operation actually in flight. hardDeadline caps it the same
+// way it does for idleTimeoutReader.
 type idleTimeoutWriter struct {
 	*ResponseWriterWrapper
-	ctrl        *http.ResponseController
-	timeout     time.Duration
-	unsupported bool
-	logger      *zap.Logger
+	ctrl         *http.ResponseController
+	timeout      time.Duration
+	hardDeadline time.Time
+	unsupported  bool
+	logger       *zap.Logger
 }
 
 func (w *idleTimeoutWriter) resetDeadline() {
@@ -67,7 +76,11 @@ func (w *idleTimeoutWriter) resetDeadline() {
 		return
 	}
 
-	if err := w.ctrl.SetWriteDeadline(time.Now().Add(w.timeout)); err != nil {
+	deadline := time.Now().Add(w.timeout)
+	if !w.hardDeadline.IsZero() && deadline.After(w.hardDeadline) {
+		deadline = w.hardDeadline
+	}
+	if err := w.ctrl.SetWriteDeadline(deadline); err != nil {
 		w.unsupported = true
 		if c := w.logger.Check(zapcore.DebugLevel, "could not set write deadline"); c != nil {
 			c.Write(zap.Error(err))

--- a/modules/caddyhttp/idletimeout.go
+++ b/modules/caddyhttp/idletimeout.go
@@ -23,124 +23,142 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// idleDeadline computes the next read/write deadline for the idle-reset
-// mechanism shared by idleTimeoutReader and idleTimeoutWriter.
+// DefaultMaxWriteChunk is used by IdleTimeoutWriter when MaxChunk is zero.
+// See IdleTimeoutWriter for why a limit is needed at all; nginx's
+// analogous sendfile_max_chunk defaults to 2 MiB and is admin-tunable
+// for the same reason this is exposed as a field rather than a constant.
+const DefaultMaxWriteChunk = 64 * 1024
+
+// IdleDeadline computes the next read/write deadline for the idle-reset
+// mechanism shared by IdleTimeoutReader and IdleTimeoutWriter.
 //
-// With minRate == 0, the deadline is simply pushed forward on every
-// call (now+timeout): a slow but steadily-progressing transfer is never
+// With MinRate == 0, the deadline is simply pushed forward on every
+// call (now+Timeout): a slow but steadily-progressing transfer is never
 // killed, while a connection that stalls (no bytes for the duration of
-// timeout) is. This alone doesn't bound a transfer that trickles just
+// Timeout) is. This alone doesn't bound a transfer that trickles just
 // enough data to never go idle.
 //
-// With minRate > 0, the allowance instead grows from a fixed start
-// based on bytes transferred so far (1/minRate seconds of extra
+// With MinRate > 0, the allowance instead grows from a fixed Start
+// based on bytes transferred so far (1/MinRate seconds of extra
 // allowance per byte), matching Apache mod_reqtimeout's MinRate: a
-// trickle that doesn't sustain minRate bytes/sec falls behind real
+// trickle that doesn't sustain MinRate bytes/sec falls behind real
 // time and gets cut, even though no single call ever stalls.
 //
-// hardDeadline, if non-zero, caps the result either way, so this can't
+// HardDeadline, if non-zero, caps the result either way, so this can't
 // silently defeat an explicitly configured ReadTimeout/WriteTimeout
 // ceiling.
-type idleDeadline struct {
-	start        time.Time
-	timeout      time.Duration
-	minRate      int64
-	hardDeadline time.Time
-	transferred  int64
+type IdleDeadline struct {
+	Start        time.Time
+	Timeout      time.Duration
+	MinRate      int64
+	HardDeadline time.Time
+
+	transferred int64
 }
 
-func (d *idleDeadline) next() (deadline time.Time) {
-	if d.minRate > 0 {
-		credit := time.Duration(d.transferred) * time.Second / time.Duration(d.minRate)
-		deadline = d.start.Add(d.timeout + credit)
+func (d *IdleDeadline) next() (deadline time.Time) {
+	if d.MinRate > 0 {
+		credit := time.Duration(d.transferred) * time.Second / time.Duration(d.MinRate)
+		deadline = d.Start.Add(d.Timeout + credit)
 	} else {
-		deadline = time.Now().Add(d.timeout)
+		deadline = time.Now().Add(d.Timeout)
 	}
-	if !d.hardDeadline.IsZero() && deadline.After(d.hardDeadline) {
-		deadline = d.hardDeadline
+	if !d.HardDeadline.IsZero() && deadline.After(d.HardDeadline) {
+		deadline = d.HardDeadline
 	}
 
 	return
 }
 
-// idleTimeoutReader wraps a request body with idleDeadline, resetting
+// IdleTimeoutReader wraps a request body with IdleDeadline, resetting
 // the read deadline before every Read call instead of bounding the
 // whole body transfer with a single hard deadline.
-type idleTimeoutReader struct {
+type IdleTimeoutReader struct {
 	io.ReadCloser
-	ctrl        *http.ResponseController
-	deadline    idleDeadline
+	Ctrl     *http.ResponseController
+	Deadline IdleDeadline
+	Logger   *zap.Logger
+
 	unsupported bool
-	logger      *zap.Logger
 }
 
-func (r *idleTimeoutReader) Read(p []byte) (int, error) {
+func (r *IdleTimeoutReader) Read(p []byte) (int, error) {
 	if !r.unsupported {
-		if err := r.ctrl.SetReadDeadline(r.deadline.next()); err != nil {
+		if err := r.Ctrl.SetReadDeadline(r.Deadline.next()); err != nil {
 			r.unsupported = true
-			if c := r.logger.Check(zapcore.DebugLevel, "could not set read deadline"); c != nil {
+			if c := r.Logger.Check(zapcore.DebugLevel, "could not set read deadline"); c != nil {
 				c.Write(zap.Error(err))
 			}
 		}
 	}
 
 	n, err := r.ReadCloser.Read(p)
-	r.deadline.transferred += int64(n)
+	r.Deadline.transferred += int64(n)
 
 	return n, err
 }
 
-// idleTimeoutWriter wraps a ResponseWriter with idleDeadline, resetting
+// IdleTimeoutWriter wraps a ResponseWriter with IdleDeadline, resetting
 // the write deadline before every Write call, the same way
-// idleTimeoutReader does for reads. A handler that pauses between
-// writes (e.g. streaming or SSE) is unaffected, since with minRate == 0
+// IdleTimeoutReader does for reads. A handler that pauses between
+// writes (e.g. streaming or SSE) is unaffected, since with MinRate == 0
 // the deadline only bounds the duration of the write actually in flight.
-type idleTimeoutWriter struct {
+//
+// MaxChunk bounds how much a single underlying Write/ReadFrom call is
+// allowed to cover; zero uses DefaultMaxWriteChunk. SetWriteDeadline
+// bounds the whole call it precedes, not just a stall within it:
+// net.Conn.Write loops internally until the entire buffer is sent
+// (unlike Read, which returns after one syscall), and
+// ResponseWriter.ReadFrom hands the entire remaining source to the
+// connection in one call, be it via sendfile or an internal buffered
+// copy loop. Without chunking, a single large Write or a large body
+// copied via io.Copy would have its whole transfer bounded by one
+// deadline, silently truncating a slow-but-healthy transfer exactly
+// like a hard WriteTimeout would. A 64 KiB default still preserves
+// most of the sendfile fast path's benefit (net/sendfile.go
+// special-cases *io.LimitedReader to keep using sendfile per chunk).
+type IdleTimeoutWriter struct {
 	*ResponseWriterWrapper
-	ctrl        *http.ResponseController
-	deadline    idleDeadline
+	Ctrl     *http.ResponseController
+	Deadline IdleDeadline
+	MaxChunk int
+	Logger   *zap.Logger
+
 	unsupported bool
-	logger      *zap.Logger
 }
 
-func (w *idleTimeoutWriter) resetDeadline() {
+func (w *IdleTimeoutWriter) resetDeadline() {
 	if w.unsupported {
 		return
 	}
 
-	if err := w.ctrl.SetWriteDeadline(w.deadline.next()); err != nil {
+	if err := w.Ctrl.SetWriteDeadline(w.Deadline.next()); err != nil {
 		w.unsupported = true
-		if c := w.logger.Check(zapcore.DebugLevel, "could not set write deadline"); c != nil {
+		if c := w.Logger.Check(zapcore.DebugLevel, "could not set write deadline"); c != nil {
 			c.Write(zap.Error(err))
 		}
 	}
 }
 
-// maxWriteChunk bounds how much a single underlying Write/ReadFrom call
-// is allowed to cover. SetWriteDeadline bounds the whole call it precedes,
-// not just a stall within it: net.Conn.Write loops internally until the
-// entire buffer is sent (unlike Read, which returns after one syscall),
-// and ResponseWriter.ReadFrom hands the entire remaining source to the
-// connection in one call, be it via sendfile or an internal buffered
-// copy loop. Without chunking, a single large Write or a large body
-// copied via io.Copy would have its whole transfer bounded by one
-// deadline, silently truncating a slow-but-healthy transfer exactly
-// like a hard WriteTimeout would. 64 KiB still preserves most of the
-// sendfile fast path's benefit (net/sendfile.go special-cases
-// *io.LimitedReader to keep using sendfile per chunk).
-const maxWriteChunk = 64 * 1024
+func (w *IdleTimeoutWriter) maxChunk() int {
+	if w.MaxChunk > 0 {
+		return w.MaxChunk
+	}
+	return DefaultMaxWriteChunk
+}
 
-func (w *idleTimeoutWriter) Write(p []byte) (int, error) {
+func (w *IdleTimeoutWriter) Write(p []byte) (int, error) {
+	maxChunk := w.maxChunk()
 	var total int
 	for len(p) > 0 {
 		chunk := p
-		if len(chunk) > maxWriteChunk {
-			chunk = chunk[:maxWriteChunk]
+		if len(chunk) > maxChunk {
+			chunk = chunk[:maxChunk]
 		}
 		w.resetDeadline()
 		n, err := w.ResponseWriterWrapper.Write(chunk)
 		total += n
-		w.deadline.transferred += int64(n)
+		w.Deadline.transferred += int64(n)
 		p = p[n:]
 		if err != nil {
 			return total, err
@@ -149,17 +167,18 @@ func (w *idleTimeoutWriter) Write(p []byte) (int, error) {
 	return total, nil
 }
 
-func (w *idleTimeoutWriter) ReadFrom(r io.Reader) (int64, error) {
+func (w *IdleTimeoutWriter) ReadFrom(r io.Reader) (int64, error) {
+	maxChunk := w.maxChunk()
 	var total int64
 	for {
 		w.resetDeadline()
-		n, err := w.ResponseWriterWrapper.ReadFrom(io.LimitReader(r, maxWriteChunk))
+		n, err := w.ResponseWriterWrapper.ReadFrom(io.LimitReader(r, int64(maxChunk)))
 		total += n
-		w.deadline.transferred += n
+		w.Deadline.transferred += n
 		if err != nil {
 			return total, err
 		}
-		if n < maxWriteChunk {
+		if n < int64(maxChunk) {
 			return total, nil
 		}
 	}
@@ -167,7 +186,7 @@ func (w *idleTimeoutWriter) ReadFrom(r io.Reader) (int64, error) {
 
 // Interface guards
 var (
-	_ io.ReadCloser       = (*idleTimeoutReader)(nil)
-	_ http.ResponseWriter = (*idleTimeoutWriter)(nil)
-	_ io.ReaderFrom       = (*idleTimeoutWriter)(nil)
+	_ io.ReadCloser       = (*IdleTimeoutReader)(nil)
+	_ http.ResponseWriter = (*IdleTimeoutWriter)(nil)
+	_ io.ReaderFrom       = (*IdleTimeoutWriter)(nil)
 )

--- a/modules/caddyhttp/idletimeout.go
+++ b/modules/caddyhttp/idletimeout.go
@@ -116,22 +116,53 @@ func (w *idleTimeoutWriter) resetDeadline() {
 	}
 }
 
+// maxWriteChunk bounds how much a single underlying Write/ReadFrom call
+// is allowed to cover. SetWriteDeadline bounds the whole call it precedes,
+// not just a stall within it: net.Conn.Write loops internally until the
+// entire buffer is sent (unlike Read, which returns after one syscall),
+// and ResponseWriter.ReadFrom hands the entire remaining source to the
+// connection in one call, be it via sendfile or an internal buffered
+// copy loop. Without chunking, a single large Write or a large body
+// copied via io.Copy would have its whole transfer bounded by one
+// deadline, silently truncating a slow-but-healthy transfer exactly
+// like a hard WriteTimeout would. 64 KiB still preserves most of the
+// sendfile fast path's benefit (net/sendfile.go special-cases
+// *io.LimitedReader to keep using sendfile per chunk).
+const maxWriteChunk = 64 * 1024
+
 func (w *idleTimeoutWriter) Write(p []byte) (int, error) {
-	w.resetDeadline()
-
-	n, err := w.ResponseWriterWrapper.Write(p)
-	w.deadline.transferred += int64(n)
-
-	return n, err
+	var total int
+	for len(p) > 0 {
+		chunk := p
+		if len(chunk) > maxWriteChunk {
+			chunk = chunk[:maxWriteChunk]
+		}
+		w.resetDeadline()
+		n, err := w.ResponseWriterWrapper.Write(chunk)
+		total += n
+		w.deadline.transferred += int64(n)
+		p = p[n:]
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
 }
 
 func (w *idleTimeoutWriter) ReadFrom(r io.Reader) (int64, error) {
-	w.resetDeadline()
-
-	n, err := w.ResponseWriterWrapper.ReadFrom(r)
-	w.deadline.transferred += n
-
-	return n, err
+	var total int64
+	for {
+		w.resetDeadline()
+		n, err := w.ResponseWriterWrapper.ReadFrom(io.LimitReader(r, maxWriteChunk))
+		total += n
+		w.deadline.transferred += n
+		if err != nil {
+			return total, err
+		}
+		if n < maxWriteChunk {
+			return total, nil
+		}
+	}
 }
 
 // Interface guards

--- a/modules/caddyhttp/idletimeout_test.go
+++ b/modules/caddyhttp/idletimeout_test.go
@@ -49,11 +49,11 @@ func TestIdleTimeoutReader(t *testing.T) {
 	const timeout = 150 * time.Millisecond
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		wrapped := &idleTimeoutReader{
+		wrapped := &IdleTimeoutReader{
 			ReadCloser: r.Body,
-			ctrl:       http.NewResponseController(w),
-			deadline:   idleDeadline{timeout: timeout},
-			logger:     zap.NewNop(),
+			Ctrl:       http.NewResponseController(w),
+			Deadline:   IdleDeadline{Timeout: timeout},
+			Logger:     zap.NewNop(),
 		}
 		_, err := io.Copy(io.Discard, wrapped)
 		if err != nil {
@@ -92,14 +92,14 @@ func TestIdleTimeoutReader_HardDeadlineCapsIdleReset(t *testing.T) {
 	const hard = 200 * time.Millisecond
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		wrapped := &idleTimeoutReader{
+		wrapped := &IdleTimeoutReader{
 			ReadCloser: r.Body,
-			ctrl:       http.NewResponseController(w),
-			deadline: idleDeadline{
-				timeout:      idle,
-				hardDeadline: time.Now().Add(hard),
+			Ctrl:       http.NewResponseController(w),
+			Deadline: IdleDeadline{
+				Timeout:      idle,
+				HardDeadline: time.Now().Add(hard),
 			},
-			logger: zap.NewNop(),
+			Logger: zap.NewNop(),
 		}
 		_, err := io.Copy(io.Discard, wrapped)
 		if err != nil {
@@ -129,18 +129,18 @@ func TestIdleTimeoutReader_MinRateCatchesTrickle(t *testing.T) {
 	const chunkDelay = 150 * time.Millisecond
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		wrapped := &idleTimeoutReader{
+		wrapped := &IdleTimeoutReader{
 			ReadCloser: r.Body,
-			ctrl:       http.NewResponseController(w),
-			deadline: idleDeadline{
-				start:   time.Now(),
-				timeout: idle,
+			Ctrl:       http.NewResponseController(w),
+			Deadline: IdleDeadline{
+				Start:   time.Now(),
+				Timeout: idle,
 				// a huge min rate means even a full-size read call
 				// earns virtually no extra credit, so a byte-sized
 				// trickle can't keep the connection alive past idle
-				minRate: 100_000_000,
+				MinRate: 100_000_000,
 			},
-			logger: zap.NewNop(),
+			Logger: zap.NewNop(),
 		}
 		_, err := io.Copy(io.Discard, wrapped)
 		if err != nil {
@@ -169,15 +169,15 @@ func TestIdleTimeoutReader_MinRateAllowsSustainedRate(t *testing.T) {
 	const minRate = 1000 // bytes/second
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		wrapped := &idleTimeoutReader{
+		wrapped := &IdleTimeoutReader{
 			ReadCloser: r.Body,
-			ctrl:       http.NewResponseController(w),
-			deadline: idleDeadline{
-				start:   time.Now(),
-				timeout: idle,
-				minRate: minRate,
+			Ctrl:       http.NewResponseController(w),
+			Deadline: IdleDeadline{
+				Start:   time.Now(),
+				Timeout: idle,
+				MinRate: minRate,
 			},
-			logger: zap.NewNop(),
+			Logger: zap.NewNop(),
 		}
 		_, err := io.Copy(io.Discard, wrapped)
 		if err != nil {
@@ -203,11 +203,11 @@ func TestIdleTimeoutWriter(t *testing.T) {
 	const timeout = 150 * time.Millisecond
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		wrapped := &idleTimeoutWriter{
+		wrapped := &IdleTimeoutWriter{
 			ResponseWriterWrapper: &ResponseWriterWrapper{ResponseWriter: w},
-			ctrl:                  http.NewResponseController(w),
-			deadline:              idleDeadline{timeout: timeout},
-			logger:                zap.NewNop(),
+			Ctrl:                  http.NewResponseController(w),
+			Deadline:              IdleDeadline{Timeout: timeout},
+			Logger:                zap.NewNop(),
 		}
 		flusher, _ := wrapped.ResponseWriterWrapper.ResponseWriter.(http.Flusher)
 		for range 8 {
@@ -240,14 +240,14 @@ func TestIdleTimeoutWriter_HardDeadlineCapsIdleReset(t *testing.T) {
 	const hard = 200 * time.Millisecond
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		wrapped := &idleTimeoutWriter{
+		wrapped := &IdleTimeoutWriter{
 			ResponseWriterWrapper: &ResponseWriterWrapper{ResponseWriter: w},
-			ctrl:                  http.NewResponseController(w),
-			deadline: idleDeadline{
-				timeout:      idle,
-				hardDeadline: time.Now().Add(hard),
+			Ctrl:                  http.NewResponseController(w),
+			Deadline: IdleDeadline{
+				Timeout:      idle,
+				HardDeadline: time.Now().Add(hard),
 			},
-			logger: zap.NewNop(),
+			Logger: zap.NewNop(),
 		}
 		flusher, _ := wrapped.ResponseWriterWrapper.ResponseWriter.(http.Flusher)
 		for range 8 {
@@ -313,42 +313,63 @@ func (c *readFromCounter) Write(p []byte) (int, error) {
 }
 
 func TestIdleTimeoutWriter_ReadFromChunksLargeTransfer(t *testing.T) {
-	const size = maxWriteChunk*3 + 100 // 3 full chunks plus a partial tail
+	const size = DefaultMaxWriteChunk*3 + 100 // 3 full chunks plus a partial tail
 
 	counter := &readFromCounter{ResponseRecorder: httptest.NewRecorder()}
-	wrapped := &idleTimeoutWriter{
+	wrapped := &IdleTimeoutWriter{
 		ResponseWriterWrapper: &ResponseWriterWrapper{ResponseWriter: counter},
-		ctrl:                  http.NewResponseController(counter),
-		deadline:              idleDeadline{timeout: time.Second},
-		logger:                zap.NewNop(),
+		Ctrl:                  http.NewResponseController(counter),
+		Deadline:              IdleDeadline{Timeout: time.Second},
+		Logger:                zap.NewNop(),
 	}
 
 	n, err := wrapped.ReadFrom(bytes.NewReader(make([]byte, size)))
 	require.NoError(t, err)
 	assert.EqualValues(t, size, n)
 	assert.EqualValues(t, size, counter.total)
-	assert.LessOrEqual(t, counter.maxCall, maxWriteChunk,
-		"no single underlying ReadFrom call should cover more than maxWriteChunk bytes, "+
+	assert.LessOrEqual(t, counter.maxCall, DefaultMaxWriteChunk,
+		"no single underlying ReadFrom call should cover more than DefaultMaxWriteChunk bytes, "+
 			"since SetWriteDeadline bounds the whole call it precedes, not just a stall within it")
 	assert.Equal(t, 4, counter.calls, "expected 3 full chunks plus a partial tail chunk")
 }
 
 func TestIdleTimeoutWriter_WriteChunksLargePayload(t *testing.T) {
-	const size = maxWriteChunk*2 + 1
+	const size = DefaultMaxWriteChunk*2 + 1
 
 	counter := &readFromCounter{ResponseRecorder: httptest.NewRecorder()}
-	wrapped := &idleTimeoutWriter{
+	wrapped := &IdleTimeoutWriter{
 		ResponseWriterWrapper: &ResponseWriterWrapper{ResponseWriter: counter},
-		ctrl:                  http.NewResponseController(counter),
-		deadline:              idleDeadline{timeout: time.Second},
-		logger:                zap.NewNop(),
+		Ctrl:                  http.NewResponseController(counter),
+		Deadline:              IdleDeadline{Timeout: time.Second},
+		Logger:                zap.NewNop(),
 	}
 
 	n, err := wrapped.Write(make([]byte, size))
 	require.NoError(t, err)
 	assert.EqualValues(t, size, n)
 	assert.EqualValues(t, size, counter.ResponseRecorder.Body.Len())
-	assert.LessOrEqual(t, counter.maxWriteCall, maxWriteChunk,
-		"no single underlying Write call should cover more than maxWriteChunk bytes")
+	assert.LessOrEqual(t, counter.maxWriteCall, DefaultMaxWriteChunk,
+		"no single underlying Write call should cover more than DefaultMaxWriteChunk bytes")
 	assert.Equal(t, 3, counter.writeCalls, "expected 2 full chunks plus a 1-byte tail chunk")
+}
+
+func TestIdleTimeoutWriter_MaxChunkOverride(t *testing.T) {
+	const size = 1000
+	const maxChunk = 100
+
+	counter := &readFromCounter{ResponseRecorder: httptest.NewRecorder()}
+	wrapped := &IdleTimeoutWriter{
+		ResponseWriterWrapper: &ResponseWriterWrapper{ResponseWriter: counter},
+		Ctrl:                  http.NewResponseController(counter),
+		Deadline:              IdleDeadline{Timeout: time.Second},
+		MaxChunk:              maxChunk,
+		Logger:                zap.NewNop(),
+	}
+
+	n, err := wrapped.Write(make([]byte, size))
+	require.NoError(t, err)
+	assert.EqualValues(t, size, n)
+	assert.LessOrEqual(t, counter.maxWriteCall, maxChunk,
+		"a configured MaxChunk should override DefaultMaxWriteChunk")
+	assert.Equal(t, size/maxChunk, counter.writeCalls)
 }

--- a/modules/caddyhttp/idletimeout_test.go
+++ b/modules/caddyhttp/idletimeout_test.go
@@ -1,0 +1,123 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddyhttp
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// pacedReader emits chunkCount chunks of chunkSize bytes, sleeping delay
+// before each one, simulating a client that trickles a request body.
+type pacedReader struct {
+	delay      time.Duration
+	chunkSize  int
+	chunkCount int
+}
+
+func (p *pacedReader) Read(b []byte) (int, error) {
+	if p.chunkCount <= 0 {
+		return 0, io.EOF
+	}
+	time.Sleep(p.delay)
+	p.chunkCount--
+	n := copy(b, make([]byte, p.chunkSize))
+	return n, nil
+}
+
+func TestIdleTimeoutReader(t *testing.T) {
+	const timeout = 150 * time.Millisecond
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wrapped := &idleTimeoutReader{
+			ReadCloser: r.Body,
+			ctrl:       http.NewResponseController(w),
+			timeout:    timeout,
+			logger:     zap.NewNop(),
+		}
+		_, err := io.Copy(io.Discard, wrapped)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusRequestTimeout)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Run("slow but steadily progressing upload is not killed", func(t *testing.T) {
+		// each gap is well under timeout, but the cumulative transfer
+		// time is well over it; a hard deadline would kill this
+		body := &pacedReader{delay: timeout / 4, chunkSize: 8, chunkCount: 8}
+		resp, err := http.Post(srv.URL, "application/octet-stream", body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("stalled upload is aborted", func(t *testing.T) {
+		// a single gap that exceeds timeout must trip the deadline
+		body := &pacedReader{delay: timeout * 4, chunkSize: 8, chunkCount: 2}
+		resp, err := http.Post(srv.URL, "application/octet-stream", body)
+		if err != nil {
+			// the connection may also be reset outright, which is fine
+			return
+		}
+		defer resp.Body.Close()
+		assert.NotEqual(t, http.StatusOK, resp.StatusCode)
+	})
+}
+
+func TestIdleTimeoutWriter(t *testing.T) {
+	const timeout = 150 * time.Millisecond
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wrapped := &idleTimeoutWriter{
+			ResponseWriterWrapper: &ResponseWriterWrapper{ResponseWriter: w},
+			ctrl:                  http.NewResponseController(w),
+			timeout:               timeout,
+			logger:                zap.NewNop(),
+		}
+		flusher, _ := wrapped.ResponseWriterWrapper.ResponseWriter.(http.Flusher)
+		for range 8 {
+			time.Sleep(timeout / 4)
+			_, err := wrapped.Write(make([]byte, 8))
+			if err != nil {
+				t.Errorf("unexpected write error: %v", err)
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+	}))
+	defer srv.Close()
+
+	// each write gap is well under timeout, but the cumulative streaming
+	// time is well over it; a hard deadline would kill this response
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	n, err := io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	assert.EqualValues(t, 64, n)
+}

--- a/modules/caddyhttp/idletimeout_test.go
+++ b/modules/caddyhttp/idletimeout_test.go
@@ -51,7 +51,7 @@ func TestIdleTimeoutReader(t *testing.T) {
 		wrapped := &idleTimeoutReader{
 			ReadCloser: r.Body,
 			ctrl:       http.NewResponseController(w),
-			timeout:    timeout,
+			deadline:   idleDeadline{timeout: timeout},
 			logger:     zap.NewNop(),
 		}
 		_, err := io.Copy(io.Discard, wrapped)
@@ -92,11 +92,13 @@ func TestIdleTimeoutReader_HardDeadlineCapsIdleReset(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		wrapped := &idleTimeoutReader{
-			ReadCloser:   r.Body,
-			ctrl:         http.NewResponseController(w),
-			timeout:      idle,
-			hardDeadline: time.Now().Add(hard),
-			logger:       zap.NewNop(),
+			ReadCloser: r.Body,
+			ctrl:       http.NewResponseController(w),
+			deadline: idleDeadline{
+				timeout:      idle,
+				hardDeadline: time.Now().Add(hard),
+			},
+			logger: zap.NewNop(),
 		}
 		_, err := io.Copy(io.Discard, wrapped)
 		if err != nil {
@@ -121,6 +123,81 @@ func TestIdleTimeoutReader_HardDeadlineCapsIdleReset(t *testing.T) {
 	assert.NotEqual(t, http.StatusOK, resp.StatusCode)
 }
 
+func TestIdleTimeoutReader_MinRateCatchesTrickle(t *testing.T) {
+	const idle = 250 * time.Millisecond
+	const chunkDelay = 150 * time.Millisecond
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wrapped := &idleTimeoutReader{
+			ReadCloser: r.Body,
+			ctrl:       http.NewResponseController(w),
+			deadline: idleDeadline{
+				start:   time.Now(),
+				timeout: idle,
+				// a huge min rate means even a full-size read call
+				// earns virtually no extra credit, so a byte-sized
+				// trickle can't keep the connection alive past idle
+				minRate: 100_000_000,
+			},
+			logger: zap.NewNop(),
+		}
+		_, err := io.Copy(io.Discard, wrapped)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusRequestTimeout)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// each individual gap (150ms) is under the idle window (250ms), so
+	// pure idle-reset alone would never trip; MinRate must still catch
+	// this trickle since it never earns meaningful credit
+	body := &pacedReader{delay: chunkDelay, chunkSize: 1, chunkCount: 6}
+	resp, err := http.Post(srv.URL, "application/octet-stream", body)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	assert.NotEqual(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestIdleTimeoutReader_MinRateAllowsSustainedRate(t *testing.T) {
+	const idle = 250 * time.Millisecond
+	const chunkDelay = 100 * time.Millisecond
+	const minRate = 1000 // bytes/second
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wrapped := &idleTimeoutReader{
+			ReadCloser: r.Body,
+			ctrl:       http.NewResponseController(w),
+			deadline: idleDeadline{
+				start:   time.Now(),
+				timeout: idle,
+				minRate: minRate,
+			},
+			logger: zap.NewNop(),
+		}
+		_, err := io.Copy(io.Discard, wrapped)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusRequestTimeout)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// 200 bytes every 100ms is 2000 bytes/second, comfortably above the
+	// 1000 bytes/second minRate, so credit earned per chunk (200ms)
+	// outpaces the real time elapsed per chunk (100ms): this transfer
+	// must complete despite exceeding the idle window cumulatively
+	body := &pacedReader{delay: chunkDelay, chunkSize: 200, chunkCount: 8}
+	resp, err := http.Post(srv.URL, "application/octet-stream", body)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
 func TestIdleTimeoutWriter(t *testing.T) {
 	const timeout = 150 * time.Millisecond
 
@@ -128,7 +205,7 @@ func TestIdleTimeoutWriter(t *testing.T) {
 		wrapped := &idleTimeoutWriter{
 			ResponseWriterWrapper: &ResponseWriterWrapper{ResponseWriter: w},
 			ctrl:                  http.NewResponseController(w),
-			timeout:               timeout,
+			deadline:              idleDeadline{timeout: timeout},
 			logger:                zap.NewNop(),
 		}
 		flusher, _ := wrapped.ResponseWriterWrapper.ResponseWriter.(http.Flusher)
@@ -165,9 +242,11 @@ func TestIdleTimeoutWriter_HardDeadlineCapsIdleReset(t *testing.T) {
 		wrapped := &idleTimeoutWriter{
 			ResponseWriterWrapper: &ResponseWriterWrapper{ResponseWriter: w},
 			ctrl:                  http.NewResponseController(w),
-			timeout:               idle,
-			hardDeadline:          time.Now().Add(hard),
-			logger:                zap.NewNop(),
+			deadline: idleDeadline{
+				timeout:      idle,
+				hardDeadline: time.Now().Add(hard),
+			},
+			logger: zap.NewNop(),
 		}
 		flusher, _ := wrapped.ResponseWriterWrapper.ResponseWriter.(http.Flusher)
 		for range 8 {

--- a/modules/caddyhttp/idletimeout_test.go
+++ b/modules/caddyhttp/idletimeout_test.go
@@ -86,6 +86,41 @@ func TestIdleTimeoutReader(t *testing.T) {
 	})
 }
 
+func TestIdleTimeoutReader_HardDeadlineCapsIdleReset(t *testing.T) {
+	const idle = 500 * time.Millisecond
+	const hard = 200 * time.Millisecond
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wrapped := &idleTimeoutReader{
+			ReadCloser:   r.Body,
+			ctrl:         http.NewResponseController(w),
+			timeout:      idle,
+			hardDeadline: time.Now().Add(hard),
+			logger:       zap.NewNop(),
+		}
+		_, err := io.Copy(io.Discard, wrapped)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusRequestTimeout)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// each gap is under the idle timeout, so the connection is never
+	// idle, but the cumulative transfer time exceeds hardDeadline: an
+	// explicit hard ceiling must still cut it off despite the ongoing
+	// idle-reset activity
+	body := &pacedReader{delay: hard, chunkSize: 8, chunkCount: 8}
+	resp, err := http.Post(srv.URL, "application/octet-stream", body)
+	if err != nil {
+		// the connection may also be reset outright, which is fine
+		return
+	}
+	defer resp.Body.Close()
+	assert.NotEqual(t, http.StatusOK, resp.StatusCode)
+}
+
 func TestIdleTimeoutWriter(t *testing.T) {
 	const timeout = 150 * time.Millisecond
 
@@ -120,4 +155,46 @@ func TestIdleTimeoutWriter(t *testing.T) {
 	n, err := io.Copy(io.Discard, resp.Body)
 	require.NoError(t, err)
 	assert.EqualValues(t, 64, n)
+}
+
+func TestIdleTimeoutWriter_HardDeadlineCapsIdleReset(t *testing.T) {
+	const idle = 500 * time.Millisecond
+	const hard = 200 * time.Millisecond
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wrapped := &idleTimeoutWriter{
+			ResponseWriterWrapper: &ResponseWriterWrapper{ResponseWriter: w},
+			ctrl:                  http.NewResponseController(w),
+			timeout:               idle,
+			hardDeadline:          time.Now().Add(hard),
+			logger:                zap.NewNop(),
+		}
+		flusher, _ := wrapped.ResponseWriterWrapper.ResponseWriter.(http.Flusher)
+		for range 8 {
+			time.Sleep(hard)
+			if _, err := wrapped.Write(make([]byte, 8)); err != nil {
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+	}))
+	defer srv.Close()
+
+	// each write gap is under the idle timeout, so the connection is
+	// never idle, but the cumulative streaming time exceeds
+	// hardDeadline: an explicit hard ceiling must still cut it off,
+	// whether that surfaces as a failed request, a truncated body, or
+	// both
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	n, err := io.Copy(io.Discard, resp.Body)
+	if err == nil {
+		assert.Less(t, n, int64(64))
+	}
 }

--- a/modules/caddyhttp/idletimeout_test.go
+++ b/modules/caddyhttp/idletimeout_test.go
@@ -15,6 +15,7 @@
 package caddyhttp
 
 import (
+	"bytes"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -276,4 +277,78 @@ func TestIdleTimeoutWriter_HardDeadlineCapsIdleReset(t *testing.T) {
 	if err == nil {
 		assert.Less(t, n, int64(64))
 	}
+}
+
+// readFromCounter is a fake http.ResponseWriter that records how many
+// times ReadFrom was called on it and the size of the largest call, so
+// tests can assert on chunking behavior deterministically instead of
+// depending on real TCP timing.
+type readFromCounter struct {
+	*httptest.ResponseRecorder
+	calls        int
+	maxCall      int
+	total        int64
+	writeCalls   int
+	maxWriteCall int
+}
+
+func (c *readFromCounter) SetWriteDeadline(time.Time) error { return nil }
+
+func (c *readFromCounter) ReadFrom(r io.Reader) (int64, error) {
+	c.calls++
+	n, err := io.Copy(io.Discard, r)
+	c.total += n
+	if int(n) > c.maxCall {
+		c.maxCall = int(n)
+	}
+	return n, err
+}
+
+func (c *readFromCounter) Write(p []byte) (int, error) {
+	c.writeCalls++
+	if len(p) > c.maxWriteCall {
+		c.maxWriteCall = len(p)
+	}
+	return c.ResponseRecorder.Write(p)
+}
+
+func TestIdleTimeoutWriter_ReadFromChunksLargeTransfer(t *testing.T) {
+	const size = maxWriteChunk*3 + 100 // 3 full chunks plus a partial tail
+
+	counter := &readFromCounter{ResponseRecorder: httptest.NewRecorder()}
+	wrapped := &idleTimeoutWriter{
+		ResponseWriterWrapper: &ResponseWriterWrapper{ResponseWriter: counter},
+		ctrl:                  http.NewResponseController(counter),
+		deadline:              idleDeadline{timeout: time.Second},
+		logger:                zap.NewNop(),
+	}
+
+	n, err := wrapped.ReadFrom(bytes.NewReader(make([]byte, size)))
+	require.NoError(t, err)
+	assert.EqualValues(t, size, n)
+	assert.EqualValues(t, size, counter.total)
+	assert.LessOrEqual(t, counter.maxCall, maxWriteChunk,
+		"no single underlying ReadFrom call should cover more than maxWriteChunk bytes, "+
+			"since SetWriteDeadline bounds the whole call it precedes, not just a stall within it")
+	assert.Equal(t, 4, counter.calls, "expected 3 full chunks plus a partial tail chunk")
+}
+
+func TestIdleTimeoutWriter_WriteChunksLargePayload(t *testing.T) {
+	const size = maxWriteChunk*2 + 1
+
+	counter := &readFromCounter{ResponseRecorder: httptest.NewRecorder()}
+	wrapped := &idleTimeoutWriter{
+		ResponseWriterWrapper: &ResponseWriterWrapper{ResponseWriter: counter},
+		ctrl:                  http.NewResponseController(counter),
+		deadline:              idleDeadline{timeout: time.Second},
+		logger:                zap.NewNop(),
+	}
+
+	n, err := wrapped.Write(make([]byte, size))
+	require.NoError(t, err)
+	assert.EqualValues(t, size, n)
+	assert.EqualValues(t, size, counter.ResponseRecorder.Body.Len())
+	assert.LessOrEqual(t, counter.maxWriteCall, maxWriteChunk,
+		"no single underlying Write call should cover more than maxWriteChunk bytes")
+	assert.Equal(t, 3, counter.writeCalls, "expected 2 full chunks plus a 1-byte tail chunk")
 }

--- a/modules/caddyhttp/requestbody/caddyfile.go
+++ b/modules/caddyhttp/requestbody/caddyfile.go
@@ -15,6 +15,7 @@
 package requestbody
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -57,6 +58,17 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 			}
 			rb.ReadTimeout = timeout
 
+		case "read_min_rate":
+			var rateStr string
+			if !h.AllArgs(&rateStr) {
+				return nil, h.ArgErr()
+			}
+			rate, err := strconv.ParseInt(rateStr, 10, 64)
+			if err != nil {
+				return nil, h.Errf("parsing read_min_rate: %v", err)
+			}
+			rb.ReadMinRate = rate
+
 		case "write_timeout":
 			var timeoutStr string
 			if !h.AllArgs(&timeoutStr) {
@@ -67,6 +79,28 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 				return nil, h.Errf("parsing write_timeout: %v", err)
 			}
 			rb.WriteTimeout = timeout
+
+		case "write_min_rate":
+			var rateStr string
+			if !h.AllArgs(&rateStr) {
+				return nil, h.ArgErr()
+			}
+			rate, err := strconv.ParseInt(rateStr, 10, 64)
+			if err != nil {
+				return nil, h.Errf("parsing write_min_rate: %v", err)
+			}
+			rb.WriteMinRate = rate
+
+		case "max_write_chunk":
+			var sizeStr string
+			if !h.AllArgs(&sizeStr) {
+				return nil, h.ArgErr()
+			}
+			size, err := humanize.ParseBytes(sizeStr)
+			if err != nil {
+				return nil, h.Errf("parsing max_write_chunk: %v", err)
+			}
+			rb.MaxWriteChunk = int(size)
 
 		case "set":
 			var setStr string

--- a/modules/caddyhttp/requestbody/caddyfile.go
+++ b/modules/caddyhttp/requestbody/caddyfile.go
@@ -15,9 +15,6 @@
 package requestbody
 
 import (
-	"strconv"
-	"time"
-
 	"github.com/dustin/go-humanize"
 
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
@@ -46,61 +43,6 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 				return nil, h.Errf("parsing max_size: %v", err)
 			}
 			rb.MaxSize = int64(size)
-
-		case "read_timeout":
-			var timeoutStr string
-			if !h.AllArgs(&timeoutStr) {
-				return nil, h.ArgErr()
-			}
-			timeout, err := time.ParseDuration(timeoutStr)
-			if err != nil {
-				return nil, h.Errf("parsing read_timeout: %v", err)
-			}
-			rb.ReadTimeout = timeout
-
-		case "read_min_rate":
-			var rateStr string
-			if !h.AllArgs(&rateStr) {
-				return nil, h.ArgErr()
-			}
-			rate, err := strconv.ParseInt(rateStr, 10, 64)
-			if err != nil {
-				return nil, h.Errf("parsing read_min_rate: %v", err)
-			}
-			rb.ReadMinRate = rate
-
-		case "write_timeout":
-			var timeoutStr string
-			if !h.AllArgs(&timeoutStr) {
-				return nil, h.ArgErr()
-			}
-			timeout, err := time.ParseDuration(timeoutStr)
-			if err != nil {
-				return nil, h.Errf("parsing write_timeout: %v", err)
-			}
-			rb.WriteTimeout = timeout
-
-		case "write_min_rate":
-			var rateStr string
-			if !h.AllArgs(&rateStr) {
-				return nil, h.ArgErr()
-			}
-			rate, err := strconv.ParseInt(rateStr, 10, 64)
-			if err != nil {
-				return nil, h.Errf("parsing write_min_rate: %v", err)
-			}
-			rb.WriteMinRate = rate
-
-		case "max_write_chunk":
-			var sizeStr string
-			if !h.AllArgs(&sizeStr) {
-				return nil, h.ArgErr()
-			}
-			size, err := humanize.ParseBytes(sizeStr)
-			if err != nil {
-				return nil, h.Errf("parsing max_write_chunk: %v", err)
-			}
-			rb.MaxWriteChunk = int(size)
 
 		case "set":
 			var setStr string

--- a/modules/caddyhttp/requestbody/requestbody.go
+++ b/modules/caddyhttp/requestbody/requestbody.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
@@ -38,11 +37,39 @@ type RequestBody struct {
 	// If more bytes are read, an error with HTTP status 413 is returned.
 	MaxSize int64 `json:"max_size,omitempty"`
 
+	// How long to allow a read from the request body to stall before
+	// aborting the connection, reset on every successful read (like the
+	// server-wide read_idle_timeout, but scoped to routes matching this
+	// handler). If zero, no idle timeout is applied here.
 	// EXPERIMENTAL. Subject to change/removal.
 	ReadTimeout time.Duration `json:"read_timeout,omitempty"`
 
+	// ReadMinRate requires the client to sustain at least this many
+	// bytes/second, averaged from the start of the read, or the
+	// connection is aborted (Apache mod_reqtimeout's MinRate). Only
+	// takes effect if ReadTimeout is also set.
+	// EXPERIMENTAL. Subject to change/removal.
+	ReadMinRate int64 `json:"read_min_rate,omitempty"`
+
+	// How long to allow a write to the client to stall before aborting
+	// the connection, reset on every successful write (like the
+	// server-wide write_idle_timeout, but scoped to routes matching this
+	// handler). If zero, no idle timeout is applied here.
 	// EXPERIMENTAL. Subject to change/removal.
 	WriteTimeout time.Duration `json:"write_timeout,omitempty"`
+
+	// WriteMinRate is like ReadMinRate, but for writes to the client.
+	// Only takes effect if WriteTimeout is also set.
+	// EXPERIMENTAL. Subject to change/removal.
+	WriteMinRate int64 `json:"write_min_rate,omitempty"`
+
+	// MaxWriteChunk bounds how many bytes a single underlying write
+	// operation is allowed to cover, so WriteTimeout/WriteMinRate can
+	// actually apply between chunks of a large response instead of
+	// being bounded by one deadline for the whole thing. If zero,
+	// caddyhttp.DefaultMaxWriteChunk is used.
+	// EXPERIMENTAL. Subject to change/removal.
+	MaxWriteChunk int `json:"max_write_chunk,omitempty"`
 
 	// This field permit to replace body on the fly
 	// EXPERIMENTAL. Subject to change/removal.
@@ -86,18 +113,30 @@ func (rb RequestBody) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	if rb.ReadTimeout > 0 || rb.WriteTimeout > 0 {
 		//nolint:bodyclose
 		rc := http.NewResponseController(w)
+		start := time.Now()
 		if rb.ReadTimeout > 0 {
-			if err := rc.SetReadDeadline(time.Now().Add(rb.ReadTimeout)); err != nil {
-				if c := rb.logger.Check(zapcore.ErrorLevel, "could not set read deadline"); c != nil {
-					c.Write(zap.Error(err))
-				}
+			r.Body = &caddyhttp.IdleTimeoutReader{
+				ReadCloser: r.Body,
+				Ctrl:       rc,
+				Deadline: caddyhttp.IdleDeadline{
+					Start:   start,
+					Timeout: rb.ReadTimeout,
+					MinRate: rb.ReadMinRate,
+				},
+				Logger: rb.logger,
 			}
 		}
 		if rb.WriteTimeout > 0 {
-			if err := rc.SetWriteDeadline(time.Now().Add(rb.WriteTimeout)); err != nil {
-				if c := rb.logger.Check(zapcore.ErrorLevel, "could not set write deadline"); c != nil {
-					c.Write(zap.Error(err))
-				}
+			w = &caddyhttp.IdleTimeoutWriter{
+				ResponseWriterWrapper: &caddyhttp.ResponseWriterWrapper{ResponseWriter: w},
+				Ctrl:                  rc,
+				Deadline: caddyhttp.IdleDeadline{
+					Start:   start,
+					Timeout: rb.WriteTimeout,
+					MinRate: rb.WriteMinRate,
+				},
+				MaxChunk: rb.MaxWriteChunk,
+				Logger:   rb.logger,
 			}
 		}
 	}

--- a/modules/caddyhttp/requestbody/requestbody.go
+++ b/modules/caddyhttp/requestbody/requestbody.go
@@ -19,9 +19,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"time"
-
-	"go.uber.org/zap"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
@@ -37,45 +34,9 @@ type RequestBody struct {
 	// If more bytes are read, an error with HTTP status 413 is returned.
 	MaxSize int64 `json:"max_size,omitempty"`
 
-	// How long to allow a read from the request body to stall before
-	// aborting the connection, reset on every successful read (like the
-	// server-wide read_idle_timeout, but scoped to routes matching this
-	// handler). If zero, no idle timeout is applied here.
-	// EXPERIMENTAL. Subject to change/removal.
-	ReadTimeout time.Duration `json:"read_timeout,omitempty"`
-
-	// ReadMinRate requires the client to sustain at least this many
-	// bytes/second, averaged from the start of the read, or the
-	// connection is aborted (Apache mod_reqtimeout's MinRate). Only
-	// takes effect if ReadTimeout is also set.
-	// EXPERIMENTAL. Subject to change/removal.
-	ReadMinRate int64 `json:"read_min_rate,omitempty"`
-
-	// How long to allow a write to the client to stall before aborting
-	// the connection, reset on every successful write (like the
-	// server-wide write_idle_timeout, but scoped to routes matching this
-	// handler). If zero, no idle timeout is applied here.
-	// EXPERIMENTAL. Subject to change/removal.
-	WriteTimeout time.Duration `json:"write_timeout,omitempty"`
-
-	// WriteMinRate is like ReadMinRate, but for writes to the client.
-	// Only takes effect if WriteTimeout is also set.
-	// EXPERIMENTAL. Subject to change/removal.
-	WriteMinRate int64 `json:"write_min_rate,omitempty"`
-
-	// MaxWriteChunk bounds how many bytes a single underlying write
-	// operation is allowed to cover, so WriteTimeout/WriteMinRate can
-	// actually apply between chunks of a large response instead of
-	// being bounded by one deadline for the whole thing. If zero,
-	// caddyhttp.DefaultMaxWriteChunk is used.
-	// EXPERIMENTAL. Subject to change/removal.
-	MaxWriteChunk int `json:"max_write_chunk,omitempty"`
-
 	// This field permit to replace body on the fly
 	// EXPERIMENTAL. Subject to change/removal.
 	Set string `json:"set,omitempty"`
-
-	logger *zap.Logger
 }
 
 // CaddyModule returns the Caddy module information.
@@ -84,11 +45,6 @@ func (RequestBody) CaddyModule() caddy.ModuleInfo {
 		ID:  "http.handlers.request_body",
 		New: func() caddy.Module { return new(RequestBody) },
 	}
-}
-
-func (rb *RequestBody) Provision(ctx caddy.Context) error {
-	rb.logger = ctx.Logger()
-	return nil
 }
 
 func (rb RequestBody) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
@@ -109,36 +65,6 @@ func (rb RequestBody) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	}
 	if rb.MaxSize > 0 {
 		r.Body = errorWrapper{http.MaxBytesReader(w, r.Body, rb.MaxSize)}
-	}
-	if rb.ReadTimeout > 0 || rb.WriteTimeout > 0 {
-		//nolint:bodyclose
-		rc := http.NewResponseController(w)
-		start := time.Now()
-		if rb.ReadTimeout > 0 {
-			r.Body = &caddyhttp.IdleTimeoutReader{
-				ReadCloser: r.Body,
-				Ctrl:       rc,
-				Deadline: caddyhttp.IdleDeadline{
-					Start:   start,
-					Timeout: rb.ReadTimeout,
-					MinRate: rb.ReadMinRate,
-				},
-				Logger: rb.logger,
-			}
-		}
-		if rb.WriteTimeout > 0 {
-			w = &caddyhttp.IdleTimeoutWriter{
-				ResponseWriterWrapper: &caddyhttp.ResponseWriterWrapper{ResponseWriter: w},
-				Ctrl:                  rc,
-				Deadline: caddyhttp.IdleDeadline{
-					Start:   start,
-					Timeout: rb.WriteTimeout,
-					MinRate: rb.WriteMinRate,
-				},
-				MaxChunk: rb.MaxWriteChunk,
-				Logger:   rb.logger,
-			}
-		}
 	}
 	return next.ServeHTTP(w, r)
 }

--- a/modules/caddyhttp/requestbody/requestbody_test.go
+++ b/modules/caddyhttp/requestbody/requestbody_test.go
@@ -1,0 +1,108 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package requestbody
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+// pacedReader emits chunkCount chunks of chunkSize bytes, sleeping delay
+// before each one, simulating a client that trickles a request body.
+type pacedReader struct {
+	delay      time.Duration
+	chunkSize  int
+	chunkCount int
+}
+
+func (p *pacedReader) Read(b []byte) (int, error) {
+	if p.chunkCount <= 0 {
+		return 0, io.EOF
+	}
+	time.Sleep(p.delay)
+	p.chunkCount--
+	n := copy(b, make([]byte, p.chunkSize))
+	return n, nil
+}
+
+// noError adapts a caddyhttp.Handler to a plain http.Handler for httptest.NewServer.
+func noError(h caddyhttp.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := h.ServeHTTP(w, r); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}
+
+func TestRequestBody_ReadTimeoutIsIdleReset(t *testing.T) {
+	const timeout = 150 * time.Millisecond
+
+	rb := RequestBody{ReadTimeout: timeout}
+	rb.logger = zap.NewNop()
+
+	srv := httptest.NewServer(noError(caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return rb.ServeHTTP(w, r, caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+			_, err := io.Copy(io.Discard, r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusRequestTimeout)
+				return nil
+			}
+			w.WriteHeader(http.StatusOK)
+			return nil
+		}))
+	})))
+	defer srv.Close()
+
+	// each gap is well under timeout, but the cumulative transfer time
+	// is well over it; a hard (non-idle-reset) deadline would kill this
+	body := &pacedReader{delay: timeout / 4, chunkSize: 8, chunkCount: 8}
+	resp, err := http.Post(srv.URL, "application/octet-stream", body)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestRequestBody_WriteMaxChunkOverride(t *testing.T) {
+	const size = 10000
+	const maxChunk = 100
+
+	rb := RequestBody{WriteTimeout: time.Second, MaxWriteChunk: maxChunk}
+	rb.logger = zap.NewNop()
+
+	srv := httptest.NewServer(noError(caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return rb.ServeHTTP(w, r, caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+			_, err := w.Write(make([]byte, size))
+			return err
+		}))
+	})))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	n, err := io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	assert.EqualValues(t, size, n)
+}

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -60,24 +60,38 @@ type Server struct {
 	// of the base packet conn. They are applied in the given order.
 	PacketConnWrappersRaw []json.RawMessage `json:"packet_conn_wrappers,omitempty" caddy:"namespace=caddy.packetconns inline_key=wrapper"`
 
-	// How long to allow a read from a client's upload to stall before
-	// aborting the connection. The deadline is pushed forward on every
-	// successful read, so this mitigates slowloris-style attacks
-	// without penalizing large uploads from legitimately slow clients.
-	// Default is 1 minute.
+	// How long to allow a read from a client's upload. Setting this
+	// to a short, non-zero value can mitigate slowloris attacks, but
+	// may also affect legitimately slow clients.
 	ReadTimeout caddy.Duration `json:"read_timeout,omitempty"`
 
 	// ReadHeaderTimeout is like ReadTimeout but for request headers.
 	// Default is 1 minute.
 	ReadHeaderTimeout caddy.Duration `json:"read_header_timeout,omitempty"`
 
-	// How long to allow a write to a client to stall before aborting
-	// the connection. Like ReadTimeout, the deadline is pushed forward
-	// on every successful write, so a handler that streams a large
-	// response, or pauses between writes (e.g. SSE), is unaffected as
-	// long as each individual write keeps making progress.
+	// How long to allow a read from a client's upload to stall before
+	// aborting the connection, reset on every successful read. Unlike
+	// ReadTimeout, which bounds the whole transfer with a single
+	// deadline, this only fires if the connection actually stalls, so
+	// it mitigates slowloris-style attacks without penalizing large
+	// uploads from legitimately slow clients. Combine with ReadTimeout
+	// for a hard ceiling on top.
 	// Default is 1 minute.
+	ReadIdleTimeout caddy.Duration `json:"read_idle_timeout,omitempty"`
+
+	// WriteTimeout is how long to allow a write to a client. Note
+	// that setting this to a small value when serving large files
+	// may negatively affect legitimately slow clients.
 	WriteTimeout caddy.Duration `json:"write_timeout,omitempty"`
+
+	// How long to allow a write to a client to stall before aborting
+	// the connection, reset on every successful write, the same way
+	// ReadIdleTimeout works for reads. A handler that streams a large
+	// response, or pauses between writes (e.g. SSE), is unaffected as
+	// long as each individual write keeps making progress. Combine
+	// with WriteTimeout for a hard ceiling on top.
+	// Default is 1 minute.
+	WriteIdleTimeout caddy.Duration `json:"write_idle_timeout,omitempty"`
 
 	// IdleTimeout is the maximum time to wait for the next request
 	// when keep-alives are enabled. If zero, a default timeout of
@@ -449,19 +463,19 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// reset on every successful read/write, so this doesn't affect
 	// legitimately slow clients as long as they keep making progress
 	rc := http.NewResponseController(w)
-	if s.ReadTimeout > 0 && r.Body != nil {
+	if s.ReadIdleTimeout > 0 && r.Body != nil {
 		r.Body = &idleTimeoutReader{
 			ReadCloser: r.Body,
 			ctrl:       rc,
-			timeout:    time.Duration(s.ReadTimeout),
+			timeout:    time.Duration(s.ReadIdleTimeout),
 			logger:     s.logger,
 		}
 	}
-	if s.WriteTimeout > 0 {
+	if s.WriteIdleTimeout > 0 {
 		w = &idleTimeoutWriter{
 			ResponseWriterWrapper: &ResponseWriterWrapper{ResponseWriter: w},
 			ctrl:                  rc,
-			timeout:               time.Duration(s.WriteTimeout),
+			timeout:               time.Duration(s.WriteIdleTimeout),
 			logger:                s.logger,
 		}
 	}

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -105,6 +105,13 @@ type Server struct {
 	// WriteMinRate is like ReadMinRate, but for writes to the client.
 	WriteMinRate int64 `json:"write_min_rate,omitempty"`
 
+	// MaxWriteChunk bounds how many bytes a single underlying write
+	// operation is allowed to cover, so that WriteIdleTimeout/WriteMinRate
+	// can actually apply between chunks of a large response instead of
+	// being bounded by one deadline for the whole thing (nginx's
+	// sendfile_max_chunk exists for the same reason). Default: 64 KiB.
+	MaxWriteChunk int `json:"max_write_chunk,omitempty"`
+
 	// IdleTimeout is the maximum time to wait for the next request
 	// when keep-alives are enabled. If zero, a default timeout of
 	// 5m is applied to help avoid resource exhaustion.
@@ -487,29 +494,30 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeHardDeadline = start.Add(time.Duration(s.WriteTimeout))
 	}
 	if s.ReadIdleTimeout > 0 && r.Body != nil {
-		r.Body = &idleTimeoutReader{
+		r.Body = &IdleTimeoutReader{
 			ReadCloser: r.Body,
-			ctrl:       rc,
-			deadline: idleDeadline{
-				start:        start,
-				timeout:      time.Duration(s.ReadIdleTimeout),
-				minRate:      s.ReadMinRate,
-				hardDeadline: readHardDeadline,
+			Ctrl:       rc,
+			Deadline: IdleDeadline{
+				Start:        start,
+				Timeout:      time.Duration(s.ReadIdleTimeout),
+				MinRate:      s.ReadMinRate,
+				HardDeadline: readHardDeadline,
 			},
-			logger: s.logger,
+			Logger: s.logger,
 		}
 	}
 	if s.WriteIdleTimeout > 0 {
-		w = &idleTimeoutWriter{
+		w = &IdleTimeoutWriter{
 			ResponseWriterWrapper: &ResponseWriterWrapper{ResponseWriter: w},
-			ctrl:                  rc,
-			deadline: idleDeadline{
-				start:        start,
-				timeout:      time.Duration(s.WriteIdleTimeout),
-				minRate:      s.WriteMinRate,
-				hardDeadline: writeHardDeadline,
+			Ctrl:                  rc,
+			Deadline: IdleDeadline{
+				Start:        start,
+				Timeout:      time.Duration(s.WriteIdleTimeout),
+				MinRate:      s.WriteMinRate,
+				HardDeadline: writeHardDeadline,
 			},
-			logger: s.logger,
+			MaxChunk: s.MaxWriteChunk,
+			Logger:   s.logger,
 		}
 	}
 

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -60,18 +60,23 @@ type Server struct {
 	// of the base packet conn. They are applied in the given order.
 	PacketConnWrappersRaw []json.RawMessage `json:"packet_conn_wrappers,omitempty" caddy:"namespace=caddy.packetconns inline_key=wrapper"`
 
-	// How long to allow a read from a client's upload. Setting this
-	// to a short, non-zero value can mitigate slowloris attacks, but
-	// may also affect legitimately slow clients.
+	// How long to allow a read from a client's upload to stall before
+	// aborting the connection. The deadline is pushed forward on every
+	// successful read, so this mitigates slowloris-style attacks
+	// without penalizing large uploads from legitimately slow clients.
+	// Default is 1 minute.
 	ReadTimeout caddy.Duration `json:"read_timeout,omitempty"`
 
 	// ReadHeaderTimeout is like ReadTimeout but for request headers.
 	// Default is 1 minute.
 	ReadHeaderTimeout caddy.Duration `json:"read_header_timeout,omitempty"`
 
-	// WriteTimeout is how long to allow a write to a client. Note
-	// that setting this to a small value when serving large files
-	// may negatively affect legitimately slow clients.
+	// How long to allow a write to a client to stall before aborting
+	// the connection. Like ReadTimeout, the deadline is pushed forward
+	// on every successful write, so a handler that streams a large
+	// response, or pauses between writes (e.g. SSE), is unaffected as
+	// long as each individual write keeps making progress.
+	// Default is 1 minute.
 	WriteTimeout caddy.Duration `json:"write_timeout,omitempty"`
 
 	// IdleTimeout is the maximum time to wait for the next request
@@ -435,6 +440,29 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if c := s.logger.Check(zapcore.WarnLevel, "failed to enable full duplex"); c != nil {
 				c.Write(zap.Error(err))
 			}
+		}
+	}
+
+	// guard against slowloris-style attacks by aborting the connection
+	// if a read from the request body or a write to the response
+	// stalls for longer than the configured timeout; the deadline is
+	// reset on every successful read/write, so this doesn't affect
+	// legitimately slow clients as long as they keep making progress
+	rc := http.NewResponseController(w)
+	if s.ReadTimeout > 0 && r.Body != nil {
+		r.Body = &idleTimeoutReader{
+			ReadCloser: r.Body,
+			ctrl:       rc,
+			timeout:    time.Duration(s.ReadTimeout),
+			logger:     s.logger,
+		}
+	}
+	if s.WriteTimeout > 0 {
+		w = &idleTimeoutWriter{
+			ResponseWriterWrapper: &ResponseWriterWrapper{ResponseWriter: w},
+			ctrl:                  rc,
+			timeout:               time.Duration(s.WriteTimeout),
+			logger:                s.logger,
 		}
 	}
 

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -461,14 +461,26 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// if a read from the request body or a write to the response
 	// stalls for longer than the configured timeout; the deadline is
 	// reset on every successful read/write, so this doesn't affect
-	// legitimately slow clients as long as they keep making progress
+	// legitimately slow clients as long as they keep making progress.
+	// hardDeadline, anchored to this handler's start, caps how far
+	// that reset can push the deadline out, so an explicitly configured
+	// ReadTimeout/WriteTimeout ceiling still applies on top instead of
+	// being silently overwritten by the first read/write.
 	rc := http.NewResponseController(w)
+	var readHardDeadline, writeHardDeadline time.Time
+	if s.ReadTimeout > 0 {
+		readHardDeadline = start.Add(time.Duration(s.ReadTimeout))
+	}
+	if s.WriteTimeout > 0 {
+		writeHardDeadline = start.Add(time.Duration(s.WriteTimeout))
+	}
 	if s.ReadIdleTimeout > 0 && r.Body != nil {
 		r.Body = &idleTimeoutReader{
-			ReadCloser: r.Body,
-			ctrl:       rc,
-			timeout:    time.Duration(s.ReadIdleTimeout),
-			logger:     s.logger,
+			ReadCloser:   r.Body,
+			ctrl:         rc,
+			timeout:      time.Duration(s.ReadIdleTimeout),
+			hardDeadline: readHardDeadline,
+			logger:       s.logger,
 		}
 	}
 	if s.WriteIdleTimeout > 0 {
@@ -476,6 +488,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			ResponseWriterWrapper: &ResponseWriterWrapper{ResponseWriter: w},
 			ctrl:                  rc,
 			timeout:               time.Duration(s.WriteIdleTimeout),
+			hardDeadline:          writeHardDeadline,
 			logger:                s.logger,
 		}
 	}

--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -79,6 +79,15 @@ type Server struct {
 	// Default is 1 minute.
 	ReadIdleTimeout caddy.Duration `json:"read_idle_timeout,omitempty"`
 
+	// ReadMinRate, if set, requires the client to sustain at least this
+	// many bytes/second, averaged from the start of the request body
+	// read, or the connection is aborted. Unlike ReadIdleTimeout alone,
+	// this also catches a trickle that sends just enough to never go
+	// idle, but never accumulates real throughput (a "MinRate" in
+	// Apache mod_reqtimeout terms). If zero, no rate is enforced and
+	// ReadIdleTimeout resets to a flat window on every read instead.
+	ReadMinRate int64 `json:"read_min_rate,omitempty"`
+
 	// WriteTimeout is how long to allow a write to a client. Note
 	// that setting this to a small value when serving large files
 	// may negatively affect legitimately slow clients.
@@ -92,6 +101,9 @@ type Server struct {
 	// with WriteTimeout for a hard ceiling on top.
 	// Default is 1 minute.
 	WriteIdleTimeout caddy.Duration `json:"write_idle_timeout,omitempty"`
+
+	// WriteMinRate is like ReadMinRate, but for writes to the client.
+	WriteMinRate int64 `json:"write_min_rate,omitempty"`
 
 	// IdleTimeout is the maximum time to wait for the next request
 	// when keep-alives are enabled. If zero, a default timeout of
@@ -476,20 +488,28 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if s.ReadIdleTimeout > 0 && r.Body != nil {
 		r.Body = &idleTimeoutReader{
-			ReadCloser:   r.Body,
-			ctrl:         rc,
-			timeout:      time.Duration(s.ReadIdleTimeout),
-			hardDeadline: readHardDeadline,
-			logger:       s.logger,
+			ReadCloser: r.Body,
+			ctrl:       rc,
+			deadline: idleDeadline{
+				start:        start,
+				timeout:      time.Duration(s.ReadIdleTimeout),
+				minRate:      s.ReadMinRate,
+				hardDeadline: readHardDeadline,
+			},
+			logger: s.logger,
 		}
 	}
 	if s.WriteIdleTimeout > 0 {
 		w = &idleTimeoutWriter{
 			ResponseWriterWrapper: &ResponseWriterWrapper{ResponseWriter: w},
 			ctrl:                  rc,
-			timeout:               time.Duration(s.WriteIdleTimeout),
-			hardDeadline:          writeHardDeadline,
-			logger:                s.logger,
+			deadline: idleDeadline{
+				start:        start,
+				timeout:      time.Duration(s.WriteIdleTimeout),
+				minRate:      s.WriteMinRate,
+				hardDeadline: writeHardDeadline,
+			},
+			logger: s.logger,
 		}
 	}
 

--- a/modules/caddyhttp/standard/imports.go
+++ b/modules/caddyhttp/standard/imports.go
@@ -21,5 +21,6 @@ import (
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy/forwardauth"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/rewrite"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/templates"
+	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/timeouts"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/tracing"
 )

--- a/modules/caddyhttp/timeouts/caddyfile.go
+++ b/modules/caddyhttp/timeouts/caddyfile.go
@@ -1,0 +1,92 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timeouts
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/dustin/go-humanize"
+
+	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+func init() {
+	httpcaddyfile.RegisterHandlerDirective("timeouts", parseCaddyfile)
+}
+
+func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
+	h.Next() // consume directive name
+
+	t := new(Timeouts)
+
+	// configuration should be in a block
+	for h.NextBlock(0) {
+		switch h.Val() {
+		case "read_timeout":
+			args := h.RemainingArgs()
+			if len(args) < 1 || len(args) > 2 {
+				return nil, h.ArgErr()
+			}
+			timeout, err := time.ParseDuration(args[0])
+			if err != nil {
+				return nil, h.Errf("parsing read_timeout: %v", err)
+			}
+			t.ReadTimeout = timeout
+			if len(args) == 2 {
+				rate, err := strconv.ParseInt(args[1], 10, 64)
+				if err != nil {
+					return nil, h.Errf("parsing read_timeout min_rate: %v", err)
+				}
+				t.ReadMinRate = rate
+			}
+
+		case "write_timeout":
+			args := h.RemainingArgs()
+			if len(args) < 1 || len(args) > 2 {
+				return nil, h.ArgErr()
+			}
+			timeout, err := time.ParseDuration(args[0])
+			if err != nil {
+				return nil, h.Errf("parsing write_timeout: %v", err)
+			}
+			t.WriteTimeout = timeout
+			if len(args) == 2 {
+				rate, err := strconv.ParseInt(args[1], 10, 64)
+				if err != nil {
+					return nil, h.Errf("parsing write_timeout min_rate: %v", err)
+				}
+				t.WriteMinRate = rate
+			}
+
+		case "max_write_chunk":
+			var sizeStr string
+			if !h.AllArgs(&sizeStr) {
+				return nil, h.ArgErr()
+			}
+			size, err := humanize.ParseBytes(sizeStr)
+			if err != nil {
+				return nil, h.Errf("parsing max_write_chunk: %v", err)
+			}
+			t.MaxWriteChunk = int(size)
+
+		default:
+			return nil, h.Errf("unrecognized timeouts subdirective '%s'", h.Val())
+		}
+	}
+
+	return t, nil
+}

--- a/modules/caddyhttp/timeouts/timeouts.go
+++ b/modules/caddyhttp/timeouts/timeouts.go
@@ -1,0 +1,127 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timeouts
+
+import (
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+func init() {
+	caddy.RegisterModule(Timeouts{})
+}
+
+// Timeouts is a middleware that applies read/write idle timeouts, minimum
+// transfer rates, and a write chunk size cap to routes matching this
+// handler, independent of the server-wide equivalents.
+type Timeouts struct {
+	// How long to allow a read from the request body to stall before
+	// aborting the connection, reset on every successful read (like the
+	// server-wide read_idle_timeout, but scoped to routes matching this
+	// handler). If zero, no idle timeout is applied here.
+	// EXPERIMENTAL. Subject to change/removal.
+	ReadTimeout time.Duration `json:"read_timeout,omitempty"`
+
+	// ReadMinRate requires the client to sustain at least this many
+	// bytes/second, averaged from the start of the read, or the
+	// connection is aborted (Apache mod_reqtimeout's MinRate). Only
+	// takes effect if ReadTimeout is also set.
+	// EXPERIMENTAL. Subject to change/removal.
+	ReadMinRate int64 `json:"read_min_rate,omitempty"`
+
+	// How long to allow a write to the client to stall before aborting
+	// the connection, reset on every successful write (like the
+	// server-wide write_idle_timeout, but scoped to routes matching this
+	// handler). If zero, no idle timeout is applied here.
+	// EXPERIMENTAL. Subject to change/removal.
+	WriteTimeout time.Duration `json:"write_timeout,omitempty"`
+
+	// WriteMinRate is like ReadMinRate, but for writes to the client.
+	// Only takes effect if WriteTimeout is also set.
+	// EXPERIMENTAL. Subject to change/removal.
+	WriteMinRate int64 `json:"write_min_rate,omitempty"`
+
+	// MaxWriteChunk bounds how many bytes a single underlying write
+	// operation is allowed to cover, so WriteTimeout/WriteMinRate can
+	// actually apply between chunks of a large response instead of
+	// being bounded by one deadline for the whole thing. If zero,
+	// caddyhttp.DefaultMaxWriteChunk is used.
+	// EXPERIMENTAL. Subject to change/removal.
+	MaxWriteChunk int `json:"max_write_chunk,omitempty"`
+
+	logger *zap.Logger
+}
+
+// CaddyModule returns the Caddy module information.
+func (Timeouts) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "http.handlers.timeouts",
+		New: func() caddy.Module { return new(Timeouts) },
+	}
+}
+
+func (t *Timeouts) Provision(ctx caddy.Context) error {
+	t.logger = ctx.Logger()
+	return nil
+}
+
+func (t Timeouts) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
+	if t.ReadTimeout <= 0 && t.WriteTimeout <= 0 {
+		return next.ServeHTTP(w, r)
+	}
+
+	//nolint:bodyclose
+	rc := http.NewResponseController(w)
+	start := time.Now()
+
+	if t.ReadTimeout > 0 && r.Body != nil {
+		r.Body = &caddyhttp.IdleTimeoutReader{
+			ReadCloser: r.Body,
+			Ctrl:       rc,
+			Deadline: caddyhttp.IdleDeadline{
+				Start:   start,
+				Timeout: t.ReadTimeout,
+				MinRate: t.ReadMinRate,
+			},
+			Logger: t.logger,
+		}
+	}
+	if t.WriteTimeout > 0 {
+		w = &caddyhttp.IdleTimeoutWriter{
+			ResponseWriterWrapper: &caddyhttp.ResponseWriterWrapper{ResponseWriter: w},
+			Ctrl:                  rc,
+			Deadline: caddyhttp.IdleDeadline{
+				Start:   start,
+				Timeout: t.WriteTimeout,
+				MinRate: t.WriteMinRate,
+			},
+			MaxChunk: t.MaxWriteChunk,
+			Logger:   t.logger,
+		}
+	}
+
+	return next.ServeHTTP(w, r)
+}
+
+// Interface guards
+var (
+	_ caddy.Provisioner           = (*Timeouts)(nil)
+	_ caddyhttp.MiddlewareHandler = (*Timeouts)(nil)
+)

--- a/modules/caddyhttp/timeouts/timeouts_test.go
+++ b/modules/caddyhttp/timeouts/timeouts_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package requestbody
+package timeouts
 
 import (
 	"io"
@@ -55,14 +55,14 @@ func noError(h caddyhttp.Handler) http.HandlerFunc {
 	}
 }
 
-func TestRequestBody_ReadTimeoutIsIdleReset(t *testing.T) {
+func TestTimeouts_ReadTimeoutIsIdleReset(t *testing.T) {
 	const timeout = 150 * time.Millisecond
 
-	rb := RequestBody{ReadTimeout: timeout}
-	rb.logger = zap.NewNop()
+	tm := Timeouts{ReadTimeout: timeout}
+	tm.logger = zap.NewNop()
 
 	srv := httptest.NewServer(noError(caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-		return rb.ServeHTTP(w, r, caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return tm.ServeHTTP(w, r, caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 			_, err := io.Copy(io.Discard, r.Body)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusRequestTimeout)
@@ -83,15 +83,15 @@ func TestRequestBody_ReadTimeoutIsIdleReset(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestRequestBody_WriteMaxChunkOverride(t *testing.T) {
+func TestTimeouts_WriteMaxChunkOverride(t *testing.T) {
 	const size = 10000
 	const maxChunk = 100
 
-	rb := RequestBody{WriteTimeout: time.Second, MaxWriteChunk: maxChunk}
-	rb.logger = zap.NewNop()
+	tm := Timeouts{WriteTimeout: time.Second, MaxWriteChunk: maxChunk}
+	tm.logger = zap.NewNop()
 
 	srv := httptest.NewServer(noError(caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-		return rb.ServeHTTP(w, r, caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return tm.ServeHTTP(w, r, caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 			_, err := w.Write(make([]byte, size))
 			return err
 		}))


### PR DESCRIPTION
## Summary

Adds `ReadIdleTimeout`/`WriteIdleTimeout` (`read_idle_timeout`/`write_idle_timeout` in JSON, `read_body_idle`/`write_idle` in the Caddyfile `timeouts` block), reset on every successful read/write via `http.ResponseController`. A stalled connection is killed; a slow-but-progressing one isn't — matching nginx's `client_body_timeout`/`send_timeout` semantics.

The existing `ReadTimeout`/`WriteTimeout` fields are untouched: same hard-deadline-over-the-whole-transfer semantics, same default (0/unbounded) as before. No behavior change for existing configs. Combine an idle timeout with its hard counterpart for a ceiling on top — the idle-reset deadline is capped so it can't silently push past an explicitly configured `ReadTimeout`/`WriteTimeout`.

Also adds `ReadMinRate`/`WriteMinRate` (bytes/second, 0 = disabled), matching Apache `mod_reqtimeout`'s `MinRate`. Idle-reset alone doesn't bound a client that trickles just enough data to never go idle; with a min rate set, the allowed deadline grows from a fixed start based on bytes transferred so far instead of resetting to a flat window on every call, so a transfer that doesn't sustain the configured rate falls behind real time and gets cut, even though no single read/write ever stalls. In the Caddyfile, min rate is a second, optional argument on the idle-timeout directive rather than a separate one: `read_body_idle 60s 100`/`write_idle 60s 100`.

All new fields default to 1 minute (idle) / 0 (min rate, opt-in) — safe to default the idle timeouts since they're new fields, so no existing config could have depended on a different value.

### Write chunking

`SetWriteDeadline` bounds the whole call it precedes, not just a stall within it: `net.Conn.Write` loops internally until a buffer is fully sent, and `ResponseWriter.ReadFrom` hands the entire remaining source to the connection in one call (sendfile or an internal buffered copy loop — the latter always for TLS, since `*tls.Conn` isn't an `io.ReaderFrom`). Without chunking, a single large `Write`, or any response body copied via `io.Copy` triggering the `ReadFrom` fast path (`http.ServeContent`, static file serving), had its whole transfer bounded by one deadline — silently truncating a slow-but-healthy transfer exactly like a hard `WriteTimeout` would. This is the same bug independently found and fixed the same way in FrankenPHP's `go_ub_write` ([php/frankenphp#2574](https://github.com/php/frankenphp/pull/2574)), and nginx hit it historically too (`sendfile_max_chunk`, added after a single fast connection could seize a worker process entirely).

Fixed by capping each underlying `Write`/`ReadFrom` call and resetting the deadline between chunks. The cap is configurable (`MaxWriteChunk`/`max_write_chunk` on `Server`, `write_max_chunk` in the Caddyfile `timeouts` block), defaulting to 64 KiB — matching nginx's own tunable `sendfile_max_chunk`. `net/sendfile.go` special-cases `*io.LimitedReader`, so chunked `ReadFrom` still gets the sendfile fast path per chunk.

### Per-route granularity

New `timeouts` handler (`http.handlers.timeouts`, Caddyfile directive `timeouts`) applies the same idle-reset `ReadTimeout`/`WriteTimeout`/`ReadMinRate`/`WriteMinRate`/`MaxWriteChunk` per-route, independent of the rest of the server block — matching nginx's `location{}` and Apache's `<Directory>` scoping. Same Caddyfile shape as the server-wide option: `read_timeout 60s 100`/`write_timeout 60s 100` take the min rate as an optional second argument.

Kept separate from `request_body` rather than bolted onto it: `request_body` is about the request body specifically (`max_size`, `set`), while write-side pacing is a response concern that has nothing to do with the request body. A dedicated handler keeps that boundary clean and mirrors the server-wide `timeouts` option one level down.

Covers HTTP/1.1, HTTP/2, and HTTP/3 (quic-go's `http3.responseWriter` implements `SetReadDeadline`/`SetWriteDeadline` directly, on the same stream used for the request body).

## Assistance Disclosure

This PR has been designed and reviewed by me, the code has been written by Claude Code.
