### PR TITLE
fileserver: parallelize directory listing to speed up large-directory browsing

### DIFF
--- a/caddytest/integration/caddyfile_adapt/file_server_browse_concurrency.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/file_server_browse_concurrency.caddyfiletest
@@ -1,0 +1,36 @@
+:80
+
+file_server {
+	browse {
+		concurrency 8
+	}
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":80"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"browse": {
+										"concurrency": 8
+									},
+									"handler": "file_server",
+									"hide": [
+										"./Caddyfile"
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -69,10 +69,26 @@ type Browse struct {
 
 	// FileLimit limits the number of up to n DirEntry values in directory order.
 	FileLimit int `json:"file_limit,omitempty"`
+
+	// Concurrency sets how many directory entries are stat'd (and, for
+	// symlinks, have their target resolved) at once while building a
+	// listing. Gathering this per-entry info involves filesystem syscalls,
+	// so raising this can speed up listings of large directories; lowering
+	// it reduces the burst of concurrent filesystem calls a single listing
+	// request can generate. If 0 (default), a built-in default is used.
+	Concurrency int `json:"concurrency,omitempty"`
 }
 
 const (
 	defaultDirEntryLimit = 10000
+
+	// defaultDirListingConcurrency is how many directory entries are
+	// stat'd concurrently by default when Browse.Concurrency is unset.
+	// This work is syscall/IO-bound rather than CPU-bound, so it isn't
+	// tied to GOMAXPROCS; the value is kept modest because it's a
+	// per-request bound, not a global one - many simultaneous listing
+	// requests each fan out to this many concurrent filesystem calls.
+	defaultDirListingConcurrency = 16
 )
 
 func (fsrv *FileServer) serveBrowse(fileSystem fs.FS, root, dirPath string, w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {

--- a/modules/caddyhttp/fileserver/browsetplcontext.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -34,6 +35,26 @@ import (
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 )
 
+// readLinkFS extends fs.FS for filesystems that can resolve symlink targets.
+type readLinkFS interface {
+	fs.FS
+	ReadLink(name string) (string, error)
+}
+
+// direntResult holds the outcome of stat'ing a single directory entry
+// (statDirEntry). ok is false if the entry could not be stat'd and should
+// be skipped entirely; it's tracked explicitly (rather than relying on a
+// zero-value fileInfo) because a legitimately empty file has Size == 0.
+type direntResult struct {
+	fi      fileInfo
+	ownSize int64
+	ok      bool
+}
+
+// directoryListing gathers the entries of a directory into a
+// browseTemplateContext. fileSystem is invoked concurrently from multiple
+// goroutines (Stat, for symlink targets), so any fs.FS passed here must
+// support concurrent use; the standard OS-backed filesystem does.
 func (fsrv *FileServer) directoryListing(ctx context.Context, fileSystem fs.FS, parentModTime time.Time, entries []fs.DirEntry, canGoUp bool, root, urlPath string, repl *caddy.Replacer) *browseTemplateContext {
 	filesToHide := fsrv.transformHidePaths(repl)
 
@@ -49,95 +70,80 @@ func (fsrv *FileServer) directoryListing(ctx context.Context, fileSystem fs.FS, 
 		Items: make([]fileInfo, 0, len(entries)),
 	}
 
+	// pass 1: filter out hidden entries; cheap, no syscalls involved, so
+	// this stays sequential
+	visible := make([]fs.DirEntry, 0, len(entries))
 	for _, entry := range entries {
-		if err := ctx.Err(); err != nil {
-			break
+		if !fileHidden(entry.Name(), filesToHide) {
+			visible = append(visible, entry)
 		}
+	}
 
-		name := entry.Name()
+	// pass 2: gather per-entry info (Info/Stat/Readlink - all syscalls on
+	// most platforms) concurrently across a bounded set of workers, since
+	// this is the expensive part of building a listing for large
+	// directories
+	results := make([]direntResult, len(visible))
+	concurrency := defaultDirListingConcurrency
+	if fsrv.Browse.Concurrency > 0 {
+		concurrency = fsrv.Browse.Concurrency
+	}
+	if concurrency > len(visible) {
+		concurrency = len(visible)
+	}
 
-		if fileHidden(name, filesToHide) {
-			continue
-		}
+	if concurrency > 0 {
+		chunkSize := (len(visible) + concurrency - 1) / concurrency
 
-		info, err := entry.Info()
-		if err != nil {
-			if c := fsrv.logger.Check(zapcore.ErrorLevel, "could not get info about directory entry"); c != nil {
-				c.Write(zap.String("name", entry.Name()), zap.String("root", root))
+		var wg sync.WaitGroup
+		for w := 0; w < concurrency; w++ {
+			lo := w * chunkSize
+			hi := min(lo+chunkSize, len(visible))
+			if lo >= hi {
+				continue
 			}
+
+			wg.Go(func() {
+				for i := lo; i < hi; i++ {
+					if ctx.Err() != nil {
+						return
+					}
+					fi, ownSize, ok := fsrv.statDirEntry(fileSystem, visible[i], root, urlPath)
+					if ok {
+						results[i] = direntResult{fi: fi, ownSize: ownSize, ok: true}
+					}
+				}
+			})
+		}
+		wg.Wait()
+	}
+
+	// pass 3: aggregate the per-entry results in original order; cheap, no
+	// syscalls involved, so this stays sequential
+	for _, res := range results {
+		if !res.ok {
 			continue
 		}
+		fi := res.fi
 
 		// keep track of the most recently modified item in the listing
-		modTime := info.ModTime()
-		if tplCtx.lastModified.IsZero() || modTime.After(tplCtx.lastModified) {
-			tplCtx.lastModified = modTime
+		if tplCtx.lastModified.IsZero() || fi.ModTime.After(tplCtx.lastModified) {
+			tplCtx.lastModified = fi.ModTime
 		}
 
-		fileIsSymlink := isSymlink(info)
-		size := info.Size()
-
-		// for a symlink, a single stat of its target tells us both whether
-		// the target is a directory and what its size is
-		var targetInfo fs.FileInfo
-		var targetPath string
-		if fileIsSymlink {
-			targetPath = caddyhttp.SanitizedPathJoin(root, path.Join(urlPath, info.Name()))
-			// An error most likely means the symlink target doesn't exist,
-			// which isn't entirely unusual and shouldn't fail the listing.
-			// In this case, targetInfo stays nil and we fall back to
-			// treating it as a non-directory, using the symlink's own size.
-			targetInfo, _ = fs.Stat(fileSystem, targetPath)
-		}
-
-		isDir := entry.IsDir() || (targetInfo != nil && targetInfo.IsDir())
-
-		// add the slash after the escape of path to avoid escaping the slash as well
-		if isDir {
-			name += "/"
+		if fi.IsDir {
 			tplCtx.NumDirs++
 		} else {
 			tplCtx.NumFiles++
-		}
-
-		if !isDir {
-			// increase the total by the symlink's size, not the target's size,
-			// by incrementing before we follow the symlink
-			tplCtx.TotalFileSize += size
-		}
-
-		symlinkPath := ""
-		if fileIsSymlink {
-			if targetInfo != nil {
-				size = targetInfo.Size()
-			}
-
-			if fsrv.Browse.RevealSymlinks {
-				symLinkTarget, err := os.Readlink(targetPath)
-				if err == nil {
-					symlinkPath = symLinkTarget
-				}
-			}
-		}
-
-		if !isDir {
+			// increase the total by the symlink's own size, not the
+			// target's size
+			tplCtx.TotalFileSize += res.ownSize
 			// increase the total including the symlink target's size
-			tplCtx.TotalFileSizeFollowingSymlinks += size
+			tplCtx.TotalFileSizeFollowingSymlinks += fi.Size
 		}
 
-		u := url.URL{Path: "./" + name} // prepend with "./" to fix paths with ':' in the name
-
-		tplCtx.Items = append(tplCtx.Items, fileInfo{
-			IsDir:       isDir,
-			IsSymlink:   fileIsSymlink,
-			Name:        name,
-			Size:        size,
-			URL:         u.String(),
-			ModTime:     modTime.UTC(),
-			Mode:        info.Mode(),
-			Tpl:         tplCtx, // a reference up to the template context is useful
-			SymlinkPath: symlinkPath,
-		})
+		fi.Tpl = tplCtx // a reference up to the template context is useful
+		tplCtx.Items = append(tplCtx.Items, fi)
 	}
 
 	// this time is used for the Last-Modified header and comparing If-Modified-Since from client
@@ -145,6 +151,86 @@ func (fsrv *FileServer) directoryListing(ctx context.Context, fileSystem fs.FS, 
 	// see: https://github.com/caddyserver/caddy/issues/6828
 	tplCtx.lastModified = tplCtx.lastModified.UTC()
 	return tplCtx
+}
+
+// statDirEntry gathers the fileInfo for a single directory entry, including
+// resolving symlink targets. It performs filesystem syscalls (Info, and for
+// symlinks, an extra Stat and optionally Readlink), so it's designed to be
+// safe to call concurrently for different entries - it only reads fsrv's
+// config fields and doesn't mutate any shared state.
+//
+// It returns ok=false if the entry's info could not be obtained, in which
+// case the entry should be skipped from the listing (matching prior
+// behavior). ownSize is the entry's own size, ignoring any symlink target -
+// distinct from the returned fileInfo.Size, which follows symlinks.
+func (fsrv *FileServer) statDirEntry(fileSystem fs.FS, entry fs.DirEntry, root, urlPath string) (fi fileInfo, ownSize int64, ok bool) {
+	name := entry.Name()
+
+	info, err := entry.Info()
+	if err != nil {
+		if c := fsrv.logger.Check(zapcore.ErrorLevel, "could not get info about directory entry"); c != nil {
+			c.Write(zap.String("name", entry.Name()), zap.String("root", root))
+		}
+		return fileInfo{}, 0, false
+	}
+
+	modTime := info.ModTime()
+	fileIsSymlink := isSymlink(info)
+	size := info.Size()
+	ownSize = size
+
+	// for a symlink, a single stat of its target tells us both whether
+	// the target is a directory and what its size is
+	var targetInfo fs.FileInfo
+	var targetPath string
+	if fileIsSymlink {
+		targetPath = caddyhttp.SanitizedPathJoin(root, path.Join(urlPath, info.Name()))
+		// An error most likely means the symlink target doesn't exist,
+		// which isn't entirely unusual and shouldn't fail the listing.
+		// In this case, targetInfo stays nil and we fall back to
+		// treating it as a non-directory, using the symlink's own size.
+		targetInfo, _ = fs.Stat(fileSystem, targetPath)
+	}
+
+	isDir := entry.IsDir() || (targetInfo != nil && targetInfo.IsDir())
+
+	// add the slash after the escape of path to avoid escaping the slash as well
+	if isDir {
+		name += "/"
+	}
+
+	symlinkPath := ""
+	if fileIsSymlink {
+		if targetInfo != nil {
+			size = targetInfo.Size()
+		}
+
+		if fsrv.Browse.RevealSymlinks {
+			var symLinkTarget string
+			var err error
+			if rlFS, ok := fileSystem.(readLinkFS); ok {
+				symLinkTarget, err = rlFS.ReadLink(targetPath)
+			} else {
+				symLinkTarget, err = os.Readlink(targetPath)
+			}
+			if err == nil {
+				symlinkPath = symLinkTarget
+			}
+		}
+	}
+
+	u := url.URL{Path: "./" + name} // prepend with "./" to fix paths with ':' in the name
+
+	return fileInfo{
+		IsDir:       isDir,
+		IsSymlink:   fileIsSymlink,
+		Name:        name,
+		Size:        size,
+		URL:         u.String(),
+		ModTime:     modTime.UTC(),
+		Mode:        info.Mode(),
+		SymlinkPath: symlinkPath,
+	}, ownSize, true
 }
 
 // browseTemplateContext provides the template context for directory listings.

--- a/modules/caddyhttp/fileserver/browsetplcontext.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext.go
@@ -74,6 +74,9 @@ func (fsrv *FileServer) directoryListing(ctx context.Context, fileSystem fs.FS, 
 	// this stays sequential
 	visible := make([]fs.DirEntry, 0, len(entries))
 	for _, entry := range entries {
+		if ctx.Err() != nil {
+			return tplCtx
+		}
 		if !fileHidden(entry.Name(), filesToHide) {
 			visible = append(visible, entry)
 		}
@@ -103,8 +106,9 @@ func (fsrv *FileServer) directoryListing(ctx context.Context, fileSystem fs.FS, 
 				continue
 			}
 
+			lo2, hi2 := lo, hi
 			wg.Go(func() {
-				for i := lo; i < hi; i++ {
+				for i := lo2; i < hi2; i++ {
 					if ctx.Err() != nil {
 						return
 					}

--- a/modules/caddyhttp/fileserver/browsetplcontext_test.go
+++ b/modules/caddyhttp/fileserver/browsetplcontext_test.go
@@ -15,8 +15,128 @@
 package fileserver
 
 import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
 )
+
+// failingDirEntry is a fs.DirEntry whose Info() always fails, simulating an
+// entry that vanished between ReadDir and stat (e.g. deleted concurrently).
+// It's used to verify that directoryListing skips such entries without
+// affecting the rest of the listing, the same way it does today.
+type failingDirEntry struct{ name string }
+
+func (f failingDirEntry) Name() string               { return f.name }
+func (f failingDirEntry) IsDir() bool                { return false }
+func (f failingDirEntry) Type() fs.FileMode          { return 0 }
+func (f failingDirEntry) Info() (fs.FileInfo, error) { return nil, fs.ErrNotExist }
+
+// TestDirectoryListing verifies directoryListing's aggregate output
+// (NumDirs, NumFiles, the two total-size counters, and the resulting items)
+// against a directory with regular files, a subdirectory, and symlinks to
+// each - and confirms the result is identical whether entries are stat'd
+// with the default (parallel) concurrency or forced down to Concurrency: 1
+// (effectively sequential), to guard against the chunk-splitting rewrite
+// introducing an aggregation bug.
+func TestDirectoryListing(t *testing.T) {
+	dir := t.TempDir()
+	makeBenchDir(t, dir, 3) // file-0.txt, file-1.txt, file-2.txt (1 byte each), subdir/, symlink-to-file, symlink-to-dir
+
+	fileSystem, entries := readBenchDirEntries(t, dir)
+	entries = append(entries, failingDirEntry{name: "gone.txt"})
+
+	linkInfo, err := os.Lstat(filepath.Join(dir, "symlink-to-file"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantNumFiles := 4 // 3 regular files + symlink-to-file
+	wantNumDirs := 2  // subdir + symlink-to-dir
+	wantTotalFileSize := int64(3) + linkInfo.Size()
+	wantTotalFileSizeFollowingSymlinks := int64(3) + 1 // symlink-to-file's target (file-0.txt) is 1 byte
+	wantNames := map[string]bool{
+		"file-0.txt":      false,
+		"file-1.txt":      false,
+		"file-2.txt":      false,
+		"subdir/":         false,
+		"symlink-to-file": false,
+		"symlink-to-dir/": false,
+	}
+
+	ctx := context.Background()
+	repl := caddy.NewReplacer()
+
+	check := func(t *testing.T, l *browseTemplateContext) {
+		t.Helper()
+
+		if l.NumFiles != wantNumFiles {
+			t.Errorf("NumFiles = %d, want %d", l.NumFiles, wantNumFiles)
+		}
+		if l.NumDirs != wantNumDirs {
+			t.Errorf("NumDirs = %d, want %d", l.NumDirs, wantNumDirs)
+		}
+		if l.TotalFileSize != wantTotalFileSize {
+			t.Errorf("TotalFileSize = %d, want %d", l.TotalFileSize, wantTotalFileSize)
+		}
+		if l.TotalFileSizeFollowingSymlinks != wantTotalFileSizeFollowingSymlinks {
+			t.Errorf("TotalFileSizeFollowingSymlinks = %d, want %d", l.TotalFileSizeFollowingSymlinks, wantTotalFileSizeFollowingSymlinks)
+		}
+		if len(l.Items) != wantNumFiles+wantNumDirs {
+			t.Fatalf("len(Items) = %d, want %d", len(l.Items), wantNumFiles+wantNumDirs)
+		}
+
+		gotNames := make(map[string]bool, len(wantNames))
+		for k := range wantNames {
+			gotNames[k] = false
+		}
+		for _, item := range l.Items {
+			if _, ok := gotNames[item.Name]; !ok {
+				t.Errorf("unexpected item in listing: %q", item.Name)
+				continue
+			}
+			gotNames[item.Name] = true
+			if item.Tpl != l {
+				t.Errorf("item %q: Tpl does not point back to the listing", item.Name)
+			}
+		}
+		for name, seen := range gotNames {
+			if !seen {
+				t.Errorf("expected item %q missing from listing", name)
+			}
+		}
+	}
+
+	fsrv := benchFileServer()
+	t.Run("default concurrency", func(t *testing.T) {
+		l := fsrv.directoryListing(ctx, fileSystem, time.Time{}, entries, true, dir, "/", repl)
+		check(t, l)
+	})
+
+	fsrv.Browse.Concurrency = 1
+	t.Run("concurrency=1", func(t *testing.T) {
+		l := fsrv.directoryListing(ctx, fileSystem, time.Time{}, entries, true, dir, "/", repl)
+		check(t, l)
+	})
+
+	fsrv.Browse.Concurrency = 0
+	t.Run("concurrency=0 (treated as default)", func(t *testing.T) {
+		l := fsrv.directoryListing(ctx, fileSystem, time.Time{}, entries, true, dir, "/", repl)
+		check(t, l)
+	})
+
+	t.Run("cancelled context does not panic", func(t *testing.T) {
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+		l := fsrv.directoryListing(cancelCtx, fileSystem, time.Time{}, entries, true, dir, "/", repl)
+		if l == nil {
+			t.Fatal("expected non-nil listing even with cancelled context")
+		}
+	})
+}
 
 func TestBreadcrumbs(t *testing.T) {
 	testdata := []struct {

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -117,6 +117,7 @@ func (fsrv *FileServer) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			}
 			fsrv.Browse = new(Browse)
 			d.Args(&fsrv.Browse.TemplateFile)
+			var concurrencySet bool
 			for nesting := d.Nesting(); d.NextBlock(nesting); {
 				switch d.Val() {
 				case "reveal_symlinks":
@@ -144,6 +145,23 @@ func (fsrv *FileServer) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 						return d.Err("file_limit is already enabled")
 					}
 					fsrv.Browse.FileLimit = val
+				case "concurrency":
+					concurrency := d.RemainingArgs()
+					if len(concurrency) != 1 {
+						return d.Err("concurrency should have an integer value")
+					}
+					val, err := strconv.Atoi(concurrency[0])
+					if err != nil {
+						return d.Err("concurrency should have an integer value")
+					}
+					if val < 0 {
+						return d.Err("concurrency cannot be negative")
+					}
+					if concurrencySet {
+						return d.Err("concurrency already set")
+					}
+					fsrv.Browse.Concurrency = val
+					concurrencySet = true
 				default:
 					return d.Errf("unknown subdirective '%s'", d.Val())
 				}


### PR DESCRIPTION
## Summary

`file_server browse` listings were slow for directories with many entries.
`directoryListing()` called `entry.Info()` for every entry sequentially - on Unix that's a real `Lstat` syscall per entry (Windows already gets this for free from `FindNextFile`), plus a second `Stat` (and optional `Readlink`) for every symlink. A directory with thousands of files paid thousands of sequential syscall round-trips.

This splits the work into three passes and parallelizes the expensive one:

1. **Filter** (sequential) — drop hidden entries, no syscalls involved.
2. **Stat** (parallel) — a bounded pool of workers (`sync.WaitGroup.Go`, Go 1.25+) each stat a contiguous chunk of the remaining entries. Each worker owns disjoint indices into a preallocated results slice, so there's no shared mutable state and no locking. Workers bail out on `ctx.Err()` per item, matching the previous cancellation behavior.
3. **Aggregate** (sequential) — sum `NumDirs`/`NumFiles`/`TotalFileSize`/`TotalFileSizeFollowingSymlinks` and build `Items` from the results. Cheap, no syscalls.

Final `Items` order doesn't matter here since `applySortAndLimit` always resorts before any output format (JSON/text/HTML) uses it.

Worker count defaults to 16 (`browse.go`'s `defaultDirListingConcurrency`), deliberately conservative rather than tied to `GOMAXPROCS`: this is a syscall/IO-bound workload (Go already scales OS threads for blocked syscalls independent of `GOMAXPROCS`), and the bound is *per request*, not global — nothing caps concurrent syscalls across simultaneous browse requests, so a high default would multiply badly under concurrent load. It's now also configurable per-site:

```caddyfile
file_server {
    browse {
        concurrency 32
    }
}
```

(0/unset uses the built-in default.)

RevealSymlinks now also checks whether the fs.FS implements a new readLinkFS interface (ReadLink(name string) (string, error)) before falling back to os.Readlink, so custom filesystem modules can resolve symlinks their own way instead of assuming an OS path.

## Benchmark

go test -bench=BenchmarkDirectoryListing -benchmem -run '^$' ./modules/caddyhttp/fileserver/, real OS-backed directories (existing BenchmarkDirectoryListing harness), before vs. after, ns/op:


| entries  |   before     |   after    | speedup |
| -------: | -----------: | --: | --: |
|       100 |      178,349 |    138,127 |   ~1.3x |
|    1,000 |   1,773,131 |    772,169 |   ~2.3x |
|  10,000 | 20,534,202 |  4,599,638 |   ~4.5x |
|  50,000 | 96,676,685 | 22,168,099 |   ~4.4x |

Allocations rise modestly (e.g. ~56KB → ~80KB at 100 entries) from goroutine/closure overhead — an accepted tradeoff for the wall-clock win, and there's no regression even at small directory sizes since worker count is capped at min(concurrency, len(visible)).

## Assistance Disclosure

I used Claude Code to design and implement this change (directory-listing parallelization, the Concurrency config option and its Caddyfile syntax, and the new test), working from my own investigation that large-directory listings were slow. I reviewed the design, benchmarked it, and made additional changes myself on top (the readLinkFS symlink-resolution interface, and the concurrencySet fix in the Caddyfile parser).