### PR TITLE
rewrite: fix URI splitting when a query or fragment arrives via a placeholder

### DIFF
--- a/modules/caddyhttp/rewrite/rewrite.go
+++ b/modules/caddyhttp/rewrite/rewrite.go
@@ -217,6 +217,7 @@ func (rewr Rewrite) Rewrite(r *http.Request, repl *caddy.Replacer) bool {
 
 		// before continuing, we need to check if a query string
 		// snuck into the path component during replacements
+		queryInjected := false
 		if before, after, found := strings.Cut(newPath, "?"); found {
 			// recompute; new path contains a query string
 			var injectedQuery string
@@ -233,6 +234,13 @@ func (rewr Rewrite) Rewrite(r *http.Request, repl *caddy.Replacer) bool {
 				injectedQuery = strings.ReplaceAll(injectedQuery, "{", "%7B")
 				injectedQuery = strings.ReplaceAll(injectedQuery, "}", "%7D")
 				query = injectedQuery
+
+				// the replacement value spoke about the query string, so the
+				// query must be written back even though the configured URI
+				// had no literal '?' to set qsStart. an injected query that
+				// is empty (a value ending in '?') clears the query, which is
+				// consistent with configuring a bare '?'.
+				queryInjected = true
 			}
 		}
 
@@ -253,7 +261,7 @@ func (rewr Rewrite) Rewrite(r *http.Request, repl *caddy.Replacer) bool {
 			}
 			r.URL.RawPath = "" // force recomputing when EscapedPath() is called
 		}
-		if qsStart >= 0 {
+		if qsStart >= 0 || queryInjected {
 			r.URL.RawQuery = newQuery
 		}
 		if fragStart >= 0 {

--- a/modules/caddyhttp/rewrite/rewrite.go
+++ b/modules/caddyhttp/rewrite/rewrite.go
@@ -344,6 +344,12 @@ func buildQueryString(qs string, repl *caddy.Replacer) string {
 		// determine the end of this component, which will be at
 		// the next equal sign or ampersand, whichever comes first
 		nextEq, nextAmp := strings.Index(qs, "="), strings.Index(qs, "&")
+		if !wroteVal {
+			// we are consuming a value, and '=' only delimits a key from
+			// its value; any further '=' bytes are literal data, such as
+			// base64 padding in a signature. only '&' ends a value.
+			nextEq = -1
+		}
 		ampIsNext := nextAmp >= 0 && (nextAmp < nextEq || nextEq < 0)
 		end := len(qs) // assume no delimiter remains...
 		if ampIsNext {

--- a/modules/caddyhttp/rewrite/rewrite.go
+++ b/modules/caddyhttp/rewrite/rewrite.go
@@ -215,6 +215,16 @@ func (rewr Rewrite) Rewrite(r *http.Request, repl *caddy.Replacer) bool {
 			newPath = repl.ReplaceAll(path, "")
 		}
 
+		// a fragment may have snuck into the path component during
+		// replacements; everything after the first '#' is fragment
+		// (RFC 3986 section 4.2), which is never sent to the server,
+		// so drop it. this mirrors how a literal '#' in the configured
+		// URI is handled by the scan above, and prevents the fragment
+		// from being mistaken for part of the path or query below.
+		if before, _, found := strings.Cut(newPath, "#"); found {
+			newPath = before
+		}
+
 		// before continuing, we need to check if a query string
 		// snuck into the path component during replacements
 		queryInjected := false

--- a/modules/caddyhttp/rewrite/rewrite_test.go
+++ b/modules/caddyhttp/rewrite/rewrite_test.go
@@ -409,6 +409,51 @@ func TestRewrite(t *testing.T) {
 			input:  newRequest(t, "GET", "/hello"),
 			expect: newRequest(t, "GET", "/hello?x=1&sig=YWJjZA=="),
 		},
+
+		// a query string that arrives via a replacement value is honored even
+		// though the configured URI has no literal '?' (see issue #5208).
+		{
+			rule:   Rewrite{URI: "{http.request.header.X-Accel-Redirect}"},
+			input:  newRequestWithHeader(t, "GET", "/orig", "X-Accel-Redirect", "/hello?some=param&some_other=param"),
+			expect: newRequest(t, "GET", "/hello?some=param&some_other=param"),
+		},
+		{
+			// an injected query replaces the original one, as a configured query would
+			rule:   Rewrite{URI: "{http.request.header.X-Accel-Redirect}"},
+			input:  newRequestWithHeader(t, "GET", "/orig?keep=me", "X-Accel-Redirect", "/hello?some=param"),
+			expect: newRequest(t, "GET", "/hello?some=param"),
+		},
+		{
+			// a value ending in '?' clears the query, same as configuring a bare '?'
+			rule:   Rewrite{URI: "{http.request.header.X-Accel-Redirect}"},
+			input:  newRequestWithHeader(t, "GET", "/orig?keep=me", "X-Accel-Redirect", "/hello?"),
+			expect: newRequest(t, "GET", "/hello"),
+		},
+		{
+			// no '?' in the value means the query is not touched
+			rule:   Rewrite{URI: "{http.request.header.X-Accel-Redirect}"},
+			input:  newRequestWithHeader(t, "GET", "/orig?keep=me", "X-Accel-Redirect", "/hello"),
+			expect: newRequest(t, "GET", "/hello?keep=me"),
+		},
+		{
+			// an explicitly configured query still wins over an injected one
+			rule:   Rewrite{URI: "{http.request.header.X-Accel-Redirect}?a=b"},
+			input:  newRequestWithHeader(t, "GET", "/orig", "X-Accel-Redirect", "/hello?some=param"),
+			expect: newRequest(t, "GET", "/hello?a=b"),
+		},
+		{
+			// an escaped '?' in the request path does not split the URI, so the
+			// implicit rewrites of try_files and php_fastcgi stay safe
+			rule:   Rewrite{URI: "{http.request.uri.path}"},
+			input:  newRequest(t, "GET", "/bar%3Fbaz?keep=me"),
+			expect: newRequest(t, "GET", "/bar%3Fbaz?keep=me"),
+		},
+		{
+			// an S3 presigned URL arriving via a replacement value survives intact
+			rule:   Rewrite{URI: "{http.request.header.X-Ph}"},
+			input:  newRequestWithHeader(t, "GET", "/orig", "X-Ph", "/f.jpg?X-Amz-Credential=AK%2Ffr-par%2Fs3&X-Amz-Signature=YWJjZA=="),
+			expect: newRequest(t, "GET", "/f.jpg?X-Amz-Credential=AK%2Ffr-par%2Fs3&X-Amz-Signature=YWJjZA=="),
+		},
 	} {
 		// copy the original input just enough so that we can
 		// compare it after the rewrite to see if it changed

--- a/modules/caddyhttp/rewrite/rewrite_test.go
+++ b/modules/caddyhttp/rewrite/rewrite_test.go
@@ -396,6 +396,19 @@ func TestRewrite(t *testing.T) {
 			input:  newRequestWithHeader(t, "GET", "/anything", "X-Fwd", "ok?path={file./etc/passwd}"),
 			expect: newRequest(t, "GET", "/serve/ok?path=%7Bfile./etc/passwd%7D"),
 		},
+
+		// '=' delimits a key from its value only once; any further '=' bytes
+		// are literal data, such as base64 padding in a signature.
+		{
+			rule:   Rewrite{URI: "?sig=YWJjZA=="},
+			input:  newRequest(t, "GET", "/hello"),
+			expect: newRequest(t, "GET", "/hello?sig=YWJjZA=="),
+		},
+		{
+			rule:   Rewrite{URI: "?x=1&sig=YWJjZA=="},
+			input:  newRequest(t, "GET", "/hello"),
+			expect: newRequest(t, "GET", "/hello?x=1&sig=YWJjZA=="),
+		},
 	} {
 		// copy the original input just enough so that we can
 		// compare it after the rewrite to see if it changed

--- a/modules/caddyhttp/rewrite/rewrite_test.go
+++ b/modules/caddyhttp/rewrite/rewrite_test.go
@@ -454,6 +454,44 @@ func TestRewrite(t *testing.T) {
 			input:  newRequestWithHeader(t, "GET", "/orig", "X-Ph", "/f.jpg?X-Amz-Credential=AK%2Ffr-par%2Fs3&X-Amz-Signature=YWJjZA=="),
 			expect: newRequest(t, "GET", "/f.jpg?X-Amz-Credential=AK%2Ffr-par%2Fs3&X-Amz-Signature=YWJjZA=="),
 		},
+
+		// a fragment that arrives via a replacement value is dropped: everything
+		// after '#' is fragment (RFC 3986 section 4.2) and is never sent to the
+		// server, so it must not leak into the path or query.
+		{
+			rule:   Rewrite{URI: "{http.request.header.X-Ph}"},
+			input:  newRequestWithHeader(t, "GET", "/orig", "X-Ph", "/hello#frag"),
+			expect: newRequest(t, "GET", "/hello"),
+		},
+		{
+			rule:   Rewrite{URI: "{http.request.header.X-Ph}"},
+			input:  newRequestWithHeader(t, "GET", "/orig", "X-Ph", "/hello?a=b#frag"),
+			expect: newRequest(t, "GET", "/hello?a=b"),
+		},
+		{
+			// a '?' after the injected '#' is fragment, not a query delimiter
+			rule:   Rewrite{URI: "{http.request.header.X-Ph}"},
+			input:  newRequestWithHeader(t, "GET", "/orig", "X-Ph", "/hello#frag?notquery"),
+			expect: newRequest(t, "GET", "/hello"),
+		},
+		{
+			// a configured fragment still wins over an injected one
+			rule:   Rewrite{URI: "{http.request.header.X-Ph}#cfgfrag"},
+			input:  newRequestWithHeader(t, "GET", "/orig", "X-Ph", "/hello?a=b#frag"),
+			expect: newRequest(t, "GET", "/hello?a=b#cfgfrag"),
+		},
+		{
+			// an escaped '#' is not a fragment delimiter and is preserved
+			rule:   Rewrite{URI: "{http.request.header.X-Ph}"},
+			input:  newRequestWithHeader(t, "GET", "/orig", "X-Ph", "/hello%23frag"),
+			expect: newRequest(t, "GET", "/hello%23frag"),
+		},
+		{
+			// a fragment-only value leaves the original query alone
+			rule:   Rewrite{URI: "{http.request.header.X-Ph}"},
+			input:  newRequestWithHeader(t, "GET", "/orig?keep=me", "X-Ph", "/hello#frag"),
+			expect: newRequest(t, "GET", "/hello?keep=me"),
+		},
 	} {
 		// copy the original input just enough so that we can
 		// compare it after the rewrite to see if it changed


### PR DESCRIPTION
Three related bugs in `Rewrite`, one per commit. Found while digging into #5208.

### 1. A query string injected by a replacement value was discarded

Which URI components get written back was decided from the *literal* config string, before placeholders were expanded, but an injected query is only detected *after* expansion. For `rewrite * {rp.header.X-Accel-Redirect}` there is no literal `?`, so `qsStart` stayed `-1` and the correctly-built query string was computed and then thrown away by the `if qsStart >= 0` guard.

Only half the split was applied, so the query wasn't preserved either — it was dropped, and any query already on the request survived in its place:

```
GET /orig?keep=me   X-Accel-Redirect: /hello?some=param
before => /hello?keep=me
after  => /hello?some=param
```

Appending a literal `?` to the value was the known workaround precisely because it set `qsStart`. That keeps working and is now unnecessary.

The flag is only set where the injected query is actually adopted, so an explicitly configured query still wins, and a value with no `?` still leaves the query untouched — which is what the implicit rewrites of `try_files` and `php_fastcgi` rely on. Those stay safe regardless, since `escapePathPlaceholders` (#7683) already escapes the two placeholders they use, so a client-supplied `%3F` cannot split the URI. There's a test pinning that.

### 2. A fragment injected by a replacement value leaked into the path or query

Same root cause — the path/query/fragment scan only sees the literal config string, so a `#` arriving via a placeholder was never treated as a delimiter:

```
X-Accel-Redirect: /hello?p=x#frag   =>   RawQuery = "p=x#frag"
```

Everything after `#` is fragment (RFC 3986 §4.2) and a fragment is never sent to the server, so it's dropped before the path is split, mirroring how the scan already handles a literal `#`. An escaped `%23` is unaffected, so a real `#` is still expressible, and a configured fragment still wins over an injected one.

### 3. `buildQueryString` dropped a trailing `=`

Independent of the above, and reproducible with no placeholders at all:

```
rewrite * ?x=1&sig=YWJjZA==   =>   ?x=1&sig=YWJjZA=
```

The component scan looked for `=` unconditionally, but `=` delimits a key from its value only once; any further `=` bytes are literal data. When the query ended with `=`, that byte was consumed as a delimiter with nothing after it to re-emit. Only the *final* `=` was affected — `?sig=YWJjZA==&x=1` came through intact.

This corrupts base64 padding in the last query parameter, i.e. the shape of an S3 presigned URL (`X-Amz-Signature`), turning a valid signature into a 403. That's the setup in #5208, where it would have been masked by the `uri replace %3D =` workarounds people posted.

### Behaviour changes worth noting in the changelog

- A rewrite value containing `?` now sets the query. Reachable only by configs interpolating an untrusted value into the path position (`{http.request.uri}`, `{http.request.orig_uri}`, a header) — for those, treating `?` as a delimiter is the evident intent, and #7761's `{`/`}` escaping still prevents the injected query from being re-expanded as placeholder syntax.
- `{ph}&foo=bar` with a value containing `?` and `#` now drops the `&foo=bar`, since it sits after the fragment delimiter. RFC-correct and consistent with a literal `#`, but it is a change.

### Alternative considered

#5438 gates this behind an opt-in `modify_query`. The downside is that the current half-applied split stays the default: the path is *still* truncated at an injected `?` while the query is dropped, so no config gets correct behaviour by default and the data loss stays silent. Happy to switch to the opt-in if you'd rather, @mholt — the tracking flag is the same either way.

### Testing

15 cases added to the `TestRewrite` table, covering all three fixes plus the precedence and safety guardrails. They produce 33 assertion failures against unpatched `rewrite.go` and pass with it. Each of the three commits is independently green (verified via `git rebase --exec`). `./modules/caddyhttp/...` and `./caddyconfig/...` pass; `go vet` and `gofmt` clean.

### Not fixed here

There is still no way to spell "append a param to whatever query the placeholder carries" in a single rewrite: `{ph}&foo=bar` only works when the value happens to contain a `?` (otherwise `&foo=bar` is glued onto the path, and `&` can't be made a delimiter since it's a legal path character), and `{ph}?foo=bar` discards the injected query. Two rewrites do work and compose cleanly, since `{query}` reads `URL.RawQuery` live:

```
rewrite * {rp.header.X-Accel-Redirect}?
rewrite * ?{query}&foo=bar
```

Worth a docs note rather than more code, I think.

## Assistance Disclosure

🤖 Generated with [Claude Code](https://claude.com/claude-code)