### PR TITLE
network_proxy: reject proxy URLs that resolve to a port with no host

### DIFF
--- a/modules/internal/network/networkproxy.go
+++ b/modules/internal/network/networkproxy.go
@@ -78,7 +78,7 @@ func (p ProxyFromURL) ProxyFunc() func(*http.Request) (*url.URL, error) {
 			if err != nil {
 				p.logger.Warn("failed to derive transport proxy from network_proxy URL")
 				pUrl = nil
-			} else if pUrl.Host == "" || strings.Split("", pUrl.Host)[0] == ":" {
+			} else if pUrl.Hostname() == "" {
 				// url.Parse does not return an error on these values:
 				//
 				// - http://:80

--- a/modules/internal/network/networkproxy_test.go
+++ b/modules/internal/network/networkproxy_test.go
@@ -1,0 +1,85 @@
+package network
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
+)
+
+// TestProxyFromURLPlaceholderHostValidation checks that a network_proxy URL
+// which resolves to a value without a host is rejected after placeholders are
+// applied. url.Parse accepts both "http://:80" and "/some/path" without
+// returning an error, so ProxyFunc has to reject them itself.
+func TestProxyFromURLPlaceholderHostValidation(t *testing.T) {
+	for i, tc := range []struct {
+		name     string
+		url      string
+		hostRepl string
+		wantErr  bool
+	}{
+		{
+			name:     "port only, no host",
+			url:      "http://{proxy.host}:80",
+			hostRepl: "",
+			wantErr:  true,
+		},
+		{
+			name:     "no scheme or host, path only",
+			url:      "{proxy.host}/some/path",
+			hostRepl: "",
+			wantErr:  true,
+		},
+		{
+			name:     "host and port",
+			url:      "http://{proxy.host}:8080",
+			hostRepl: "proxy.example.com",
+			wantErr:  false,
+		},
+		{
+			name:     "host without port",
+			url:      "http://{proxy.host}",
+			hostRepl: "proxy.example.com",
+			wantErr:  false,
+		},
+	} {
+		p := ProxyFromURL{URL: tc.url, logger: zap.NewNop()}
+
+		repl := caddy.NewReplacer()
+		repl.Set("proxy.host", tc.hostRepl)
+
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+		req = req.WithContext(context.WithValue(req.Context(), caddy.ReplacerCtxKey, repl))
+
+		proxyURL, err := p.ProxyFunc()(req)
+
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("Test %d (%s): expected an error for %q but got none (proxy URL: %v)",
+					i, tc.name, tc.url, proxyURL)
+			}
+			if proxyURL != nil {
+				t.Errorf("Test %d (%s): expected a nil proxy URL for %q, got %v",
+					i, tc.name, tc.url, proxyURL)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("Test %d (%s): unexpected error for %q: %v", i, tc.name, tc.url, err)
+			continue
+		}
+		if proxyURL == nil {
+			t.Errorf("Test %d (%s): expected a proxy URL for %q, got nil", i, tc.name, tc.url)
+			continue
+		}
+		if proxyURL.Hostname() != tc.hostRepl {
+			t.Errorf("Test %d (%s): expected host %q, got %q",
+				i, tc.name, tc.hostRepl, proxyURL.Hostname())
+		}
+	}
+}

--- a/modules/internal/network/networkproxy_test.go
+++ b/modules/internal/network/networkproxy_test.go
@@ -20,6 +20,7 @@ func TestProxyFromURLPlaceholderHostValidation(t *testing.T) {
 		name     string
 		url      string
 		hostRepl string
+		wantHost string
 		wantErr  bool
 	}{
 		{
@@ -35,15 +36,43 @@ func TestProxyFromURLPlaceholderHostValidation(t *testing.T) {
 			wantErr:  true,
 		},
 		{
+			// url.Parse puts the userinfo elsewhere, so Host is still just
+			// ":8080" here. The comment above the check doesn't name this
+			// form, but it is equally host-less and equally unusable.
+			name:     "userinfo but no host",
+			url:      "http://user:pass@{proxy.host}:8080",
+			hostRepl: "",
+			wantErr:  true,
+		},
+		{
 			name:     "host and port",
 			url:      "http://{proxy.host}:8080",
 			hostRepl: "proxy.example.com",
+			wantHost: "proxy.example.com",
 			wantErr:  false,
 		},
 		{
 			name:     "host without port",
 			url:      "http://{proxy.host}",
 			hostRepl: "proxy.example.com",
+			wantHost: "proxy.example.com",
+			wantErr:  false,
+		},
+		{
+			// Guards against a repair that splits Host on ":" instead of
+			// using Hostname(): an IPv6 literal is full of colons and must
+			// not be mistaken for a missing host.
+			name:     "IPv6 literal with port",
+			url:      "http://[{proxy.host}]:8080",
+			hostRepl: "::1",
+			wantHost: "::1",
+			wantErr:  false,
+		},
+		{
+			name:     "IPv6 literal without port",
+			url:      "http://[{proxy.host}]",
+			hostRepl: "2001:db8::1",
+			wantHost: "2001:db8::1",
 			wantErr:  false,
 		},
 	} {
@@ -77,9 +106,9 @@ func TestProxyFromURLPlaceholderHostValidation(t *testing.T) {
 			t.Errorf("Test %d (%s): expected a proxy URL for %q, got nil", i, tc.name, tc.url)
 			continue
 		}
-		if proxyURL.Hostname() != tc.hostRepl {
+		if proxyURL.Hostname() != tc.wantHost {
 			t.Errorf("Test %d (%s): expected host %q, got %q",
-				i, tc.name, tc.hostRepl, proxyURL.Hostname())
+				i, tc.name, tc.wantHost, proxyURL.Hostname())
 		}
 	}
 }


### PR DESCRIPTION
Found by code inspection, not from a bug report, so there's no issue to link. It is a one-character-class typo with a real behavioural effect, and it is self-contained.

## Problem

A `network_proxy` URL that contains placeholders and resolves to a value with a port but **no host** — `http://:80` — is accepted and returned as the proxy to use. The code immediately below the check says that case is meant to be rejected:

```go
// url.Parse does not return an error on these values:
//
// - http://:80
//   - pUrl.Host == ":80"
// - /some/path
//   - pUrl.Host == ""
//
// Super edge cases, but humans are human.
err = errors.New("supplied network_proxy URL is missing a host value")
```

Instead of that clear error, the host-less URL is handed to the transport and the problem resurfaces later as a confusing dial failure.

## Root cause

`modules/internal/network/networkproxy.go:81` — the arguments to `strings.Split` are swapped:

```go
} else if pUrl.Host == "" || strings.Split("", pUrl.Host)[0] == ":" {
```

This splits **the empty string**, using `pUrl.Host` as the *separator*. `strings.Split("", sep)` returns `[""]` for any non-empty `sep`, so element `0` is always `""` and can never equal `":"`. The comparison is dead for every possible host value:

| `pUrl.Host` | `strings.Split("", pUrl.Host)` | `[0] == ":"` |
|---|---|---|
| `":80"` | `[""]` | false |
| `"example.com:80"` | `[""]` | false |
| `"example.com"` | `[""]` | false |

Only the `pUrl.Host == ""` half of the condition ever did anything, which is why `/some/path` was still caught and `http://:80` was not.

Worth noting: `strings.Split("", "")` returns a **zero-length** slice, so `[0]` would panic outright. That is currently unreachable only because `pUrl.Host == ""` short-circuits to the left of it. The expression is dead today and one refactor away from an index panic.

## Fix

```go
} else if pUrl.Hostname() == "" {
```

`url.URL.Hostname()` returns the host with any port stripped, so it is `""` for exactly the two cases the comment names and non-empty for everything legitimate — including IPv6 literals and userinfo forms, which a hand-rolled `":"` split has to special-case:

| input | `.Host` | `.Hostname()` | rejected |
|---|---|---|---|
| `http://:80` | `:80` | `""` | yes |
| `/some/path` | `""` | `""` | yes |
| `http://proxy.example.com:8080` | `proxy.example.com:8080` | `proxy.example.com` | no |
| `http://[::1]:80` | `[::1]:80` | `::1` | no |
| `http://user:pass@h.example:8080` | `h.example:8080` | `h.example` | no |

This collapses both clauses into one expression. If you would rather keep the original two-clause shape, `pUrl.Host == "" || strings.HasPrefix(pUrl.Host, ":")` is the minimal repair and I'm happy to switch.

## Scope

Deliberately left alone:

- The non-placeholder branch (`return url.Parse(p.URL)` at the end of `ProxyFunc`) does not validate the host at all. That is a pre-existing inconsistency and changing it could reject configs that work today, so it belongs in its own PR if you want it.
- I grepped for other swapped-argument `strings.*("" , …)` call sites and for other always-false `Split(...)[0] ==` comparisons across the repo. There are none — this is a one-off typo, not a pattern.

## Tests

`modules/internal/network` had no test file; this adds one, table-driven per `AGENTS.md`. On `master` without the fix, the new test fails with exactly the reported symptom:

```
--- FAIL: TestProxyFromURLPlaceholderHostValidation (0.00s)
    networkproxy_test.go:62: Test 0 (port only, no host): expected an error for "http://{proxy.host}:80" but got none (proxy URL: http://:80)
    networkproxy_test.go:66: Test 0 (port only, no host): expected a nil proxy URL for "http://{proxy.host}:80", got http://:80
FAIL
FAIL	github.com/caddyserver/caddy/v2/modules/internal/network	0.666s
```

The `/some/path` case passes without the fix — that half of the condition already worked — so the test discriminates the actual bug rather than restating the patch.

## Verification

`go test -race -short ./...`, on `e096ca9`:

| | packages ok | FAIL | no test files |
|---|---|---|---|
| baseline (clean `master`) | 24 | 0 | 23 |
| with this PR | 25 | 0 | 22 |

Exit 0 both times, no pre-existing failures in this repo. The only delta is the intended one: `modules/internal/network` moves from *no test files* to *ok*.

`go vet ./modules/internal/network/` clean · `gofmt -l` clean · `golangci-lint run ./modules/internal/network/... --timeout 10m` → `0 issues.`

Happy to reshape any of this — split the test file out, use the two-clause form, or add the non-placeholder branch.

## Assistance Disclosure

Claude Code (Claude Opus 5) was used substantially here: it found the bug by inspecting the repository, wrote the fix and the test file, and ran the verification steps above.

I've deliberately kept every claim in this description checkable rather than asking you to take it on trust — the `strings.Split` semantics are shown as a table, the failing-test output is quoted literally, and the suite counts are stated for both sides. The two-line sequence in the follow-up comment reproduces the failure on `master` in about a minute.
