### PR TITLE
reverseproxy: add least_latency selection policy

### DIFF
--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -17,6 +17,7 @@ package reverseproxy
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/netip"
 	"strconv"
 	"sync"
@@ -182,9 +183,18 @@ func (u *Upstream) fillDynamicHost() {
 // Host is the basic, in-memory representation of the state of a remote host.
 // Its fields are accessed atomically and Host values must not be copied.
 type Host struct {
-	numRequests atomic.Int64
-	fails       atomic.Int64
+	numRequests    atomic.Int64
+	fails          atomic.Int64
+	latency        atomic.Int64 // peak-EWMA of roundtrip latency, in nanoseconds
+	latencyUpdated atomic.Int64 // time of the last latency sample, in Unix nanoseconds
 }
+
+// latencyDecayTau is the time constant of the exponential decay applied
+// to a host's peak-EWMA latency: roughly, how long a latency spike keeps
+// dominating the estimate after conditions improve. After one tau with
+// only faster samples (or no samples at all), about 63% of the spike has
+// decayed away.
+const latencyDecayTau = 10 * time.Second
 
 // NumRequests returns the number of active requests to the upstream.
 func (h *Host) NumRequests() int {
@@ -194,6 +204,55 @@ func (h *Host) NumRequests() int {
 // Fails returns the number of recent failures with the upstream.
 func (h *Host) Fails() int {
 	return int(h.fails.Load())
+}
+
+// Latency returns a peak-sensitive exponentially weighted moving average
+// of the host's roundtrip latency, decayed by the time elapsed since the
+// last sample so that a host which stops receiving requests does not
+// keep a stale peak forever. It returns 0 if no latency sample has been
+// recorded yet.
+func (h *Host) Latency() time.Duration {
+	value := h.latency.Load()
+	if value == 0 {
+		return 0
+	}
+	elapsed := time.Now().UnixNano() - h.latencyUpdated.Load()
+	return time.Duration(decayLatency(value, elapsed))
+}
+
+// recordLatency folds a roundtrip latency sample into the host's
+// peak-sensitive EWMA (as in Finagle's PeakEwma load balancer): a sample
+// above the current estimate replaces it immediately, while lower samples
+// only pull the estimate down gradually, weighted by the time elapsed
+// since the previous sample relative to latencyDecayTau. This makes the
+// estimate react instantly to slowdowns but forgive them over time.
+func (h *Host) recordLatency(sample time.Duration) {
+	if sample < 0 {
+		sample = 0
+	}
+	now := time.Now().UnixNano()
+	last := h.latencyUpdated.Swap(now)
+	for {
+		current := h.latency.Load()
+		next := int64(sample)
+		if current > next {
+			weight := math.Exp(-float64(now-last) / float64(latencyDecayTau))
+			next += int64(float64(current-next) * weight)
+		}
+		if h.latency.CompareAndSwap(current, next) {
+			return
+		}
+	}
+}
+
+// decayLatency exponentially decays a latency value (in nanoseconds)
+// toward zero according to how much time has elapsed since it was
+// recorded, with time constant latencyDecayTau.
+func decayLatency(value, elapsed int64) float64 {
+	if elapsed <= 0 {
+		return float64(value)
+	}
+	return float64(value) * math.Exp(-float64(elapsed)/float64(latencyDecayTau))
 }
 
 // countRequest mutates the active request count by

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -183,10 +183,18 @@ func (u *Upstream) fillDynamicHost() {
 // Host is the basic, in-memory representation of the state of a remote host.
 // Its fields are accessed atomically and Host values must not be copied.
 type Host struct {
-	numRequests    atomic.Int64
-	fails          atomic.Int64
-	latency        atomic.Int64 // peak-EWMA of roundtrip latency, in nanoseconds
-	latencyUpdated atomic.Int64 // time of the last latency sample, in Unix nanoseconds
+	numRequests atomic.Int64
+	fails       atomic.Int64
+	latency     atomic.Pointer[latencyEstimate] // peak-EWMA of roundtrip latency; nil until first sample
+}
+
+// latencyEstimate is an immutable (value, timestamp) pair: the peak-EWMA
+// latency estimate and the time it was computed. Host.latency swaps whole
+// pairs atomically so readers never observe an estimate with a timestamp
+// from a different update.
+type latencyEstimate struct {
+	value   int64 // nanoseconds
+	updated int64 // Unix nanoseconds
 }
 
 // latencyDecayTau is the time constant of the exponential decay applied
@@ -212,12 +220,12 @@ func (h *Host) Fails() int {
 // keep a stale peak forever. It returns 0 if no latency sample has been
 // recorded yet.
 func (h *Host) Latency() time.Duration {
-	value := h.latency.Load()
-	if value == 0 {
+	est := h.latency.Load()
+	if est == nil {
 		return 0
 	}
-	elapsed := time.Now().UnixNano() - h.latencyUpdated.Load()
-	return time.Duration(decayLatency(value, elapsed))
+	elapsed := time.Now().UnixNano() - est.updated
+	return time.Duration(decayLatency(est.value, elapsed))
 }
 
 // recordLatency folds a roundtrip latency sample into the host's
@@ -231,13 +239,12 @@ func (h *Host) recordLatency(sample time.Duration) {
 		sample = 0
 	}
 	now := time.Now().UnixNano()
-	last := h.latencyUpdated.Swap(now)
 	for {
 		current := h.latency.Load()
-		next := int64(sample)
-		if current > next {
-			weight := math.Exp(-float64(now-last) / float64(latencyDecayTau))
-			next += int64(float64(current-next) * weight)
+		next := &latencyEstimate{value: int64(sample), updated: now}
+		if current != nil && current.value > next.value {
+			weight := math.Exp(-float64(now-current.updated) / float64(latencyDecayTau))
+			next.value += int64(float64(current.value-next.value) * weight)
 		}
 		if h.latency.CompareAndSwap(current, next) {
 			return

--- a/modules/caddyhttp/reverseproxy/hosts.go
+++ b/modules/caddyhttp/reverseproxy/hosts.go
@@ -185,16 +185,16 @@ func (u *Upstream) fillDynamicHost() {
 type Host struct {
 	numRequests atomic.Int64
 	fails       atomic.Int64
-	latency     atomic.Pointer[latencyEstimate] // peak-EWMA of roundtrip latency; nil until first sample
-}
 
-// latencyEstimate is an immutable (value, timestamp) pair: the peak-EWMA
-// latency estimate and the time it was computed. Host.latency swaps whole
-// pairs atomically so readers never observe an estimate with a timestamp
-// from a different update.
-type latencyEstimate struct {
-	value   int64 // nanoseconds
-	updated int64 // Unix nanoseconds
+	// latencyMu guards the peak-EWMA latency estimate and its sample
+	// timestamp so they always change as one coherent pair. A mutex
+	// (rather than a CAS loop over an allocated pair) keeps updates
+	// allocation-free and makes the value/timestamp coherence trivial.
+	// The handler only records samples when the configured selection
+	// policy implements LatencyConsumer, so other policies never touch it.
+	latencyMu      sync.Mutex
+	latencyValue   int64 // peak-EWMA of roundtrip latency, in nanoseconds
+	latencyUpdated int64 // time of the last sample, in Unix nanoseconds
 }
 
 // latencyDecayTau is the time constant of the exponential decay applied
@@ -220,12 +220,18 @@ func (h *Host) Fails() int {
 // keep a stale peak forever. It returns 0 if no latency sample has been
 // recorded yet.
 func (h *Host) Latency() time.Duration {
-	est := h.latency.Load()
-	if est == nil {
+	return h.latencyAt(time.Now().UnixNano())
+}
+
+// latencyAt is Latency evaluated at the given Unix-nanosecond time.
+func (h *Host) latencyAt(now int64) time.Duration {
+	h.latencyMu.Lock()
+	value, updated := h.latencyValue, h.latencyUpdated
+	h.latencyMu.Unlock()
+	if value == 0 {
 		return 0
 	}
-	elapsed := time.Now().UnixNano() - est.updated
-	return time.Duration(decayLatency(est.value, elapsed))
+	return time.Duration(decayLatency(value, now-updated))
 }
 
 // recordLatency folds a roundtrip latency sample into the host's
@@ -235,21 +241,33 @@ func (h *Host) Latency() time.Duration {
 // since the previous sample relative to latencyDecayTau. This makes the
 // estimate react instantly to slowdowns but forgive them over time.
 func (h *Host) recordLatency(sample time.Duration) {
+	h.recordLatencyAt(sample, time.Now().UnixNano())
+}
+
+// recordLatencyAt is recordLatency for a sample observed at the given
+// Unix-nanosecond time. The estimate and its timestamp are updated under
+// one critical section, so a reader can never pair an estimate with a
+// timestamp from a different update. A sample that is older than the
+// currently published one (a delayed writer, or a clock stepping back)
+// is folded in as if it were current: the elapsed time is clamped to
+// zero so the decay weight never exceeds 1, and a stale sample can only
+// raise the estimate if it is a genuine new peak, never by inflating it
+// through a negative elapsed time.
+func (h *Host) recordLatencyAt(sample time.Duration, now int64) {
 	if sample < 0 {
 		sample = 0
 	}
-	now := time.Now().UnixNano()
-	for {
-		current := h.latency.Load()
-		next := &latencyEstimate{value: int64(sample), updated: now}
-		if current != nil && current.value > next.value {
-			weight := math.Exp(-float64(now-current.updated) / float64(latencyDecayTau))
-			next.value += int64(float64(current.value-next.value) * weight)
-		}
-		if h.latency.CompareAndSwap(current, next) {
-			return
-		}
+	h.latencyMu.Lock()
+	if now < h.latencyUpdated {
+		now = h.latencyUpdated
 	}
+	next := int64(sample)
+	if h.latencyValue > next {
+		weight := math.Exp(-float64(now-h.latencyUpdated) / float64(latencyDecayTau))
+		next += int64(float64(h.latencyValue-next) * weight)
+	}
+	h.latencyValue, h.latencyUpdated = next, now
+	h.latencyMu.Unlock()
 }
 
 // decayLatency exponentially decays a latency value (in nanoseconds)

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -1046,6 +1046,11 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, origRe
 	res, err := h.Transport.RoundTrip(req)
 	duration := time.Since(start)
 
+	// record the roundtrip latency for latency-aware selection policies;
+	// errored roundtrips count too, with the time elapsed until the error
+	// (which includes any timeout), so that failing upstreams score as slow
+	di.Upstream.Host.recordLatency(duration)
+
 	// record that the round trip is done for the 1xx response handler
 	roundTripMutex.Lock()
 	roundTripDone = true

--- a/modules/caddyhttp/reverseproxy/reverseproxy.go
+++ b/modules/caddyhttp/reverseproxy/reverseproxy.go
@@ -224,6 +224,11 @@ type Handler struct {
 	CB               CircuitBreaker    `json:"-"`
 	DynamicUpstreams UpstreamSource    `json:"-"`
 
+	// recordLatency is true when the selection policy implements
+	// LatencyConsumer; only then does the handler record a roundtrip
+	// latency sample on the upstream's Host after each roundtrip.
+	recordLatency bool
+
 	// transportHeaderOps is a set of header operations provided
 	// by the transport at provision time, if the transport
 	// implements TransportHeaderOpsProvider. These ops are
@@ -380,6 +385,7 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 	if h.LoadBalancing.SelectionPolicy == nil {
 		h.LoadBalancing.SelectionPolicy = RandomSelection{}
 	}
+	_, h.recordLatency = h.LoadBalancing.SelectionPolicy.(LatencyConsumer)
 	if h.LoadBalancing.TryDuration > 0 && h.LoadBalancing.TryInterval == 0 {
 		// a non-zero try_duration with a zero try_interval
 		// will always spin the CPU for try_duration if the
@@ -1046,10 +1052,12 @@ func (h *Handler) reverseProxy(rw http.ResponseWriter, req *http.Request, origRe
 	res, err := h.Transport.RoundTrip(req)
 	duration := time.Since(start)
 
-	// record the roundtrip latency for latency-aware selection policies;
+	// record the roundtrip latency if the selection policy consumes it;
 	// errored roundtrips count too, with the time elapsed until the error
 	// (which includes any timeout), so that failing upstreams score as slow
-	di.Upstream.Host.recordLatency(duration)
+	if h.recordLatency {
+		di.Upstream.Host.recordLatency(duration)
+	}
 
 	// record that the round trip is done for the 1xx response handler
 	roundTripMutex.Lock()

--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -317,6 +317,16 @@ func (r *LeastConnSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	return nil
 }
 
+// LatencyConsumer is implemented by selection policies that consume the
+// roundtrip latency tracked on each Host. The proxy handler records a
+// latency sample after every roundtrip only when the configured selection
+// policy implements this interface, so that policies which never read
+// Host.Latency do not pay for maintaining it on the request path.
+type LatencyConsumer interface {
+	// ConsumesLatency is a marker method with no behavior.
+	ConsumesLatency()
+}
+
 // LeastLatencySelection is a policy that samples two available hosts
 // at random ("power of two choices") and selects the one with the
 // lower latency score, which is the host's peak-sensitive EWMA of
@@ -388,6 +398,10 @@ func (r *LeastLatencySelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error
 	}
 	return nil
 }
+
+// ConsumesLatency marks this policy as a consumer of roundtrip latency
+// samples, so the proxy handler records them; see LatencyConsumer.
+func (LeastLatencySelection) ConsumesLatency() {}
 
 // latencyScore scores an upstream for least_latency selection: its
 // peak-EWMA latency scaled by its active request count. Adding 1 to

--- a/modules/caddyhttp/reverseproxy/selectionpolicies.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies.go
@@ -40,6 +40,7 @@ func init() {
 	caddy.RegisterModule(RandomSelection{})
 	caddy.RegisterModule(RandomChoiceSelection{})
 	caddy.RegisterModule(LeastConnSelection{})
+	caddy.RegisterModule(LeastLatencySelection{})
 	caddy.RegisterModule(new(RoundRobinSelection))
 	caddy.RegisterModule(new(WeightedRoundRobinSelection))
 	caddy.RegisterModule(FirstSelection{})
@@ -314,6 +315,88 @@ func (r *LeastConnSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		return d.ArgErr()
 	}
 	return nil
+}
+
+// LeastLatencySelection is a policy that samples two available hosts
+// at random ("power of two choices") and selects the one with the
+// lower latency score, which is the host's peak-sensitive EWMA of
+// roundtrip latency scaled by its number of active requests. Compared
+// to policies that balance on request counts alone, this steers
+// traffic away from upstreams that have become slow (garbage
+// collection pauses, cold caches, resource contention) before
+// requests pile up on them.
+type LeastLatencySelection struct{}
+
+// CaddyModule returns the Caddy module information.
+func (LeastLatencySelection) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "http.reverse_proxy.selection_policies.least_latency",
+		New: func() caddy.Module { return new(LeastLatencySelection) },
+	}
+}
+
+// Select samples two distinct available hosts uniformly at random
+// and returns the one with the lower latency score, breaking exact
+// ties (such as between hosts with no latency recorded yet) randomly.
+func (LeastLatencySelection) Select(pool UpstreamPool, _ *http.Request, _ http.ResponseWriter) *Upstream {
+	// reservoir sampling (Algorithm R) with a reservoir of 2 over the
+	// available upstreams, so both candidates are sampled uniformly
+	// no matter how many upstreams are unavailable (see the analogous
+	// loop in RandomChoiceSelection.Select)
+	var first, second *Upstream
+	var available int
+	for _, upstream := range pool {
+		if !upstream.Available() {
+			continue
+		}
+		available++
+		switch {
+		case first == nil:
+			first = upstream
+		case second == nil:
+			second = upstream
+		default:
+			switch j := weakrand.IntN(available); j { //nolint:gosec
+			case 0:
+				first = upstream
+			case 1:
+				second = upstream
+			}
+		}
+	}
+	if second == nil {
+		return first // 0 or 1 available upstreams
+	}
+	firstScore, secondScore := latencyScore(first), latencyScore(second)
+	if firstScore < secondScore {
+		return first
+	}
+	if secondScore < firstScore {
+		return second
+	}
+	if weakrand.IntN(2) == 0 { //nolint:gosec
+		return first
+	}
+	return second
+}
+
+// UnmarshalCaddyfile sets up the module from Caddyfile tokens.
+func (r *LeastLatencySelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	d.Next() // consume policy name
+	if d.NextArg() {
+		return d.ArgErr()
+	}
+	return nil
+}
+
+// latencyScore scores an upstream for least_latency selection: its
+// peak-EWMA latency scaled by its active request count. Adding 1 to
+// each factor keeps the active request count meaningful for upstreams
+// with no latency recorded yet: their scores stay near zero, so new or
+// long-idle upstreams win against any upstream with observed latency
+// and get warmed up (and measured) rather than starved.
+func latencyScore(u *Upstream) float64 {
+	return (float64(u.Latency()) + 1) * float64(u.NumRequests()+1)
 }
 
 // RoundRobinSelection is a policy that selects
@@ -904,6 +987,7 @@ var (
 	_ Selector = (*RandomSelection)(nil)
 	_ Selector = (*RandomChoiceSelection)(nil)
 	_ Selector = (*LeastConnSelection)(nil)
+	_ Selector = (*LeastLatencySelection)(nil)
 	_ Selector = (*RoundRobinSelection)(nil)
 	_ Selector = (*WeightedRoundRobinSelection)(nil)
 	_ Selector = (*FirstSelection)(nil)

--- a/modules/caddyhttp/reverseproxy/selectionpolicies_test.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies_test.go
@@ -19,9 +19,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 )
 
@@ -240,6 +242,137 @@ func TestLeastConnPolicy(t *testing.T) {
 	h = lcPolicy.Select(pool, req, nil)
 	if h != pool[0] && h != pool[1] {
 		t.Error("Expected least connection host to be first or second host.")
+	}
+}
+
+func TestLeastLatencyPolicy(t *testing.T) {
+	pool := testPool()
+	llPolicy := LeastLatencySelection{}
+	req, _ := http.NewRequest("GET", "/", nil)
+
+	// with only two available hosts, both are always the two candidates,
+	// so the lower-latency host must always be selected
+	pool[0].setHealthy(false)
+	pool[1].recordLatency(50 * time.Millisecond)
+	pool[2].recordLatency(10 * time.Millisecond)
+	for i := 0; i < 100; i++ {
+		if h := llPolicy.Select(pool, req, nil); h != pool[2] {
+			t.Fatalf("Expected the lower-latency host (pool[2]) to always be selected; got %v on iteration %d", h, i)
+		}
+	}
+
+	// enough active requests must outweigh a latency advantage
+	pool[2].countRequest(9) // score ~10ms*10 vs ~50ms*1
+	for i := 0; i < 100; i++ {
+		if h := llPolicy.Select(pool, req, nil); h != pool[1] {
+			t.Fatalf("Expected the less-loaded host (pool[1]) to always be selected; got %v on iteration %d", h, i)
+		}
+	}
+	pool[2].countRequest(-9)
+
+	// only one available host: return it; none: return nil
+	pool[1].setHealthy(false)
+	if h := llPolicy.Select(pool, req, nil); h != pool[2] {
+		t.Error("Expected the only available host (pool[2]) to be selected.")
+	}
+	pool[2].setHealthy(false)
+	if h := llPolicy.Select(pool, req, nil); h != nil {
+		t.Error("Expected nil when no host is available.")
+	}
+}
+
+func TestLeastLatencyPolicyDistribution(t *testing.T) {
+	pool := testPool()
+	llPolicy := LeastLatencySelection{}
+	req, _ := http.NewRequest("GET", "/", nil)
+
+	// a host with high latency must lose against either of the others
+	// whenever it is one of the two candidates, so it is never selected;
+	// the two remaining hosts must share the traffic
+	pool[0].recordLatency(10 * time.Millisecond)
+	pool[1].recordLatency(20 * time.Millisecond)
+	pool[2].recordLatency(500 * time.Millisecond)
+	selected := make(map[*Upstream]int)
+	for i := 0; i < 300; i++ {
+		selected[llPolicy.Select(pool, req, nil)]++
+	}
+	if selected[pool[2]] != 0 {
+		t.Errorf("Expected the high-latency host to never be selected; got %d selections", selected[pool[2]])
+	}
+	if selected[pool[0]] == 0 || selected[pool[1]] == 0 {
+		t.Errorf("Expected both low-latency hosts to be selected; got %d and %d selections", selected[pool[0]], selected[pool[1]])
+	}
+}
+
+func TestLeastLatencyPolicyColdStart(t *testing.T) {
+	pool := testPool()
+	llPolicy := LeastLatencySelection{}
+	req, _ := http.NewRequest("GET", "/", nil)
+
+	// with no latency recorded anywhere, ties must be broken randomly
+	// so that traffic spreads over the pool
+	selected := make(map[*Upstream]int)
+	for i := 0; i < 300; i++ {
+		selected[llPolicy.Select(pool, req, nil)]++
+	}
+	for i, upstream := range pool {
+		if selected[upstream] == 0 {
+			t.Errorf("Expected every cold host to receive traffic, but pool[%d] got none", i)
+		}
+	}
+
+	// a host with no recorded latency must win against a host with
+	// observed latency, even a fast one, so it gets warmed up
+	pool[0].setHealthy(false)
+	pool[1].recordLatency(time.Millisecond)
+	for i := 0; i < 100; i++ {
+		if h := llPolicy.Select(pool, req, nil); h != pool[2] {
+			t.Fatalf("Expected the cold host (pool[2]) to always be selected; got %v on iteration %d", h, i)
+		}
+	}
+}
+
+func TestHostLatencyPeakEwma(t *testing.T) {
+	host := new(Host)
+	if host.Latency() != 0 {
+		t.Error("Expected zero latency before any sample is recorded.")
+	}
+
+	// the first sample is taken as-is
+	host.recordLatency(10 * time.Millisecond)
+	if got := host.Latency(); got < 9*time.Millisecond || got > 10*time.Millisecond {
+		t.Errorf("Expected latency near 10ms after first sample, got %v", got)
+	}
+
+	// a higher sample takes effect immediately (peak sensitivity)
+	host.recordLatency(50 * time.Millisecond)
+	if got := host.Latency(); got < 45*time.Millisecond {
+		t.Errorf("Expected latency to jump to ~50ms after a slow sample, got %v", got)
+	}
+
+	// an immediately following lower sample barely moves the estimate
+	host.recordLatency(10 * time.Millisecond)
+	if got := host.Latency(); got < 40*time.Millisecond || got > 50*time.Millisecond {
+		t.Errorf("Expected latency to stay near the 50ms peak, got %v", got)
+	}
+
+	// after a long idle period the estimate decays toward zero
+	host.latencyUpdated.Store(time.Now().Add(-5 * latencyDecayTau).UnixNano())
+	if got := host.Latency(); got > time.Millisecond {
+		t.Errorf("Expected latency to decay to under 1ms after idling, got %v", got)
+	}
+}
+
+func TestLeastLatencyUnmarshalCaddyfile(t *testing.T) {
+	d := caddyfile.NewTestDispenser("least_latency")
+	llPolicy := new(LeastLatencySelection)
+	if err := llPolicy.UnmarshalCaddyfile(d); err != nil {
+		t.Errorf("Expected no error for bare policy name, got: %v", err)
+	}
+
+	d = caddyfile.NewTestDispenser("least_latency 2")
+	if err := llPolicy.UnmarshalCaddyfile(d); err == nil {
+		t.Error("Expected an error when an argument is given.")
 	}
 }
 

--- a/modules/caddyhttp/reverseproxy/selectionpolicies_test.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies_test.go
@@ -357,7 +357,11 @@ func TestHostLatencyPeakEwma(t *testing.T) {
 	}
 
 	// after a long idle period the estimate decays toward zero
-	host.latencyUpdated.Store(time.Now().Add(-5 * latencyDecayTau).UnixNano())
+	est := host.latency.Load()
+	host.latency.Store(&latencyEstimate{
+		value:   est.value,
+		updated: time.Now().Add(-5 * latencyDecayTau).UnixNano(),
+	})
 	if got := host.Latency(); got > time.Millisecond {
 		t.Errorf("Expected latency to decay to under 1ms after idling, got %v", got)
 	}

--- a/modules/caddyhttp/reverseproxy/selectionpolicies_test.go
+++ b/modules/caddyhttp/reverseproxy/selectionpolicies_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -357,13 +358,132 @@ func TestHostLatencyPeakEwma(t *testing.T) {
 	}
 
 	// after a long idle period the estimate decays toward zero
-	est := host.latency.Load()
-	host.latency.Store(&latencyEstimate{
-		value:   est.value,
-		updated: time.Now().Add(-5 * latencyDecayTau).UnixNano(),
-	})
-	if got := host.Latency(); got > time.Millisecond {
+	idle := time.Now().Add(5 * latencyDecayTau).UnixNano()
+	if got := host.latencyAt(idle); got > time.Millisecond {
 		t.Errorf("Expected latency to decay to under 1ms after idling, got %v", got)
+	}
+}
+
+// TestHostLatencyStaleSample is a regression test for a delayed writer
+// publishing a sample with a timestamp older than the currently published
+// one. Such a sample must never inflate the estimate: with a negative
+// elapsed time the decay weight would exceed 1 and the old, lower sample
+// would push the estimate above the newer, higher one.
+func TestHostLatencyStaleSample(t *testing.T) {
+	host := new(Host)
+	base := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC).UnixNano()
+
+	// an old sample, then a newer, higher peak
+	host.recordLatencyAt(10*time.Millisecond, base)
+	host.recordLatencyAt(100*time.Millisecond, base+int64(latencyDecayTau))
+	before := host.latencyAt(base + int64(latencyDecayTau))
+	if before != 100*time.Millisecond {
+		t.Fatalf("Expected the newer 100ms peak to be published, got %v", before)
+	}
+
+	// a delayed writer now lands with a timestamp from *before* the peak
+	// and a lower sample: the estimate must not move up, and the
+	// published timestamp must not move backwards
+	host.recordLatencyAt(10*time.Millisecond, base+int64(latencyDecayTau)/2)
+	after := host.latencyAt(base + int64(latencyDecayTau))
+	if after > before {
+		t.Errorf("Expected a stale lower sample not to inflate the estimate; went from %v to %v", before, after)
+	}
+	if after < before {
+		t.Errorf("Expected a stale lower sample not to decay the estimate ahead of time; went from %v to %v", before, after)
+	}
+	host.latencyMu.Lock()
+	updated := host.latencyUpdated
+	host.latencyMu.Unlock()
+	if updated != base+int64(latencyDecayTau) {
+		t.Errorf("Expected the published timestamp to stay at the newest sample, got %d (want %d)", updated, base+int64(latencyDecayTau))
+	}
+
+	// a stale sample that is a genuine new peak still takes effect
+	host.recordLatencyAt(200*time.Millisecond, base)
+	if got := host.latencyAt(base + int64(latencyDecayTau)); got != 200*time.Millisecond {
+		t.Errorf("Expected a stale higher sample to raise the estimate to 200ms, got %v", got)
+	}
+}
+
+// TestHostLatencyConcurrentRecord hammers one host from many goroutines
+// with samples that are all at or below a known maximum, interleaved with
+// readers, and checks that the published estimate never exceeds that
+// maximum and that the published timestamp never moves backwards. Run
+// with -race to also verify the value/timestamp pair is updated coherently.
+func TestHostLatencyConcurrentRecord(t *testing.T) {
+	const (
+		writers   = 16
+		perWriter = 2000
+		maxSample = 100 * time.Millisecond
+	)
+	host := new(Host)
+	var wg sync.WaitGroup
+	for w := range writers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range perWriter {
+				// alternate high and low samples so writers race to
+				// publish both peaks and decays
+				sample := maxSample
+				if (i+w)%2 == 0 {
+					sample = time.Duration(i%10) * time.Millisecond
+				}
+				host.recordLatency(sample)
+				if got := host.Latency(); got > maxSample {
+					t.Errorf("latency estimate %v exceeds the maximum recorded sample %v", got, maxSample)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if got := host.Latency(); got > maxSample {
+		t.Errorf("final latency estimate %v exceeds the maximum recorded sample %v", got, maxSample)
+	}
+}
+
+// BenchmarkHostRecordLatency measures the cost of recording a sample on
+// one host from many goroutines at once, i.e. many concurrent requests to
+// a single upstream: the worst case for the handler's per-roundtrip cost
+// when a LatencyConsumer policy is configured.
+func BenchmarkHostRecordLatency(b *testing.B) {
+	host := new(Host)
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			host.recordLatency(5 * time.Millisecond)
+		}
+	})
+}
+
+// BenchmarkHostLatency measures the cost of reading the decayed estimate
+// under concurrent writers, as a selection policy would on every Select.
+func BenchmarkHostLatency(b *testing.B) {
+	host := new(Host)
+	host.recordLatency(5 * time.Millisecond)
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for i := 0; pb.Next(); i++ {
+			if i%8 == 0 {
+				host.recordLatency(5 * time.Millisecond)
+			}
+			_ = host.Latency()
+		}
+	})
+}
+
+// TestLatencyConsumer checks which policies opt in to latency recording,
+// through the same assertion the handler makes at provision time.
+func TestLatencyConsumer(t *testing.T) {
+	if _, ok := Selector(new(LeastLatencySelection)).(LatencyConsumer); !ok {
+		t.Error("Expected least_latency to implement LatencyConsumer.")
+	}
+	for _, policy := range []Selector{RandomSelection{}, RandomChoiceSelection{}, LeastConnSelection{}, new(RoundRobinSelection)} {
+		if _, ok := policy.(LatencyConsumer); ok {
+			t.Errorf("Expected %T not to implement LatencyConsumer.", policy)
+		}
 	}
 }
 


### PR DESCRIPTION
Implements the `least_latency` selection policy proposed and discussed in #7879, following the shape agreed there: the peak-EWMA latency lives on the shared `Host` next to `NumRequests`/`Fails` (a mutex-guarded value/timestamp pair, allocation-free), and is updated from the existing `RoundTrip` call site in the handler only when the configured policy opts in via the `LatencyConsumer` marker interface.

## What it does

`least_latency` samples two available upstreams uniformly at random ("power of two choices") and sends the request to the one with the lower score:

```
score = (peakEWMA(latency) + 1) × (activeRequests + 1)
```

- **Peak-sensitive EWMA** (as in Finagle's `PeakEwma`): a sample slower than the current estimate replaces it immediately; faster samples only pull it down gradually, weighted by time elapsed since the last sample against a 10 s time constant. Slowdowns (GC pauses, cold caches, contention) are reacted to on the very next request; recoveries are forgiven over ~10 s.
- **Idle decay**: `Latency()` decays the stored value by the time since the last sample, so an upstream that stops receiving requests loses its stale peak and gets re-probed instead of starved forever.
- **Scaling by active requests** keeps the policy sane when latencies are equal (it degrades to `least_conn` over the two candidates), and the `+1` terms let brand-new upstreams (no sample yet) win and warm up.
- **Errored roundtrips** are recorded with their elapsed time (including dial/response-header timeouts), so failing upstreams score as slow even before the passive health checker marks them down.
- Two-candidate sampling uses reservoir sampling over *available* upstreams (same approach as `random_choose`), so unavailable upstreams don't bias the draw.

## Usage

```caddyfile
reverse_proxy backend1:8080 backend2:8080 backend3:8080 {
	lb_policy least_latency
}
```

JSON: `"selection_policy": {"policy": "least_latency"}`. No options.

## Changes

- `hosts.go`: mutex-guarded `latencyValue`/`latencyUpdated` on `Host`, `Latency()`, `recordLatency()`, `decayLatency()`.
- `reverseproxy.go`: one call to `recordLatency` after `Transport.RoundTrip`, guarded by a bool set at provision time (`SelectionPolicy` implements `LatencyConsumer`); other policies pay nothing.
- `selectionpolicies.go`: `LatencyConsumer` interface, `LeastLatencySelection` module + `latencyScore`.
- `selectionpolicies_test.go`: tests for peak/decay behaviour of the EWMA, selection preferring the faster of two hosts, distribution over repeated draws, cold-start preference for unsampled hosts, single/zero-host pools, Caddyfile parsing, a deterministic stale-sample regression, a concurrent writer/reader test (run under `-race`), the `LatencyConsumer` opt-in, and parallel benchmarks for recording/reading latency.

`go test ./modules/caddyhttp/reverseproxy/...`, `go vet`, `gofmt` all clean. Docs PR for the website to follow once this lands.

## Assistance Disclosure

I designed the approach (P2C + peak-EWMA on the shared `Host`, as discussed in #7879) and reviewed every line. Claude (Anthropic's coding assistant) was used to generate the initial implementation and test code from that design; I iterated on it and verified it for correctness locally.

