### PR TITLE
caddyfile: clarify ArgErr documentation

### DIFF
--- a/caddyconfig/caddyfile/dispenser.go
+++ b/caddyconfig/caddyfile/dispenser.go
@@ -405,10 +405,11 @@ func (d *Dispenser) Reset() {
 	d.nesting = 0
 }
 
-// ArgErr returns an argument error, meaning that another
-// argument was expected but not found. In other words,
-// a line break or open curly brace was encountered instead of
-// an argument.
+// ArgErr returns an argument error, meaning that the wrong
+// number of arguments was given: either a required one was
+// missing, or an extra one was found. If an argument is
+// present but its value is invalid, use Errf or SyntaxErr
+// instead.
 func (d *Dispenser) ArgErr() error {
 	if isOpenCurlyBrace(d.Token()) {
 		return d.Err("unexpected token '{', expecting argument")


### PR DESCRIPTION
Closes #7959

`ArgErr` is called both when a required argument is missing and when an unexpected extra argument is found, but the doc comment only described the missing case. Since it's used ~450 times across the repo and by anyone writing a custom module parser, the narrower wording is misleading.

Examples of both directions in the current code:

- `caddyhttp/celmatcher.go` errors when `NextArg()` returns false (missing)
- `caddyhttp/caddyauth/caddyfile.go` errors when `NextArg()` returns true (extra)

Also adds a line pointing at `Errf` / `SyntaxErr` for the case where an argument is present but its value is invalid, per @steadytao's note on the issue.

Docs only, no behaviour change.

## Assistance Disclosure

Used Claude to help navigate the codebase and discuss wording. I read the source, verified both usage patterns myself, and wrote the change.