### PR TITLE
caddytls: load existing cert for subdomains when wildcard fails

### DIFF
--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log"
 	"net"
 	"net/http"
@@ -573,6 +575,13 @@ func (t *TLS) Manage(subjects map[string]struct{}) error {
 		// subdomains by adding the name to the 'automate' cert loader
 		if t.managingWildcardFor(subj, subjects) {
 			if _, ok := t.automateNames[subj]; !ok {
+				// not going to request a new cert for subj since a covering wildcard is being managed instead. But the wildcard may never succeed, so make sure we dont ignore a cert we already have in disk for that subj.
+				_, err := ap.magic.CacheManagedCertificate(t.ctx.Context, subj)
+				if err != nil && !errors.Is(err, fs.ErrNotExist) {
+					if c := t.logger.Check(zap.ErrorLevel, "loading existing certificate for wildcard covered subdomain"); c != nil {
+						c.Write(zap.String("domain", subj), zap.Error(err))
+					}
+				}
 				continue
 			}
 		}

--- a/modules/caddytls/tls_wildcard_test.go
+++ b/modules/caddytls/tls_wildcard_test.go
@@ -16,6 +16,7 @@ package caddytls
 
 import (
 	"encoding/json"
+	"slices"
 	"testing"
 
 	"github.com/caddyserver/caddy/v2"
@@ -121,25 +122,21 @@ func TestWildcardCoveredSubdomainKeepsExistingCert(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Simulate "subdomain already has a valid certificate on disk", obtained
-	// at some point before any wildcard was ever added to the config.
+	// simulate subdomain already having a valid cert saved before any wildcard existed
 	ap := tlsApp.getAutomationPolicyForName(subdomain)
 	if err := ap.magic.ObtainCertSync(ctx.Context, subdomain); err != nil {
 		t.Fatalf("seeding certificate for %s: %v", subdomain, err)
 	}
 	issuerKey := ap.magic.Issuers[0].IssuerKey()
 
-	// Now simulate a fresh process start: nothing is in the in-memory cert
-	// cache yet (as it would be right after boot), but the certificate is
-	// still sitting in storage from before.
+	// simulate a fresh restart: cache is empty but the cert is still in storage
 	certCache.RemoveManaged([]certmagic.SubjectIssuer{{Subject: subdomain, IssuerKey: issuerKey}})
 	if cached := certCache.AllMatchingCertificates(subdomain); len(cached) != 0 {
 		t.Fatalf("test setup failed: expected no cached certificate for %s, got %d", subdomain, len(cached))
 	}
 
-	// A wildcard covering the subdomain is requested in the same batch. Prior
-	// to the fix, this made Caddy skip the subdomain entirely -- it would
-	// never even check whether a certificate already existed for it.
+	// a wildcard covering the subdomain is requested in the same batch, which
+	// used to make caddy skip the subdomain entirely without checking for an existing cert
 	err = tlsApp.Manage(map[string]struct{}{
 		subdomain: {},
 		wildcard:  {},
@@ -148,8 +145,16 @@ func TestWildcardCoveredSubdomainKeepsExistingCert(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if cached := certCache.AllMatchingCertificates(subdomain); len(cached) == 0 {
-		t.Errorf("expected existing certificate for %s to be loaded into the cache even though "+
-			"a covering wildcard (%s) is also being managed; see issue #7365", subdomain, wildcard)
+	var foundSubdomainCert bool
+	for _, cert := range certCache.AllMatchingCertificates(subdomain) {
+		if slices.Contains(cert.Names, subdomain) {
+			foundSubdomainCert = true
+			break
+		}
+	}
+	if !foundSubdomainCert {
+		t.Errorf("expected existing certificate for %s specifically (not just a covering wildcard) "+
+			"to be loaded into the cache even though wildcard %s is also being managed",
+			subdomain, wildcard)
 	}
 }

--- a/modules/caddytls/tls_wildcard_test.go
+++ b/modules/caddytls/tls_wildcard_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/certmagic"
 )
 
 func TestAvoidDuplicateAutomation(t *testing.T) {
@@ -92,5 +93,63 @@ func TestAvoidDuplicateAutomation(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestWildcardCoveredSubdomainKeepsExistingCert(t *testing.T) {
+	const subdomain = "covered.example.net"
+	const wildcard = "*.example.net"
+
+	tlsApp := &TLS{
+		Automation: &AutomationConfig{
+			Policies: []*AutomationPolicy{
+				{
+					IssuersRaw: []json.RawMessage{
+						[]byte(`{"module": "internal"}`),
+					},
+				},
+			},
+		},
+	}
+
+	var cfg caddy.Config
+	ctx, err := caddy.ProvisionContext(&cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tlsApp.Provision(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate "subdomain already has a valid certificate on disk", obtained
+	// at some point before any wildcard was ever added to the config.
+	ap := tlsApp.getAutomationPolicyForName(subdomain)
+	if err := ap.magic.ObtainCertSync(ctx.Context, subdomain); err != nil {
+		t.Fatalf("seeding certificate for %s: %v", subdomain, err)
+	}
+	issuerKey := ap.magic.Issuers[0].IssuerKey()
+
+	// Now simulate a fresh process start: nothing is in the in-memory cert
+	// cache yet (as it would be right after boot), but the certificate is
+	// still sitting in storage from before.
+	certCache.RemoveManaged([]certmagic.SubjectIssuer{{Subject: subdomain, IssuerKey: issuerKey}})
+	if cached := certCache.AllMatchingCertificates(subdomain); len(cached) != 0 {
+		t.Fatalf("test setup failed: expected no cached certificate for %s, got %d", subdomain, len(cached))
+	}
+
+	// A wildcard covering the subdomain is requested in the same batch. Prior
+	// to the fix, this made Caddy skip the subdomain entirely -- it would
+	// never even check whether a certificate already existed for it.
+	err = tlsApp.Manage(map[string]struct{}{
+		subdomain: {},
+		wildcard:  {},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cached := certCache.AllMatchingCertificates(subdomain); len(cached) == 0 {
+		t.Errorf("expected existing certificate for %s to be loaded into the cache even though "+
+			"a covering wildcard (%s) is also being managed; see issue #7365", subdomain, wildcard)
 	}
 }

--- a/modules/caddytls/tls_wildcard_test.go
+++ b/modules/caddytls/tls_wildcard_test.go
@@ -118,16 +118,31 @@ func TestWildcardCoveredSubdomainKeepsExistingCert(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx, cancel := caddy.NewContext(ctx)
+
+	var addedToCache []certmagic.SubjectIssuer
+	t.Cleanup(func() {
+		cancel()
+		certCacheMu.RLock()
+		defer certCacheMu.RUnlock()
+		if certCache != nil {
+			certCache.RemoveManaged(addedToCache)
+		}
+	})
+
 	if err := tlsApp.Provision(ctx); err != nil {
 		t.Fatal(err)
 	}
 
 	// simulate subdomain already having a valid cert saved before any wildcard existed
 	ap := tlsApp.getAutomationPolicyForName(subdomain)
+	issuerKey := ap.magic.Issuers[0].IssuerKey()
+	// an empty issuer key matches any issuer, so this evicts every managed cert
+	// this test causes to be cached for these names
+	addedToCache = []certmagic.SubjectIssuer{{Subject: subdomain}, {Subject: wildcard}}
 	if err := ap.magic.ObtainCertSync(ctx.Context, subdomain); err != nil {
 		t.Fatalf("seeding certificate for %s: %v", subdomain, err)
 	}
-	issuerKey := ap.magic.Issuers[0].IssuerKey()
 
 	// simulate a fresh restart: cache is empty but the cert is still in storage
 	certCache.RemoveManaged([]certmagic.SubjectIssuer{{Subject: subdomain, IssuerKey: issuerKey}})


### PR DESCRIPTION
When a wildcard like `*.domain.com` fails to obtain a certificate, subdomains covered by it can stop serving HTTPS even if they already have a certificate on disk.

Caddy currently skips these subdomains while the wildcard is being managed:

```go
if t.managingWildcardFor(subj, subjects) {
    if _, ok := t.automateNames[subj]; !ok {
        continue
    }
}
```

There is an `automate` escape hatch for this, but it is not exposed through the Caddyfile. This change loads an existing certificate from storage before skipping the subdomain:

```go
_, err := ap.magic.CacheManagedCertificate(t.ctx.Context, subj)
```

No new certificate is requested, so the existing wildcard optimization stays the same.

## Testing

Added `TestWildcardCoveredSubdomainKeepsExistingCert` to verify an existing certificate is loaded when a covering wildcard fails.

Also ran:

```text
go test ./modules/caddytls/...
go test ./modules/caddyhttp/...
go build ./...
go vet ./modules/caddytls/...
```

Reproduced the issue with Pebble and confirmed the existing certificate is served without another ACME request.

Fixes #7365

## Assistance Disclosure

AI assistance was used to navigate the codebase and reproduce the issue with Pebble. The code and tests were reviewed and verified manually.
