### PR TITLE
caddyfile: make Format converge and stop dropping a trailing open brace

### DIFF
--- a/caddyconfig/caddyfile/formatter.go
+++ b/caddyconfig/caddyfile/formatter.go
@@ -300,12 +300,17 @@ func Format(input []byte) []byte {
 		switch {
 		case ch == '{':
 			finishToken()
-			openBrace = true
-			openBraceSpace = spacePrior && !beginningOfLine
-			openBraceOwnLine = newLines > 0
-			if openBraceSpace && newLines == 0 {
-				write(' ')
+			// a brace that follows one still waiting to be written must not
+			// reset the spacing decided for the pending one, or the space
+			// already emitted for it gets written a second time
+			if !openBrace || openBraceWritten {
+				openBraceSpace = spacePrior && !beginningOfLine
+				if openBraceSpace && newLines == 0 {
+					write(' ')
+				}
 			}
+			openBrace = true
+			openBraceOwnLine = newLines > 0
 			openBraceWritten = false
 			if quotes == "`" {
 				write('{')
@@ -321,6 +326,11 @@ func Format(input []byte) []byte {
 				write('}')
 				continue
 			}
+			// this brace closed a block, so a '{' still marked open was not a
+			// literal one waiting for its pair; leaving it open would make the
+			// next '}' come out inline on this pass but as a block closer on
+			// the next one, so Format would never converge
+			openBrace = false
 			if last != '\n' {
 				nextLine()
 			}
@@ -365,6 +375,21 @@ func Format(input []byte) []byte {
 		write(ch)
 
 		beginningOfLine = false
+	}
+
+	// an open brace is only written once we know what follows it, so one that
+	// ends the input has not been written yet; emit it rather than dropping it
+	// from the output
+	if openBrace && !openBraceWritten {
+		for i := 0; i < min(newLines, 2); i++ {
+			nextLine()
+		}
+		if beginningOfLine {
+			indent()
+		} else if !unicode.IsSpace(last) {
+			write(' ')
+		}
+		write('{')
 	}
 
 	// the Caddyfile does not need any leading or trailing spaces, but...

--- a/caddyconfig/caddyfile/formatter_test.go
+++ b/caddyconfig/caddyfile/formatter_test.go
@@ -495,6 +495,24 @@ import ./conf.d/matcher_not_my_subnet.caddy
 	order appsec after crowdsec
 }`,
 		},
+		{
+			description: "closing brace after an inline brace",
+			input:       `example.com{respond hi }}`,
+			expect: `example.com{respond hi
+}
+}`,
+		},
+		{
+			description: "open brace at the end of the input is not dropped",
+			input:       `{`,
+			expect:      `{`,
+		},
+		{
+			description: "open brace right after another one is not spaced twice",
+			input:       `example.com {{ respond hi`,
+			expect: `example.com {
+	respond hi`,
+		},
 	} {
 		// the formatter should output a trailing newline,
 		// even if the tests aren't written to expect that
@@ -507,6 +525,13 @@ import ./conf.d/matcher_not_my_subnet.caddy
 		if string(actual) != tc.expect {
 			t.Errorf("\n[TEST %d: %s]\n====== EXPECTED ======\n%s\n====== ACTUAL ======\n%s^^^^^^^^^^^^^^^^^^^^^",
 				i, tc.description, string(tc.expect), string(actual))
+		}
+
+		// formatting must converge: `caddy fmt` on already-formatted input
+		// has to be a no-op, or `--diff` never comes out empty
+		if reformatted := Format(actual); string(reformatted) != string(actual) {
+			t.Errorf("\n[TEST %d: %s] not idempotent\n====== ONCE ======\n%s\n====== TWICE ======\n%s^^^^^^^^^^^^^^^^^^^^^",
+				i, tc.description, string(actual), string(reformatted))
 		}
 	}
 }


### PR DESCRIPTION
`caddy fmt` should be a no-op on its own output. `formatter_fuzz.go` already encodes that property:

```go
func FuzzFormat(input []byte) int {
	formatted := Format(input)
	if bytes.Equal(formatted, Format(formatted)) {
		return 1
	}
	return 0
}
```

It returns `0` rather than failing, though, so an input that breaks the property only scores lower in the corpus and never gets reported. Running the same property as a native Go fuzz target turns up three unrelated defects. Each has a test in `formatter_test.go`, and each of those tests fails on `master`.

### 1. A closing brace shifts between passes

An open brace written inline stays marked open, so a later `}` that is not preceded by a space is written inline on one pass and treated as a block closer on the next:

```
0{0 }}   ->   0{0     ->   0{0
              }            }
                           }
              }
```

A brace that closed a block now clears that state. The flag itself still has to survive whitespace — it is what keeps `{placeholder}` tokens and the braces inside quoted/backquoted strings from being split, which the existing "Preserve braces wrapped by quotes" cases cover. My first attempt cleared it at every token boundary and those cases caught it immediately.

### 2. An open brace at the end of the input is dropped

The formatter only writes `{` once the following token decides how to place it, so a brace with nothing after it was never written:

```go
Format([]byte("{"))  // returned "\n"
```

Content silently disappearing is worse than it being formatted oddly — an unclosed block is usually a typo, and `caddy fmt` was removing the evidence. It is now emitted, on its own line if that is where it appeared.

### 3. Two open braces in a row emit a double space

The second brace overwrote the spacing state of the first while that one was still pending, so the space already written for it got written again: `example.com {{ respond hi` came out as `example.com  {`.

### Also

The existing table-driven cases are now checked for convergence too (`Format(Format(x)) == Format(x)`). They all pass on `master` — it is the three new cases that pin defects 1 and 3 — but it makes the property explicit for future cases.

### What this does not fix

This does **not** make `Format` idempotent in general. Fuzzing still finds inputs that combine escapes with braces and do not converge, the smallest being `{ {\`. That looks like a separate problem in the escape handling and I did not want to widen this PR into it — happy to follow up if you'd like.

### Verification

- `go test ./caddyconfig/... ./cmd/...` passes; `gofmt` and `go vet` are clean.
- Each new test case fails on `master` and passes here (checked by stashing only `formatter.go`).
- `go test -fuzz FuzzFormatIsIdempotent` on a local (uncommitted) harness now runs past all three of these; it stops at the escape case above.

### A note on process

CONTRIBUTING asks for an issue first. This is small, self-contained, and each claim is a failing test, so I opened it directly rather than describing it twice — happy to convert it to an issue if you'd rather discuss the approach first, or to drop parts 1 and 3 and keep only the dropped-brace fix.

## Assistance Disclosure

Heavy AI assistance, disclosed in full: I directed the work, and Claude Code (claude-opus-5) found the bugs by fuzzing, wrote the fixes and the tests, and drafted this description. I reviewed the diff and the reasoning before opening it. The one-line "clear the flag on every token boundary" fix was rejected during that review because it broke the existing quoted-brace cases; the fix here is the narrower one that keeps them passing.
