### PR TITLE
reverseproxy: fix TLS placeholders through HTTP proxies

### DIFF
--- a/modules/caddyhttp/reverseproxy/httptransport.go
+++ b/modules/caddyhttp/reverseproxy/httptransport.go
@@ -29,6 +29,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pires/go-proxyproto"
@@ -37,6 +38,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/net/http2"
+	"golang.org/x/net/idna"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
@@ -164,6 +166,9 @@ type HTTPTransport struct {
 
 	h3Transport   *http3.Transport // TODO: EXPERIMENTAL (May 2024)
 	quicTransport *quic.Transport  // used by h3Transport if sni placeholder is used, otherwise nil
+
+	dynamicTLSConnLimiter *transportConnLimiter
+	dynamicTLSTransports  *dynamicTLSTransportCache
 }
 
 // CaddyModule returns the Caddy module information.
@@ -178,6 +183,107 @@ var (
 	allowedVersions       = []string{"1.1", "2", "h2c", "3"}
 	allowedVersionsString = strings.Join(allowedVersions, ", ")
 )
+
+type proxyLookupCtxKey struct{}
+
+type proxyLookupResult struct {
+	url *url.URL
+	err error
+}
+
+type dynamicTLSTransportCache struct {
+	mu         sync.Mutex
+	transports map[string]*http.Transport
+	closed     bool
+}
+
+func (c *dynamicTLSTransportCache) loadOrNew(key string, newTransport func() (*http.Transport, error)) (*http.Transport, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closed {
+		return nil, fmt.Errorf("dynamic TLS transport cache is closed")
+	}
+	if transport := c.transports[key]; transport != nil {
+		return transport, nil
+	}
+	transport, err := newTransport()
+	if err != nil {
+		return nil, err
+	}
+	c.transports[key] = transport
+	return transport, nil
+}
+
+func (c *dynamicTLSTransportCache) closeIdleConnections() {
+	c.mu.Lock()
+	c.closed = true
+	transports := c.transports
+	c.transports = nil
+	c.mu.Unlock()
+
+	for _, transport := range transports {
+		transport.CloseIdleConnections()
+	}
+}
+
+type transportConnLimiter struct {
+	mu      sync.Mutex
+	limit   int
+	entries map[string]*transportConnLimitEntry
+}
+
+type transportConnLimitEntry struct {
+	permits chan struct{}
+	refs    int
+}
+
+func (l *transportConnLimiter) acquire(ctx context.Context, key string) (func(), error) {
+	l.mu.Lock()
+	entry := l.entries[key]
+	if entry == nil {
+		entry = &transportConnLimitEntry{permits: make(chan struct{}, l.limit)}
+		l.entries[key] = entry
+	}
+	entry.refs++
+	l.mu.Unlock()
+
+	select {
+	case entry.permits <- struct{}{}:
+		var once sync.Once
+		return func() {
+			once.Do(func() {
+				<-entry.permits
+				l.releaseRef(key, entry)
+			})
+		}, nil
+	case <-ctx.Done():
+		l.releaseRef(key, entry)
+		return nil, ctx.Err()
+	}
+}
+
+func (l *transportConnLimiter) releaseRef(key string, entry *transportConnLimitEntry) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	entry.refs--
+	if entry.refs == 0 && l.entries[key] == entry {
+		delete(l.entries, key)
+	}
+}
+
+type releaseConn struct {
+	net.Conn
+	release func()
+	once    sync.Once
+}
+
+func (c *releaseConn) Close() error {
+	err := c.Conn.Close()
+	c.once.Do(c.release)
+	return err
+}
 
 // Provision sets up h.Transport with a *http.Transport
 // that is ready to use.
@@ -205,6 +311,20 @@ func (h *HTTPTransport) Provision(ctx caddy.Context) error {
 
 // NewTransport builds a standard-lib-compatible http.Transport value from h.
 func (h *HTTPTransport) NewTransport(caddyCtx caddy.Context) (*http.Transport, error) {
+	if h.TLS != nil && strings.Contains(h.TLS.ServerName, "{") {
+		h.dynamicTLSTransports = &dynamicTLSTransportCache{transports: make(map[string]*http.Transport)}
+	} else {
+		h.dynamicTLSTransports = nil
+	}
+	if h.MaxConnsPerHost > 0 {
+		h.dynamicTLSConnLimiter = &transportConnLimiter{
+			limit:   h.MaxConnsPerHost,
+			entries: make(map[string]*transportConnLimitEntry),
+		}
+	} else {
+		h.dynamicTLSConnLimiter = nil
+	}
+
 	// Set keep-alive defaults if it wasn't otherwise configured
 	if h.KeepAlive == nil {
 		h.KeepAlive = new(KeepAlive)
@@ -393,16 +513,20 @@ func (h *HTTPTransport) NewTransport(caddyCtx caddy.Context) (*http.Transport, e
 	}
 	// we need to keep track if a proxy is used for a request
 	proxyWrapper := func(req *http.Request) (*url.URL, error) {
-		if proxy == nil {
-			return nil, nil
+		var result proxyLookupResult
+		var cached bool
+		if result, cached = req.Context().Value(proxyLookupCtxKey{}).(proxyLookupResult); !cached {
+			if proxy == nil {
+				return nil, nil
+			}
+			result.url, result.err = proxy(req)
 		}
-		u, err := proxy(req)
-		if u == nil || err != nil {
-			return u, err
+		if result.url == nil || result.err != nil {
+			return result.url, result.err
 		}
 		// there must be a proxy for this request
-		caddyhttp.SetVar(req.Context(), proxyVarKey, u)
-		return u, nil
+		caddyhttp.SetVar(req.Context(), proxyVarKey, result.url)
+		return result.url, nil
 	}
 
 	rt := &http.Transport{
@@ -649,7 +773,107 @@ func (h *HTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return h.h3Transport.RoundTrip(req)
 	}
 
-	return h.Transport.RoundTrip(req)
+	if req.URL.Scheme != "https" || h.TLS == nil || !strings.Contains(h.TLS.ServerName, "{") || h.Transport.Proxy == nil {
+		return h.Transport.RoundTrip(req)
+	}
+
+	proxyURL, proxyErr := h.Transport.Proxy(req)
+	requestCtx := context.WithValue(req.Context(), proxyLookupCtxKey{}, proxyLookupResult{url: proxyURL, err: proxyErr})
+	req = req.WithContext(requestCtx)
+	if proxyURL == nil || proxyErr != nil {
+		return h.Transport.RoundTrip(req)
+	}
+	repl := req.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+	serverName := repl.ReplaceAll(h.Transport.TLSClientConfig.ServerName, "")
+	cacheKey := dynamicTLSConnKey(req, proxyURL) + "\x00" + serverName
+	transport, err := h.dynamicTLSTransports.loadOrNew(cacheKey, func() (*http.Transport, error) {
+		return h.newDynamicTLSTransport(req, proxyURL, serverName)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return transport.RoundTrip(req)
+}
+
+func (h *HTTPTransport) newDynamicTLSTransport(req *http.Request, proxyURL *url.URL, serverName string) (*http.Transport, error) {
+	// CONNECT tunnels bypass DialTLSContext, so use a transport whose TLS
+	// configuration is specific to the expanded server name.
+	transport := h.Transport.Clone()
+	transport.TLSClientConfig.ServerName = serverName
+
+	// Preserve max_conns_per_host across transports with different TLS configs.
+	if h.dynamicTLSConnLimiter != nil {
+		baseDialContext := transport.DialContext
+		connKey := dynamicTLSConnKey(req, proxyURL)
+		transport.MaxConnsPerHost = 0
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			release, err := h.dynamicTLSConnLimiter.acquire(ctx, connKey)
+			if err != nil {
+				return nil, err
+			}
+			conn, err := baseDialContext(ctx, network, addr)
+			if err != nil {
+				release()
+				return nil, err
+			}
+			return &releaseConn{Conn: conn, release: release}, nil
+		}
+	}
+
+	// Give HTTP/2 an isolated connection pool too.
+	if slices.Contains(h.Versions, "2") || slices.Contains(h.Versions, "h2c") {
+		transport.TLSNextProto = nil
+		if err := http2.ConfigureTransport(transport); err != nil {
+			return nil, fmt.Errorf("configuring HTTP/2 transport clone: %v", err)
+		}
+	}
+
+	if strings.EqualFold(proxyURL.Scheme, "https") {
+		baseDialContext := transport.DialContext
+		proxyTLSConfig := transport.TLSClientConfig.Clone()
+		proxyTLSConfig.ServerName = proxyURL.Hostname()
+		transport.DialTLSContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := baseDialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			tlsConfig := proxyTLSConfig.Clone()
+			if caddyhttp.GetVar(ctx, tlsH1OnlyVarKey) == true {
+				tlsConfig.NextProtos = nil
+			}
+			tlsConn := tls.Client(conn, tlsConfig)
+			if transport.TLSHandshakeTimeout != 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeoutCause(ctx, transport.TLSHandshakeTimeout, fmt.Errorf("HTTP transport TLS handshake %ds timeout", int(transport.TLSHandshakeTimeout.Seconds())))
+				defer cancel()
+			}
+			if err := tlsConn.HandshakeContext(ctx); err != nil {
+				_ = tlsConn.Close()
+				return nil, err
+			}
+			return tlsConn, nil
+		}
+	}
+
+	return transport, nil
+}
+
+func dynamicTLSConnKey(req *http.Request, proxyURL *url.URL) string {
+	port := req.URL.Port()
+	if port == "" {
+		port = "443"
+	}
+	targetHost := req.URL.Hostname()
+	if asciiHost, err := idna.Lookup.ToASCII(targetHost); err == nil {
+		targetHost = asciiHost
+	}
+	targetAddr := net.JoinHostPort(strings.ToLower(targetHost), port)
+	key := proxyURL.String() + "\x00" + req.URL.Scheme + "\x00" + targetAddr
+	if caddyhttp.GetVar(req.Context(), tlsH1OnlyVarKey) == true {
+		key += "\x00h1"
+	}
+	return key
 }
 
 // SetScheme ensures that the outbound request req
@@ -711,11 +935,14 @@ func (h HTTPTransport) ProxyProtocolEnabled() bool {
 }
 
 // Cleanup implements caddy.CleanerUpper and closes any idle connections.
-func (h HTTPTransport) Cleanup() error {
+func (h *HTTPTransport) Cleanup() error {
 	if h.Transport == nil {
 		return nil
 	}
 	h.Transport.CloseIdleConnections()
+	if h.dynamicTLSTransports != nil {
+		h.dynamicTLSTransports.closeIdleConnections()
+	}
 	// h3 related cleanup, errors are ignored as nothing can be done.
 	// TODO: log these errors if any
 	if h.h3Transport != nil {

--- a/modules/caddyhttp/reverseproxy/httptransport_test.go
+++ b/modules/caddyhttp/reverseproxy/httptransport_test.go
@@ -2,20 +2,27 @@ package reverseproxy
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"net/netip"
 	"net/url"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/caddyserver/caddy/v2/modules/internal/network"
 )
 
 func TestHTTPTransportUnmarshalCaddyFileWithCaPools(t *testing.T) {
@@ -200,6 +207,617 @@ func TestHTTPTransport_DialTLSContext_ProxyProtocol(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestHTTPTransportTLSPlaceholderThroughHTTPProxy covers CONNECT's separate TLS path.
+func TestHTTPTransportTLSPlaceholderThroughHTTPProxy(t *testing.T) {
+	const (
+		responseBody = "hello from TLS upstream"
+		serverName   = "example.com"
+	)
+
+	for _, tc := range []struct {
+		name           string
+		tlsServerName  string
+		proxyScheme    string
+		versions       []string
+		wantProtoMajor int
+	}{
+		{"fixed server name without proxy", serverName, "", []string{"1.1"}, 1},
+		{"placeholder server name without proxy", "{http.request.host}", "", []string{"1.1"}, 1},
+		{"fixed server name through HTTP proxy", serverName, "http", []string{"1.1"}, 1},
+		{"placeholder server name through HTTP proxy", "{http.request.host}", "http", []string{"1.1"}, 1},
+		{"placeholder server name through HTTPS proxy", "{http.request.host}", "https", []string{"1.1"}, 1},
+		{"placeholder server name through proxy with HTTP2", "{http.request.host}", "http", []string{"1.1", "2"}, 2},
+		{"placeholder server name through proxy with h2c enabled", "{http.request.host}", "http", []string{"h2c"}, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			serverNames := make(chan string, 1)
+			upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = io.WriteString(w, responseBody)
+			}))
+			upstream.EnableHTTP2 = true
+			upstream.TLS = &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+					select {
+					case serverNames <- hello.ServerName:
+					default:
+					}
+					return nil, nil
+				},
+			}
+			upstream.StartTLS()
+			t.Cleanup(upstream.Close)
+
+			var connectProxy *testHTTPConnectProxy
+			var proxyURL string
+			var proxyRoots []*x509.Certificate
+			if tc.proxyScheme != "" {
+				connectProxy = newTestHTTPConnectProxy(t, tc.proxyScheme == "https")
+				proxyURL = connectProxy.url
+				if connectProxy.certificate != nil {
+					proxyRoots = append(proxyRoots, connectProxy.certificate)
+				}
+			}
+			h := newDynamicSNITestTransport(t, upstream, tc.tlsServerName, proxyURL, tc.versions, 0, proxyRoots...)
+			rt := h.Transport
+			var proxySelections atomic.Int32
+			baseProxy := rt.Proxy
+			rt.Proxy = func(req *http.Request) (*url.URL, error) {
+				if _, cached := req.Context().Value(proxyLookupCtxKey{}).(proxyLookupResult); !cached {
+					proxySelections.Add(1)
+				}
+				return baseProxy(req)
+			}
+			reqCtx, reqCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer reqCancel()
+			req := newDynamicSNITestRequest(t, reqCtx, upstream.URL, serverName)
+
+			resp, err := h.RoundTrip(req)
+			if err != nil {
+				t.Fatalf("RoundTrip: %v", err)
+			}
+			select {
+			case gotServerName := <-serverNames:
+				if gotServerName != serverName {
+					t.Errorf("TLS server name = %q, want %q", gotServerName, serverName)
+				}
+			case <-req.Context().Done():
+				t.Fatalf("TLS upstream did not receive a ClientHello: %v", req.Context().Err())
+			}
+			if connectProxy != nil {
+				select {
+				case target := <-connectProxy.connectTargets:
+					if target != req.URL.Host {
+						t.Fatalf("CONNECT target = %q, want %q", target, req.URL.Host)
+					}
+				default:
+					t.Fatal("proxy did not receive a CONNECT request")
+				}
+			}
+			if tc.proxyScheme == "https" {
+				select {
+				case gotServerName := <-connectProxy.serverNames:
+					if gotServerName != "" {
+						t.Errorf("HTTPS proxy TLS server name = %q, want empty for IP proxy host", gotServerName)
+					}
+				default:
+					t.Fatal("HTTPS proxy did not receive a TLS ClientHello")
+				}
+			}
+			defer resp.Body.Close()
+			if resp.ProtoMajor != tc.wantProtoMajor {
+				t.Errorf("response protocol = %s, want HTTP/%d", resp.Proto, tc.wantProtoMajor)
+			}
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("read response body: %v", err)
+			}
+			if got := string(body); got != responseBody {
+				t.Fatalf("response body = %q, want %q", got, responseBody)
+			}
+			if got := proxySelections.Load(); got != 1 {
+				t.Fatalf("proxy selections = %d, want 1", got)
+			}
+		})
+	}
+}
+
+func TestHTTPTransportDynamicSNIMaxConnsPerHost(t *testing.T) {
+	const serverName = "example.com"
+
+	requestEntered := make(chan int, 2)
+	var requestCount atomic.Int32
+	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestNumber := int(requestCount.Add(1))
+		requestEntered <- requestNumber
+		if requestNumber == 1 {
+			w.Header().Set("Content-Length", "100")
+			w.WriteHeader(http.StatusOK)
+			w.(http.Flusher).Flush()
+			<-r.Context().Done()
+			return
+		}
+		_, _ = io.WriteString(w, "second response")
+	}))
+	upstream.TLS = &tls.Config{MinVersion: tls.VersionTLS12}
+	upstream.StartTLS()
+	t.Cleanup(upstream.Close)
+
+	connectProxy := newTestHTTPConnectProxy(t, false)
+	h := newDynamicSNITestTransport(t, upstream, "{http.request.host}", connectProxy.url, []string{"1.1"}, 1)
+	dialFailure := errors.New("test dial failure")
+	baseDialContext := h.Transport.DialContext
+	var failNextDial atomic.Bool
+	failNextDial.Store(true)
+	h.Transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if failNextDial.CompareAndSwap(true, false) {
+			return nil, dialFailure
+		}
+		return baseDialContext(ctx, network, addr)
+	}
+
+	type roundTripResult struct {
+		resp   *http.Response
+		err    error
+		cancel context.CancelFunc
+	}
+	results := make(chan roundTripResult, 2)
+	startRequest := func(host string) {
+		reqCtx, reqCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		req := newDynamicSNITestRequest(t, reqCtx, upstream.URL, host)
+		resp, err := h.RoundTrip(req)
+		results <- roundTripResult{resp: resp, err: err, cancel: reqCancel}
+	}
+	nextResult := func(label string) roundTripResult {
+		t.Helper()
+		select {
+		case result := <-results:
+			return result
+		case <-time.After(5 * time.Second):
+			t.Fatalf("%s RoundTrip did not return", label)
+			return roundTripResult{}
+		}
+	}
+	checkFailedResult := func(label string, result roundTripResult) {
+		t.Helper()
+		if result.cancel != nil {
+			result.cancel()
+		}
+		if result.resp != nil {
+			_ = result.resp.Body.Close()
+		}
+		if result.err == nil {
+			t.Fatalf("%s unexpectedly succeeded", label)
+		}
+	}
+
+	go startRequest(serverName)
+	dialResult := nextResult("dial failure")
+	checkFailedResult("dial failure", dialResult)
+	if !errors.Is(dialResult.err, dialFailure) {
+		t.Fatalf("dial error = %v, want %v", dialResult.err, dialFailure)
+	}
+	go startRequest("wrong.example")
+	failedResult := nextResult("invalid TLS server name")
+	checkFailedResult("invalid TLS server name", failedResult)
+
+	go startRequest(serverName)
+	select {
+	case requestNumber := <-requestEntered:
+		if requestNumber != 1 {
+			t.Fatalf("first request number = %d, want 1", requestNumber)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("first request did not reach upstream")
+	}
+	firstResult := nextResult("first")
+	if firstResult.err != nil {
+		t.Fatalf("first RoundTrip: %v", firstResult.err)
+	}
+	defer firstResult.cancel()
+	defer firstResult.resp.Body.Close()
+
+	go startRequest(serverName)
+	waitDeadline := time.Now().Add(5 * time.Second)
+	for {
+		h.dynamicTLSConnLimiter.mu.Lock()
+		waiting := false
+		for _, entry := range h.dynamicTLSConnLimiter.entries {
+			if entry.refs == 2 {
+				waiting = true
+				break
+			}
+		}
+		h.dynamicTLSConnLimiter.mu.Unlock()
+		if waiting {
+			break
+		}
+		if time.Now().After(waitDeadline) {
+			_ = firstResult.resp.Body.Close()
+			t.Fatal("second request did not wait for a connection permit")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	select {
+	case requestNumber := <-requestEntered:
+		_ = firstResult.resp.Body.Close()
+		t.Fatalf("request %d reached upstream while the first connection was still active", requestNumber)
+	default:
+	}
+
+	if err := firstResult.resp.Body.Close(); err != nil {
+		t.Fatalf("close first response body: %v", err)
+	}
+	select {
+	case requestNumber := <-requestEntered:
+		if requestNumber != 2 {
+			t.Fatalf("second request number = %d, want 2", requestNumber)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("second request remained blocked after the first connection closed")
+	}
+	secondResult := nextResult("second")
+	if secondResult.cancel != nil {
+		defer secondResult.cancel()
+	}
+	if secondResult.err != nil {
+		t.Fatalf("second RoundTrip: %v", secondResult.err)
+	}
+	defer secondResult.resp.Body.Close()
+	body, err := io.ReadAll(secondResult.resp.Body)
+	if err != nil {
+		t.Fatalf("read second response: %v", err)
+	}
+	if got := string(body); got != "second response" {
+		t.Fatalf("second response body = %q, want %q", got, "second response")
+	}
+}
+
+func TestHTTPTransportDynamicSNIDirectConnectionReuse(t *testing.T) {
+	const serverName = "example.com"
+
+	var handshakes atomic.Int32
+	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	upstream.TLS = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
+			handshakes.Add(1)
+			return nil, nil
+		},
+	}
+	upstream.StartTLS()
+	t.Cleanup(upstream.Close)
+
+	h := newDynamicSNITestTransport(t, upstream, "{http.request.host}", "", []string{"1.1"}, 0)
+
+	for i := 0; i < 2; i++ {
+		req := newDynamicSNITestRequest(t, context.Background(), upstream.URL, serverName)
+		resp, err := h.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("RoundTrip %d: %v", i, err)
+		}
+		if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+			_ = resp.Body.Close()
+			t.Fatalf("read response %d: %v", i, err)
+		}
+		if err := resp.Body.Close(); err != nil {
+			t.Fatalf("close response %d: %v", i, err)
+		}
+	}
+
+	if got := handshakes.Load(); got != 1 {
+		t.Fatalf("TLS handshakes = %d, want 1 reused connection", got)
+	}
+}
+
+func TestHTTPTransportDynamicSNIProxyConnectionReuse(t *testing.T) {
+	const serverName = "example.com"
+
+	for _, tc := range []struct {
+		name     string
+		proxyTLS bool
+	}{
+		{"HTTP proxy", false},
+		{"HTTPS proxy", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var upstreamHandshakes atomic.Int32
+			upstreamServerNames := make(chan string, 2)
+			upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = io.WriteString(w, "ok")
+			}))
+			upstream.TLS = &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+					upstreamHandshakes.Add(1)
+					upstreamServerNames <- hello.ServerName
+					return nil, nil
+				},
+			}
+			upstream.StartTLS()
+			t.Cleanup(upstream.Close)
+
+			connectProxy := newTestHTTPConnectProxy(t, tc.proxyTLS)
+			var proxyRoots []*x509.Certificate
+			if connectProxy.certificate != nil {
+				proxyRoots = append(proxyRoots, connectProxy.certificate)
+			}
+			h := newDynamicSNITestTransport(t, upstream, "{http.request.host}", connectProxy.url, []string{"1.1"}, 0, proxyRoots...)
+
+			roundTrip := func(requestNumber int, requestServerName string) {
+				t.Helper()
+				req := newDynamicSNITestRequest(t, context.Background(), upstream.URL, requestServerName)
+				resp, err := h.RoundTrip(req)
+				if err != nil {
+					t.Fatalf("RoundTrip %d: %v", requestNumber, err)
+				}
+				if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+					_ = resp.Body.Close()
+					t.Fatalf("read response %d: %v", requestNumber, err)
+				}
+				if err := resp.Body.Close(); err != nil {
+					t.Fatalf("close response %d: %v", requestNumber, err)
+				}
+			}
+			for i := 0; i < 2; i++ {
+				roundTrip(i, serverName)
+			}
+
+			if got := connectProxy.connections.Load(); got != 1 {
+				t.Errorf("proxy connections = %d, want 1 reused connection", got)
+			}
+			if got := connectProxy.connects.Load(); got != 1 {
+				t.Errorf("CONNECT requests = %d, want 1 reused tunnel", got)
+			}
+			if got := upstreamHandshakes.Load(); got != 1 {
+				t.Errorf("upstream TLS handshakes = %d, want 1 reused connection", got)
+			}
+			wantProxyHandshakes := int32(0)
+			if tc.proxyTLS {
+				wantProxyHandshakes = 1
+			}
+			if got := connectProxy.tlsHandshakes.Load(); got != wantProxyHandshakes {
+				t.Errorf("proxy TLS handshakes = %d, want %d", got, wantProxyHandshakes)
+			}
+			select {
+			case gotServerName := <-upstreamServerNames:
+				if gotServerName != serverName {
+					t.Errorf("upstream TLS server name = %q, want %q", gotServerName, serverName)
+				}
+			default:
+				t.Fatal("upstream did not receive a TLS ClientHello")
+			}
+
+			const secondServerName = "second.example.com"
+			roundTrip(2, secondServerName)
+			if got := connectProxy.connections.Load(); got != 2 {
+				t.Errorf("proxy connections after SNI change = %d, want 2 separate connections", got)
+			}
+			if got := connectProxy.connects.Load(); got != 2 {
+				t.Errorf("CONNECT requests after SNI change = %d, want 2 separate tunnels", got)
+			}
+			if got := upstreamHandshakes.Load(); got != 2 {
+				t.Errorf("upstream TLS handshakes after SNI change = %d, want 2", got)
+			}
+			wantProxyHandshakes *= 2
+			if got := connectProxy.tlsHandshakes.Load(); got != wantProxyHandshakes {
+				t.Errorf("proxy TLS handshakes after SNI change = %d, want %d", got, wantProxyHandshakes)
+			}
+			select {
+			case gotServerName := <-upstreamServerNames:
+				if gotServerName != secondServerName {
+					t.Errorf("second upstream TLS server name = %q, want %q", gotServerName, secondServerName)
+				}
+			default:
+				t.Fatal("upstream did not receive a second TLS ClientHello")
+			}
+		})
+	}
+}
+
+func TestTransportConnLimiter(t *testing.T) {
+	limiter := &transportConnLimiter{
+		limit:   1,
+		entries: make(map[string]*transportConnLimitEntry),
+	}
+
+	releaseA, err := limiter.acquire(context.Background(), "target-a")
+	if err != nil {
+		t.Fatalf("acquire target-a: %v", err)
+	}
+	releaseB, err := limiter.acquire(context.Background(), "target-b")
+	if err != nil {
+		t.Fatalf("acquire independent target-b: %v", err)
+	}
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer waitCancel()
+	if _, err := limiter.acquire(waitCtx, "target-a"); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("blocked acquire error = %v, want context deadline exceeded", err)
+	}
+
+	releaseA()
+	releaseA()
+	releaseAAgain, err := limiter.acquire(context.Background(), "target-a")
+	if err != nil {
+		t.Fatalf("reacquire target-a: %v", err)
+	}
+	releaseAAgain()
+	releaseB()
+
+	limiter.mu.Lock()
+	defer limiter.mu.Unlock()
+	if len(limiter.entries) != 0 {
+		t.Fatalf("limiter retained %d unused entries, want 0", len(limiter.entries))
+	}
+}
+
+func TestDynamicTLSConnKey(t *testing.T) {
+	proxyURL, err := url.Parse("http://proxy.example:3128")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		targetURL string
+		h1Only    bool
+		want      string
+	}{
+		{"https://BÜCHER.example/path", false, "http://proxy.example:3128\x00https\x00xn--bcher-kva.example:443"},
+		{"https://Example.COM:8443", true, "http://proxy.example:3128\x00https\x00example.com:8443\x00h1"},
+	} {
+		req := newDynamicSNITestRequest(t, context.Background(), tc.targetURL, "example.com")
+		if tc.h1Only {
+			caddyhttp.SetVar(req.Context(), tlsH1OnlyVarKey, true)
+		}
+		if got := dynamicTLSConnKey(req, proxyURL); got != tc.want {
+			t.Errorf("dynamicTLSConnKey(%q) = %q, want %q", tc.targetURL, got, tc.want)
+		}
+	}
+}
+
+func newDynamicSNITestTransport(
+	t *testing.T,
+	upstream *httptest.Server,
+	tlsServerName, proxyURL string,
+	versions []string,
+	maxConnsPerHost int,
+	extraRoots ...*x509.Certificate,
+) *HTTPTransport {
+	t.Helper()
+
+	networkProxyRaw := caddyconfig.JSONModuleObject(network.ProxyFromNone{}, "from", "none", nil)
+	if proxyURL != "" {
+		networkProxyRaw = caddyconfig.JSONModuleObject(network.ProxyFromURL{URL: proxyURL}, "from", "url", nil)
+	}
+	h := &HTTPTransport{
+		TLS:             &TLSConfig{ServerName: tlsServerName},
+		NetworkProxyRaw: networkProxyRaw,
+		Versions:        versions,
+		MaxConnsPerHost: maxConnsPerHost,
+	}
+	ctx, cancel := caddy.NewContext(caddy.Context{Context: context.Background()})
+	t.Cleanup(cancel)
+	rt, err := h.NewTransport(ctx)
+	if err != nil {
+		t.Fatalf("NewTransport: %v", err)
+	}
+	roots := x509.NewCertPool()
+	roots.AddCert(upstream.Certificate())
+	for _, cert := range extraRoots {
+		roots.AddCert(cert)
+	}
+	rt.TLSClientConfig.RootCAs = roots
+	h.Transport = rt
+	t.Cleanup(func() {
+		if err := h.Cleanup(); err != nil {
+			t.Errorf("cleanup HTTP transport: %v", err)
+		}
+	})
+	return h
+}
+
+func newDynamicSNITestRequest(t *testing.T, ctx context.Context, targetURL, host string) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Host = host
+	return caddyhttp.PrepareRequest(req, caddy.NewReplacer(), nil, &caddyhttp.Server{})
+}
+
+type testHTTPConnectProxy struct {
+	url            string
+	certificate    *x509.Certificate
+	connectTargets <-chan string
+	serverNames    <-chan string
+	connections    atomic.Int32
+	connects       atomic.Int32
+	tlsHandshakes  atomic.Int32
+}
+
+func newTestHTTPConnectProxy(t *testing.T, useTLS bool) *testHTTPConnectProxy {
+	t.Helper()
+
+	connectTargets := make(chan string, 10)
+	serverNames := make(chan string, 10)
+	result := &testHTTPConnectProxy{
+		connectTargets: connectTargets,
+		serverNames:    serverNames,
+	}
+	proxy := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodConnect {
+			http.Error(w, "CONNECT required", http.StatusMethodNotAllowed)
+			return
+		}
+
+		upstreamConn, err := net.DialTimeout("tcp", r.Host, 5*time.Second)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		defer upstreamConn.Close()
+
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+			return
+		}
+		clientConn, clientReadWriter, err := hijacker.Hijack()
+		if err != nil {
+			return
+		}
+		defer clientConn.Close()
+
+		result.connects.Add(1)
+		connectTargets <- r.Host
+		if _, err := clientReadWriter.WriteString("HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
+			return
+		}
+		if err := clientReadWriter.Flush(); err != nil {
+			return
+		}
+
+		copyDone := make(chan struct{}, 2)
+		go func() {
+			_, _ = io.Copy(upstreamConn, clientReadWriter)
+			copyDone <- struct{}{}
+		}()
+		go func() {
+			_, _ = io.Copy(clientConn, upstreamConn)
+			copyDone <- struct{}{}
+		}()
+		<-copyDone
+	}))
+	proxy.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			result.connections.Add(1)
+		}
+	}
+	if useTLS {
+		proxy.TLS = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+				result.tlsHandshakes.Add(1)
+				serverNames <- hello.ServerName
+				return nil, nil
+			},
+		}
+		proxy.StartTLS()
+		result.certificate = proxy.Certificate()
+	} else {
+		proxy.Start()
+	}
+	t.Cleanup(proxy.Close)
+
+	result.url = proxy.URL
+	return result
 }
 
 func TestHTTPTransport_DialContext_ProxyProtocolClosesConnectionOnError(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #7225.

TLS server name placeholders were expanded in `DialTLSContext`, which works for direct HTTPS connections. However, Go does not use that path after an HTTP proxy establishes a CONNECT tunnel, causing the literal placeholder to be used during the upstream TLS handshake.

This change:

- expands the TLS server name using a request-local transport for proxied HTTPS requests;
- avoids mutating shared TLS configuration;
- evaluates the proxy selection only once per request;
- preserves `max_conns_per_host` across request-local transports;
- isolates HTTP/2 connection pools for request-specific TLS configuration; and
- keeps the existing direct-connection pooling behavior unchanged.

Regression tests cover fixed and placeholder server names, direct and proxied connections, HTTP/1.1, HTTP/2, `h2c`, connection limits, connection reuse, TLS and dial failures, proxy selection, and connection-key generation.

## Testing

- `go test ./modules/caddyhttp/reverseproxy -run "TestHTTPTransportTLSPlaceholderThroughHTTPProxy|TestHTTPTransportDynamicSNI|TestTransportConnLimiter|TestDynamicTLSConnKey" -count=10`
- `go test ./modules/caddyhttp/reverseproxy/... -count=1`
- `go test -short ./... -count=1`
- `go build ./...`

Race-enabled tests could not be run locally because the installed Windows C compiler does not support 64-bit mode.

## Assistance Disclosure

OpenAI Codex assisted with writing and refactoring the tests, and reviewing the changes. I manually reviewed the code and ran the tests and build commands listed above.