### PR TITLE
caddyhttp: dedupe MatchPath godoc for %* wildcards

### DIFF
--- a/modules/caddyhttp/matchers.go
+++ b/modules/caddyhttp/matchers.go
@@ -90,15 +90,11 @@ type (
 	// the literal percent sign (%) in normalized space can be done using the
 	// escaped form, `%25`.
 	//
-	// Even though wildcards (`*`) operate in the normalized space, the special
-	// escaped wildcard (`%*`), which is not a valid escape sequence, may be
-	// used in place of a span that should NOT be decoded; that is, `/bands/%*`
-	// will match `/bands/AC%2fDC` whereas `/bands/*` will not.
-	//
-	// Even though path matching is done in normalized space, the special
-	// wildcard `%*` may be used in place of a span that should NOT be decoded;
-	// that is, `/bands/%*/` will match `/bands/AC%2fDC/` whereas `/bands/*/`
-	// will not.
+	// Even though path matching (and wildcards `*`) operate in normalized space,
+	// the special escaped wildcard (`%*`), which is not a valid escape sequence,
+	// may be used in place of a span that should NOT be decoded; that is,
+	// `/bands/%*` will match `/bands/AC%2fDC` whereas `/bands/*` will not, and
+	// `/bands/%*/` will match `/bands/AC%2fDC/` whereas `/bands/*/` will not.
 	//
 	// This matcher is fast, so it does not support regular expressions or
 	// capture groups. For slower but more powerful matching, use the


### PR DESCRIPTION
The path matcher docs on the website (and the godoc that feeds them) had two near-identical paragraphs about `%*`. Folded them into one that still shows both examples.

Fixes caddyserver/website#484

## Assistance Disclosure

No AI tooling on this change — small godoc edit by hand.