### PR TITLE
chore: fix lint errors from newer golangci-lint

### DIFF
--- a/caddytest/caddytest.go
+++ b/caddytest/caddytest.go
@@ -340,7 +340,6 @@ func CreateTestingTransport() *http.Transport {
 	dialer := net.Dialer{
 		Timeout:   5 * time.Second,
 		KeepAlive: 5 * time.Second,
-		DualStack: true,
 	}
 
 	dialContext := func(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/modules/caddyhttp/fileserver/matcher.go
+++ b/modules/caddyhttp/fileserver/matcher.go
@@ -622,7 +622,7 @@ func isCELTryFilesLiteral(e ast.Expr) bool {
 					return false
 				}
 			case "try_policy", "root":
-				if !(isCELStringExpr(mapVal)) {
+				if !isCELStringExpr(mapVal) {
 					return false
 				}
 			default:

--- a/modules/caddytls/fileloader.go
+++ b/modules/caddytls/fileloader.go
@@ -117,6 +117,6 @@ func (fl FileLoader) LoadCertificates() ([]Certificate, error) {
 
 // Interface guard
 var (
-	_ CertificateLoader = (FileLoader)(nil)
-	_ caddy.Provisioner = (FileLoader)(nil)
+	_ CertificateLoader = FileLoader(nil)
+	_ caddy.Provisioner = FileLoader(nil)
 )

--- a/modules/caddytls/folderloader.go
+++ b/modules/caddytls/folderloader.go
@@ -175,6 +175,6 @@ func tlsCertFromCertAndKeyPEMBundle(bundle []byte) (tls.Certificate, error) {
 }
 
 var (
-	_ CertificateLoader = (FolderLoader)(nil)
-	_ caddy.Provisioner = (FolderLoader)(nil)
+	_ CertificateLoader = FolderLoader(nil)
+	_ caddy.Provisioner = FolderLoader(nil)
 )

--- a/modules/caddytls/pemloader.go
+++ b/modules/caddytls/pemloader.go
@@ -89,6 +89,6 @@ func (pl PEMLoader) LoadCertificates() ([]Certificate, error) {
 
 // Interface guard
 var (
-	_ CertificateLoader = (PEMLoader)(nil)
-	_ caddy.Provisioner = (PEMLoader)(nil)
+	_ CertificateLoader = PEMLoader(nil)
+	_ caddy.Provisioner = PEMLoader(nil)
 )


### PR DESCRIPTION
CI lint is red on master, but it looks like it’s not caused by a code change. The workflow uses `version: latest`, and golangci-lint v2.13.0 landed with updates to two bundled linters.

**gofumpt v0.9.2 → v0.11.0**

* caddytls: `(FileLoader)(nil)` → `FileLoader(nil)`, same for `FolderLoader` and `PEMLoader`
* `fileserver/matcher.go`: `if !(...)` → `if !...`

**staticcheck v0.7.0 → v0.8.0**

* `caddytest.go`: removed `DualStack: true`, which has been inert since Go 1.12

One slightly confusing thing: CI reports 4 errors, but there are actually 5. `max-same-issues` is set to 3, so one of the gofumpt errors gets hidden because they have the same message. The hidden one is `matcher.go`, so fixing only caddytls still leaves CI red. `--max-same-issues=0` shows all 5.

I verified this with golangci-lint v2.13.1 (current `latest`) and it’s clean now. Build, vet, and tests also pass for the touched packages.

This was what was blocking CI on #7946.

cc @steadytao

AI disclosure: I used AI to help figure out which files CI was complaining about and why.