### PR TITLE
fix: honour skip_install_trust for explicit tls internal issuers

### DIFF
--- a/caddyconfig/httpcaddyfile/pkiapp.go
+++ b/caddyconfig/httpcaddyfile/pkiapp.go
@@ -22,6 +22,7 @@ import (
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddypki"
+	"github.com/caddyserver/caddy/v2/modules/caddytls"
 )
 
 func init() {
@@ -249,11 +250,31 @@ func (st ServerType) buildPKIApp(
 		}
 	}
 
+	// Detect whether any site block explicitly uses tls internal. When it
+	// does, the PKI app will provision the default local CA at runtime, so
+	// we must add it here with InstallTrust=false to honour skip_install_trust
+	// even when auto_https is completely disabled.
+	internalIssuerUsed := false
+	if skipInstallTrust {
+		outer:
+		for _, p := range pairings {
+			for _, sblock := range p.serverBlocks {
+				for _, issuerVal := range sblock.pile["tls.cert_issuer"] {
+					if _, ok := issuerVal.Value.(*caddytls.InternalIssuer); ok {
+						internalIssuerUsed = true
+						break outer
+					}
+				}
+			}
+		}
+	}
+
 	// if there was no CAs defined in any of the servers,
 	// and we were requested to not install trust, then
 	// add one for the default/local CA to do so
-	// only if auto_https is not completely disabled
-	if len(pkiApp.CAs) == 0 && skipInstallTrust && !autoHTTPSOff {
+	// only if auto_https is not completely disabled, or if a site
+	// explicitly uses tls internal (which always needs the local CA)
+	if len(pkiApp.CAs) == 0 && skipInstallTrust && (!autoHTTPSOff || internalIssuerUsed) {
 		ca := new(caddypki.CA)
 		ca.ID = caddypki.DefaultCAID
 		ca.InstallTrust = &falseBool


### PR DESCRIPTION
### Problem\n\nWhen `auto_https off` is set alongside `skip_install_trust`, and a site uses an explicit `tls internal` directive, the local CA still attempts to install its root certificate into the OS trust store — the `skip_install_trust` option is silently ignored.\n\nThe root cause is in `buildPKIApp`: the guard that adds the default `local` CA with `InstallTrust = false` reads:\n\n```go\nif len(pkiApp.CAs) == 0 && skipInstallTrust && !autoHTTPSOff {\n```\n\nWith `auto_https off`, `autoHTTPSOff` is `true`, so this block never runs. No CA entry is added to `pkiApp`, and the PKI app provisions the default local CA at runtime with default behaviour — which means it tries to install trust.\n\nThis was fixed for the implicit auto-HTTPS path by #7238, but the `tls internal` directive creates its CA through a different code path that was not covered.\n\n### Fix\n\nWhen `skip_install_trust` is set, scan all server blocks for `tls.cert_issuer` pile entries of type `*caddytls.InternalIssuer`. If any site explicitly uses `tls internal`, create the default CA with `InstallTrust = false` regardless of `auto_https`.\n\nThis preserves the existing behaviour for configurations that have `auto_https off` without any `tls internal` sites (no CA is created), while correctly suppressing trust installation when `tls internal` is actually used.\n\n### Repro\n\n```caddyfile\n{\n    auto_https off\n    skip_install_trust\n}\n\ninternal.example.com {\n    respond \"explicit tls internal site\"\n    tls internal\n}\n```\n\nBefore: `{\"level\":\"error\",\"logger\":\"pki.ca.local\",\"msg\":\"failed to install root certificate\",...}`\n\nAfter: no trust installation attempt.\n\nFixes #7893