### PR TITLE
provision: allow third-party apps to access caddytls.TLS.dns field

### DIFF
--- a/modules/caddytls/acmeissuer.go
+++ b/modules/caddytls/acmeissuer.go
@@ -208,8 +208,8 @@ func (iss *ACMEIssuer) Provision(ctx caddy.Context) error {
 			// no locally configured DNS challenge provider, but if there is
 			// a global DNS module configured with the TLS app, use that
 			tlsApp := tlsAppIface.(*TLS)
-			if tlsApp.dns != nil {
-				prov = tlsApp.dns.(certmagic.DNSProvider)
+			if tlsApp.Dns != nil {
+				prov = tlsApp.Dns.(certmagic.DNSProvider)
 			}
 		}
 		if prov == nil {

--- a/modules/caddytls/ech.go
+++ b/modules/caddytls/ech.go
@@ -330,7 +330,7 @@ func (t *TLS) publishECHConfigs(logger *zap.Logger) error {
 	// configured, then this whole function is basically a no-op)
 	publicationList := t.EncryptedClientHello.Publication
 	if publicationList == nil {
-		if dnsProv, ok := t.dns.(ECHDNSProvider); ok {
+		if dnsProv, ok := t.Dns.(ECHDNSProvider); ok {
 			publicationList = []*ECHPublication{
 				{
 					publishers: []ECHPublisher{

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -132,7 +132,7 @@ type TLS struct {
 	// EXPERIMENTAL: Subject to change.
 	Resolvers []string `json:"resolvers,omitempty"`
 
-	dns                any // technically, it should be any/all of the libdns interfaces (RecordSetter, RecordAppender, etc.)
+	Dns                any // technically, it should be any/all of the libdns interfaces (RecordSetter, RecordAppender, etc.)
 	certificateLoaders []CertificateLoader
 	automateNames      map[string]struct{}
 	ctx                caddy.Context
@@ -190,7 +190,7 @@ func (t *TLS) Provision(ctx caddy.Context) error {
 		default:
 			return fmt.Errorf("DNS module does not implement the most common libdns interfaces: %T", dnsMod)
 		}
-		t.dns = dnsMod
+		t.Dns = dnsMod
 	}
 
 	// set up a new certificate cache; this (re)loads all certificates


### PR DESCRIPTION
No AI was used.

The global [`dns`](https://caddyserver.com/docs/caddyfile/options#dns) option can be used publicly, but `caddytls.TLS.dns` should be exported for use by third-party app; otherwise, reflection must be used.
For example, https://github.com/mholt/caddy-dynamicdns/pull/106
https://github.com/mholt/caddy-dynamicdns/pull/106/changes#diff-3d56da1a5c865a0689b48c66b4b24ff2441ea4c442c2bc9dd074814034f78fc8R136-R152
```go
tlsAppModule, err := a.ctx.App("tls")
if err != nil {
	return fmt.Errorf("failed to get TLS app module: %v", err)
}
tlsApp, ok := tlsAppModule.(*caddytls.TLS)
if !ok {
	return fmt.Errorf("TLS app is not of type *caddytls.TLS")
}
dnsField := reflect.ValueOf(tlsApp).Elem().FieldByName("dns")
if !dnsField.IsValid() {
	return fmt.Errorf("incompatible Caddy version: private field 'dns' not found in caddytls.TLS")
}
dnsInterface := reflect.NewAt(dnsField.Type(), unsafe.Pointer(dnsField.UnsafeAddr())).Elem().Interface()
if dnsInterface == nil {
	return fmt.Errorf("a DNS provider is required")
}
a.Providers[0].dnsProvider = dnsInterface.(libdns.RecordSetter)
```