### PR TITLE
cmd: flush buffered logs before exiting on command error [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/cmd/cobra.go
+++ b/cmd/cobra.go
@@ -155,6 +155,11 @@ func WrapCommandFuncForCobra(f CommandFunc) func(cmd *cobra.Command, _ []string)
 			// cobra's plain "Error: ..." line which lacks any highlighting.
 			caddy.Log().Error(err.Error())
 			cmd.SilenceErrors = true
+
+			// If the default logger is still buffered (e.g. a config failed
+			// to load and never replaced it), flush the buffer now so the
+			// error above is not silently lost when the process exits.
+			caddy.FlushLogs()
 		}
 		if status > 1 {
 			return &exitError{ExitCode: status, Err: err}

--- a/logging.go
+++ b/logging.go
@@ -792,15 +792,33 @@ func BufferedLog() (*zap.Logger, *zap.Logger, *internal.LogBufferCore) {
 	defaultLoggerMu.Lock()
 	defer defaultLoggerMu.Unlock()
 	origLogger := defaultLogger.logger
+	bufferedLogOrig = origLogger
 	bufferCore := internal.NewLogBufferCore(zap.InfoLevel)
 	defaultLogger.logger = zap.New(bufferCore)
 	return defaultLogger.logger, origLogger, bufferCore
+}
+
+// FlushLogs flushes any buffered log entries to the original default
+// logger's output. It is a no-op if the default logger is not currently
+// buffered. This ensures that log entries buffered before a config was
+// loaded (or while loading failed) are not silently lost when the
+// process exits before a config replaces the default logger.
+func FlushLogs() {
+	defaultLoggerMu.Lock()
+	defer defaultLoggerMu.Unlock()
+	if bufferCore, ok := defaultLogger.logger.Core().(*internal.LogBufferCore); ok && bufferedLogOrig != nil {
+		bufferCore.FlushTo(bufferedLogOrig)
+	}
 }
 
 var (
 	coloringEnabled  = os.Getenv("NO_COLOR") == "" && os.Getenv("TERM") != "xterm-mono"
 	defaultLogger, _ = newDefaultProductionLog()
 	defaultLoggerMu  sync.RWMutex
+	// bufferedLogOrig holds the original default logger that was
+	// temporarily replaced by BufferedLog, so FlushLogs can write any
+	// buffered entries back to the intended output before process exit.
+	bufferedLogOrig *zap.Logger
 )
 
 var writers = NewUsagePool()

--- a/logging_test.go
+++ b/logging_test.go
@@ -14,7 +14,14 @@
 
 package caddy
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
 
 func TestCustomLog_loggerAllowed(t *testing.T) {
 	type fields struct {
@@ -103,4 +110,52 @@ func TestCustomLog_loggerAllowed(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestFlushLogs verifies that FlushLogs writes buffered entries to the
+// original default logger, so startup errors logged through a buffered
+// default logger are not silently lost when the process exits.
+func TestFlushLogs(t *testing.T) {
+	// set up a buffer that acts as the "original" default logger target
+	var buf bytes.Buffer
+	encoder := zapcore.NewConsoleEncoder(zap.NewProductionEncoderConfig())
+	core := zapcore.NewCore(encoder, zapcore.AddSync(&buf), zapcore.InfoLevel)
+	origLogger := zap.New(core)
+
+	// swap the default logger to a buffered one, remembering the original
+	defaultLoggerMu.Lock()
+	savedLogger := defaultLogger
+	savedOrig := bufferedLogOrig
+	defaultLogger = &defaultCustomLog{logger: origLogger}
+	bufferedLogOrig = origLogger
+	defaultLoggerMu.Unlock()
+
+	buffered, _, _ := BufferedLog()
+
+	// log through the buffered logger; nothing should be written yet
+	buffered.Error("startup failed: config is invalid")
+	if buf.Len() != 0 {
+		t.Fatalf("expected buffered log to not be written yet, got %q", buf.String())
+	}
+
+	// flush should write the buffered entry to the original logger target
+	FlushLogs()
+
+	// and the entry should have been written to the original output
+	if !strings.Contains(buf.String(), "startup failed: config is invalid") {
+		t.Fatalf("expected flushed log to contain error message, got %q", buf.String())
+	}
+
+	// flushing again must be a no-op (the buffer was drained), so the
+	// entry is not duplicated
+	FlushLogs()
+	if got := strings.Count(buf.String(), "startup failed: config is invalid"); got != 1 {
+		t.Fatalf("expected error message exactly once after second flush, got %d occurrences in %q", got, buf.String())
+	}
+
+	// restore global state
+	defaultLoggerMu.Lock()
+	defaultLogger = savedLogger
+	bufferedLogOrig = savedOrig
+	defaultLoggerMu.Unlock()
 }


### PR DESCRIPTION
### What
Fixes #7962 — config/startup errors are silently dropped because they are logged through the buffered default logger and never flushed before the process exits.

### Root cause
When a config fails to load, `cmdRun` (in `cmd/commandfuncs.go`) flushes the log buffer via `logBuffer.FlushTo(defaultLogger)` and returns the error. `WrapCommandFuncForCobra` (in `cmd/cobra.go`) then logs that error with `caddy.Log()`. At that point `caddy.Log()` still returns the **buffered** logger, because the config never loaded and thus never replaced the default logger with the configured one. The error is written into the buffer and lost when `Main()` calls `os.Exit` — nothing flushes the buffer afterwards.

### Fix
- Add `caddy.FlushLogs()` which flushes any buffered log entries to the original default logger's output (no-op when the default logger is not buffered). `BufferedLog()` now remembers the original logger so it can be flushed later.
- Call `caddy.FlushLogs()` from `WrapCommandFuncForCobra`'s error path, right after the error is logged, so the error is actually written to stderr before the process exits.

### Test
- New `TestFlushLogs` verifies: (1) entries logged through the buffered logger are not written immediately, (2) `FlushLogs` writes them to the original logger's output, (3) a second `FlushLogs` is a no-op (the buffer was drained, entry not duplicated).

### Verification
- `go vet ./ ./cmd/` passes
- `go test ./ -run TestFlushLogs` passes
- `go test ./cmd/ -run TestCommandsAreAvailable` passes

### AI disclosure
This contribution was prepared with assistance from an AI agent (Hermes Agent by Nous Research). The change, test, and this description were reviewed by the human author, who can explain every line. Full build+run verification was limited on the author's machine by network/TLS constraints; unit tests above pass locally.

Signed-off-by: waterWang <waterWang@users.noreply.github.com>