### PR TITLE
admin: stabilise log redaction test

### DIFF
--- a/admin_test.go
+++ b/admin_test.go
@@ -271,19 +271,21 @@ func TestAdminHandlerServeHTTPRedactsSensitiveHeadersInLogs(t *testing.T) {
 	handler := adminHandler{
 		mux: http.NewServeMux(),
 	}
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/redaction-test", nil)
 	req.Header.Set("Authorization", "Bearer secret")
 	req.Header.Set("Cookie", "session=secret")
 	req.Header.Set("X-Test", "ok")
 	rr := httptest.NewRecorder()
 
+	Log().Info("unrelated test log")
 	handler.ServeHTTP(rr, req)
 
-	if logs.Len() == 0 {
-		t.Fatal("expected request log entry")
+	entries := logs.FilterMessage("received request").FilterField(zap.String("uri", req.RequestURI)).All()
+	if len(entries) != 1 {
+		t.Fatalf("request log entries = %d, want 1", len(entries))
 	}
 
-	ctx := logs.All()[0].ContextMap()
+	ctx := entries[0].ContextMap()
 	headers, ok := ctx["headers"].(map[string]any)
 	if !ok {
 		t.Fatalf("expected headers field in log context, got %T", ctx["headers"])


### PR DESCRIPTION
I noticed this test was flaky when it failed during CI for #7940. Select the expected admin request log entry instead of assuming it is the observers first entry.

## Assistance Disclosure
No AI was used.