### PR TITLE
reverseproxy: reduce lock contention in dynamic SRV and A upstreams

### DIFF
--- a/modules/caddyhttp/reverseproxy/upstreams.go
+++ b/modules/caddyhttp/reverseproxy/upstreams.go
@@ -3,16 +3,19 @@ package reverseproxy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	weakrand "math/rand/v2"
 	"net"
 	"net/http"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/caddyserver/caddy/v2"
 )
@@ -75,9 +78,13 @@ type SRVUpstreams struct {
 	// accepted values. For example, to restrict to IPv4, use "tcp4".
 	DialNetwork string `json:"dial_network,omitempty"`
 
-	resolver *net.Resolver
+	resolver srvResolver
 
 	logger *zap.Logger
+}
+
+type srvResolver interface {
+	LookupSRV(ctx context.Context, service, proto, name string) (cname string, addrs []*net.SRV, err error)
 }
 
 // CaddyModule returns the Caddy module information.
@@ -119,15 +126,22 @@ func (su *SRVUpstreams) Provision(ctx caddy.Context) error {
 	return nil
 }
 
+// ResetCache clears the cached value for a specific key, or the entire
+// cache if r is nil. A single key is tombstoned (kept, with gen bumped)
+// rather than deleted, since a lookup may still be in flight for it; a
+// full reset bumps the epoch instead.
 func (su *SRVUpstreams) ResetCache(r *http.Request) error {
 	srvsMu.Lock()
+	defer srvsMu.Unlock()
 	if r == nil {
+		// epoch covers in-flight lookups, so the entries can go
 		srvs = make(map[string]srvLookup)
+		srvEpoch++
 	} else {
 		suAddr, _, _, _ := su.expandedAddr(r)
-		delete(srvs, suAddr)
+		makeRoom(srvs, suAddr)
+		srvs[suAddr] = srvs[suAddr].invalidated()
 	}
-	srvsMu.Unlock()
 	return nil
 }
 
@@ -137,84 +151,137 @@ func (su SRVUpstreams) GetUpstreams(r *http.Request) ([]*Upstream, error) {
 	// first, use a cheap read-lock to return a cached result quickly
 	srvsMu.RLock()
 	cached := srvs[suAddr]
+	startEpoch := srvEpoch
+	startGen := cached.gen
 	srvsMu.RUnlock()
 	if cached.isFresh() {
 		return allNew(cached.upstreams), nil
 	}
 
-	// otherwise, obtain a write-lock to update the cached value
-	srvsMu.Lock()
-	defer srvsMu.Unlock()
+	// dedupe lookups by key, gen is folded in so a request after a reset
+	// starts its own lookup instead of joining one from before the reset
+	sfKey := fmt.Sprintf("%s#%d#%d", suAddr, startEpoch, startGen)
+	resultChan := srvGroup.DoChan(sfKey, func() (any, error) {
+		// might already be refreshed by whoever got here first
+		srvsMu.RLock()
+		c := srvs[suAddr]
+		srvsMu.RUnlock()
+		if c.isFresh() {
+			return c.upstreams, nil
+		}
 
-	// check to see if it's still stale, since we're now in a different
-	// lock from when we first checked freshness; another goroutine might
-	// have refreshed it in the meantime before we re-obtained our lock
-	cached = srvs[suAddr]
-	if cached.isFresh() {
-		return allNew(cached.upstreams), nil
-	}
+		if logC := su.logger.Check(zapcore.DebugLevel, "refreshing SRV upstreams"); logC != nil {
+			logC.Write(
+				zap.String("service", service),
+				zap.String("proto", proto),
+				zap.String("name", name),
+			)
+		}
 
-	if c := su.logger.Check(zapcore.DebugLevel, "refreshing SRV upstreams"); c != nil {
-		c.Write(
-			zap.String("service", service),
-			zap.String("proto", proto),
-			zap.String("name", name),
-		)
-	}
+		// detached so a cancelled leader request doesn't kill the lookup
+		// for every other request sharing this flight, but bounded so a
+		// stuck resolver can't outlive its waiters
+		lookupCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), upstreamsLookupTimeout)
+		defer cancel()
 
-	_, records, err := su.resolver.LookupSRV(r.Context(), service, proto, name)
-	if err != nil {
-		// From LookupSRV docs: "If the response contains invalid names, those records are filtered
-		// out and an error will be returned alongside the remaining results, if any." Thus, we
-		// only return an error if no records were also returned.
-		if len(records) == 0 {
-			if su.GracePeriod > 0 {
-				if c := su.logger.Check(zapcore.ErrorLevel, "SRV lookup failed; using previously cached"); c != nil {
-					c.Write(zap.Error(err))
+		// every distinct key starts its own lookup, so cap how many can
+		// reach the resolver at once
+		if err := upstreamsLookups.acquire(lookupCtx); err != nil {
+			// we still have something cached, so serve that instead of
+			// failing. slightly stale beats a 502
+			if su.GracePeriod > 0 && len(c.upstreams) > 0 {
+				if logC := su.logger.Check(zapcore.WarnLevel, "SRV lookup not started; using previously cached"); logC != nil {
+					logC.Write(zap.Error(err))
 				}
-				cached.freshness = time.Now().Add(time.Duration(su.GracePeriod) - time.Duration(su.Refresh))
-				srvs[suAddr] = cached
-				return allNew(cached.upstreams), nil
+				return su.keepStale(suAddr, c, startEpoch, startGen), nil
 			}
 			return nil, err
 		}
-		if c := su.logger.Check(zapcore.WarnLevel, "SRV records filtered"); c != nil {
-			c.Write(zap.Error(err))
-		}
-	}
+		defer upstreamsLookups.release()
 
-	upstreams := make([]Upstream, len(records))
-	for i, rec := range records {
-		if c := su.logger.Check(zapcore.DebugLevel, "discovered SRV record"); c != nil {
-			c.Write(
-				zap.String("target", rec.Target),
-				zap.Uint16("port", rec.Port),
-				zap.Uint16("priority", rec.Priority),
-				zap.Uint16("weight", rec.Weight),
-			)
+		// no lock held here, so a slow lookup doesn't block anything else
+		_, records, err := su.resolver.LookupSRV(lookupCtx, service, proto, name)
+		if err != nil {
+			// From LookupSRV docs: "If the response contains invalid names, those records are filtered
+			// out and an error will be returned alongside the remaining results, if any." Thus, we
+			// only return an error if no records were also returned.
+			if len(records) == 0 {
+				if su.GracePeriod > 0 {
+					if logC := su.logger.Check(zapcore.ErrorLevel, "SRV lookup failed; using previously cached"); logC != nil {
+						logC.Write(zap.Error(err))
+					}
+					return su.keepStale(suAddr, c, startEpoch, startGen), nil
+				}
+				return nil, err
+			}
+			if logC := su.logger.Check(zapcore.WarnLevel, "SRV records filtered"); logC != nil {
+				logC.Write(zap.Error(err))
+			}
 		}
-		addr := net.JoinHostPort(rec.Target, strconv.Itoa(int(rec.Port)))
-		if su.DialNetwork != "" {
-			addr = su.DialNetwork + "/" + addr
+
+		upstreams := make([]Upstream, len(records))
+		for i, rec := range records {
+			if logC := su.logger.Check(zapcore.DebugLevel, "discovered SRV record"); logC != nil {
+				logC.Write(
+					zap.String("target", rec.Target),
+					zap.Uint16("port", rec.Port),
+					zap.Uint16("priority", rec.Priority),
+					zap.Uint16("weight", rec.Weight),
+				)
+			}
+			addr := net.JoinHostPort(rec.Target, strconv.Itoa(int(rec.Port)))
+			if su.DialNetwork != "" {
+				addr = su.DialNetwork + "/" + addr
+			}
+			upstreams[i] = Upstream{Dial: addr}
 		}
-		upstreams[i] = Upstream{Dial: addr}
-	}
 
-	// before adding a new one to the cache (as opposed to replacing stale one), make room if cache is full
-	if cached.freshness.IsZero() && len(srvs) >= 100 {
-		for randomKey := range srvs {
-			delete(srvs, randomKey)
-			break
+		srvsMu.Lock()
+		// reset happened mid-lookup, don't write a stale result back
+		if srvEpoch != startEpoch || srvs[suAddr].gen != startGen {
+			srvsMu.Unlock()
+			return upstreams, nil
 		}
-	}
 
-	srvs[suAddr] = srvLookup{
-		srvUpstreams: su,
-		freshness:    time.Now(),
-		upstreams:    upstreams,
-	}
+		makeRoom(srvs, suAddr)
 
-	return allNew(upstreams), nil
+		srvs[suAddr] = srvLookup{
+			srvUpstreams: su,
+			freshness:    time.Now(),
+			upstreams:    upstreams,
+			gen:          startGen,
+		}
+		srvsMu.Unlock()
+
+		return upstreams, nil
+	})
+
+	select {
+	case res := <-resultChan:
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		return allNew(res.Val.([]Upstream)), nil
+	case <-r.Context().Done():
+		return nil, r.Context().Err()
+	}
+}
+
+// keepStale pushes a stale entry's freshness out by the grace period and
+// returns what it holds, so a lookup we couldn't run serves the old value
+// instead of failing. skips the write if the cache was reset meanwhile.
+// call it without srvsMu held.
+func (su SRVUpstreams) keepStale(suAddr string, c srvLookup, startEpoch, startGen uint64) []Upstream {
+	srvsMu.Lock()
+	defer srvsMu.Unlock()
+	// skip if reset happened while we were looking this up
+	if srvEpoch == startEpoch && srvs[suAddr].gen == startGen {
+		c.freshness = time.Now().Add(time.Duration(su.GracePeriod) - time.Duration(su.Refresh))
+		c.gen = startGen
+		makeRoom(srvs, suAddr)
+		srvs[suAddr] = c
+	}
+	return c.upstreams
 }
 
 func (su SRVUpstreams) String() string {
@@ -251,10 +318,23 @@ type srvLookup struct {
 	srvUpstreams SRVUpstreams
 	freshness    time.Time
 	upstreams    []Upstream
+
+	// gen tracks resets for this key, bumped by invalidated. it's folded
+	// into the singleflight key so requests after a reset don't join a
+	// lookup that started before it, and kept on the entry (rather than a
+	// separate map) so it stays bounded by the same 100-entry cache cap
+	gen uint64
 }
 
 func (sl srvLookup) isFresh() bool {
 	return time.Since(sl.freshness) < time.Duration(sl.srvUpstreams.Refresh)
+}
+
+// invalidated returns a tombstoned copy: upstreams dropped, gen bumped.
+// keeping the entry (instead of deleting it) is what gives an in-flight
+// lookup for this key something to compare its generation against.
+func (sl srvLookup) invalidated() srvLookup {
+	return srvLookup{srvUpstreams: sl.srvUpstreams, gen: sl.gen + 1}
 }
 
 type IPVersions struct {
@@ -307,9 +387,13 @@ type AUpstreams struct {
 	// correspond to A and AAAA records respectively.
 	Versions *IPVersions `json:"versions,omitempty"`
 
-	resolver *net.Resolver
+	resolver aResolver
 
 	logger *zap.Logger
+}
+
+type aResolver interface {
+	LookupIP(ctx context.Context, network, host string) (addrs []net.IP, err error)
 }
 
 // CaddyModule returns the Caddy module information.
@@ -354,6 +438,24 @@ func (au *AUpstreams) Provision(ctx caddy.Context) error {
 	return nil
 }
 
+// ResetCache clears the cached value for a specific key, or the entire
+// cache if r is nil. See SRVUpstreams.ResetCache for why entries are
+// tombstoned instead of deleted.
+func (au *AUpstreams) ResetCache(r *http.Request) error {
+	aAaaaMu.Lock()
+	defer aAaaaMu.Unlock()
+	if r == nil {
+		// epoch covers in-flight lookups, so the entries can go
+		aAaaa = make(map[string]aLookup)
+		aEpoch++
+	} else {
+		auStr := au.expandedAddr(r)
+		makeRoom(aAaaa, auStr)
+		aAaaa[auStr] = aAaaa[auStr].invalidated()
+	}
+	return nil
+}
+
 func (au AUpstreams) GetUpstreams(r *http.Request) ([]*Upstream, error) {
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 
@@ -367,24 +469,14 @@ func (au AUpstreams) GetUpstreams(r *http.Request) ([]*Upstream, error) {
 	// while keeping the cache-invalidation as simple as it currently is.
 	ipVersion := resolveIpVersion(au.Versions)
 
-	auStr := repl.ReplaceAll(au.String()+ipVersion, "")
+	auStr := au.expandedAddr(r)
 
 	// first, use a cheap read-lock to return a cached result quickly
 	aAaaaMu.RLock()
 	cached := aAaaa[auStr]
+	startEpoch := aEpoch
+	startGen := cached.gen
 	aAaaaMu.RUnlock()
-	if cached.isFresh() {
-		return allNew(cached.upstreams), nil
-	}
-
-	// otherwise, obtain a write-lock to update the cached value
-	aAaaaMu.Lock()
-	defer aAaaaMu.Unlock()
-
-	// check to see if it's still stale, since we're now in a different
-	// lock from when we first checked freshness; another goroutine might
-	// have refreshed it in the meantime before we re-obtained our lock
-	cached = aAaaa[auStr]
 	if cached.isFresh() {
 		return allNew(cached.upstreams), nil
 	}
@@ -392,56 +484,106 @@ func (au AUpstreams) GetUpstreams(r *http.Request) ([]*Upstream, error) {
 	name := repl.ReplaceAll(au.Name, "")
 	port := repl.ReplaceAll(au.Port, "")
 
-	if c := au.logger.Check(zapcore.DebugLevel, "refreshing A upstreams"); c != nil {
-		c.Write(
-			zap.String("version", ipVersion),
-			zap.String("name", name),
-			zap.String("port", port),
-		)
-	}
-
-	ips, err := au.resolver.LookupIP(r.Context(), ipVersion, name)
-	if err != nil {
-		return nil, err
-	}
-
-	upstreams := make([]Upstream, len(ips))
-	for i, ip := range ips {
-		if c := au.logger.Check(zapcore.DebugLevel, "discovered A record"); c != nil {
-			c.Write(zap.String("ip", ip.String()))
+	// dedupe lookups by key, gen is folded in so a request after a reset
+	// starts its own lookup instead of joining one from before the reset
+	sfKey := fmt.Sprintf("%s#%d#%d", auStr, startEpoch, startGen)
+	resultChan := aGroup.DoChan(sfKey, func() (any, error) {
+		aAaaaMu.RLock()
+		c := aAaaa[auStr]
+		aAaaaMu.RUnlock()
+		if c.isFresh() {
+			return c.upstreams, nil
 		}
-		upstreams[i] = Upstream{
-			Dial: net.JoinHostPort(ip.String(), port),
+
+		if logC := au.logger.Check(zapcore.DebugLevel, "refreshing A upstreams"); logC != nil {
+			logC.Write(
+				zap.String("version", ipVersion),
+				zap.String("name", name),
+				zap.String("port", port),
+			)
 		}
-	}
 
-	// before adding a new one to the cache (as opposed to replacing stale one), make room if cache is full
-	if cached.freshness.IsZero() && len(aAaaa) >= 100 {
-		for randomKey := range aAaaa {
-			delete(aAaaa, randomKey)
-			break
+		// as with SRV: detached from the leader request, but bounded
+		lookupCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), upstreamsLookupTimeout)
+		defer cancel()
+
+		// as above, share the gate. no grace period here to fall back on,
+		// so a shed lookup has to fail the request
+		if err := upstreamsLookups.acquire(lookupCtx); err != nil {
+			return nil, err
 		}
-	}
+		defer upstreamsLookups.release()
 
-	aAaaa[auStr] = aLookup{
-		aUpstreams: au,
-		freshness:  time.Now(),
-		upstreams:  upstreams,
-	}
+		// no lock held here
+		ips, err := au.resolver.LookupIP(lookupCtx, ipVersion, name)
+		if err != nil {
+			return nil, err
+		}
 
-	return allNew(upstreams), nil
+		upstreams := make([]Upstream, len(ips))
+		for i, ip := range ips {
+			if logC := au.logger.Check(zapcore.DebugLevel, "discovered A record"); logC != nil {
+				logC.Write(zap.String("ip", ip.String()))
+			}
+			upstreams[i] = Upstream{
+				Dial: net.JoinHostPort(ip.String(), port),
+			}
+		}
+
+		aAaaaMu.Lock()
+		// reset happened mid-lookup, don't write a stale result back
+		if aEpoch != startEpoch || aAaaa[auStr].gen != startGen {
+			aAaaaMu.Unlock()
+			return upstreams, nil
+		}
+
+		makeRoom(aAaaa, auStr)
+
+		aAaaa[auStr] = aLookup{
+			aUpstreams: au,
+			freshness:  time.Now(),
+			upstreams:  upstreams,
+			gen:        startGen,
+		}
+		aAaaaMu.Unlock()
+
+		return upstreams, nil
+	})
+
+	select {
+	case res := <-resultChan:
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		return allNew(res.Val.([]Upstream)), nil
+	case <-r.Context().Done():
+		return nil, r.Context().Err()
+	}
 }
 
 func (au AUpstreams) String() string { return net.JoinHostPort(au.Name, au.Port) }
+
+// expandedAddr expands placeholders in the configured A/AAAA upstream domain
+// and returns the cache key used for this request.
+func (au AUpstreams) expandedAddr(r *http.Request) string {
+	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+	return repl.ReplaceAll(au.String()+resolveIpVersion(au.Versions), "")
+}
 
 type aLookup struct {
 	aUpstreams AUpstreams
 	freshness  time.Time
 	upstreams  []Upstream
+	gen        uint64
 }
 
 func (al aLookup) isFresh() bool {
 	return time.Since(al.freshness) < time.Duration(al.aUpstreams.Refresh)
+}
+
+// invalidated returns a tombstoned copy. see srvLookup.invalidated.
+func (al aLookup) invalidated() aLookup {
+	return aLookup{aUpstreams: al.aUpstreams, gen: al.gen + 1}
 }
 
 // MultiUpstreams is a single dynamic upstream source that
@@ -551,6 +693,90 @@ func (u *UpstreamResolver) ParseAddresses() error {
 	return nil
 }
 
+// upstreamsCacheCap is the max number of entries kept in each dynamic
+// upstreams cache.
+const upstreamsCacheCap = 100
+
+// upstreamsLookupTimeout bounds a shared lookup, which can't take any one
+// request's deadline.
+const upstreamsLookupTimeout = 30 * time.Second
+
+// makeRoom evicts a random entry if the cache is full and key isn't
+// already in it. caller must hold the cache's lock.
+func makeRoom[V any](cache map[string]V, key string) {
+	if _, ok := cache[key]; ok || len(cache) < upstreamsCacheCap {
+		return
+	}
+	for k := range cache {
+		delete(cache, k)
+		break
+	}
+}
+
+// upstreamsMaxLookups is the max number of unique lookups allowed to run at
+// once, shared by every SRV and A source. requests that join a lookup already
+// in flight don't count against it.
+const upstreamsMaxLookups = 64
+
+// upstreamsMaxPendingLookups is the max number of lookups allowed to wait for
+// a slot. beyond that they're shed rather than parked, so a stream of distinct
+// keys can't pile up goroutines for the length of upstreamsLookupTimeout.
+const upstreamsMaxPendingLookups = 256
+
+// errTooManyLookups is returned when the lookup gate is saturated.
+var errTooManyLookups = errors.New("too many dynamic upstream lookups in flight")
+
+// lookupGate is a counting semaphore with a bounded wait queue, so outstanding
+// resolver work stays capped no matter how many distinct keys come in.
+type lookupGate struct {
+	running    chan struct{}
+	pending    atomic.Int64
+	maxPending int64
+}
+
+func newLookupGate(maxRunning, maxPending int) *lookupGate {
+	return &lookupGate{
+		running:    make(chan struct{}, maxRunning),
+		maxPending: int64(maxPending),
+	}
+}
+
+// acquire takes a slot, waiting until ctx is done. it gives up right away
+// with errTooManyLookups if the queue is full.
+func (g *lookupGate) acquire(ctx context.Context) error {
+	// a free slot goes to whoever asks first, even ahead of parked waiters.
+	// that's on purpose, it keeps the common case to one channel send.
+	// waiters are still first come first served among themselves.
+	select {
+	case g.running <- struct{}{}:
+		return nil
+	default:
+	}
+	if g.pending.Add(1) > g.maxPending {
+		g.pending.Add(-1)
+		return errTooManyLookups
+	}
+	defer g.pending.Add(-1)
+	select {
+	case g.running <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// release gives back a slot. call it once per successful acquire and never
+// otherwise. only release takes slots out, so a holder always finds one here.
+// the default case is unreachable if that holds, it's there so a stray call
+// can't block forever. we don't panic since this runs inside a singleflight
+// call, where a panic would take down the process.
+func (g *lookupGate) release() {
+	select {
+	case <-g.running:
+	default:
+	}
+}
+
 func allNew(upstreams []Upstream) []*Upstream {
 	results := make([]*Upstream, len(upstreams))
 	for i := range upstreams {
@@ -560,11 +786,18 @@ func allNew(upstreams []Upstream) []*Upstream {
 }
 
 var (
-	srvs   = make(map[string]srvLookup)
-	srvsMu sync.RWMutex
+	srvs     = make(map[string]srvLookup)
+	srvsMu   sync.RWMutex
+	srvEpoch uint64 // bumped on a full reset, guarded by srvsMu
+	srvGroup singleflight.Group
 
 	aAaaa   = make(map[string]aLookup)
 	aAaaaMu sync.RWMutex
+	aEpoch  uint64 // bumped on a full reset, guarded by aAaaaMu
+	aGroup  singleflight.Group
+
+	// shared by both, so the total resolver work stays bounded
+	upstreamsLookups = newLookupGate(upstreamsMaxLookups, upstreamsMaxPendingLookups)
 )
 
 // Interface guards
@@ -574,4 +807,5 @@ var (
 	_ CachingUpstreamSource = (*SRVUpstreams)(nil)
 	_ caddy.Provisioner     = (*AUpstreams)(nil)
 	_ UpstreamSource        = (*AUpstreams)(nil)
+	_ CachingUpstreamSource = (*AUpstreams)(nil)
 )

--- a/modules/caddyhttp/reverseproxy/upstreams_test.go
+++ b/modules/caddyhttp/reverseproxy/upstreams_test.go
@@ -1,6 +1,21 @@
 package reverseproxy
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2"
+)
 
 func TestResolveIpVersion(t *testing.T) {
 	falseBool := false
@@ -51,5 +66,1146 @@ func TestResolveIpVersion(t *testing.T) {
 		if ipVersion != test.expectedIpVersion {
 			t.Errorf("resolveIpVersion(): Expected %s got %s", test.expectedIpVersion, ipVersion)
 		}
+	}
+}
+
+// fakeSRVResolver implements srvResolver so tests can control the timing and
+// results of SRV lookups without a real DNS server.
+type fakeSRVResolver struct {
+	lookupSRV func(ctx context.Context, service, proto, name string) (string, []*net.SRV, error)
+}
+
+func (f *fakeSRVResolver) LookupSRV(ctx context.Context, service, proto, name string) (string, []*net.SRV, error) {
+	return f.lookupSRV(ctx, service, proto, name)
+}
+
+// newTestRequest returns an HTTP request carrying the replacer that
+// GetUpstreams relies on.
+func newTestRequest() *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	return req.WithContext(context.WithValue(req.Context(), caddy.ReplacerCtxKey, caddy.NewReplacer()))
+}
+
+// TestSRVUpstreamsSlowLookupDoesNotBlockOtherKeys is a regression test for the
+// case where a slow SRV lookup for one key held the global cache lock across
+// the DNS call, blocking lookups for every unrelated key. The slow lookup is
+// held open on a channel while a second, independent key is looked up; the
+// second lookup must complete quickly rather than waiting for the slow one.
+func TestSRVUpstreamsSlowLookupDoesNotBlockOtherKeys(t *testing.T) {
+	release := make(chan struct{})
+	blockedEntered := make(chan struct{})
+
+	resolver := &fakeSRVResolver{
+		lookupSRV: func(_ context.Context, _, _, name string) (string, []*net.SRV, error) {
+			switch name {
+			case "slow.example.com":
+				close(blockedEntered)
+				<-release
+				return "", []*net.SRV{{Target: "10.0.0.1", Port: 80}}, nil
+			case "fast.example.com":
+				return "", []*net.SRV{{Target: "10.0.0.2", Port: 80}}, nil
+			default:
+				return "", nil, fmt.Errorf("unexpected SRV lookup for %q", name)
+			}
+		},
+	}
+
+	slow := &SRVUpstreams{
+		Name:     "slow.example.com",
+		Refresh:  caddy.Duration(time.Minute),
+		resolver: resolver,
+		logger:   zap.NewNop(),
+	}
+	fast := &SRVUpstreams{
+		Name:     "fast.example.com",
+		Refresh:  caddy.Duration(time.Minute),
+		resolver: resolver,
+		logger:   zap.NewNop(),
+	}
+
+	// start from a clean cache so both keys are guaranteed to be a miss
+	slow.ResetCache(nil)
+	fast.ResetCache(nil)
+
+	slowErr := make(chan error, 1)
+	go func() {
+		_, err := slow.GetUpstreams(newTestRequest())
+		slowErr <- err
+	}()
+
+	// wait until the slow lookup is actually in flight before racing the fast one
+	<-blockedEntered
+
+	fastStart := time.Now()
+	fastRes := make(chan struct {
+		ups []*Upstream
+		err error
+	}, 1)
+	go func() {
+		ups, err := fast.GetUpstreams(newTestRequest())
+		fastRes <- struct {
+			ups []*Upstream
+			err error
+		}{ups, err}
+	}()
+
+	select {
+	case res := <-fastRes:
+		if res.err != nil {
+			t.Fatalf("fast lookup errored: %v", res.err)
+		}
+		if len(res.ups) != 1 || res.ups[0].Dial != "10.0.0.2:80" {
+			t.Fatalf("unexpected fast lookup result: %+v", res.ups)
+		}
+		if elapsed := time.Since(fastStart); elapsed > 500*time.Millisecond {
+			t.Fatalf("fast lookup took %v; it should not be blocked by the slow lookup", elapsed)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("fast lookup was blocked behind the slow lookup")
+	}
+
+	// release the slow lookup and make sure it completes successfully
+	close(release)
+	if err := <-slowErr; err != nil {
+		t.Fatalf("slow lookup errored: %v", err)
+	}
+}
+
+// TestSRVUpstreamsResetCacheDuringLookup verifies that a lookup that is still
+// in flight when ResetCache runs does not repopulate the cache afterwards
+// (which would silently undo the reset).
+func TestSRVUpstreamsResetCacheDuringLookup(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		reset func(su *SRVUpstreams, req *http.Request) error
+	}{
+		{
+			name: "full reset",
+			reset: func(su *SRVUpstreams, _ *http.Request) error {
+				return su.ResetCache(nil)
+			},
+		},
+		{
+			name: "targeted reset",
+			reset: func(su *SRVUpstreams, req *http.Request) error {
+				return su.ResetCache(req)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			release := make(chan struct{})
+			entered := make(chan struct{})
+			resolver := &fakeSRVResolver{
+				lookupSRV: func(_ context.Context, _, _, _ string) (string, []*net.SRV, error) {
+					close(entered)
+					<-release
+					return "", []*net.SRV{{Target: "10.0.0.1", Port: 80}}, nil
+				},
+			}
+			su := &SRVUpstreams{
+				Name:     "reset.example.com",
+				Refresh:  caddy.Duration(time.Minute),
+				resolver: resolver,
+				logger:   zap.NewNop(),
+			}
+			su.ResetCache(nil)
+
+			req := newTestRequest()
+			done := make(chan error, 1)
+			go func() {
+				_, err := su.GetUpstreams(req)
+				done <- err
+			}()
+
+			<-entered
+			if err := tc.reset(su, req); err != nil {
+				t.Fatalf("ResetCache: %v", err)
+			}
+			close(release)
+			if err := <-done; err != nil {
+				t.Fatalf("GetUpstreams: %v", err)
+			}
+
+			srvsMu.RLock()
+			cached := srvs["reset.example.com"]
+			srvsMu.RUnlock()
+			if cached.isFresh() || len(cached.upstreams) != 0 {
+				t.Fatal("stale in-flight lookup repopulated the cache after reset")
+			}
+		})
+	}
+}
+
+// TestSRVUpstreamsResetCacheStartsNewFlight verifies that a request arriving
+// after ResetCache starts its own lookup rather than joining the lookup that was
+// already in flight when the reset happened, which would hand it back the very
+// result the reset discarded.
+func TestSRVUpstreamsResetCacheStartsNewFlight(t *testing.T) {
+	release := make(chan struct{})
+	entered := make(chan struct{})
+
+	var mu sync.Mutex
+	var lookups int
+	resolver := &fakeSRVResolver{
+		lookupSRV: func(_ context.Context, _, _, _ string) (string, []*net.SRV, error) {
+			mu.Lock()
+			lookups++
+			n := lookups
+			mu.Unlock()
+			if n == 1 {
+				close(entered)
+				<-release
+				return "", []*net.SRV{{Target: "10.0.0.1", Port: 80}}, nil
+			}
+			return "", []*net.SRV{{Target: "10.0.0.2", Port: 80}}, nil
+		},
+	}
+
+	su := &SRVUpstreams{
+		Name:     "flight.example.com",
+		Refresh:  caddy.Duration(time.Minute),
+		resolver: resolver,
+		logger:   zap.NewNop(),
+	}
+	su.ResetCache(nil)
+
+	firstErr := make(chan error, 1)
+	go func() {
+		_, err := su.GetUpstreams(newTestRequest())
+		firstErr <- err
+	}()
+
+	// once the first lookup is in flight, discard its still-pending result
+	<-entered
+	if err := su.ResetCache(newTestRequest()); err != nil {
+		t.Fatalf("ResetCache: %v", err)
+	}
+
+	second := make(chan struct {
+		ups []*Upstream
+		err error
+	}, 1)
+	go func() {
+		ups, err := su.GetUpstreams(newTestRequest())
+		second <- struct {
+			ups []*Upstream
+			err error
+		}{ups, err}
+	}()
+
+	select {
+	case res := <-second:
+		if res.err != nil {
+			t.Fatalf("post-reset lookup errored: %v", res.err)
+		}
+		if len(res.ups) != 1 || res.ups[0].Dial != "10.0.0.2:80" {
+			t.Fatalf("post-reset request was served the pre-reset result: %+v", res.ups)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("post-reset request joined the pre-reset lookup instead of starting its own")
+	}
+
+	close(release)
+	if err := <-firstErr; err != nil {
+		t.Fatalf("first lookup errored: %v", err)
+	}
+}
+
+// TestSRVUpstreamsStaleLookupDoesNotOverwriteNewer covers a lookup that is
+// overtaken both by a reset and by a second, newer lookup: when the stale one
+// finally finishes it must not write its result over the newer one. This is why
+// the per-key generation counter is never removed once bumped -- recycling it
+// back to zero lets the stale lookup's captured generation match again.
+func TestSRVUpstreamsStaleLookupDoesNotOverwriteNewer(t *testing.T) {
+	release := make(chan struct{})
+	entered := make(chan struct{})
+
+	var mu sync.Mutex
+	var lookups int
+	su := &SRVUpstreams{
+		Name:    "stale.example.com",
+		Refresh: caddy.Duration(time.Minute),
+		resolver: &fakeSRVResolver{
+			lookupSRV: func(context.Context, string, string, string) (string, []*net.SRV, error) {
+				mu.Lock()
+				lookups++
+				n := lookups
+				mu.Unlock()
+				if n == 1 {
+					close(entered)
+					<-release
+					return "", []*net.SRV{{Target: "10.0.0.1", Port: 80}}, nil
+				}
+				return "", []*net.SRV{{Target: "10.0.0.2", Port: 80}}, nil
+			},
+		},
+		logger: zap.NewNop(),
+	}
+	su.ResetCache(nil)
+
+	staleErr := make(chan error, 1)
+	go func() {
+		_, err := su.GetUpstreams(newTestRequest())
+		staleErr <- err
+	}()
+	<-entered
+
+	// discard the in-flight lookup's result, then let a newer lookup land
+	if err := su.ResetCache(newTestRequest()); err != nil {
+		t.Fatalf("ResetCache: %v", err)
+	}
+	newer := make(chan error, 1)
+	go func() {
+		_, err := su.GetUpstreams(newTestRequest())
+		newer <- err
+	}()
+	select {
+	case err := <-newer:
+		if err != nil {
+			t.Fatalf("newer lookup errored: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		close(release) // don't wedge the stale lookup's goroutine
+		t.Fatal("newer lookup joined the stale in-flight lookup instead of starting its own")
+	}
+
+	// the stale lookup finishes last; its result is no longer wanted
+	close(release)
+	if err := <-staleErr; err != nil {
+		t.Fatalf("stale lookup errored: %v", err)
+	}
+
+	srvsMu.RLock()
+	cached := srvs["stale.example.com"]
+	srvsMu.RUnlock()
+	if len(cached.upstreams) != 1 || cached.upstreams[0].Dial != "10.0.0.2:80" {
+		t.Fatalf("stale lookup overwrote the newer result: %+v", cached.upstreams)
+	}
+}
+
+// fakeAResolver implements aResolver so tests can control the timing and
+// results of A/AAAA lookups without a real DNS server.
+type fakeAResolver struct {
+	lookupIP func(ctx context.Context, network, host string) ([]net.IP, error)
+}
+
+func (f *fakeAResolver) LookupIP(ctx context.Context, network, host string) ([]net.IP, error) {
+	return f.lookupIP(ctx, network, host)
+}
+
+// testAUpstreams returns an AUpstreams restricted to IPv4 and backed by the
+// given lookup function.
+func testAUpstreams(name string, lookupIP func(ctx context.Context, network, host string) ([]net.IP, error)) *AUpstreams {
+	ipv4, ipv6 := true, false
+	return &AUpstreams{
+		Name:     name,
+		Port:     "80",
+		Refresh:  caddy.Duration(time.Minute),
+		Versions: &IPVersions{IPv4: &ipv4, IPv6: &ipv6},
+		resolver: &fakeAResolver{lookupIP: lookupIP},
+		logger:   zap.NewNop(),
+	}
+}
+
+// TestAUpstreamsSlowLookupDoesNotBlockOtherKeys is the A/AAAA equivalent of
+// TestSRVUpstreamsSlowLookupDoesNotBlockOtherKeys.
+func TestAUpstreamsSlowLookupDoesNotBlockOtherKeys(t *testing.T) {
+	release := make(chan struct{})
+	entered := make(chan struct{})
+
+	slow := testAUpstreams("slow.example.com", func(context.Context, string, string) ([]net.IP, error) {
+		close(entered)
+		<-release
+		return []net.IP{net.IPv4(10, 0, 0, 1)}, nil
+	})
+	fast := testAUpstreams("fast.example.com", func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{net.IPv4(10, 0, 0, 2)}, nil
+	})
+
+	slow.ResetCache(nil)
+	fast.ResetCache(nil)
+
+	slowErr := make(chan error, 1)
+	go func() {
+		_, err := slow.GetUpstreams(newTestRequest())
+		slowErr <- err
+	}()
+
+	<-entered
+
+	fastStart := time.Now()
+	fastRes := make(chan struct {
+		ups []*Upstream
+		err error
+	}, 1)
+	go func() {
+		ups, err := fast.GetUpstreams(newTestRequest())
+		fastRes <- struct {
+			ups []*Upstream
+			err error
+		}{ups, err}
+	}()
+
+	select {
+	case res := <-fastRes:
+		if res.err != nil {
+			t.Fatalf("fast lookup errored: %v", res.err)
+		}
+		if len(res.ups) != 1 || res.ups[0].Dial != "10.0.0.2:80" {
+			t.Fatalf("unexpected fast lookup result: %+v", res.ups)
+		}
+		if elapsed := time.Since(fastStart); elapsed > 500*time.Millisecond {
+			t.Fatalf("fast lookup took %v; it should not be blocked by the slow lookup", elapsed)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("fast lookup was blocked behind the slow lookup")
+	}
+
+	close(release)
+	if err := <-slowErr; err != nil {
+		t.Fatalf("slow lookup errored: %v", err)
+	}
+}
+
+// TestAUpstreamsResetCacheDuringLookup verifies the A/AAAA equivalent of the
+// SRV reset-during-lookup behavior.
+func TestAUpstreamsResetCacheDuringLookup(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		reset func(au *AUpstreams, req *http.Request) error
+	}{
+		{
+			name: "full reset",
+			reset: func(au *AUpstreams, _ *http.Request) error {
+				return au.ResetCache(nil)
+			},
+		},
+		{
+			name: "targeted reset",
+			reset: func(au *AUpstreams, req *http.Request) error {
+				return au.ResetCache(req)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			release := make(chan struct{})
+			entered := make(chan struct{})
+
+			au := testAUpstreams("reset.example.com", func(context.Context, string, string) ([]net.IP, error) {
+				close(entered)
+				<-release
+				return []net.IP{net.IPv4(10, 0, 0, 1)}, nil
+			})
+			au.ResetCache(nil)
+
+			req := newTestRequest()
+			done := make(chan error, 1)
+			go func() {
+				_, err := au.GetUpstreams(req)
+				done <- err
+			}()
+
+			<-entered
+			if err := tc.reset(au, req); err != nil {
+				t.Fatalf("ResetCache: %v", err)
+			}
+			close(release)
+			if err := <-done; err != nil {
+				t.Fatalf("GetUpstreams: %v", err)
+			}
+
+			key := au.String() + resolveIpVersion(au.Versions)
+			aAaaaMu.RLock()
+			cached := aAaaa[key]
+			aAaaaMu.RUnlock()
+			if cached.isFresh() || len(cached.upstreams) != 0 {
+				t.Fatal("stale in-flight lookup repopulated the cache after reset")
+			}
+		})
+	}
+}
+
+// TestAUpstreamsResetCacheStartsNewFlight is the A/AAAA equivalent of
+// TestSRVUpstreamsResetCacheStartsNewFlight.
+func TestAUpstreamsResetCacheStartsNewFlight(t *testing.T) {
+	release := make(chan struct{})
+	entered := make(chan struct{})
+
+	var mu sync.Mutex
+	var lookups int
+	au := testAUpstreams("flight.example.com", func(context.Context, string, string) ([]net.IP, error) {
+		mu.Lock()
+		lookups++
+		n := lookups
+		mu.Unlock()
+		if n == 1 {
+			close(entered)
+			<-release
+			return []net.IP{net.IPv4(10, 0, 0, 1)}, nil
+		}
+		return []net.IP{net.IPv4(10, 0, 0, 2)}, nil
+	})
+	au.ResetCache(nil)
+
+	firstErr := make(chan error, 1)
+	go func() {
+		_, err := au.GetUpstreams(newTestRequest())
+		firstErr <- err
+	}()
+
+	// once the first lookup is in flight, discard its still-pending result
+	<-entered
+	if err := au.ResetCache(newTestRequest()); err != nil {
+		t.Fatalf("ResetCache: %v", err)
+	}
+
+	second := make(chan struct {
+		ups []*Upstream
+		err error
+	}, 1)
+	go func() {
+		ups, err := au.GetUpstreams(newTestRequest())
+		second <- struct {
+			ups []*Upstream
+			err error
+		}{ups, err}
+	}()
+
+	select {
+	case res := <-second:
+		if res.err != nil {
+			t.Fatalf("post-reset lookup errored: %v", res.err)
+		}
+		if len(res.ups) != 1 || res.ups[0].Dial != "10.0.0.2:80" {
+			t.Fatalf("post-reset request was served the pre-reset result: %+v", res.ups)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("post-reset request joined the pre-reset lookup instead of starting its own")
+	}
+
+	close(release)
+	if err := <-firstErr; err != nil {
+		t.Fatalf("first lookup errored: %v", err)
+	}
+}
+
+// TestAUpstreamsStaleLookupDoesNotOverwriteNewer is the A/AAAA equivalent of
+// TestSRVUpstreamsStaleLookupDoesNotOverwriteNewer.
+func TestAUpstreamsStaleLookupDoesNotOverwriteNewer(t *testing.T) {
+	release := make(chan struct{})
+	entered := make(chan struct{})
+
+	var mu sync.Mutex
+	var lookups int
+	au := testAUpstreams("stale.example.com", func(context.Context, string, string) ([]net.IP, error) {
+		mu.Lock()
+		lookups++
+		n := lookups
+		mu.Unlock()
+		if n == 1 {
+			close(entered)
+			<-release
+			return []net.IP{net.IPv4(10, 0, 0, 1)}, nil
+		}
+		return []net.IP{net.IPv4(10, 0, 0, 2)}, nil
+	})
+	au.ResetCache(nil)
+
+	staleErr := make(chan error, 1)
+	go func() {
+		_, err := au.GetUpstreams(newTestRequest())
+		staleErr <- err
+	}()
+	<-entered
+
+	// discard the in-flight lookup's result, then let a newer lookup land
+	if err := au.ResetCache(newTestRequest()); err != nil {
+		t.Fatalf("ResetCache: %v", err)
+	}
+	newer := make(chan error, 1)
+	go func() {
+		_, err := au.GetUpstreams(newTestRequest())
+		newer <- err
+	}()
+	select {
+	case err := <-newer:
+		if err != nil {
+			t.Fatalf("newer lookup errored: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		close(release) // don't wedge the stale lookup's goroutine
+		t.Fatal("newer lookup joined the stale in-flight lookup instead of starting its own")
+	}
+
+	// the stale lookup finishes last; its result is no longer wanted
+	close(release)
+	if err := <-staleErr; err != nil {
+		t.Fatalf("stale lookup errored: %v", err)
+	}
+
+	key := au.String() + resolveIpVersion(au.Versions)
+	aAaaaMu.RLock()
+	cached := aAaaa[key]
+	aAaaaMu.RUnlock()
+	if len(cached.upstreams) != 1 || cached.upstreams[0].Dial != "10.0.0.2:80" {
+		t.Fatalf("stale lookup overwrote the newer result: %+v", cached.upstreams)
+	}
+}
+
+// TestSRVUpstreamsLeaderCancellationDoesNotAffectOtherWaiters is a
+// regression test for the shared lookup being tied to whichever request
+// happened to trigger it. It cancels the request that started the
+// singleflight lookup while a second, independent request is still waiting
+// on the same flight, and checks two things: the cancelled request returns
+// promptly with its own context error instead of waiting for the lookup,
+// and the other waiter still gets a correct result once the lookup
+// completes, unaffected by the leader's cancellation.
+func TestSRVUpstreamsLeaderCancellationDoesNotAffectOtherWaiters(t *testing.T) {
+	release := make(chan struct{})
+	entered := make(chan struct{})
+
+	resolver := &fakeSRVResolver{
+		lookupSRV: func(ctx context.Context, _, _, _ string) (string, []*net.SRV, error) {
+			close(entered)
+			select {
+			case <-release:
+				return "", []*net.SRV{{Target: "10.0.0.1", Port: 80}}, nil
+			case <-ctx.Done():
+				// only reached if the lookup is still tied to the leader's
+				// context; that's the bug this test guards against
+				return "", nil, ctx.Err()
+			}
+		},
+	}
+
+	su := &SRVUpstreams{
+		Name:     "leader-cancel.example.com",
+		Refresh:  caddy.Duration(time.Minute),
+		resolver: resolver,
+		logger:   zap.NewNop(),
+	}
+	su.ResetCache(nil)
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leaderReq := httptest.NewRequest(http.MethodGet, "http://example.com/", nil).
+		WithContext(context.WithValue(leaderCtx, caddy.ReplacerCtxKey, caddy.NewReplacer()))
+
+	leaderDone := make(chan error, 1)
+	go func() {
+		_, err := su.GetUpstreams(leaderReq)
+		leaderDone <- err
+	}()
+
+	// wait until the lookup the leader triggered is actually running
+	<-entered
+
+	// a second, independent request for the same key joins the same flight
+	waiterDone := make(chan struct {
+		ups []*Upstream
+		err error
+	}, 1)
+	go func() {
+		ups, err := su.GetUpstreams(newTestRequest())
+		waiterDone <- struct {
+			ups []*Upstream
+			err error
+		}{ups, err}
+	}()
+
+	// give the waiter a moment to actually join the leader's flight
+	time.Sleep(50 * time.Millisecond)
+
+	cancelLeader()
+	select {
+	case err := <-leaderDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected leader to return context.Canceled, got %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("leader did not return promptly after its own context was cancelled")
+	}
+
+	// the lookup must still be running for the waiter, unaffected by the
+	// leader's cancellation
+	close(release)
+	select {
+	case res := <-waiterDone:
+		if res.err != nil {
+			t.Fatalf("waiter errored: %v", res.err)
+		}
+		if len(res.ups) != 1 || res.ups[0].Dial != "10.0.0.1:80" {
+			t.Fatalf("unexpected waiter result: %+v", res.ups)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("waiter never received a result after the lookup completed")
+	}
+}
+
+// TestAUpstreamsLeaderCancellationDoesNotAffectOtherWaiters is the A/AAAA
+// equivalent of TestSRVUpstreamsLeaderCancellationDoesNotAffectOtherWaiters.
+func TestAUpstreamsLeaderCancellationDoesNotAffectOtherWaiters(t *testing.T) {
+	release := make(chan struct{})
+	entered := make(chan struct{})
+
+	au := testAUpstreams("leader-cancel.example.com", func(ctx context.Context, _, _ string) ([]net.IP, error) {
+		close(entered)
+		select {
+		case <-release:
+			return []net.IP{net.IPv4(10, 0, 0, 1)}, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	})
+	au.ResetCache(nil)
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leaderReq := httptest.NewRequest(http.MethodGet, "http://example.com/", nil).
+		WithContext(context.WithValue(leaderCtx, caddy.ReplacerCtxKey, caddy.NewReplacer()))
+
+	leaderDone := make(chan error, 1)
+	go func() {
+		_, err := au.GetUpstreams(leaderReq)
+		leaderDone <- err
+	}()
+
+	<-entered
+
+	waiterDone := make(chan struct {
+		ups []*Upstream
+		err error
+	}, 1)
+	go func() {
+		ups, err := au.GetUpstreams(newTestRequest())
+		waiterDone <- struct {
+			ups []*Upstream
+			err error
+		}{ups, err}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	cancelLeader()
+	select {
+	case err := <-leaderDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected leader to return context.Canceled, got %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("leader did not return promptly after its own context was cancelled")
+	}
+
+	close(release)
+	select {
+	case res := <-waiterDone:
+		if res.err != nil {
+			t.Fatalf("waiter errored: %v", res.err)
+		}
+		if len(res.ups) != 1 || res.ups[0].Dial != "10.0.0.1:80" {
+			t.Fatalf("unexpected waiter result: %+v", res.ups)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("waiter never received a result after the lookup completed")
+	}
+}
+
+// saturateSeq keeps the keys used by saturateLookupGate distinct between
+// calls, so a later call can't be served from the cache the earlier one filled.
+var saturateSeq atomic.Uint64
+
+// saturateLookupGate fills every slot on the shared lookup gate with SRV
+// lookups that stall inside the resolver, and returns the func that releases
+// them and waits for them to finish.
+func saturateLookupGate(t *testing.T) func() {
+	t.Helper()
+
+	seq := saturateSeq.Add(1)
+	release := make(chan struct{})
+	running := make(chan struct{}, upstreamsMaxLookups)
+	resolver := &fakeSRVResolver{
+		lookupSRV: func(context.Context, string, string, string) (string, []*net.SRV, error) {
+			running <- struct{}{}
+			<-release
+			return "", []*net.SRV{{Target: "10.0.0.1", Port: 80}}, nil
+		},
+	}
+
+	var wg sync.WaitGroup
+	for i := range upstreamsMaxLookups {
+		su := &SRVUpstreams{
+			Name:     fmt.Sprintf("saturate-%d-%d.example.com", seq, i),
+			Refresh:  caddy.Duration(time.Minute),
+			resolver: resolver,
+			logger:   zap.NewNop(),
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := su.GetUpstreams(newTestRequest()); err != nil {
+				t.Errorf("saturating lookup errored: %v", err)
+			}
+		}()
+	}
+
+	unsaturate := func() {
+		close(release)
+		wg.Wait()
+	}
+
+	// the gate is full once every one of those is inside the resolver
+	for range upstreamsMaxLookups {
+		select {
+		case <-running:
+		case <-time.After(10 * time.Second):
+			unsaturate()
+			t.Fatal("lookups never filled the gate")
+		}
+	}
+	return unsaturate
+}
+
+type upstreamsResult struct {
+	ups []*Upstream
+	err error
+}
+
+// TestLookupGate covers the gate on its own: it hands out no more than
+// maxRunning slots, sheds once the wait queue is full, lets a queued caller be
+// cancelled by its own context, and recovers as slots are released.
+func TestLookupGate(t *testing.T) {
+	gate := newLookupGate(2, 1)
+
+	// saturation: both slots go out, so the next caller has to wait
+	for i := range 2 {
+		if err := gate.acquire(context.Background()); err != nil {
+			t.Fatalf("acquire %d: %v", i, err)
+		}
+	}
+
+	waiterCtx, cancelWaiter := context.WithCancel(context.Background())
+	waiting := make(chan error, 1)
+	go func() { waiting <- gate.acquire(waiterCtx) }()
+
+	// wait until that caller is actually queued
+	deadline := time.Now().Add(10 * time.Second)
+	for gate.pending.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("waiter never queued")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// the queue is full now, so anyone else is shed instead of parked
+	if err := gate.acquire(context.Background()); !errors.Is(err, errTooManyLookups) {
+		t.Fatalf("expected errTooManyLookups once the queue was full, got %v", err)
+	}
+
+	// cancellation: the queued caller leaves on its own context, and the
+	// queue accounting has to come back with it
+	cancelWaiter()
+	select {
+	case err := <-waiting:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected the queued caller to return context.Canceled, got %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("queued caller did not return after its context was cancelled")
+	}
+	if p := gate.pending.Load(); p != 0 {
+		t.Fatalf("expected the queue to drain back to 0, got %d", p)
+	}
+
+	// recovery: a released slot is usable again
+	gate.release()
+	if err := gate.acquire(context.Background()); err != nil {
+		t.Fatalf("expected to reuse the released slot, got %v", err)
+	}
+	gate.release()
+	gate.release()
+}
+
+// TestLookupGateStrayReleaseDoesNotBlock pins the acquire/release rule. a
+// release with nothing held is a bug, but it must return instead of hanging
+// the goroutine, since it runs inside a singleflight call.
+func TestLookupGateStrayReleaseDoesNotBlock(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		newLookupGate(2, 1).release()
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("a release with nothing held blocked instead of returning")
+	}
+}
+
+// TestSRVUpstreamsLookupsAreBounded checks that the gate is wired into the SRV
+// lookup path. Distinct keys each start a lookup of their own, so without a
+// shared bound a stream of them would be unbounded concurrent resolver work.
+// While the gate is saturated a further key must not reach the resolver at all,
+// and it must resolve normally once slots free up.
+func TestSRVUpstreamsLookupsAreBounded(t *testing.T) {
+	var lookups atomic.Int32
+	su := &SRVUpstreams{
+		Name:    "bounded.example.com",
+		Refresh: caddy.Duration(time.Minute),
+		resolver: &fakeSRVResolver{
+			lookupSRV: func(context.Context, string, string, string) (string, []*net.SRV, error) {
+				lookups.Add(1)
+				return "", []*net.SRV{{Target: "10.0.0.2", Port: 80}}, nil
+			},
+		},
+		logger: zap.NewNop(),
+	}
+	su.ResetCache(nil)
+
+	unsaturate := saturateLookupGate(t)
+
+	done := make(chan upstreamsResult, 1)
+	go func() {
+		ups, err := su.GetUpstreams(newTestRequest())
+		done <- upstreamsResult{ups, err}
+	}()
+
+	// saturation: the lookup waits for a slot instead of running
+	select {
+	case res := <-done:
+		unsaturate()
+		t.Fatalf("lookup completed while the gate was saturated: %+v (err %v)", res.ups, res.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if n := lookups.Load(); n != 0 {
+		unsaturate()
+		t.Fatalf("expected the resolver to be untouched while saturated, saw %d lookups", n)
+	}
+
+	// recovery: with slots back, the queued lookup runs and returns
+	unsaturate()
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatalf("queued lookup errored: %v", res.err)
+		}
+		if len(res.ups) != 1 || res.ups[0].Dial != "10.0.0.2:80" {
+			t.Fatalf("unexpected upstreams: %+v", res.ups)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("queued lookup never ran after slots freed up")
+	}
+}
+
+// TestSRVUpstreamsQueuedLookupStillCancels checks that waiting for a slot
+// doesn't cost a request its own cancellation: it returns as soon as its
+// context is cancelled, even though the lookup it started is still queued.
+func TestSRVUpstreamsQueuedLookupStillCancels(t *testing.T) {
+	su := &SRVUpstreams{
+		Name:    "queued.example.com",
+		Refresh: caddy.Duration(time.Minute),
+		resolver: &fakeSRVResolver{
+			lookupSRV: func(context.Context, string, string, string) (string, []*net.SRV, error) {
+				return "", []*net.SRV{{Target: "10.0.0.2", Port: 80}}, nil
+			},
+		},
+		logger: zap.NewNop(),
+	}
+	su.ResetCache(nil)
+
+	unsaturate := saturateLookupGate(t)
+
+	reqCtx, cancelReq := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil).
+		WithContext(context.WithValue(reqCtx, caddy.ReplacerCtxKey, caddy.NewReplacer()))
+
+	queued := make(chan error, 1)
+	go func() {
+		_, err := su.GetUpstreams(req)
+		queued <- err
+	}()
+
+	// give the lookup a moment to park on the gate
+	time.Sleep(50 * time.Millisecond)
+
+	cancelReq()
+	select {
+	case err := <-queued:
+		if !errors.Is(err, context.Canceled) {
+			unsaturate()
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		unsaturate()
+		t.Fatal("queued request did not return after its context was cancelled")
+	}
+
+	// the lookup itself outlives the request that started it, so let it
+	// finish before leaving, and confirm the key still resolves
+	unsaturate()
+	if _, err := su.GetUpstreams(newTestRequest()); err != nil {
+		t.Fatalf("key did not resolve after the queued request was cancelled: %v", err)
+	}
+}
+
+// TestAUpstreamsLookupsAreBounded is the A/AAAA equivalent of
+// TestSRVUpstreamsLookupsAreBounded. The gate is shared, so SRV lookups are
+// what saturate it here.
+func TestAUpstreamsLookupsAreBounded(t *testing.T) {
+	var lookups atomic.Int32
+	au := testAUpstreams("bounded.example.com", func(context.Context, string, string) ([]net.IP, error) {
+		lookups.Add(1)
+		return []net.IP{net.IPv4(10, 0, 0, 2)}, nil
+	})
+	au.ResetCache(nil)
+
+	unsaturate := saturateLookupGate(t)
+
+	done := make(chan upstreamsResult, 1)
+	go func() {
+		ups, err := au.GetUpstreams(newTestRequest())
+		done <- upstreamsResult{ups, err}
+	}()
+
+	select {
+	case res := <-done:
+		unsaturate()
+		t.Fatalf("lookup completed while the gate was saturated: %+v (err %v)", res.ups, res.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if n := lookups.Load(); n != 0 {
+		unsaturate()
+		t.Fatalf("expected the resolver to be untouched while saturated, saw %d lookups", n)
+	}
+
+	unsaturate()
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatalf("queued lookup errored: %v", res.err)
+		}
+		if len(res.ups) != 1 || res.ups[0].Dial != "10.0.0.2:80" {
+			t.Fatalf("unexpected upstreams: %+v", res.ups)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("queued lookup never ran after slots freed up")
+	}
+}
+
+// installSheddingGate swaps in a gate with no free slot and no room to queue,
+// so every lookup during the test is shed right away. puts the real one back
+// at the end.
+func installSheddingGate(t *testing.T) {
+	t.Helper()
+
+	previous := upstreamsLookups
+	gate := newLookupGate(1, 0)
+	if err := gate.acquire(context.Background()); err != nil {
+		t.Fatalf("priming the shedding gate: %v", err)
+	}
+	upstreamsLookups = gate
+	t.Cleanup(func() { upstreamsLookups = previous })
+}
+
+// newStaleSRVUpstreams returns an SRV source with a cached entry that's
+// already stale, plus a count of resolver lookups so far.
+func newStaleSRVUpstreams(t *testing.T, name string, gracePeriod time.Duration) (*SRVUpstreams, *atomic.Int32) {
+	t.Helper()
+
+	var lookups atomic.Int32
+	su := &SRVUpstreams{
+		Name:        name,
+		Refresh:     caddy.Duration(time.Millisecond),
+		GracePeriod: caddy.Duration(gracePeriod),
+		resolver: &fakeSRVResolver{
+			lookupSRV: func(context.Context, string, string, string) (string, []*net.SRV, error) {
+				lookups.Add(1)
+				return "", []*net.SRV{{Target: "10.0.0.5", Port: 80}}, nil
+			},
+		},
+		logger: zap.NewNop(),
+	}
+	su.ResetCache(nil)
+
+	// fill the cache, then let it age past refresh so the next request
+	// has to try a lookup
+	if _, err := su.GetUpstreams(newTestRequest()); err != nil {
+		t.Fatalf("priming the cache: %v", err)
+	}
+	if n := lookups.Load(); n != 1 {
+		t.Fatalf("expected exactly one priming lookup, saw %d", n)
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	return su, &lookups
+}
+
+// TestSRVUpstreamsShedServesStale checks that shedding still honors the grace
+// period. a request that can't get a slot but has a stale entry should get
+// those upstreams, not an error.
+func TestSRVUpstreamsShedServesStale(t *testing.T) {
+	su, lookups := newStaleSRVUpstreams(t, "shed-stale.example.com", time.Minute)
+
+	installSheddingGate(t)
+
+	ups, err := su.GetUpstreams(newTestRequest())
+	if err != nil {
+		t.Fatalf("expected the stale cache to be served when shed, got %v", err)
+	}
+	if len(ups) != 1 || ups[0].Dial != "10.0.0.5:80" {
+		t.Fatalf("unexpected upstreams: %+v", ups)
+	}
+	if n := lookups.Load(); n != 1 {
+		t.Fatalf("expected the resolver to be untouched while shed, saw %d lookups", n)
+	}
+}
+
+// TestSRVUpstreamsShedErrors covers when serving stale isn't possible, so
+// no grace period or nothing cached yet.
+func TestSRVUpstreamsShedErrors(t *testing.T) {
+	t.Run("no grace period", func(t *testing.T) {
+		su, _ := newStaleSRVUpstreams(t, "shed-nograce.example.com", 0)
+
+		installSheddingGate(t)
+
+		if _, err := su.GetUpstreams(newTestRequest()); !errors.Is(err, errTooManyLookups) {
+			t.Fatalf("expected errTooManyLookups without a grace period, got %v", err)
+		}
+	})
+
+	t.Run("nothing cached", func(t *testing.T) {
+		su := &SRVUpstreams{
+			Name:        "shed-uncached.example.com",
+			Refresh:     caddy.Duration(time.Minute),
+			GracePeriod: caddy.Duration(time.Minute),
+			resolver: &fakeSRVResolver{
+				lookupSRV: func(context.Context, string, string, string) (string, []*net.SRV, error) {
+					t.Error("resolver reached while the gate was shedding")
+					return "", nil, nil
+				},
+			},
+			logger: zap.NewNop(),
+		}
+		su.ResetCache(nil)
+
+		installSheddingGate(t)
+
+		// a grace period doesn't help with nothing to fall back on
+		if _, err := su.GetUpstreams(newTestRequest()); !errors.Is(err, errTooManyLookups) {
+			t.Fatalf("expected errTooManyLookups with an empty cache, got %v", err)
+		}
+	})
+}
+
+// TestAUpstreamsShedErrors checks the A side. no grace period there, so a
+// shed lookup has to fail.
+func TestAUpstreamsShedErrors(t *testing.T) {
+	au := testAUpstreams("shed.example.com", func(context.Context, string, string) ([]net.IP, error) {
+		t.Error("resolver reached while the gate was shedding")
+		return nil, nil
+	})
+	au.ResetCache(nil)
+
+	installSheddingGate(t)
+
+	if _, err := au.GetUpstreams(newTestRequest()); !errors.Is(err, errTooManyLookups) {
+		t.Fatalf("expected errTooManyLookups, got %v", err)
 	}
 }


### PR DESCRIPTION
Fixes #7946

Replaces coarse-grained mutex locks during SRV and A record lookups with `singleflight` and per-key lock isolation. 

Previously, `GetUpstreams` held a global lock during DNS lookups, causing a slow or timing-out service to block requests for all unrelated healthy upstreams.

**Changes:**
* Moved DNS lookups outside the global cache lock.
* Used `singleflight` to deduplicate concurrent lookups for the same key.
* Added per-key generation tracking so `ResetCache()` cleanly invalidates in-flight lookups.
* Added concurrency unit tests for slow lookups and cache resets.
* Passed `go test -race` and `go test -bench=. -benchmem`.

## Assistance Disclosure
I authored and coded the solution and unit tests; I used AI to generate in-code documentation and comments for the tests I wrote.