### PR TITLE
caddyhttp: avoid cloning the request for logging on the non-logging hot path

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -455,20 +455,29 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	repl := caddy.NewReplacer()
 	r = PrepareRequest(r, repl, w, s)
 
-	// clone the request for logging purposes before it enters any handler chain;
-	// this is necessary to capture the original request in case it gets modified
-	// during handling (cloning the request and using .WithLazy is considerably
-	// faster than using .With, which will JSON-encode the request immediately)
 	shouldLogCredentials := s.Logs != nil && s.Logs.ShouldLogCredentials
-	loggableReq := zap.Object("request", LoggableHTTPRequest{
-		Request:              r.Clone(r.Context()),
-		ShouldLogCredentials: shouldLogCredentials,
-	})
-	errLog := s.errorLogger.WithLazy(loggableReq)
+
+	// Capturing the request for logging requires a deep clone (headers, URL, etc.)
+	// before handlers can mutate it; only pay for that on requests we actually log,
+	// so the non-logging hot path avoids an unconditional clone per request. The
+	// error path below clones lazily if a request errors without access logging.
+	// Cloning and using .WithLazy is considerably faster than .With, which would
+	// JSON-encode the request immediately.
+	shouldLog := s.shouldLogRequest(r)
+
+	errLog := s.errorLogger
+	var loggableReq zap.Field
+	if shouldLog {
+		loggableReq = zap.Object("request", LoggableHTTPRequest{
+			Request:              r.Clone(r.Context()),
+			ShouldLogCredentials: shouldLogCredentials,
+		})
+		errLog = errLog.WithLazy(loggableReq)
+	}
 
 	var duration time.Duration
 
-	if s.shouldLogRequest(r) {
+	if shouldLog {
 		wrec := NewResponseRecorder(w, nil, nil)
 		w = wrec
 
@@ -512,6 +521,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r.RemoteAddr = origReq.RemoteAddr
 		r.RequestURI = origReq.RequestURI
 		cloneURL(origReq.URL, r.URL)
+	}
+
+	// if the request wasn't already snapshotted for access logging, attach it now
+	// so the error log still carries request details (method/URL are restored just
+	// above; headers may reflect handler modifications as no pre-handler snapshot exists)
+	if !shouldLog {
+		errLog = errLog.WithLazy(zap.Object("request", LoggableHTTPRequest{
+			Request:              r.Clone(r.Context()),
+			ShouldLogCredentials: shouldLogCredentials,
+		}))
 	}
 
 	// prepare the error log

--- a/modules/caddyhttp/server_test.go
+++ b/modules/caddyhttp/server_test.go
@@ -170,6 +170,34 @@ func BenchmarkServer_LogRequest_WithTrace(b *testing.B) {
 	}
 }
 
+// BenchmarkServer_ServeHTTP_NoLog measures the request hot path when access
+// logging is disabled and the request succeeds, i.e. the common case where no
+// request snapshot should be needed.
+func BenchmarkServer_ServeHTTP_NoLog(b *testing.B) {
+	s := &Server{
+		logger:      zap.NewNop(),
+		errorLogger: zap.NewNop(),
+		primaryHandlerChain: HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+			return nil
+		}),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	req.Header.Set("Accept-Encoding", "gzip, deflate, br")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36")
+	req.Header.Set("Cookie", "session=abc123; theme=dark")
+	req.Header.Set("Referer", "https://example.com/previous")
+
+	rec := httptest.NewRecorder()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		s.ServeHTTP(rec, req)
+	}
+}
+
 func TestServer_TrustedRealClientIP_NoTrustedHeaders(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 	req.RemoteAddr = "192.0.2.1:12345"


### PR DESCRIPTION
ServeHTTP unconditionally deep-cloned every request (r.Clone) to build a lazy "request" log field for both the access logger and the error logger, before checking whether the request would actually be logged. r.Clone copies the URL and all header/trailer maps, so this cost O(number of headers) allocations on every request even when access logging was disabled and the request succeeded.

Only take the snapshot when it will be consumed:

- When access logging is enabled (shouldLogRequest), clone eagerly as before and share the field between the access and error loggers. Fidelity here is unchanged.
- Otherwise, skip the clone on the hot path. If the request later errors, the error branch clones lazily so the error log still carries request details.

The request is compiled once via shouldLog := s.shouldLogRequest(r) instead of being evaluated separately for the eager clone and the logging branch.

The tradeoff being made here happens when access logging is off and a request errors: the error log's request is now snapshotted in the error branch rather than pre-handler. Method, RemoteAddr, RequestURI and URL are still restored from OriginalRequestCtxKey, but headers may reflect handler modifications since no pre-handler snapshot is taken. This matches the existing "does not restore original headers if modified (for efficiency)" behavior already in that block. When access logging is on, error-log fidelity is unchanged.

Benchmark (BenchmarkServer_ServeHTTP_NoLog, linux/arm64, count=5), happy path with access logging disabled and a realistic request header set:

    before: ~6000 ns/op   3240 B/op   37 allocs/op
    after:  ~3500 ns/op   1944 B/op   26 allocs/op

~42% faster, ~40% less memory, 11 fewer allocations per request.

Adds BenchmarkServer_ServeHTTP_NoLog covering the non-logging success path, as per policy.




## Assistance Disclosure

"No AI was used."