### PR TITLE
reverseproxy: normalize empty HTTP/3 request bodies

### DIFF
--- a/AI_DISCLOSURE.md
+++ b/AI_DISCLOSURE.md
@@ -1,0 +1,1 @@
+I am just a bot. You are interacting with a bot.

--- a/caddytest/integration/reverseproxy_h3_test.go
+++ b/caddytest/integration/reverseproxy_h3_test.go
@@ -1,0 +1,171 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go/http3"
+
+	"github.com/caddyserver/caddy/v2/caddytest"
+)
+
+func TestReverseProxyHTTP3RequestBodyToHTTP2Upstream(t *testing.T) {
+	type observation struct {
+		proto         string
+		contentLength int64
+		body          string
+	}
+
+	observations := make(chan observation, 2)
+	origin := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		observations <- observation{
+			proto:         r.Proto,
+			contentLength: r.ContentLength,
+			body:          string(body),
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	origin.EnableHTTP2 = true
+	origin.StartTLS()
+	t.Cleanup(origin.Close)
+
+	tester := caddytest.NewTester(t)
+	tester.InitServer(fmt.Sprintf(`
+	{
+		"admin": {"listen": "localhost:2999"},
+		"apps": {
+			"http": {
+				"grace_period": 1,
+				"servers": {
+					"h3_proxy": {
+						"listen": [":9443"],
+						"protocols": ["h3"],
+						"automatic_https": {"disable": true},
+						"tls_connection_policies": [
+							{
+								"match": {"sni": ["localhost"]},
+								"certificate_selection": {"any_tag": ["h3_test"]}
+							}
+						],
+						"routes": [{
+							"handle": [{
+								"handler": "reverse_proxy",
+								"upstreams": [{"dial": %q}],
+								"transport": {
+									"protocol": "http",
+									"versions": ["2"],
+									"tls": {"insecure_skip_verify": true}
+								}
+							}]
+						}]
+					}
+				}
+			},
+			"tls": {
+				"certificates": {
+					"load_files": [{
+						"certificate": "/caddy.localhost.crt",
+						"key": "/caddy.localhost.key",
+						"tags": ["h3_test"]
+					}]
+				}
+			}
+		}
+	}
+	`, origin.Listener.Addr().String()), "json")
+
+	h3Transport := &http3.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+	}
+	t.Cleanup(func() {
+		if err := h3Transport.Close(); err != nil {
+			t.Errorf("closing HTTP/3 transport: %v", err)
+		}
+	})
+	client := &http.Client{
+		Transport: h3Transport,
+		Timeout:   5 * time.Second,
+	}
+
+	t.Run("empty body", func(t *testing.T) {
+		resp, err := client.Get("https://localhost:9443/")
+		if err != nil {
+			t.Fatalf("HTTP/3 GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		if resp.Proto != "HTTP/3.0" {
+			t.Fatalf("client protocol: got %q, want HTTP/3.0", resp.Proto)
+		}
+
+		got := <-observations
+		if got.proto != "HTTP/2.0" {
+			t.Fatalf("upstream protocol: got %q, want HTTP/2.0", got.proto)
+		}
+		if got.contentLength != 0 {
+			t.Fatalf("upstream content length: got %d, want 0", got.contentLength)
+		}
+		if got.body != "" {
+			t.Fatalf("upstream body: got %q, want empty", got.body)
+		}
+	})
+
+	t.Run("streaming body", func(t *testing.T) {
+		const wantBody = "streamed body"
+		req, err := http.NewRequest(http.MethodGet, "https://localhost:9443/", strings.NewReader(wantBody))
+		if err != nil {
+			t.Fatalf("creating HTTP/3 GET: %v", err)
+		}
+		req.ContentLength = -1
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("HTTP/3 GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		if resp.Proto != "HTTP/3.0" {
+			t.Fatalf("client protocol: got %q, want HTTP/3.0", resp.Proto)
+		}
+
+		got := <-observations
+		if got.proto != "HTTP/2.0" {
+			t.Fatalf("upstream protocol: got %q, want HTTP/2.0", got.proto)
+		}
+		if got.contentLength != -1 {
+			t.Fatalf("upstream content length: got %d, want -1", got.contentLength)
+		}
+		if got.body != wantBody {
+			t.Fatalf("upstream body: got %q, want %q", got.body, wantBody)
+		}
+	})
+}

--- a/modules/caddyhttp/reverseproxy/prepare_request_test.go
+++ b/modules/caddyhttp/reverseproxy/prepare_request_test.go
@@ -1,0 +1,157 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reverseproxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+func TestPrepareRequestNormalizesEmptyHTTP3Body(t *testing.T) {
+	body := &trackingReadCloser{Reader: strings.NewReader("")}
+	req := newHTTP3Request(body)
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader("")), nil
+	}
+	req.TransferEncoding = []string{"chunked"}
+
+	prepared, err := (Handler{}).prepareRequest(req, caddy.NewReplacer())
+	if err != nil {
+		t.Fatalf("preparing request: %v", err)
+	}
+	if prepared.ContentLength != 0 {
+		t.Fatalf("ContentLength: got %d, want 0", prepared.ContentLength)
+	}
+	if prepared.Body != nil {
+		t.Fatalf("Body: got %T, want nil", prepared.Body)
+	}
+	if prepared.GetBody != nil {
+		t.Fatal("GetBody: got non-nil, want nil")
+	}
+	if prepared.TransferEncoding != nil {
+		t.Fatalf("TransferEncoding: got %v, want nil", prepared.TransferEncoding)
+	}
+	if !body.closed {
+		t.Fatal("original body was not closed")
+	}
+}
+
+func TestPrepareRequestPreservesStreamingHTTP3Body(t *testing.T) {
+	body := &trackingReadCloser{Reader: strings.NewReader("streamed body")}
+	req := newHTTP3Request(body)
+
+	prepared, err := (Handler{}).prepareRequest(req, caddy.NewReplacer())
+	if err != nil {
+		t.Fatalf("preparing request: %v", err)
+	}
+	got, err := io.ReadAll(prepared.Body)
+	if err != nil {
+		t.Fatalf("reading prepared body: %v", err)
+	}
+	if string(got) != "streamed body" {
+		t.Fatalf("body: got %q, want %q", got, "streamed body")
+	}
+	if prepared.ContentLength != -1 {
+		t.Fatalf("ContentLength: got %d, want -1", prepared.ContentLength)
+	}
+	if body.closed {
+		t.Fatal("original body was closed before the prepared body")
+	}
+	if err := prepared.Body.Close(); err != nil {
+		t.Fatalf("closing prepared body: %v", err)
+	}
+	if !body.closed {
+		t.Fatal("closing prepared body did not close original body")
+	}
+}
+
+func TestPrepareRequestReturnsHTTP3BodyCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	body := &trackingReadCloser{Reader: contextReader{ctx: ctx}}
+	req := newHTTP3Request(body).WithContext(ctx)
+
+	prepared, err := (Handler{}).prepareRequest(req, caddy.NewReplacer())
+	if prepared != nil {
+		t.Fatalf("prepared request: got non-nil, want nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error: got %v, want context.Canceled", err)
+	}
+	if !body.closed {
+		t.Fatal("body was not closed after cancellation")
+	}
+}
+
+func TestPrepareRequestReturnsHTTP3BodyReadError(t *testing.T) {
+	wantErr := errors.New("read failed")
+	body := &trackingReadCloser{readErr: wantErr}
+	req := newHTTP3Request(body)
+
+	prepared, err := (Handler{}).prepareRequest(req, caddy.NewReplacer())
+	if prepared != nil {
+		t.Fatalf("prepared request: got non-nil, want nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error: got %v, want %v", err, wantErr)
+	}
+	if !body.closed {
+		t.Fatal("body was not closed after read error")
+	}
+}
+
+func newHTTP3Request(body io.ReadCloser) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/", nil)
+	req.Proto = "HTTP/3.0"
+	req.ProtoMajor = 3
+	req.ProtoMinor = 0
+	req.ContentLength = -1
+	req.Body = body
+	return caddyhttp.PrepareRequest(req, caddy.NewReplacer(), nil, &caddyhttp.Server{})
+}
+
+type trackingReadCloser struct {
+	io.Reader
+	readErr error
+	closed  bool
+}
+
+type contextReader struct {
+	ctx context.Context
+}
+
+func (r contextReader) Read([]byte) (int, error) {
+	return 0, r.ctx.Err()
+}
+
+func (r *trackingReadCloser) Read(p []byte) (int, error) {
+	if r.readErr != nil {
+		return 0, r.readErr
+	}
+	return r.Reader.Read(p)
+}
+
+func (r *trackingReadCloser) Close() error {
+	r.closed = true
+	return nil
+}

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -774,6 +774,10 @@ func (h Handler) prepareRequest(req *http.Request, repl *caddy.Replacer) (*http.
 		}
 	}
 
+	if err := normalizeEmptyHTTP3RequestBody(req); err != nil {
+		return nil, err
+	}
+
 	// if enabled, buffer client request; this should only be
 	// enabled if the upstream requires it and does not work
 	// with "slow clients" (gunicorn, etc.) - this obviously
@@ -875,6 +879,59 @@ func (h Handler) prepareRequest(req *http.Request, repl *caddy.Replacer) (*http.
 	req.Header.Add("Via", strconv.Itoa(req.ProtoMajor)+"."+strconv.Itoa(req.ProtoMinor)+" Caddy")
 
 	return req, nil
+}
+
+// normalizeEmptyHTTP3RequestBody distinguishes an empty HTTP/3 request body
+// from a body whose length is unknown. HTTP/3 request headers do not indicate
+// whether DATA will follow, so server requests without a declared length have
+// a non-nil body and ContentLength -1 even when the stream is already empty.
+func normalizeEmptyHTTP3RequestBody(req *http.Request) error {
+	if req.ProtoMajor != 3 || req.ContentLength >= 0 || req.Body == nil ||
+		len(req.Trailer) > 0 || len(req.Header.Values("Trailer")) > 0 {
+		return nil
+	}
+
+	var firstByte [1]byte
+	n, err := req.Body.Read(firstByte[:])
+	switch {
+	case err == io.EOF && n == 0:
+		if err := req.Body.Close(); err != nil {
+			return fmt.Errorf("closing empty HTTP/3 request body: %w", err)
+		}
+		req.Body = http.NoBody
+		req.ContentLength = 0
+		req.GetBody = nil
+		req.TransferEncoding = nil
+	case err != nil && err != io.EOF:
+		_ = req.Body.Close()
+		return fmt.Errorf("probing HTTP/3 request body: %w", err)
+	case n == 0:
+		_ = req.Body.Close()
+		return fmt.Errorf("probing HTTP/3 request body: %w", io.ErrNoProgress)
+	default:
+		req.Body = &replayReadCloser{firstByte: firstByte[0], body: req.Body, replay: true}
+	}
+
+	return nil
+}
+
+type replayReadCloser struct {
+	firstByte byte
+	body      io.ReadCloser
+	replay    bool
+}
+
+func (r *replayReadCloser) Read(p []byte) (int, error) {
+	if r.replay && len(p) > 0 {
+		p[0] = r.firstByte
+		r.replay = false
+		return 1, nil
+	}
+	return r.body.Read(p)
+}
+
+func (r *replayReadCloser) Close() error {
+	return r.body.Close()
 }
 
 // addForwardedHeaders adds the de-facto standard X-Forwarded-*


### PR DESCRIPTION
Fixes #7835.

  HTTP/3 requests without a declared content length arrive with a non-nil body
  and `ContentLength == -1`, even when the stream is empty.

  This change reads at most one byte before proxying:

  - immediate EOF: normalize to `http.NoBody` and `ContentLength = 0`;
  - data received: replay the byte and preserve the streamed body;
  - cancellation and read errors: propagate the error;
  - announced trailers: leave the request unchanged.

  Tests cover empty and streamed bodies, cancellation, read errors, and the full
  HTTP/3 client → Caddy → HTTP/2 upstream path.

  ## Testing

  - `go test -race -short ./modules/caddyhttp/reverseproxy`
  - `go test ./caddytest/integration`
  - `go test -short ./...`
  - `go build ./...`
  - `golangci-lint run --timeout 10m`

  ## Assistance Disclosure

  OpenAI Codex generated the implementation and tests under my direction.