### PR TITLE
logging: don't open log writers during validate-only provisioning

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -90,6 +90,11 @@ type Config struct {
 
 	cancelFunc context.CancelCauseFunc
 
+	// validateOnly indicates that the config is only being
+	// validated and will never be run, so provisioning should
+	// avoid side effects such as creating log files.
+	validateOnly bool
+
 	// fileSystems is a dict of fileSystems that will later be loaded from and added to.
 	fileSystems FileSystems
 }
@@ -744,6 +749,9 @@ func unsyncedStop(ctx Context) {
 // Validate loads, provisions, and validates
 // cfg, but does not start running it.
 func Validate(cfg *Config) error {
+	if cfg != nil {
+		cfg.validateOnly = true
+	}
 	_, err := run(cfg, false)
 	if err == nil {
 		cfg.cancelFunc(fmt.Errorf("validation complete")) // call Cleanup on all modules

--- a/logging.go
+++ b/logging.go
@@ -351,9 +351,15 @@ func (cl *BaseLog) provisionCommon(ctx Context, logging *Logging) error {
 		cl.writerOpener = StderrWriter{}
 	}
 	var err error
-	cl.writer, _, err = logging.openWriter(cl.writerOpener)
-	if err != nil {
-		return fmt.Errorf("opening log writer using %#v: %v", cl.writerOpener, err)
+	if ctx.cfg != nil && ctx.cfg.validateOnly && !IsWriterStandardStream(cl.writerOpener) {
+		// the config will never run, so don't create files
+		// or other side effects by opening the writer
+		cl.writer = notClosable{io.Discard}
+	} else {
+		cl.writer, _, err = logging.openWriter(cl.writerOpener)
+		if err != nil {
+			return fmt.Errorf("opening log writer using %#v: %v", cl.writerOpener, err)
+		}
 	}
 
 	// set up the log level

--- a/modules/logging/filewriter_validate_test.go
+++ b/modules/logging/filewriter_validate_test.go
@@ -1,0 +1,63 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+)
+
+// TestValidateDoesNotCreateLogFile ensures that validating a config
+// (as `caddy validate` does) leaves no log files behind. If validation
+// creates the file, running `caddy validate` as a different user than
+// the server (e.g. root vs. the caddy user) leaves a file the server
+// cannot open, so the subsequent reload fails with "permission denied".
+// See https://github.com/caddyserver/caddy/issues/7829.
+func TestValidateDoesNotCreateLogFile(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "access.log")
+
+	cfgJSON := fmt.Sprintf(`{
+		"logging": {
+			"logs": {
+				"log1": {
+					"writer": {
+						"output": "file",
+						"filename": %q
+					}
+				}
+			}
+		}
+	}`, logFile)
+
+	var cfg caddy.Config
+	if err := json.Unmarshal([]byte(cfgJSON), &cfg); err != nil {
+		t.Fatalf("unmarshaling config: %v", err)
+	}
+
+	if err := caddy.Validate(&cfg); err != nil {
+		t.Fatalf("validating config: %v", err)
+	}
+
+	if _, err := os.Stat(logFile); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("validation created log file %s (stat error: %v); validating a config must not create log files", logFile, err)
+	}
+}


### PR DESCRIPTION
Fixes #7829.

`caddy validate` fully provisions the config, and provisioning a log opens its writer — so validating a config with a file writer creates the log file as a side effect. Run as a different user than the server (e.g. `caddy validate` as root vs. the server running as the caddy user), that leaves a root-owned file the server cannot open, and the subsequent reload fails with "permission denied".

This flags validate-only configs (`Validate()` sets it) and substitutes a discard writer for non-standard-stream writers during provisioning, reusing the existing `notClosable` and `IsWriterStandardStream` helpers — validation no longer touches the filesystem.

**Trade-off, stated explicitly:** with this change, `validate` no longer probes whether the log path is openable — an unwritable path now surfaces at run time rather than validate time. Creating files with the invoker's ownership was the reported bug, and not touching the filesystem seems like the safer contract for `validate`; but if you'd prefer validate to keep some writability signal, a probe-without-create (e.g. checking directory writability without opening the file) could be layered on — happy to take that direction instead.

`TestValidateDoesNotCreateLogFile` validates a config with a file writer and asserts the file does not exist afterwards; it fails on master and passes with this change.

Files: `caddy.go`, `logging.go`, `modules/logging/filewriter_validate_test.go`

Assistance Disclosure
This patch was developed with AI assistance. It was reviewed and tested before submission (affected package tests pass), and is submitted from a human-owned account that takes responsibility for the change.