### PR TITLE
caddytls: stop mutating the live cache's options on reload

### DIFF
--- a/modules/caddytls/certcache_test.go
+++ b/modules/caddytls/certcache_test.go
@@ -1,0 +1,78 @@
+package caddytls
+
+import (
+	"testing"
+	"time"
+
+	"github.com/caddyserver/certmagic"
+)
+
+// The certificate cache's options are immutable once it is created (its
+// maintenance tickers are started with them), so a provision with changed
+// options must REPLACE the cache rather than mutate a live one, and a
+// provision with identical options must reuse it.
+func TestProvisionCertCacheReplacesOnOptionChange(t *testing.T) {
+	certCacheMu.Lock()
+	origCache, origOpts, origApp := certCache, certCacheOpts, certCacheApp
+	certCache = nil
+	certCacheMu.Unlock()
+	defer func() {
+		certCacheMu.Lock()
+		if certCache != nil && certCache != origCache {
+			certCache.Stop()
+		}
+		certCache, certCacheOpts, certCacheApp = origCache, origOpts, origApp
+		certCacheMu.Unlock()
+	}()
+
+	app := new(TLS)
+	getCfg := func(certmagic.Certificate) (*certmagic.Config, error) {
+		return nil, nil
+	}
+	optsA := certmagic.CacheOptions{
+		GetConfigForCert:   getCfg,
+		RenewCheckInterval: 1 * time.Hour,
+		OCSPCheckInterval:  1 * time.Hour,
+		Capacity:           100,
+	}
+
+	if old := provisionCertCache(app, optsA); old != nil {
+		t.Fatal("first provision returned a cache to stop")
+	}
+	certCacheMu.RLock()
+	first := certCache
+	certCacheMu.RUnlock()
+	if first == nil {
+		t.Fatal("first provision did not create the cache")
+	}
+
+	// identical options: cache is reused, nothing to stop
+	if old := provisionCertCache(app, optsA); old != nil {
+		t.Fatal("unchanged options returned a cache to stop")
+	}
+	certCacheMu.RLock()
+	same := certCache
+	certCacheMu.RUnlock()
+	if same != first {
+		t.Fatal("unchanged options replaced the cache")
+	}
+
+	// changed interval: cache is replaced and the old one handed back
+	optsB := optsA
+	optsB.RenewCheckInterval = 2 * time.Hour
+	old := provisionCertCache(app, optsB)
+	if old != first {
+		t.Fatal("changed options did not hand back the previous cache")
+	}
+	old.Stop()
+	certCacheMu.RLock()
+	replaced := certCache
+	gotOpts := certCacheOpts
+	certCacheMu.RUnlock()
+	if replaced == first {
+		t.Fatal("changed options did not replace the cache")
+	}
+	if gotOpts.RenewCheckInterval != 2*time.Hour {
+		t.Fatal("recorded options were not updated")
+	}
+}

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -46,6 +46,18 @@ func init() {
 var (
 	certCache   *certmagic.Cache
 	certCacheMu sync.RWMutex
+
+	// the TLS app that most recently provisioned the certificate
+	// cache; the cache's GetConfigForCert callback dereferences
+	// this so that reusing the cache across config reloads does
+	// not require replacing its options just to update the callback
+	certCacheApp *TLS
+
+	// the options the certificate cache was last created or
+	// updated with; setting options on a live cache races with
+	// its maintenance routines reading them, so it is only done
+	// when these values actually change
+	certCacheOpts certmagic.CacheOptions
 )
 
 // TLS provides TLS facilities including certificate
@@ -196,7 +208,10 @@ func (t *TLS) Provision(ctx caddy.Context) error {
 	// set up a new certificate cache; this (re)loads all certificates
 	cacheOpts := certmagic.CacheOptions{
 		GetConfigForCert: func(cert certmagic.Certificate) (*certmagic.Config, error) {
-			return t.getConfigForName(cert.Names[0]), nil
+			certCacheMu.RLock()
+			tlsApp := certCacheApp
+			certCacheMu.RUnlock()
+			return tlsApp.getConfigForName(cert.Names[0]), nil
 		},
 		Logger: t.logger.Named("cache"),
 	}
@@ -212,10 +227,15 @@ func (t *TLS) Provision(ctx caddy.Context) error {
 	}
 
 	certCacheMu.Lock()
+	certCacheApp = t
 	if certCache == nil {
 		certCache = certmagic.NewCache(cacheOpts)
-	} else {
+		certCacheOpts = cacheOpts
+	} else if cacheOpts.Capacity != certCacheOpts.Capacity ||
+		cacheOpts.OCSPCheckInterval != certCacheOpts.OCSPCheckInterval ||
+		cacheOpts.RenewCheckInterval != certCacheOpts.RenewCheckInterval {
 		certCache.SetOptions(cacheOpts)
+		certCacheOpts = cacheOpts
 	}
 	certCacheMu.Unlock()
 

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -53,12 +53,44 @@ var (
 	// not require replacing its options just to update the callback
 	certCacheApp *TLS
 
-	// the options the certificate cache was last created or
-	// updated with; setting options on a live cache races with
-	// its maintenance routines reading them, so it is only done
-	// when these values actually change
+	// the options the certificate cache was created with;
+	// CacheOptions are immutable once a cache exists (its
+	// maintenance tickers are created at startup), so when a
+	// reload changes them the cache is replaced, never mutated
 	certCacheOpts certmagic.CacheOptions
 )
+
+// provisionCertCache installs t as the cache's app and ensures the global
+// certificate cache exists with exactly cacheOpts. CacheOptions are
+// immutable once a cache is created: the maintenance goroutine's tickers
+// are created at startup, so mutating options on a live cache both races
+// with maintenance reading them and silently never applies new intervals
+// to the running tickers. When the options changed, the cache is therefore
+// replaced, never mutated — the new cache starts empty and is repopulated
+// by certificate loading during provisioning, exactly like a fresh start,
+// while handshakes from the outgoing config generation keep reading the
+// old cache until its maintenance loop is stopped. The previous cache is
+// returned for the caller to Stop() outside the lock, or nil if the
+// existing cache was kept.
+func provisionCertCache(t *TLS, cacheOpts certmagic.CacheOptions) *certmagic.Cache {
+	certCacheMu.Lock()
+	defer certCacheMu.Unlock()
+	certCacheApp = t
+	if certCache == nil {
+		certCache = certmagic.NewCache(cacheOpts)
+		certCacheOpts = cacheOpts
+		return nil
+	}
+	if cacheOpts.Capacity == certCacheOpts.Capacity &&
+		cacheOpts.OCSPCheckInterval == certCacheOpts.OCSPCheckInterval &&
+		cacheOpts.RenewCheckInterval == certCacheOpts.RenewCheckInterval {
+		return nil
+	}
+	oldCache := certCache
+	certCache = certmagic.NewCache(cacheOpts)
+	certCacheOpts = cacheOpts
+	return oldCache
+}
 
 // TLS provides TLS facilities including certificate
 // loading and management, client auth, and more.
@@ -226,18 +258,12 @@ func (t *TLS) Provision(ctx caddy.Context) error {
 		cacheOpts.Capacity = 10000
 	}
 
-	certCacheMu.Lock()
-	certCacheApp = t
-	if certCache == nil {
-		certCache = certmagic.NewCache(cacheOpts)
-		certCacheOpts = cacheOpts
-	} else if cacheOpts.Capacity != certCacheOpts.Capacity ||
-		cacheOpts.OCSPCheckInterval != certCacheOpts.OCSPCheckInterval ||
-		cacheOpts.RenewCheckInterval != certCacheOpts.RenewCheckInterval {
-		certCache.SetOptions(cacheOpts)
-		certCacheOpts = cacheOpts
+	if oldCache := provisionCertCache(t, cacheOpts); oldCache != nil {
+		// blocks until the old cache's maintenance goroutine exits;
+		// done outside the lock so handshakes are never stalled behind
+		// it (same idiom as the cleanup path below)
+		oldCache.Stop()
 	}
-	certCacheMu.Unlock()
 
 	// certificate loaders
 	val, err := ctx.LoadModule(t, "CertificatesRaw")


### PR DESCRIPTION
## Assistance Disclosure

This patch was generated by an engineering system operated by me; I reviewed and validated the change and I am accountable for it.

---

Fixes the data race between `SetOptions` on the reused certificate cache and
`certNeedsRenewal` in renewal workers during provisioning (#7897).

Reworked per review: cache options are now treated as immutable. On every
config reload the TLS app previously called `SetOptions` on the shared
CertMagic cache, mutating options that renewal workers read concurrently.
This change never mutates a live cache:

- A new `provisionCertCache` helper (under `certCacheMu`) reuses the
  existing cache when the effective options (capacity, renew/OCSP
  intervals) are unchanged — the common reload path touches nothing.
- When the options genuinely changed, the cache is **replaced**, never
  mutated: the new cache starts empty and is repopulated by certificate
  loading during provisioning, while handshakes on the outgoing config
  generation keep reading the old cache until `Stop()` — called outside
  the lock, same idiom as the existing cleanup path.
- `GetConfigForCert` dereferences a mutex-guarded current-app pointer, so
  reusing the cache across reloads doesn't require touching its options
  just to refresh the callback.
- `SetOptions` is no longer called anywhere, so the racing path is gone
  entirely rather than narrowed.

Notes for reviewers:
- A reload that changes cache capacity/intervals now pays a cache rebuild
  (empty cache repopulated during provisioning). That's the cost of
  immutability; it only occurs when those specific options change.
- Logger updates on reload are no longer propagated to the cache (they
  were previously carried by the unconditional `SetOptions`). If
  cache-side logging on reload matters, happy to adjust.
- `certcache_test.go` covers reuse-on-identical-options and
  replace-on-changed-options, restoring the package globals it touches.

Refs #7897
