### PR TITLE
caddyfile: support site-specific ECH configuration

### DIFF
--- a/caddyconfig/httpcaddyfile/builtins.go
+++ b/caddyconfig/httpcaddyfile/builtins.go
@@ -114,6 +114,7 @@ func parseBind(h Helper) ([]ConfigValue, error) {
 //	    get_certificate               <module_name> [...]
 //	    insecure_secrets_log          <log_file>
 //	    renewal_window_ratio          <ratio>
+//	    ech                           <public_names...>
 //	}
 func parseTLS(h Helper) ([]ConfigValue, error) {
 	h.Next() // consume directive name
@@ -131,6 +132,7 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 	var reusePrivateKeys bool
 	var forceAutomate bool
 	var renewalWindowRatio float64
+	var ech *caddytls.ECH
 
 	// Track which DNS challenge options are set
 	var dnsOptionsSet []string
@@ -489,6 +491,13 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 			}
 			renewalWindowRatio = ratio
 
+		case "ech":
+			var err error
+			ech, err = parseECH(h.NewFromNextSegment())
+			if err != nil {
+				return nil, err
+			}
+
 		default:
 			return nil, h.Errf("unknown subdirective: %s", h.Val())
 		}
@@ -606,6 +615,13 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 		})
 	}
 
+	if ech != nil {
+		configVals = append(configVals, ConfigValue{
+			Class: tlsECHClass,
+			Value: ech,
+		})
+	}
+
 	// if enabled, the names in the site addresses will be
 	// added to the automation policies
 	if forceAutomate {
@@ -632,6 +648,8 @@ func parseTLS(h Helper) ([]ConfigValue, error) {
 
 	return configVals, nil
 }
+
+const tlsECHClass = "tls.ech"
 
 // parseRoot parses the root directive. Syntax:
 //

--- a/caddyconfig/httpcaddyfile/options.go
+++ b/caddyconfig/httpcaddyfile/options.go
@@ -596,8 +596,11 @@ func parseOptDNS(d *caddyfile.Dispenser, _ any) (any, error) {
 }
 
 func parseOptECH(d *caddyfile.Dispenser, _ any) (any, error) {
-	d.Next() // consume option name
+	return parseECH(d)
+}
 
+func parseECH(d *caddyfile.Dispenser) (*caddytls.ECH, error) {
+	d.Next() // consume option name
 	ech := new(caddytls.ECH)
 
 	publicNames := d.RemainingArgs()

--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -94,9 +94,17 @@ func (st ServerType) buildTLSApp(
 
 	forcedAutomatedNames := make(map[string]struct{}) // explicitly configured to be automated, even if covered by a wildcard
 	globalECHConfigured := false
+	var globalECHConfigs []string
 	if ech, ok := options["ech"].(*caddytls.ECH); ok {
 		tlsApp.EncryptedClientHello = ech
 		globalECHConfigured = true
+		globalECHConfigs = echPublicNames(ech.Configs)
+	}
+	globalECHPublicationCount := 0
+	globalECHDomains := make(map[string]struct{})
+	siteECHConfigured := false
+	if globalECHConfigured {
+		globalECHPublicationCount = len(tlsApp.EncryptedClientHello.Publication)
 	}
 
 	for _, p := range pairings {
@@ -126,21 +134,19 @@ func (st ServerType) buildTLSApp(
 			if len(sblockHosts) == 0 && catchAllAP != nil {
 				ap = catchAllAP
 			}
+			if globalECHConfigured {
+				if _, ok := sblock.pile[tlsECHClass]; ok {
+					siteECHConfigured = true
+				} else {
+					for _, host := range sblockHosts {
+						globalECHDomains[host] = struct{}{}
+					}
+				}
+			}
 
 			if echVals, ok := sblock.pile[tlsECHClass]; ok {
 				if tlsApp.EncryptedClientHello == nil {
 					tlsApp.EncryptedClientHello = new(caddytls.ECH)
-				}
-				if globalECHConfigured && tlsApp.EncryptedClientHello.Publication == nil {
-					tlsApp.EncryptedClientHello.Publication = append(
-						tlsApp.EncryptedClientHello.Publication,
-						newECHPublication(
-							echPublicNames(tlsApp.EncryptedClientHello.Configs),
-							nil,
-							options["dns"],
-							&warnings,
-						),
-					)
 				}
 				for _, echVal := range echVals {
 					siteECH := echVal.Value.(*caddytls.ECH)
@@ -162,10 +168,11 @@ func (st ServerType) buildTLSApp(
 						continue
 					}
 					for _, publication := range siteECH.Publication {
-						publication.Domains = slices.Clone(sblockHosts)
+						publicationCopy := *publication
+						publicationCopy.Domains = slices.Clone(sblockHosts)
 						tlsApp.EncryptedClientHello.Publication = append(
 							tlsApp.EncryptedClientHello.Publication,
-							publication,
+							&publicationCopy,
 						)
 					}
 				}
@@ -339,6 +346,38 @@ func (st ServerType) buildTLSApp(
 					certLoaders = append(certLoaders, clVal.Value.(caddytls.CertificateLoader))
 				}
 			}
+		}
+	}
+	if globalECHConfigured && siteECHConfigured {
+		domains := make([]string, 0, len(globalECHDomains))
+		for domain := range globalECHDomains {
+			domains = append(domains, domain)
+		}
+		if globalECHPublicationCount == 0 {
+			if len(domains) > 0 {
+				tlsApp.EncryptedClientHello.Publication = append(
+					tlsApp.EncryptedClientHello.Publication,
+					newECHPublication(
+						globalECHConfigs,
+						domains,
+						options["dns"],
+						&warnings,
+					),
+				)
+			}
+		} else {
+			publications := make([]*caddytls.ECHPublication, 0, len(tlsApp.EncryptedClientHello.Publication))
+			for _, publication := range tlsApp.EncryptedClientHello.Publication[:globalECHPublicationCount] {
+				if publication.Domains == nil {
+					if len(domains) == 0 {
+						continue
+					}
+					publication.Domains = slices.Clone(domains)
+				}
+				publications = append(publications, publication)
+			}
+			publications = append(publications, tlsApp.EncryptedClientHello.Publication[globalECHPublicationCount:]...)
+			tlsApp.EncryptedClientHello.Publication = publications
 		}
 	}
 

--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -17,6 +17,7 @@ package httpcaddyfile
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -31,6 +32,12 @@ import (
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
+)
+
+const (
+	echAssignmentNotFound              = -1
+	echAssignmentConflictFormat        = "hostname %s has conflicting ECH assignments"
+	echCatchAllAssignmentConflictError = "catch-all ECH publication has conflicting assignments"
 )
 
 func (st ServerType) buildTLSApp(
@@ -135,9 +142,7 @@ func (st ServerType) buildTLSApp(
 				ap = catchAllAP
 			}
 			if globalECHConfigured {
-				if _, ok := sblock.pile[tlsECHClass]; ok {
-					siteECHConfigured = true
-				} else {
+				if _, ok := sblock.pile[tlsECHClass]; !ok {
 					for _, host := range sblockHosts {
 						globalECHDomains[host] = struct{}{}
 					}
@@ -145,6 +150,7 @@ func (st ServerType) buildTLSApp(
 			}
 
 			if echVals, ok := sblock.pile[tlsECHClass]; ok {
+				siteECHConfigured = true
 				if tlsApp.EncryptedClientHello == nil {
 					tlsApp.EncryptedClientHello = new(caddytls.ECH)
 				}
@@ -378,6 +384,15 @@ func (st ServerType) buildTLSApp(
 			}
 			publications = append(publications, tlsApp.EncryptedClientHello.Publication[globalECHPublicationCount:]...)
 			tlsApp.EncryptedClientHello.Publication = publications
+		}
+	}
+	if siteECHConfigured {
+		var err error
+		tlsApp.EncryptedClientHello.Publication, err = consolidateECHPublications(
+			tlsApp.EncryptedClientHello.Publication,
+		)
+		if err != nil {
+			return nil, warnings, err
 		}
 	}
 
@@ -624,6 +639,61 @@ func echPublicNames(configs []caddytls.ECHConfiguration) []string {
 		publicNames = append(publicNames, config.PublicName)
 	}
 	return publicNames
+}
+
+func consolidateECHPublications(
+	publications []*caddytls.ECHPublication,
+) ([]*caddytls.ECHPublication, error) {
+	var consolidated []*caddytls.ECHPublication
+	domainAssignments := make(map[string]int)
+	catchAllAssignment := echAssignmentNotFound
+	for _, publication := range publications {
+		slices.Sort(publication.Configs)
+		assignment := echAssignmentNotFound
+		for i, existing := range consolidated {
+			if slices.Equal(existing.Configs, publication.Configs) &&
+				reflect.DeepEqual(existing.PublishersRaw, publication.PublishersRaw) {
+				assignment = i
+				break
+			}
+		}
+		if assignment == echAssignmentNotFound {
+			publicationCopy := *publication
+			publicationCopy.Configs = slices.Clone(publication.Configs)
+			publicationCopy.Domains = nil
+			consolidated = append(consolidated, &publicationCopy)
+			assignment = len(consolidated) - 1
+		}
+		if len(publication.Domains) == 0 {
+			if catchAllAssignment != echAssignmentNotFound && catchAllAssignment != assignment {
+				return nil, errors.New(echCatchAllAssignmentConflictError)
+			}
+			for domain, previousAssignment := range domainAssignments {
+				if previousAssignment != assignment {
+					return nil, fmt.Errorf(echAssignmentConflictFormat, domain)
+				}
+			}
+			catchAllAssignment = assignment
+			consolidated[assignment].Domains = nil
+			continue
+		}
+		for _, domain := range publication.Domains {
+			if catchAllAssignment != echAssignmentNotFound && catchAllAssignment != assignment {
+				return nil, fmt.Errorf(echAssignmentConflictFormat, domain)
+			}
+			if previousAssignment, ok := domainAssignments[domain]; ok {
+				if previousAssignment != assignment {
+					return nil, fmt.Errorf(echAssignmentConflictFormat, domain)
+				}
+				continue
+			}
+			domainAssignments[domain] = assignment
+			if catchAllAssignment != assignment {
+				consolidated[assignment].Domains = append(consolidated[assignment].Domains, domain)
+			}
+		}
+	}
+	return consolidated, nil
 }
 
 func newECHPublication(

--- a/caddyconfig/httpcaddyfile/tlsapp.go
+++ b/caddyconfig/httpcaddyfile/tlsapp.go
@@ -93,6 +93,11 @@ func (st ServerType) buildTLSApp(
 	}
 
 	forcedAutomatedNames := make(map[string]struct{}) // explicitly configured to be automated, even if covered by a wildcard
+	globalECHConfigured := false
+	if ech, ok := options["ech"].(*caddytls.ECH); ok {
+		tlsApp.EncryptedClientHello = ech
+		globalECHConfigured = true
+	}
 
 	for _, p := range pairings {
 		// avoid setting up TLS automation policies for a server that is HTTP-only
@@ -120,6 +125,50 @@ func (st ServerType) buildTLSApp(
 			sblockHosts := sblock.hostsFromKeys(false)
 			if len(sblockHosts) == 0 && catchAllAP != nil {
 				ap = catchAllAP
+			}
+
+			if echVals, ok := sblock.pile[tlsECHClass]; ok {
+				if tlsApp.EncryptedClientHello == nil {
+					tlsApp.EncryptedClientHello = new(caddytls.ECH)
+				}
+				if globalECHConfigured && tlsApp.EncryptedClientHello.Publication == nil {
+					tlsApp.EncryptedClientHello.Publication = append(
+						tlsApp.EncryptedClientHello.Publication,
+						newECHPublication(
+							echPublicNames(tlsApp.EncryptedClientHello.Configs),
+							nil,
+							options["dns"],
+							&warnings,
+						),
+					)
+				}
+				for _, echVal := range echVals {
+					siteECH := echVal.Value.(*caddytls.ECH)
+					for _, config := range siteECH.Configs {
+						if !slices.Contains(tlsApp.EncryptedClientHello.Configs, config) {
+							tlsApp.EncryptedClientHello.Configs = append(tlsApp.EncryptedClientHello.Configs, config)
+						}
+					}
+					if len(siteECH.Publication) == 0 {
+						tlsApp.EncryptedClientHello.Publication = append(
+							tlsApp.EncryptedClientHello.Publication,
+							newECHPublication(
+								echPublicNames(siteECH.Configs),
+								slices.Clone(sblockHosts),
+								options["dns"],
+								&warnings,
+							),
+						)
+						continue
+					}
+					for _, publication := range siteECH.Publication {
+						publication.Domains = slices.Clone(sblockHosts)
+						tlsApp.EncryptedClientHello.Publication = append(
+							tlsApp.EncryptedClientHello.Publication,
+							publication,
+						)
+					}
+				}
 			}
 
 			// on-demand tls
@@ -339,9 +388,28 @@ func (st ServerType) buildTLSApp(
 		tlsApp.Resolvers = globalResolvers.([]string)
 	}
 
-	// set up ECH from Caddyfile options
-	if ech, ok := options["ech"].(*caddytls.ECH); ok {
-		tlsApp.EncryptedClientHello = ech
+	// ECH outer server names need certificates, so include them in an
+	// automation policy that applies any global options.
+	if ech := tlsApp.EncryptedClientHello; ech != nil {
+		sort.Slice(ech.Configs, func(i, j int) bool {
+			return ech.Configs[i].PublicName < ech.Configs[j].PublicName
+		})
+		for _, publication := range ech.Publication {
+			slices.Sort(publication.Configs)
+			slices.Sort(publication.Domains)
+		}
+		sort.Slice(ech.Publication, func(i, j int) bool {
+			if configsComparison := slices.Compare(
+				ech.Publication[i].Configs,
+				ech.Publication[j].Configs,
+			); configsComparison != 0 {
+				return configsComparison < 0
+			}
+			return slices.Compare(
+				ech.Publication[i].Domains,
+				ech.Publication[j].Domains,
+			) < 0
+		})
 
 		// outer server names will need certificates, so make sure they're included
 		// in an automation policy for them that applies any global options
@@ -509,6 +577,39 @@ func (st ServerType) buildTLSApp(
 	}
 
 	return tlsApp, warnings, nil
+}
+
+func echPublicNames(configs []caddytls.ECHConfiguration) []string {
+	publicNames := make([]string, 0, len(configs))
+	for _, config := range configs {
+		publicNames = append(publicNames, config.PublicName)
+	}
+	return publicNames
+}
+
+func newECHPublication(
+	configs, domains []string,
+	globalDNS any,
+	warnings *[]caddyconfig.Warning,
+) *caddytls.ECHPublication {
+	publication := &caddytls.ECHPublication{
+		Configs: configs,
+		Domains: domains,
+	}
+	if globalDNS != nil {
+		publication.PublishersRaw = echDNSPublisher(globalDNS, warnings)
+	}
+	return publication
+}
+
+func echDNSPublisher(globalDNS any, warnings *[]caddyconfig.Warning) caddy.ModuleMap {
+	dnsModule := globalDNS.(caddy.Module)
+	providerName := dnsModule.CaddyModule().ID.Name()
+	return caddy.ModuleMap{
+		"dns": caddyconfig.JSON(caddytls.ECHDNSPublisher{
+			ProviderRaw: caddyconfig.JSONModuleObject(dnsModule, "name", providerName, warnings),
+		}, warnings),
+	}
 }
 
 type acmeCapable interface{ GetACMEIssuer() *caddytls.ACMEIssuer }

--- a/caddyconfig/httpcaddyfile/tlsapp_test.go
+++ b/caddyconfig/httpcaddyfile/tlsapp_test.go
@@ -163,7 +163,7 @@ unprotected.example.com {
 	if diff := compareECHPublication(
 		ech.Publication[0],
 		[]string{"global-public.example.net"},
-		nil,
+		[]string{"unprotected.example.com"},
 	); diff != "" {
 		t.Fatal(diff)
 	}
@@ -226,6 +226,101 @@ func TestSiteBlockECHWithoutGlobalECH(t *testing.T) {
 	}
 }
 
+func TestSiteBlockECHRestrictsConfiguredGlobalPublication(t *testing.T) {
+	input := `{
+	ech global-public.example.net {
+		dns test
+	}
+}
+
+site.example.com {
+	tls {
+		ech site-public.example.net
+	}
+}
+
+global.example.com {
+}`
+
+	ech := adaptECH(t, input)
+	if len(ech.Publication) != 2 {
+		t.Fatalf("unexpected ECH publication count: got %d, want 2", len(ech.Publication))
+	}
+	if diff := compareECHPublication(
+		ech.Publication[0],
+		[]string{"global-public.example.net"},
+		[]string{"global.example.com"},
+	); diff != "" {
+		t.Fatal(diff)
+	}
+	if diff := compareECHPublication(
+		ech.Publication[1],
+		[]string{"site-public.example.net"},
+		[]string{"site.example.com"},
+	); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestSiteBlockECHOmitGlobalPublicationWithoutDomains(t *testing.T) {
+	input := `{
+	ech global-public.example.net {
+		dns test
+	}
+}
+
+site.example.com {
+	tls {
+		ech site-public.example.net
+	}
+}`
+
+	ech := adaptECH(t, input)
+	if len(ech.Publication) != 1 {
+		t.Fatalf("unexpected ECH publication count: got %d, want 1", len(ech.Publication))
+	}
+	if diff := compareECHPublication(
+		ech.Publication[0],
+		[]string{"site-public.example.net"},
+		[]string{"site.example.com"},
+	); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestSiteBlockECHAcrossListenerAddresses(t *testing.T) {
+	input := `{
+	dns test
+}
+
+https://a.example.com, https://b.example.com:8443 {
+	tls {
+		ech public.example.net {
+			dns test
+		}
+	}
+}`
+
+	ech := adaptECH(t, input)
+	if len(ech.Publication) != 2 {
+		t.Fatalf("unexpected ECH publication count: got %d, want 2", len(ech.Publication))
+	}
+	if diff := compareECHPublication(
+		ech.Publication[0],
+		[]string{"public.example.net"},
+		[]string{"a.example.com"},
+	); diff != "" {
+		t.Fatal(diff)
+	}
+	if diff := compareECHPublication(
+		ech.Publication[1],
+		[]string{"public.example.net"},
+		[]string{"b.example.com"},
+	); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
 func TestSiteBlockECHRequiresPublicName(t *testing.T) {
 	input := `example.com {
 	tls {
@@ -247,6 +342,27 @@ func compareECHPublication(publication *caddytls.ECHPublication, configs, domain
 		return fmt.Sprintf("unexpected publication domains: got %v, want %v", publication.Domains, domains)
 	}
 	return ""
+}
+
+func adaptECH(t *testing.T, input string) *caddytls.ECH {
+	t.Helper()
+	adapter := caddyfile.Adapter{ServerType: ServerType{}}
+	output, _, err := adapter.Adapt([]byte(input), nil)
+	if err != nil {
+		t.Fatalf("adapting Caddyfile: %v", err)
+	}
+	var config struct {
+		Apps struct {
+			TLS *caddytls.TLS `json:"tls"`
+		} `json:"apps"`
+	}
+	if err := json.Unmarshal(output, &config); err != nil {
+		t.Fatalf("unmarshaling adapted config: %v", err)
+	}
+	if config.Apps.TLS == nil || config.Apps.TLS.EncryptedClientHello == nil {
+		t.Fatal("expected ECH configuration")
+	}
+	return config.Apps.TLS.EncryptedClientHello
 }
 
 type testDNSProvider struct{}

--- a/caddyconfig/httpcaddyfile/tlsapp_test.go
+++ b/caddyconfig/httpcaddyfile/tlsapp_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/caddyserver/certmagic"
@@ -157,8 +158,8 @@ unprotected.example.com {
 	if !reflect.DeepEqual(ech.Configs, expectedConfigs) {
 		t.Fatalf("unexpected ECH configurations: got %v, want %v", ech.Configs, expectedConfigs)
 	}
-	if len(ech.Publication) != 4 {
-		t.Fatalf("unexpected ECH publication count: got %d, want 4", len(ech.Publication))
+	if len(ech.Publication) != 3 {
+		t.Fatalf("unexpected ECH publication count: got %d, want 3", len(ech.Publication))
 	}
 	if diff := compareECHPublication(
 		ech.Publication[0],
@@ -180,14 +181,7 @@ unprotected.example.com {
 	if diff := compareECHPublication(
 		ech.Publication[2],
 		[]string{"second-public.example.net"},
-		[]string{"second.example.com"},
-	); diff != "" {
-		t.Fatal(diff)
-	}
-	if diff := compareECHPublication(
-		ech.Publication[3],
-		[]string{"second-public.example.net"},
-		[]string{"shared.example.com"},
+		[]string{"second.example.com", "shared.example.com"},
 	); diff != "" {
 		t.Fatal(diff)
 	}
@@ -302,6 +296,197 @@ https://a.example.com, https://b.example.com:8443 {
 }`
 
 	ech := adaptECH(t, input)
+	if len(ech.Publication) != 1 {
+		t.Fatalf("unexpected ECH publication count: got %d, want 1", len(ech.Publication))
+	}
+	if diff := compareECHPublication(
+		ech.Publication[0],
+		[]string{"public.example.net"},
+		[]string{"a.example.com", "b.example.com"},
+	); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestSiteBlockECHRejectsConflictingAssignments(t *testing.T) {
+	tests := map[string]string{
+		"configs": `example.com {
+	tls {
+		ech first-public.example.net {
+			dns test
+		}
+	}
+}
+
+example.com:8443 {
+	tls {
+		ech second-public.example.net {
+			dns test
+		}
+	}
+}`,
+		"publishers": `example.com {
+	tls {
+		ech public.example.net {
+			dns test
+		}
+	}
+}
+
+example.com:8443 {
+	tls {
+		ech public.example.net
+	}
+}`,
+	}
+
+	adapter := caddyfile.Adapter{ServerType: ServerType{}}
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := adapter.Adapt([]byte(input), nil); err == nil {
+				t.Fatal("expected conflicting ECH assignments for the same hostname to fail")
+			} else if !strings.Contains(err.Error(), "example.com") {
+				t.Fatalf("expected conflict error to identify the hostname, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestSiteBlockECHConsolidatesIdenticalHostAssignment(t *testing.T) {
+	input := `example.com {
+	tls {
+		ech public.example.net {
+			dns test
+		}
+	}
+}
+
+example.com:8443 {
+	tls {
+		ech public.example.net {
+			dns test
+		}
+	}
+}`
+
+	ech := adaptECH(t, input)
+	if len(ech.Publication) != 1 {
+		t.Fatalf("unexpected ECH publication count: got %d, want 1", len(ech.Publication))
+	}
+	if diff := compareECHPublication(
+		ech.Publication[0],
+		[]string{"public.example.net"},
+		[]string{"example.com"},
+	); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestSiteBlockECHPreservesCatchAllAssignment(t *testing.T) {
+	input := `:443 {
+	tls {
+		ech public.example.net {
+			dns test
+		}
+	}
+}
+
+example.com:8443 {
+	tls {
+		ech public.example.net {
+			dns test
+		}
+	}
+}`
+
+	ech := adaptECH(t, input)
+	if len(ech.Publication) != 1 {
+		t.Fatalf("unexpected ECH publication count: got %d, want 1", len(ech.Publication))
+	}
+	if diff := compareECHPublication(
+		ech.Publication[0],
+		[]string{"public.example.net"},
+		nil,
+	); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestSiteBlockECHRejectsCatchAllConflict(t *testing.T) {
+	tests := map[string]string{
+		"catch-all first": `:443 {
+	tls {
+		ech catch-all-public.example.net {
+			dns test
+		}
+	}
+}
+
+example.com:8443 {
+	tls {
+		ech named-public.example.net {
+			dns test
+		}
+	}
+}`,
+		"catch-all last": `example.com:8443 {
+	tls {
+		ech named-public.example.net {
+			dns test
+		}
+	}
+}
+
+:443 {
+	tls {
+		ech catch-all-public.example.net {
+			dns test
+		}
+	}
+}`,
+		"two catch-alls": `:443 {
+	tls {
+		ech first-public.example.net {
+			dns test
+		}
+	}
+}
+
+:8443 {
+	tls {
+		ech second-public.example.net {
+			dns test
+		}
+	}
+}`,
+	}
+
+	adapter := caddyfile.Adapter{ServerType: ServerType{}}
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := adapter.Adapt([]byte(input), nil); err == nil {
+				t.Fatal("expected catch-all ECH assignments to conflict")
+			}
+		})
+	}
+}
+
+func TestSiteBlockECHSortsPublicationsWithIdenticalConfigsByDomain(t *testing.T) {
+	input := `b.example.com {
+	tls {
+		ech public.example.net
+	}
+}
+
+a.example.com {
+	tls {
+		ech public.example.net {
+			dns test
+		}
+	}
+}`
+
+	ech := adaptECH(t, input)
 	if len(ech.Publication) != 2 {
 		t.Fatalf("unexpected ECH publication count: got %d, want 2", len(ech.Publication))
 	}
@@ -318,6 +503,48 @@ https://a.example.com, https://b.example.com:8443 {
 		[]string{"b.example.com"},
 	); diff != "" {
 		t.Fatal(diff)
+	}
+}
+
+func TestConsolidateECHPublicationsRejectsCatchAllAfterNamedAssignment(t *testing.T) {
+	publications := []*caddytls.ECHPublication{
+		{
+			Configs: []string{"named-public.example.net"},
+			Domains: []string{"example.com"},
+		},
+		{
+			Configs: []string{"catch-all-public.example.net"},
+		},
+	}
+
+	if _, err := consolidateECHPublications(publications); err == nil {
+		t.Fatal("expected a named assignment followed by a catch-all assignment to conflict")
+	} else if !strings.Contains(err.Error(), "example.com") {
+		t.Fatalf("expected conflict error to identify the hostname, got: %v", err)
+	}
+}
+
+func TestSiteBlockECHRejectsGlobalAndSiteConflictForSameHost(t *testing.T) {
+	input := `{
+	dns test
+	ech global-public.example.net
+}
+
+https://example.com/api {
+	tls {
+		ech site-public.example.net {
+			dns test
+		}
+	}
+}
+
+https://example.com/app {
+	respond "hello"
+}`
+
+	adapter := caddyfile.Adapter{ServerType: ServerType{}}
+	if _, _, err := adapter.Adapt([]byte(input), nil); err == nil {
+		t.Fatal("expected global and site-specific ECH assignments for the same hostname to fail")
 	}
 }
 

--- a/caddyconfig/httpcaddyfile/tlsapp_test.go
+++ b/caddyconfig/httpcaddyfile/tlsapp_test.go
@@ -1,11 +1,23 @@
 package httpcaddyfile
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/caddyserver/certmagic"
+	"github.com/libdns/libdns"
+
+	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
 )
+
+func init() {
+	caddy.RegisterModule(testDNSProvider{})
+}
 
 func TestAutomationPolicyIsSubset(t *testing.T) {
 	for i, test := range []struct {
@@ -72,3 +84,218 @@ https://example.net localhost:8080 {
 		t.Fatalf("adapting Caddyfile: %v", err)
 	}
 }
+
+func TestSiteBlockECH(t *testing.T) {
+	const repeatedAdaptationAttempts = 10
+
+	input := `{
+	dns test
+	ech global-public.example.net
+}
+
+www.example.com, example.com {
+	tls {
+		ech public.example.net {
+			dns test
+		}
+	}
+	respond "protected"
+}
+
+second.example.com {
+	tls {
+		ech second-public.example.net
+	}
+	respond "also protected"
+}
+
+shared.example.com {
+	tls {
+		ech second-public.example.net
+	}
+	respond "shares an ECH config"
+}
+
+unprotected.example.com {
+	respond "unprotected"
+}
+`
+
+	adapter := caddyfile.Adapter{ServerType: ServerType{}}
+	output, _, err := adapter.Adapt([]byte(input), nil)
+	if err != nil {
+		t.Fatalf("adapting Caddyfile: %v", err)
+	}
+	for range repeatedAdaptationAttempts {
+		repeatedOutput, _, err := adapter.Adapt([]byte(input), nil)
+		if err != nil {
+			t.Fatalf("repeatedly adapting Caddyfile: %v", err)
+		}
+		if !reflect.DeepEqual(repeatedOutput, output) {
+			t.Fatal("adapted output is not deterministic")
+		}
+	}
+
+	var config struct {
+		Apps struct {
+			TLS *caddytls.TLS `json:"tls"`
+		} `json:"apps"`
+	}
+	if err := json.Unmarshal(output, &config); err != nil {
+		t.Fatalf("unmarshaling adapted config: %v", err)
+	}
+	if config.Apps.TLS == nil || config.Apps.TLS.EncryptedClientHello == nil {
+		t.Fatal("expected ECH configuration")
+	}
+
+	ech := config.Apps.TLS.EncryptedClientHello
+	expectedConfigs := []caddytls.ECHConfiguration{
+		{PublicName: "global-public.example.net"},
+		{PublicName: "public.example.net"},
+		{PublicName: "second-public.example.net"},
+	}
+	if !reflect.DeepEqual(ech.Configs, expectedConfigs) {
+		t.Fatalf("unexpected ECH configurations: got %v, want %v", ech.Configs, expectedConfigs)
+	}
+	if len(ech.Publication) != 4 {
+		t.Fatalf("unexpected ECH publication count: got %d, want 4", len(ech.Publication))
+	}
+	if diff := compareECHPublication(
+		ech.Publication[0],
+		[]string{"global-public.example.net"},
+		nil,
+	); diff != "" {
+		t.Fatal(diff)
+	}
+	if diff := compareECHPublication(
+		ech.Publication[1],
+		[]string{"public.example.net"},
+		[]string{"example.com", "www.example.com"},
+	); diff != "" {
+		t.Fatal(diff)
+	}
+	if _, ok := ech.Publication[1].PublishersRaw["dns"]; !ok {
+		t.Fatal("expected DNS publisher for example.com")
+	}
+	if diff := compareECHPublication(
+		ech.Publication[2],
+		[]string{"second-public.example.net"},
+		[]string{"second.example.com"},
+	); diff != "" {
+		t.Fatal(diff)
+	}
+	if diff := compareECHPublication(
+		ech.Publication[3],
+		[]string{"second-public.example.net"},
+		[]string{"shared.example.com"},
+	); diff != "" {
+		t.Fatal(diff)
+	}
+	for _, publication := range ech.Publication {
+		if _, ok := publication.PublishersRaw["dns"]; !ok {
+			t.Fatalf("expected inherited DNS publisher for %v", publication.Domains)
+		}
+	}
+}
+
+func TestSiteBlockECHWithoutGlobalECH(t *testing.T) {
+	input := `example.com {
+	tls {
+		ech public.example.net {
+			dns test
+		}
+	}
+}`
+
+	adapter := caddyfile.Adapter{ServerType: ServerType{}}
+	output, _, err := adapter.Adapt([]byte(input), nil)
+	if err != nil {
+		t.Fatalf("adapting Caddyfile: %v", err)
+	}
+
+	var config struct {
+		Apps struct {
+			TLS *caddytls.TLS `json:"tls"`
+		} `json:"apps"`
+	}
+	if err := json.Unmarshal(output, &config); err != nil {
+		t.Fatalf("unmarshaling adapted config: %v", err)
+	}
+	if config.Apps.TLS == nil || config.Apps.TLS.EncryptedClientHello == nil {
+		t.Fatal("expected site-specific ECH configuration")
+	}
+}
+
+func TestSiteBlockECHRequiresPublicName(t *testing.T) {
+	input := `example.com {
+	tls {
+		ech
+	}
+}`
+
+	adapter := caddyfile.Adapter{ServerType: ServerType{}}
+	if _, _, err := adapter.Adapt([]byte(input), nil); err == nil {
+		t.Fatal("expected adapting ECH without a public name to fail")
+	}
+}
+
+func compareECHPublication(publication *caddytls.ECHPublication, configs, domains []string) string {
+	if !reflect.DeepEqual(publication.Configs, configs) {
+		return fmt.Sprintf("unexpected publication configs: got %v, want %v", publication.Configs, configs)
+	}
+	if !reflect.DeepEqual(publication.Domains, domains) {
+		return fmt.Sprintf("unexpected publication domains: got %v, want %v", publication.Domains, domains)
+	}
+	return ""
+}
+
+type testDNSProvider struct{}
+
+func (testDNSProvider) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "dns.providers.test",
+		New: func() caddy.Module { return new(testDNSProvider) },
+	}
+}
+
+func (*testDNSProvider) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	d.Next()
+	if d.NextArg() {
+		return d.ArgErr()
+	}
+	return nil
+}
+
+func (*testDNSProvider) AppendRecords(
+	context.Context,
+	string,
+	[]libdns.Record,
+) ([]libdns.Record, error) {
+	return nil, nil
+}
+
+func (*testDNSProvider) DeleteRecords(
+	context.Context,
+	string,
+	[]libdns.Record,
+) ([]libdns.Record, error) {
+	return nil, nil
+}
+
+func (*testDNSProvider) GetRecords(context.Context, string) ([]libdns.Record, error) {
+	return nil, nil
+}
+
+func (*testDNSProvider) SetRecords(
+	context.Context,
+	string,
+	[]libdns.Record,
+) ([]libdns.Record, error) {
+	return nil, nil
+}
+
+var (
+	_ caddy.Module          = (*testDNSProvider)(nil)
+	_ caddyfile.Unmarshaler = (*testDNSProvider)(nil)
+	_ certmagic.DNSProvider = (*testDNSProvider)(nil)
+)


### PR DESCRIPTION
 ## Summary

  Adds support for configuring Encrypted Client Hello (ECH) inside a site's `tls` block:

  ```caddyfile
  example.com {
  	tls {
  		ech public.example.net {
  			dns <provider>
  		}
  	}
  }
  ```

  Site-specific ECH configurations are aggregated into the global TLS app because ECH keys are managed at the app level, while
  publication domains remain scoped to the relevant site.

  This also:

  - supports inheriting the global DNS provider;
  - keeps the implied global ECH publication, scoped to the sites that do not configure their own `ech` (a publication without domains covers every server name, so it would overlap the site-specific ones);
  - deduplicates shared ECH public names;
  - produces deterministic adapted JSON;
  - adds automation policies for ECH public names.

  ## Testing (RED -> GREEN)

  The regression test fails on the unpatched `master` branch with:

  ```text
  unknown subdirective: ech
  ```

  The review follow-up is covered by regression tests; they fail on the previous commit of this PR with:

  ```text
  --- FAIL: TestSiteBlockECH
      tlsapp_test.go:168: unexpected publication domains: got [], want [unprotected.example.com]
  --- FAIL: TestSiteBlockECHRestrictsConfiguredGlobalPublication
      tlsapp_test.go:254: unexpected publication domains: got [], want [global.example.com]
  --- FAIL: TestSiteBlockECHOmitGlobalPublicationWithoutDomains
      tlsapp_test.go:280: unexpected ECH publication count: got 2, want 1
  --- FAIL: TestSiteBlockECHAcrossListenerAddresses
      tlsapp_test.go:313: unexpected publication domains: got [b.example.com], want [a.example.com]
  ```

  and pass with the fix:

  ```text
  --- PASS: TestSiteBlockECH
  --- PASS: TestSiteBlockECHRestrictsConfiguredGlobalPublication
  --- PASS: TestSiteBlockECHOmitGlobalPublicationWithoutDomains
  --- PASS: TestSiteBlockECHAcrossListenerAddresses
  ok  	github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile
  ```

  Consolidation and catch-all regression tests also fail before the follow-up fix with:

  ```text
  --- FAIL: TestSiteBlockECHPreservesCatchAllAssignment
      unexpected publication domains: got [example.com], want []
  --- FAIL: TestSiteBlockECHRejectsCatchAllConflict
      expected catch-all and named ECH assignments to conflict
  ```

  They pass after identical publications are grouped and conflicting named or catch-all assignments are rejected.

  Validation performed:

  - race-enabled tests pass;
  - build passes;
  - lint reports 0 issues;
  - ten cross-build targets pass;
  - changed production lines have 100% test coverage (187/187).

  Closes #6971.

  ## AI assistance disclosure

  OpenAI Codex assisted with the implementation and tests; a separate Codex reviewer independently reviewed the change and
  re-ran the validation above. I reviewed the contribution, understand the submitted
  changes, and verified them with automated tests.


