### PR TITLE
reverseproxy: preallocate upstream slices with known sizes

### DIFF
--- a/modules/caddyhttp/reverseproxy/upstreams.go
+++ b/modules/caddyhttp/reverseproxy/upstreams.go
@@ -482,7 +482,9 @@ func (mu *MultiUpstreams) Provision(ctx caddy.Context) error {
 		if err != nil {
 			return fmt.Errorf("loading upstream source modules: %v", err)
 		}
-		for _, src := range mod.([]any) {
+		sources := mod.([]any)
+		mu.sources = make([]UpstreamSource, 0, len(sources))
+		for _, src := range sources {
 			mu.sources = append(mu.sources, src.(UpstreamSource))
 		}
 	}
@@ -535,6 +537,7 @@ type UpstreamResolver struct {
 // ParseAddresses parses all the configured network addresses
 // and ensures they're ready to be used.
 func (u *UpstreamResolver) ParseAddresses() error {
+	u.netAddrs = make([]caddy.NetworkAddress, 0, len(u.Addresses))
 	for _, v := range u.Addresses {
 		addr, err := caddy.ParseNetworkAddressWithDefaults(v, "udp", 53)
 		if err != nil {

--- a/modules/caddyhttp/reverseproxy/upstreams_bench_test.go
+++ b/modules/caddyhttp/reverseproxy/upstreams_bench_test.go
@@ -1,0 +1,33 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reverseproxy
+
+import "testing"
+
+func BenchmarkUpstreamResolverParseAddresses(b *testing.B) {
+	addrs := []string{"8.8.8.8", "1.1.1.1", "9.9.9.9", "208.67.222.222"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// fresh resolver each iteration: ParseAddresses is called once
+		// per resolver in practice, and this keeps the before/after
+		// comparison fair (no unbounded append growth across iterations)
+		r := UpstreamResolver{Addresses: addrs}
+		if err := r.ParseAddresses(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Preallocate the sources slice in MultiUpstreams.Provision and the netAddrs slice in UpstreamResolver.ParseAddresses now that their final lengths are known, avoiding the intermediate append regrowth allocations. For a 4-address resolver this reduces ParseAddresses from 11 to 9 allocs/op and 528 to 384 B/op; the benefit scales with the number of sources/addresses.

                                 |  before  |            after            |
                                 |  sec/op  |  sec/op     vs base         |
UpstreamResolverParseAddresses-8 | 2.289µ   |1.946µ     ~ (p=0.165) noisy |

B/op:      528 → 384   -27.27%  (p=0.000)
allocs/op:  11 →   9   -18.18%  (p=0.000)

Adds BenchmarkUpstreamResolverParseAddresses as per policy.




## Assistance Disclosure
"No AI was used."