### PR TITLE
core: support default values in placeholders

### DIFF
--- a/modules/caddyhttp/replacer_test.go
+++ b/modules/caddyhttp/replacer_test.go
@@ -335,3 +335,29 @@ func TestHTTPVarReplacementUUID(t *testing.T) {
 	}
 }
 
+func TestHTTPVarReplacementDefault(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodGet, "/?a=1", nil)
+	req.Header.Set("X-Present", "here")
+	repl := caddy.NewReplacer()
+	ctx := context.WithValue(req.Context(), caddy.ReplacerCtxKey, repl)
+	req = req.WithContext(ctx)
+	res := httptest.NewRecorder()
+	addHTTPVarsToReplacer(repl, req, res)
+
+	for i, tc := range []struct {
+		input, expect string
+	}{
+		// a present header ignores its default
+		{input: "{http.request.header.X-Present:fallback}", expect: "here"},
+		// a missing header uses its default
+		{input: "{http.request.header.X-Missing:fallback}", expect: "fallback"},
+		// a present query parameter ignores its default
+		{input: "{http.request.uri.query.a:none}", expect: "1"},
+		// a missing query parameter uses its default
+		{input: "{http.request.uri.query.missing:none}", expect: "none"},
+	} {
+		if actual := repl.ReplaceAll(tc.input, ""); actual != tc.expect {
+			t.Errorf("Test %d: input %q: expected %q, got %q", i, tc.input, tc.expect, actual)
+		}
+	}
+}

--- a/replacer.go
+++ b/replacer.go
@@ -237,6 +237,24 @@ scan:
 
 		// try to get a value for this key, handle empty values accordingly
 		val, found := r.Get(key)
+
+		// A placeholder may carry a default value after a colon:
+		// {placeholder:default}, mirroring environment-variable defaults in
+		// the Caddyfile. When the name before the delimiter is a recognized
+		// placeholder, use it, applying the default if it evaluates to empty.
+		// This is checked even when the whole key resolves, because some
+		// providers (e.g. request headers) report every key under their
+		// prefix as recognized. Unrecognized names, including JSON such as
+		// {"a": "b"}, fall through unchanged.
+		var defaultValue string
+		var hasDefault bool
+		if name, dflt, ok := strings.Cut(key, phDefaultDelimiter); ok {
+			if v, f := r.Get(name); f {
+				key, val, found = name, v, true
+				defaultValue, hasDefault = dflt, true
+			}
+		}
+
 		if !found {
 			// placeholder is unknown (unrecognized); handle accordingly
 			if errOnUnknown {
@@ -262,10 +280,13 @@ scan:
 		// convert val to a string as efficiently as possible
 		valStr := ToString(val)
 
-		// write the value; if it's empty, either return
-		// an error or write a default value
+		// write the value; if it's empty, write the placeholder's default
+		// value if one was given, otherwise either return an error or write
+		// the caller's empty-value replacement
 		if valStr == "" {
-			if errOnEmpty {
+			if hasDefault {
+				sb.WriteString(defaultValue)
+			} else if errOnEmpty {
 				return "", fmt.Errorf("evaluated placeholder %s%s%s is empty",
 					string(phOpen), key, string(phClose))
 			} else if empty != "" {
@@ -449,5 +470,10 @@ var nowFunc = time.Now
 const ReplacerCtxKey CtxKey = "replacer"
 
 const phOpen, phClose, phEscape = '{', '}', '\\'
+
+// phDefaultDelimiter separates a placeholder from an optional default value,
+// as in {placeholder:default}, mirroring the syntax used for environment
+// variable defaults in the Caddyfile.
+const phDefaultDelimiter = ":"
 
 const filePrefix = "file."

--- a/replacer_test.go
+++ b/replacer_test.go
@@ -530,3 +530,35 @@ func testReplacer() Replacer {
 		mapMutex:  &sync.RWMutex{},
 	}
 }
+
+func TestReplacerDefaultValue(t *testing.T) {
+	rep := NewReplacer()
+	rep.Set("name", "John")
+	rep.Set("empty", "")
+
+	for i, tc := range []struct {
+		input, expect string
+	}{
+		// a recognized, non-empty placeholder ignores its default
+		{input: "{name:default}", expect: "John"},
+		// a recognized but empty placeholder uses its default
+		{input: "{empty:default}", expect: "default"},
+		// the default may itself be empty
+		{input: "{empty:}", expect: ""},
+		// the default may contain spaces and other characters
+		{input: "{empty:a default value}", expect: "a default value"},
+		// only the first colon delimits the default
+		{input: "{empty:a:b:c}", expect: "a:b:c"},
+		// a default has no effect without a colon
+		{input: "{empty}", expect: ""},
+		{input: "{name}", expect: "John"},
+		// an unrecognized placeholder name is left untouched (no default is
+		// applied), which also preserves JSON-like input
+		{input: "{unknown:default}", expect: ""},
+		{input: `{"json": "object"}`, expect: ""},
+	} {
+		if actual := rep.ReplaceAll(tc.input, ""); actual != tc.expect {
+			t.Errorf("Test %d: for input %q: expected %q but got %q", i, tc.input, tc.expect, actual)
+		}
+	}
+}


### PR DESCRIPTION
Placeholders may specify a default value after a colon, {placeholder:default}, mirroring the syntax already used for environment variable defaults in the Caddyfile. The default is used when the placeholder is recognized but evaluates to an empty string. Keys whose name before the colon is not a recognized placeholder (including JSON such as {"a": "b"}) are left unchanged.

Closes #1793


## Assistance Disclosure

Claude Sonnet 5 generated the changes and the commit message, with verification and direction done by myself