### PR TITLE
caddyfile: extended (caddyfile.Dispenser).NextSegment() and caddyfile.UnmarshalModule()

### DIFF
--- a/caddyconfig/caddyfile/adapter.go
+++ b/caddyconfig/caddyfile/adapter.go
@@ -125,6 +125,14 @@ type ServerType interface {
 // type-asserted to the module's associated type for practical use
 // when setting up a config.
 func UnmarshalModule(d *Dispenser, moduleID string) (Unmarshaler, error) {
+	return UnmarshalModuleWithConsumer(d, moduleID, nil)
+}
+
+// Similar to UnmarshalModule(),
+// but running other functions consumes intermediate blocks during the execution of d.NextSegment().
+//
+//	consumer - Based on the value of d.Val(), determine whether to consume the energy, and return a consumed flag and an error.
+func UnmarshalModuleWithConsumer(d *Dispenser, moduleID string, consumer func(value string) (bool, error)) (Unmarshaler, error) {
 	mod, err := caddy.GetModule(moduleID)
 	if err != nil {
 		return nil, d.Errf("getting module named '%s': %v", moduleID, err)
@@ -134,7 +142,11 @@ func UnmarshalModule(d *Dispenser, moduleID string) (Unmarshaler, error) {
 	if !ok {
 		return nil, d.Errf("module %s is not a Caddyfile unmarshaler; is %T", mod.ID, inst)
 	}
-	err = unm.UnmarshalCaddyfile(d.NewFromNextSegment())
+	segment, err := d.NextSegmentWithConsumer(consumer)
+	if err != nil {
+		return nil, err
+	}
+	err = unm.UnmarshalCaddyfile(NewDispenser(segment))
 	if err != nil {
 		return nil, err
 	}

--- a/caddyconfig/caddyfile/dispenser.go
+++ b/caddyconfig/caddyfile/dispenser.go
@@ -360,6 +360,15 @@ func (d *Dispenser) NewFromNextSegment() *Dispenser {
 // token until the end of the line or block that starts at
 // the end of the line.
 func (d *Dispenser) NextSegment() Segment {
+	segment, _ := d.NextSegmentWithConsumer(nil)
+	return segment
+}
+
+// Similar to the NextSegment(),
+// but running other functions to consume intermediate blocks.
+//
+//	consumer - Based on the value of d.Val(), determine whether to consume the energy, and return a consumed flag and an error.
+func (d *Dispenser) NextSegmentWithConsumer(consumer func(value string) (bool, error)) (Segment, error) {
 	tkns := Segment{d.Token()}
 	for d.NextArg() {
 		tkns = append(tkns, d.Token())
@@ -377,6 +386,18 @@ func (d *Dispenser) NextSegment() Segment {
 			d.Next()
 			openedBlock = true
 		}
+
+		// Since the boundaries are handled by the functions, NewDispenser is not needed here.
+		if consumer != nil {
+			ok, err := consumer(d.Val())
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				continue
+			}
+		}
+
 		tkns = append(tkns, d.Token())
 	}
 	if openedBlock {
@@ -387,7 +408,7 @@ func (d *Dispenser) NextSegment() Segment {
 		// next iteration of the enclosing loop will
 		// call Next() and consume it
 	}
-	return tkns
+	return tkns, nil
 }
 
 // Token returns the current token.


### PR DESCRIPTION
No AI was used.

Other functions consumes intermediate blocks during the execution of d.NextSegment(), supporting the following caddyfile usage, where the `domians` field does not belong to the `dns.providers` module.
https://github.com/mholt/caddy-dynamicdns/pull/104
```caddyfile
{
	dynamic_dns {
		provider cloudflare {env.CF_TOKEN} {
			domains {
				example.com @ www
			}
		}
		provider duckdns {env.DUCK_TOKEN} {
			domains {
				example.duckdns.org @
			}
		}
	}
}
```
https://github.com/PurplestViper/caddy-dynamicdns/blob/967ac6b881f97af9f3f7af64747f0372f4debace/caddyfile.go#L109-L117
```go
unm, err := unmarshalModule(d, modID, func(value string) (bool, error) {
	if value != "domains" {
		return false, nil
	}
	if err := parseDomains(d, &prov.Domains); err != nil {
		return false, err
	}
	return true, nil
})
```
https://github.com/PurplestViper/caddy-dynamicdns/blob/967ac6b881f97af9f3f7af64747f0372f4debace/caddyfile.go#L266-L287
```go
// Similar to caddyfile.UnmarshalModule(), with consumer
func unmarshalModule(d *caddyfile.Dispenser, moduleID string, consumer func(value string) (bool, error)) (caddyfile.Unmarshaler, error) {
	mod, err := caddy.GetModule(moduleID)
	if err != nil {
		return nil, d.Errf("getting module named '%s': %v", moduleID, err)
	}
	inst := mod.New()
	unm, ok := inst.(caddyfile.Unmarshaler)
	if !ok {
		return nil, d.Errf("module %s is not a Caddyfile unmarshaler; is %T", mod.ID, inst)
	}
	seg, err := nextSegment(d, consumer)
	if err != nil {
		return nil, err
	}
	err = unm.UnmarshalCaddyfile(caddyfile.NewDispenser(seg))
	if err != nil {
		return nil, err
	}
	return unm, nil
}
```
https://github.com/PurplestViper/caddy-dynamicdns/blob/967ac6b881f97af9f3f7af64747f0372f4debace/caddyfile.go#L221-L264
```go
// Similar to the (caddyfile.Dispenser).NextSegment(),
// but allows other functions to consume intermediate blocks.
// Since the boundaries are handled by internal functions, NewDispenser is not needed here.
//
//	consumer - Currently, used to handle domains
func nextSegment(d *caddyfile.Dispenser, consumer func(value string) (bool, error)) (caddyfile.Segment, error) {
	tkns := caddyfile.Segment{d.Token()}
	for d.NextArg() {
		tkns = append(tkns, d.Token())
	}
	var openedBlock bool
	for nesting := d.Nesting(); d.NextBlock(nesting); {
		if !openedBlock {
			// because NextBlock() consumes the initial open
			// curly brace, we rewind here to append it, since
			// our case is special in that we want the new
			// dispenser to have all the tokens including
			// surrounding curly braces
			d.Prev()
			tkns = append(tkns, d.Token())
			d.Next()
			openedBlock = true
		}


		ok, err := consumer(d.Val())
		if err != nil {
			return nil, err
		}
		if ok {
			continue
		}


		tkns = append(tkns, d.Token())
	}
	if openedBlock {
		// include closing brace
		tkns = append(tkns, d.Token())


		// do not consume the closing curly brace; the
		// next iteration of the enclosing loop will
		// call Next() and consume it
	}
	return tkns, nil
}
```