### PR TITLE
caddyhttp: log recovered handler panics at ERROR level

### DIFF
--- a/caddytest/integration/panic_test.go
+++ b/caddytest/integration/panic_test.go
@@ -1,0 +1,173 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+
+	// register the standard modules (http app, file log writer, etc.)
+	_ "github.com/caddyserver/caddy/v2/modules/standard"
+)
+
+const (
+	// panicTestHandlerID is the module ID of the test-only handler that panics.
+	panicTestHandlerID = "http.handlers.panic_test"
+	// panicLogPrefix is the prefix Go's net/http server writes to
+	// http.Server.ErrorLog when it recovers a handler panic. It mirrors the
+	// unexported production constant caddyhttp.stdlibLogPrefixPanic.
+	panicLogPrefix = "http: panic serving"
+	// panicErrorLevel is the zap level string the JSON encoder emits for
+	// entries logged at error level.
+	panicErrorLevel = "error"
+	// panicLogFilename is the log file the booted server writes to.
+	panicLogFilename = "panic.log"
+	// panicListenAddr is the HTTP listener for the panic route.
+	panicListenAddr = ":9080"
+	// panicRequestURL hits the panic route.
+	panicRequestURL = "http://localhost:9080/"
+	// panicLogPollInterval is how often the test re-reads the log file while
+	// waiting for the panic entry to be flushed to disk.
+	panicLogPollInterval = 50 * time.Millisecond
+	// panicLogPollTimeout bounds how long the test waits for the entry.
+	panicLogPollTimeout = 5 * time.Second
+)
+
+// panicHandler is a test-only HTTP handler module that panics in ServeHTTP
+// with a non-ErrAbortHandler value, so Go's net/http server recovers it and
+// writes an "http: panic serving" line to http.Server.ErrorLog.
+type panicHandler struct{}
+
+func (panicHandler) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  panicTestHandlerID,
+		New: func() caddy.Module { return new(panicHandler) },
+	}
+}
+
+func (panicHandler) ServeHTTP(http.ResponseWriter, *http.Request, caddyhttp.Handler) error {
+	panic("boom from panic_test handler")
+}
+
+func init() {
+	caddy.RegisterModule(panicHandler{})
+}
+
+// TestHandlerPanicLogsAtError boots a real Caddy HTTP server whose route panics
+// while serving a request, and asserts that the recovered panic surfaces in
+// Caddy's structured logs at ERROR level (so it stays visible at the default
+// log level). Booting exercises the App.Start() server-boot wiring that routes
+// http.Server.ErrorLog through Caddy's structured logger. Regression test for
+// https://github.com/caddyserver/caddy/issues/7923.
+func TestHandlerPanicLogsAtError(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), panicLogFilename)
+
+	// Boot a real Caddy instance. caddy.Run provisions and calls App.Start
+	// synchronously, so the panic-log wiring runs before we send the request.
+	config := `{
+		"admin": {"disabled": true},
+		"logging": {
+			"logs": {
+				"default": {
+					"writer": {"output": "file", "filename": "` + logPath + `"},
+					"encoder": {"format": "json"},
+					"level": "DEBUG"
+				}
+			}
+		},
+		"apps": {
+			"http": {
+				"grace_period": 1,
+				"servers": {
+					"srv0": {
+						"listen": ["` + panicListenAddr + `"],
+						"automatic_https": {"disable": true},
+						"routes": [
+							{"handle": [{"handler": "panic_test"}]}
+						]
+					}
+				}
+			}
+		}
+	}`
+	if err := caddy.Load([]byte(config), true); err != nil {
+		t.Fatalf("failed to load caddy config: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := caddy.Stop(); err != nil {
+			t.Errorf("failed to stop caddy: %v", err)
+		}
+	})
+
+	// The panic aborts the connection, so the client sees an error; that's
+	// expected. We only care that the server logged the panic.
+	resp, err := http.Get(panicRequestURL)
+	if err == nil {
+		resp.Body.Close()
+	}
+
+	if !waitForPanicLog(t, logPath) {
+		t.Fatalf("did not find an error-level %q entry in %s", panicLogPrefix, logPath)
+	}
+}
+
+// waitForPanicLog polls the log file until it contains a JSON entry logged at
+// error level whose message begins with the net/http panic prefix, or the
+// timeout elapses.
+func waitForPanicLog(t *testing.T, logPath string) bool {
+	t.Helper()
+	deadline := time.Now().Add(panicLogPollTimeout)
+	for time.Now().Before(deadline) {
+		if scanForPanicEntry(t, logPath) {
+			return true
+		}
+		time.Sleep(panicLogPollInterval)
+	}
+	return false
+}
+
+func scanForPanicEntry(t *testing.T, logPath string) bool {
+	t.Helper()
+	f, err := os.Open(logPath)
+	if err != nil {
+		// The file may not exist yet before the first log line is written.
+		return false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var entry struct {
+			Level string `json:"level"`
+			Msg   string `json:"msg"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+		if entry.Level == panicErrorLevel && strings.HasPrefix(entry.Msg, panicLogPrefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/caddytest/integration/panic_test.go
+++ b/caddytest/integration/panic_test.go
@@ -16,11 +16,12 @@ package integration
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
-	"os"
-	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -41,8 +42,6 @@ const (
 	// panicErrorLevel is the zap level string the JSON encoder emits for
 	// entries logged at error level.
 	panicErrorLevel = "error"
-	// panicLogFilename is the log file the booted server writes to.
-	panicLogFilename = "panic.log"
 	// panicListenAddr is the HTTP listener for the panic route.
 	panicListenAddr = ":9080"
 	// panicRequestURL hits the panic route.
@@ -59,6 +58,15 @@ const (
 // writes an "http: panic serving" line to http.Server.ErrorLog.
 type panicHandler struct{}
 
+type panicLogWriter struct{}
+
+type panicLogBuffer struct {
+	sync.Mutex
+	bytes.Buffer
+}
+
+var panicLogs panicLogBuffer
+
 func (panicHandler) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID:  panicTestHandlerID,
@@ -70,8 +78,50 @@ func (panicHandler) ServeHTTP(http.ResponseWriter, *http.Request, caddyhttp.Hand
 	panic("boom from panic_test handler")
 }
 
+func (panicLogWriter) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "caddy.logging.writers.panic_test",
+		New: func() caddy.Module { return new(panicLogWriter) },
+	}
+}
+
+func (panicLogWriter) String() string {
+	return "panic test log"
+}
+
+func (panicLogWriter) WriterKey() string {
+	return "panic_test"
+}
+
+func (panicLogWriter) OpenWriter() (io.WriteCloser, error) {
+	return &panicLogs, nil
+}
+
+func (b *panicLogBuffer) Write(p []byte) (int, error) {
+	b.Lock()
+	defer b.Unlock()
+	return b.Buffer.Write(p)
+}
+
+func (*panicLogBuffer) Close() error {
+	return nil
+}
+
+func (b *panicLogBuffer) reset() {
+	b.Lock()
+	defer b.Unlock()
+	b.Buffer.Reset()
+}
+
+func (b *panicLogBuffer) snapshot() []byte {
+	b.Lock()
+	defer b.Unlock()
+	return bytes.Clone(b.Buffer.Bytes())
+}
+
 func init() {
 	caddy.RegisterModule(panicHandler{})
+	caddy.RegisterModule(panicLogWriter{})
 }
 
 // TestHandlerPanicLogsAtError boots a real Caddy HTTP server whose route panics
@@ -81,7 +131,7 @@ func init() {
 // http.Server.ErrorLog through Caddy's structured logger. Regression test for
 // https://github.com/caddyserver/caddy/issues/7923.
 func TestHandlerPanicLogsAtError(t *testing.T) {
-	logPath := filepath.Join(t.TempDir(), panicLogFilename)
+	panicLogs.reset()
 
 	// Boot a real Caddy instance. caddy.Run provisions and calls App.Start
 	// synchronously, so the panic-log wiring runs before we send the request.
@@ -89,10 +139,11 @@ func TestHandlerPanicLogsAtError(t *testing.T) {
 		"admin": {"disabled": true},
 		"logging": {
 			"logs": {
-				"default": {
-					"writer": {"output": "file", "filename": "` + logPath + `"},
+				"panic_test": {
+					"writer": {"output": "panic_test"},
 					"encoder": {"format": "json"},
-					"level": "DEBUG"
+					"level": "DEBUG",
+					"include": ["http"]
 				}
 			}
 		},
@@ -127,19 +178,19 @@ func TestHandlerPanicLogsAtError(t *testing.T) {
 		resp.Body.Close()
 	}
 
-	if !waitForPanicLog(t, logPath) {
-		t.Fatalf("did not find an error-level %q entry in %s", panicLogPrefix, logPath)
+	if !waitForPanicLog(t) {
+		t.Fatalf("did not find an error-level %q entry", panicLogPrefix)
 	}
 }
 
-// waitForPanicLog polls the log file until it contains a JSON entry logged at
-// error level whose message begins with the net/http panic prefix, or the
+// waitForPanicLog polls the log output until it contains a JSON entry logged
+// at error level whose message begins with the net/http panic prefix, or the
 // timeout elapses.
-func waitForPanicLog(t *testing.T, logPath string) bool {
+func waitForPanicLog(t *testing.T) bool {
 	t.Helper()
 	deadline := time.Now().Add(panicLogPollTimeout)
 	for time.Now().Before(deadline) {
-		if scanForPanicEntry(t, logPath) {
+		if scanForPanicEntry(t) {
 			return true
 		}
 		time.Sleep(panicLogPollInterval)
@@ -147,16 +198,10 @@ func waitForPanicLog(t *testing.T, logPath string) bool {
 	return false
 }
 
-func scanForPanicEntry(t *testing.T, logPath string) bool {
+func scanForPanicEntry(t *testing.T) bool {
 	t.Helper()
-	f, err := os.Open(logPath)
-	if err != nil {
-		// The file may not exist yet before the first log line is written.
-		return false
-	}
-	defer f.Close()
 
-	scanner := bufio.NewScanner(f)
+	scanner := bufio.NewScanner(bytes.NewReader(panicLogs.snapshot()))
 	for scanner.Scan() {
 		var entry struct {
 			Level string `json:"level"`

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -20,9 +20,11 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -463,11 +465,9 @@ func removeTLSALPN(srv *Server, target string) {
 // Start runs the app. It finishes automatic HTTPS if enabled,
 // including management of certificates.
 func (app *App) Start() error {
-	// get a logger compatible with http.Server
-	serverLogger, err := zap.NewStdLogAt(app.logger.Named("stdlib"), zap.DebugLevel)
-	if err != nil {
-		return fmt.Errorf("failed to set up server logger: %v", err)
-	}
+	// get a logger compatible with http.Server; recovered handler panics are
+	// routed to ERROR so they remain visible at the default log level (#7923)
+	serverLogger := serverErrorLogger(app.logger.Named("stdlib"))
 
 	for srvName, srv := range app.Servers {
 		srv.server = &http.Server{
@@ -662,12 +662,44 @@ func (app *App) Start() error {
 
 	// finish automatic HTTPS by finally beginning
 	// certificate management
-	err = app.automaticHTTPSPhase2()
+	err := app.automaticHTTPSPhase2()
 	if err != nil {
 		return fmt.Errorf("finalizing automatic HTTPS: %v", err)
 	}
 
 	return nil
+}
+
+// stdlibLogPrefixPanic is the prefix Go's net/http server uses when it writes a
+// recovered handler panic (and its stack trace) to http.Server.ErrorLog.
+// See the deferred recover in net/http.(*conn).serve.
+const stdlibLogPrefixPanic = "http: panic serving"
+
+// serverErrorLogger returns a *log.Logger suitable for http.Server.ErrorLog
+// that forwards the standard library's server messages to Caddy's structured
+// logger. Most of these messages are low-signal and logged at DEBUG, but
+// recovered handler panics indicate a real server-side error, so they are
+// logged at ERROR to stay visible at the default log level.
+func serverErrorLogger(logger *zap.Logger) *log.Logger {
+	return log.New(stdlibLogRouter{logger: logger}, "", 0)
+}
+
+// stdlibLogRouter is an io.Writer that routes standard library http.Server
+// error-log messages to the appropriate level on the wrapped structured logger.
+type stdlibLogRouter struct {
+	logger *zap.Logger
+}
+
+func (w stdlibLogRouter) Write(p []byte) (int, error) {
+	// log.Logger always appends a trailing newline; trim it so the structured
+	// message doesn't carry a dangling blank line.
+	msg := strings.TrimSuffix(string(p), "\n")
+	if strings.HasPrefix(msg, stdlibLogPrefixPanic) {
+		w.logger.Error(msg)
+	} else {
+		w.logger.Debug(msg)
+	}
+	return len(p), nil
 }
 
 // Stop gracefully shuts down the HTTP server.

--- a/modules/caddyhttp/app_test.go
+++ b/modules/caddyhttp/app_test.go
@@ -1,0 +1,65 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddyhttp
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// TestServerErrorLoggerLevels verifies that recovered net/http handler panics
+// written to http.Server.ErrorLog surface at ERROR level (so they're visible
+// at the default log level), while other standard library server messages stay
+// at DEBUG. Regression test for #7923.
+func TestServerErrorLoggerLevels(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		message   string
+		wantLevel zapcore.Level
+	}{
+		{
+			name:      "recovered handler panic logs at error",
+			message:   "http: panic serving 127.0.0.1:12345: boom\ngoroutine 1 [running]:\nmain.handler()",
+			wantLevel: zapcore.ErrorLevel,
+		},
+		{
+			name:      "other server message logs at debug",
+			message:   "http: TLS handshake error from 127.0.0.1:12345: EOF",
+			wantLevel: zapcore.DebugLevel,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			core, logs := observer.New(zapcore.DebugLevel)
+			serverLogger := serverErrorLogger(zap.New(core))
+
+			serverLogger.Print(tc.message)
+
+			entries := logs.All()
+			if len(entries) != 1 {
+				t.Fatalf("expected exactly 1 log entry, got %d", len(entries))
+			}
+			got := entries[0]
+			if got.Level != tc.wantLevel {
+				t.Errorf("expected level %s, got %s", tc.wantLevel, got.Level)
+			}
+			if got.Message != tc.message {
+				t.Errorf("expected message %q, got %q", tc.message, got.Message)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Assistance Disclosure

AI/LLM assistance was used and is disclosed here: I directed an AI coding
assistant (Claude) to help investigate the root cause, draft the fix, and
write the tests. I personally reviewed, ran, and verified every line locally
(RED→GREEN and the diff-coverage gate below), understand the change, and take
responsibility for it. I have the rights to contribute this change and will
sign the CLA.

Fixes #7923

## Root cause

Go's `net/http` server recovers a panic that escapes a handler and writes the
message and stack trace to `http.Server.ErrorLog` (see the deferred `recover`
in `net/http.(*conn).serve`, which emits lines prefixed `http: panic serving`).

In `caddyhttp`, `App.Start()` wired that `ErrorLog` through
`zap.NewStdLogAt(app.logger.Named("stdlib"), zap.DebugLevel)` — i.e. **every**
stdlib server message, including recovered handler panics, was logged at
`DEBUG`. At the default `INFO` level these panics were completely invisible, so
a handler panic in production would be silently swallowed.

Caddy does not recover handler panics itself in the serving path (only
`reverseproxy` health-checks/metrics use `recover()`), so a handler panic
genuinely reaches `net/http`'s serve loop and its `ErrorLog`.

## The fix

Route `http.Server.ErrorLog` through a small `io.Writer` that inspects each
message: lines prefixed `http: panic serving` are logged at **ERROR** (so they
stay visible at the default level), while other low-signal stdlib messages
remain at **DEBUG**. No behavior change for non-panic messages.

The change is confined to `modules/caddyhttp/app.go`.

## Test verification (RED → GREEN)

Two tests ship with the fix:

- `TestServerErrorLoggerLevels` (`modules/caddyhttp/app_test.go`) — unit test
  for the routing logic (both branches).
- `TestHandlerPanicLogsAtError` (`caddytest/integration/panic_test.go`) — boots
  a real Caddy server with a test-only handler that panics, sends a request that
  hits it, and asserts the recovered panic is logged at ERROR in Caddy's
  structured logs. Booting exercises the `App.Start()` server-boot wiring.

**RED** — integration test on unmodified `master` (fix reverted); the panic is
logged at DEBUG, so no ERROR entry is found:

```
    panic_test.go: did not find an error-level "http: panic serving" entry ...
--- FAIL: TestHandlerPanicLogsAtError (6.05s)
FAIL	github.com/caddyserver/caddy/v2/caddytest/integration
```

**GREEN** — with the fix:

```
--- PASS: TestHandlerPanicLogsAtError (0.01s)
ok  	github.com/caddyserver/caddy/v2/caddytest/integration
```

## Local verification

Run in `golang:1.26` (and `golangci/golangci-lint:v2.12.2`):

- `go build ./...` — OK
- `go vet ./modules/caddyhttp/` — OK
- `go test -race -short ./modules/caddyhttp/` (incl. `TestServerErrorLoggerLevels`) — OK
- `go test -race -short ./caddytest/integration/` — OK
- `golangci-lint run` on the changed packages — `0 issues`
- Diff-coverage of changed production lines: **100% (17/17)** — the boot-time
  wiring in `App.Start()` is covered by the integration test.

CI covers Linux/macOS/Windows; the change is platform-agnostic.
