### PR TITLE
caddyhttp: surface 413 for oversized request body placeholders

### DIFF
--- a/caddytest/integration/handler_test.go
+++ b/caddytest/integration/handler_test.go
@@ -57,3 +57,62 @@ func TestRespondWithJSON(t *testing.T) {
 		t.Errorf("expected Content-Type to be application/json, but was %s", res.Header.Get("Content-Type"))
 	}
 }
+
+func TestRequestBodyPlaceholderRespectsMaxSizeInTemplate(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		skip_install_trust
+		admin localhost:2999
+		http_port     9080
+		https_port    9443
+		grace_period  1ns
+	}
+	http://localhost:9080 {
+		request_body {
+			max_size 10
+		}
+		respond "{{placeholder \"http.request.body\"}}"
+		templates
+	}
+  `, "caddyfile")
+
+	req, err := http.NewRequest(http.MethodPost, "http://localhost:9080/", bytes.NewBufferString("abcdefghijklm"))
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+	res := tester.AssertResponseCode(req, http.StatusRequestEntityTooLarge)
+	res.Body.Close()
+}
+
+func TestRequestBodyPlaceholderRespectsMaxSizeInVarsRegexp(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		skip_install_trust
+		admin localhost:2999
+		http_port     9080
+		https_port    9443
+		grace_period  1ns
+	}
+	http://localhost:9080 {
+		request_body {
+			max_size 10
+		}
+		@bigbody {
+			vars_regexp {http.request.body} "^.{20}"
+		}
+		handle @bigbody {
+			respond "the body was too long matched"
+		}
+		respond "no match"
+	}
+  `, "caddyfile")
+
+	req, err := http.NewRequest(http.MethodPost, "http://localhost:9080/", bytes.NewBufferString("abcdefghijklmnopqrstuvwxyz"))
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+	res := tester.AssertResponseCode(req, http.StatusRequestEntityTooLarge)
+	res.Body.Close()
+}

--- a/modules/caddyhttp/app.go
+++ b/modules/caddyhttp/app.go
@@ -59,8 +59,8 @@ func init() {
 //
 // Placeholder | Description
 // ------------|---------------
-// `{http.request.body}` | The request body (⚠️ inefficient; use only for debugging)
-// `{http.request.body_base64}` | The request body, base64-encoded (⚠️ for debugging)
+// `{http.request.body}` | The request body (⚠️ inefficient; use only for debugging); if reading it exceeds a `request_body` `max_size` limit, the request fails with HTTP 413 instead of silently returning a truncated body
+// `{http.request.body_base64}` | The request body, base64-encoded (⚠️ for debugging); same 413 behavior on `max_size` limits as `{http.request.body}`
 // `{http.request.cookie.*}` | HTTP request cookie
 // `{http.request.duration}` | Time up to now spent handling the request (after decoding headers from client)
 // `{http.request.duration_ms}` | Same as 'duration', but in milliseconds.

--- a/modules/caddyhttp/replacer.go
+++ b/modules/caddyhttp/replacer.go
@@ -26,6 +26,7 @@ import (
 	"encoding/asn1"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -231,31 +232,21 @@ func addHTTPVarsToReplacer(repl *caddy.Replacer, req *http.Request, w http.Respo
 				if req.Body == nil {
 					return "", true
 				}
-				// normally net/http will close the body for us, but since we
-				// are replacing it with a fake one, we have to ensure we close
-				// the real body ourselves when we're done
-				defer req.Body.Close()
-				// read the request body into a buffer (can't pool because we
-				// don't know its lifetime and would have to make a copy anyway)
-				buf := new(bytes.Buffer)
-				_, _ = io.Copy(buf, req.Body) // can't handle error, so just ignore it
-				req.Body = io.NopCloser(buf)  // replace real body with buffered data
-				return buf.String(), true
+				body, err := readRequestBodyForPlaceholder(req)
+				if err != nil {
+					return err, true
+				}
+				return string(body), true
 
 			case "http.request.body_base64":
 				if req.Body == nil {
 					return "", true
 				}
-				// normally net/http will close the body for us, but since we
-				// are replacing it with a fake one, we have to ensure we close
-				// the real body ourselves when we're done
-				defer req.Body.Close()
-				// read the request body into a buffer (can't pool because we
-				// don't know its lifetime and would have to make a copy anyway)
-				buf := new(bytes.Buffer)
-				_, _ = io.Copy(buf, req.Body) // can't handle error, so just ignore it
-				req.Body = io.NopCloser(buf)  // replace real body with buffered data
-				return base64.StdEncoding.EncodeToString(buf.Bytes()), true
+				body, err := readRequestBodyForPlaceholder(req)
+				if err != nil {
+					return err, true
+				}
+				return base64.StdEncoding.EncodeToString(body), true
 
 			// original request, before any internal changes
 			case "http.request.orig_method":
@@ -414,6 +405,69 @@ func addHTTPVarsToReplacer(repl *caddy.Replacer, req *http.Request, w http.Respo
 	}
 
 	repl.Map(httpVars)
+}
+
+// RequestBodyLimitError is returned by the {http.request.body} and
+// {http.request.body_base64} placeholders when reading the request body
+// exceeded a request_body max_size limit. Placeholder consumers such as
+// templates and the vars matchers recognize exactly this condition and no
+// other error, so unrelated errors keep their existing behavior.
+type RequestBodyLimitError struct {
+	Err error // the underlying reason, e.g. *http.MaxBytesError
+}
+
+// Error returns the reason the request body could not be read in full.
+func (e RequestBodyLimitError) Error() string {
+	return fmt.Sprintf("request body: %v", e.Err)
+}
+
+// StatusCode returns 413 to match the request_body handler's response to an
+// oversized body.
+func (e RequestBodyLimitError) StatusCode() int {
+	return http.StatusRequestEntityTooLarge
+}
+
+// Unwrap returns the underlying error value. See the `errors` package for info.
+func (e RequestBodyLimitError) Unwrap() error { return e.Err }
+
+// readRequestBodyForPlaceholder reads the request body into a buffer for the
+// {http.request.body} and {http.request.body_base64} placeholders. Usually the
+// body is copied verbatim and the buffered replacement is installed on req. If
+// the read fails because the request_body max_size limit was exceeded, the
+// request_body handler wraps the http.MaxBytesError into a HandlerError
+// carrying status 413; here that error is converted to a RequestBodyLimitError,
+// which the placeholder consumers recognize, instead of silently returning the
+// truncated prefix as though it were the complete body. Only a max_size-driven
+// handler error is converted; any other read error is still ignored, as it was
+// before, because the request is probably not going to be served normally
+// anyway and we want to keep the placeholder's behavior unchanged in that case.
+func readRequestBodyForPlaceholder(req *http.Request) ([]byte, error) {
+	// normally net/http will close the body for us, but since we are replacing
+	// it with a fake one, we have to ensure we close the real body ourselves
+	defer req.Body.Close()
+
+	// read the request body into a buffer (can't pool because we don't know its
+	// lifetime and would have to make a copy anyway)
+	buf := new(bytes.Buffer)
+	_, err := io.Copy(buf, req.Body)
+	if err != nil {
+		var handlerErr HandlerError
+		var maxBytes *http.MaxBytesError
+		if errors.As(err, &handlerErr) && errors.As(handlerErr.Err, &maxBytes) {
+			// return the dedicated body-limit marker carrying only the
+			// MaxBytesError; the generated ID and stack trace of the handler
+			// error are intentionally dropped so a placeholder stringified
+			// into a response body (e.g. respond {http.request.body}) cannot
+			// leak the call stack to the client. consumers recognize this
+			// marker and no other error, so unrelated HandlerError values
+			// keep their existing behavior.
+			return nil, RequestBodyLimitError{Err: maxBytes}
+		}
+	}
+
+	// replace the real body with the buffered data
+	req.Body = io.NopCloser(buf)
+	return buf.Bytes(), nil
 }
 
 func getReqTLSReplacement(req *http.Request, key string) (any, bool) {

--- a/modules/caddyhttp/replacer_test.go
+++ b/modules/caddyhttp/replacer_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -335,3 +336,73 @@ func TestHTTPVarReplacementUUID(t *testing.T) {
 	}
 }
 
+// failingBodyReader serves some bytes and then returns a fixed error, to
+// exercise the read failure path of the request body placeholders.
+type failingBodyReader struct {
+	data []byte
+	pos  int
+	err  error
+}
+
+func (b *failingBodyReader) Read(p []byte) (int, error) {
+	if b.pos < len(b.data) {
+		n := copy(p, b.data[b.pos:])
+		b.pos += n
+		return n, nil
+	}
+	return 0, b.err
+}
+
+func (b *failingBodyReader) Close() error { return nil }
+
+// TestRequestBodyPlaceholderErrorScoping verifies that only a max_size-driven
+// handler error from the request body read becomes a RequestBodyLimitError,
+// while every other error keeps the placeholder's old ignore-and-truncate
+// behavior.
+func TestRequestBodyPlaceholderErrorScoping(t *testing.T) {
+	maxBytes := &http.MaxBytesError{Limit: 10}
+	for _, tc := range []struct {
+		name       string
+		readErr    error
+		wantMarker bool
+	}{
+		{name: "max_size handler error becomes the marker", readErr: HandlerError{Err: maxBytes, StatusCode: http.StatusRequestEntityTooLarge}, wantMarker: true},
+		{name: "unrelated handler error keeps old behavior", readErr: HandlerError{Err: errors.New("boom"), StatusCode: http.StatusInternalServerError}},
+		{name: "raw max bytes error keeps old behavior", readErr: maxBytes},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			req.Body = &failingBodyReader{data: []byte("abc"), err: tc.readErr}
+
+			body, err := readRequestBodyForPlaceholder(req)
+
+			if !tc.wantMarker {
+				if err != nil {
+					t.Fatalf("unrelated errors must be ignored like before but got %v", err)
+				}
+				if string(body) != "abc" {
+					t.Errorf("expected the truncated prefix %q but got %q", "abc", body)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected the body limit marker but got none")
+			}
+			var marker RequestBodyLimitError
+			if !errors.As(err, &marker) {
+				t.Fatalf("expected RequestBodyLimitError but got %T", err)
+			}
+			var handlerErr HandlerError
+			if errors.As(err, &handlerErr) {
+				t.Error("the marker must not be detectable as a HandlerError")
+			}
+			if marker.StatusCode() != http.StatusRequestEntityTooLarge {
+				t.Errorf("expected status 413 but got %d", marker.StatusCode())
+			}
+			var maxErr *http.MaxBytesError
+			if !errors.As(err, &maxErr) {
+				t.Error("the marker must unwrap to the MaxBytesError")
+			}
+		})
+	}
+}

--- a/modules/caddyhttp/templates/tplcontext.go
+++ b/modules/caddyhttp/templates/tplcontext.go
@@ -16,6 +16,7 @@ package templates
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -250,7 +251,7 @@ func (c *TemplateContext) executeTemplateInBuffer(tplName string, buf *bytes.Buf
 	return c.tpl.Execute(buf, c)
 }
 
-func (c TemplateContext) funcPlaceholder(name string) string {
+func (c TemplateContext) funcPlaceholder(name string) (string, error) {
 	repl := c.Req.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 
 	// For safety, we don't want to allow the file placeholder in
@@ -258,8 +259,21 @@ func (c TemplateContext) funcPlaceholder(name string) string {
 	// if the template contents were not trusted.
 	repl = repl.WithoutFile()
 
-	value, _ := repl.GetString(name)
-	return value
+	value, _ := repl.Get(name)
+
+	// propagate the request-body limit marker (a 413 from the request_body
+	// max_size limit when {http.request.body} is truncated) so the template
+	// aborts with that status rather than rendering a silently-truncated
+	// body; the marker is wrapped in a status-carrying handler error so the
+	// server renders the 413, and any other value, including unrelated
+	// errors, is converted to a string as before
+	if err, ok := value.(error); ok {
+		var bodyLimit caddyhttp.RequestBodyLimitError
+		if errors.As(err, &bodyLimit) {
+			return "", caddyhttp.HandlerError{Err: bodyLimit, StatusCode: bodyLimit.StatusCode()}
+		}
+	}
+	return caddy.ToString(value), nil
 }
 
 func (TemplateContext) funcEnv(varName string) string {

--- a/modules/caddyhttp/templates/tplcontext_test.go
+++ b/modules/caddyhttp/templates/tplcontext_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -29,6 +30,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 )
 
@@ -707,4 +709,53 @@ func initTestContext() (TemplateContext, error) {
 		Req:        request,
 		RespHeader: WrappedHeader{make(http.Header)},
 	}, nil
+}
+// TestFuncPlaceholderPropagatesOnlyBodyLimitMarker verifies that the template
+// placeholder function aborts only on the request-body limit marker and keeps
+// rendering unrelated errors as text, exactly like before.
+func TestFuncPlaceholderPropagatesOnlyBodyLimitMarker(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		value     any
+		wantAbort bool
+	}{
+		{name: "body limit marker aborts the template", value: caddyhttp.RequestBodyLimitError{Err: &http.MaxBytesError{Limit: 10}}, wantAbort: true},
+		{name: "unrelated handler error renders as text like before", value: caddyhttp.HandlerError{Err: errors.New("boom"), StatusCode: http.StatusInternalServerError}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repl := caddy.NewReplacer()
+			repl.Map(func(name string) (any, bool) {
+				if name == "http.request.body" {
+					return tc.value, true
+				}
+				return nil, false
+			})
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			req = req.WithContext(context.WithValue(req.Context(), caddy.ReplacerCtxKey, repl))
+			c := TemplateContext{Req: req}
+
+			out, err := c.funcPlaceholder("http.request.body")
+
+			if tc.wantAbort {
+				var marker caddyhttp.RequestBodyLimitError
+				if err == nil || !errors.As(err, &marker) {
+					t.Fatalf("expected the body limit marker but got %q, %v", out, err)
+				}
+				handlerErr, ok := err.(caddyhttp.HandlerError)
+				if !ok || handlerErr.StatusCode != http.StatusRequestEntityTooLarge {
+					t.Errorf("expected a 413 handler error carrying the marker but got %v", err)
+				}
+				if out != "" {
+					t.Errorf("expected an empty string on abort but got %q", out)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unrelated handler errors must render as text like before but got %v", err)
+			}
+			if !strings.Contains(out, "boom") {
+				t.Errorf("expected the error text in the output but got %q", out)
+			}
+		})
+	}
 }

--- a/modules/caddyhttp/vars.go
+++ b/modules/caddyhttp/vars.go
@@ -16,6 +16,7 @@ package caddyhttp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -198,6 +199,16 @@ func (m VarsMatcher) MatchWithError(r *http.Request) (bool, error) {
 		case fmt.Stringer:
 			varStr = vv.String()
 		case error:
+			// propagate the request-body limit marker (a 413 from the
+			// request_body max_size limit when {http.request.body} is
+			// truncated) instead of matching on its error text; unrelated
+			// errors are matched on their text as before
+			var bodyLimit RequestBodyLimitError
+			if errors.As(vv, &bodyLimit) {
+				// wrap in a status-carrying handler error so the server
+				// renders the 413
+				return false, HandlerError{Err: bodyLimit, StatusCode: bodyLimit.StatusCode()}
+			}
 			varStr = vv.Error()
 		case nil:
 			varStr = ""
@@ -335,6 +346,16 @@ func (m MatchVarsRE) MatchWithError(r *http.Request) (bool, error) {
 		case fmt.Stringer:
 			varStr = vv.String()
 		case error:
+			// propagate the request-body limit marker (a 413 from the
+			// request_body max_size limit when {http.request.body} is
+			// truncated) instead of matching on its error text; unrelated
+			// errors are matched on their text as before
+			var bodyLimit RequestBodyLimitError
+			if errors.As(vv, &bodyLimit) {
+				// wrap in a status-carrying handler error so the server
+				// renders the 413
+				return false, HandlerError{Err: bodyLimit, StatusCode: bodyLimit.StatusCode()}
+			}
 			varStr = vv.Error()
 		case nil:
 			varStr = ""

--- a/modules/caddyhttp/vars_test.go
+++ b/modules/caddyhttp/vars_test.go
@@ -16,6 +16,7 @@ package caddyhttp
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -156,4 +157,70 @@ func TestMatchVarsREDoesNotExpandResolvedValues(t *testing.T) {
 			}
 		})
 	}
+}
+// TestVarsMatchersTreatErrorsByType verifies the error handling split in the
+// vars matchers: only the request-body limit marker aborts request handling,
+// while unrelated errors are matched on their text exactly like before.
+func TestVarsMatchersTreatErrorsByType(t *testing.T) {
+	unrelated := HandlerError{Err: errors.New("boom"), StatusCode: http.StatusInternalServerError}
+	bodyLimit := RequestBodyLimitError{Err: &http.MaxBytesError{Limit: 10}}
+
+	t.Run("vars matcher matches unrelated errors on text like before", func(t *testing.T) {
+		req, _ := newVarsTestRequest(t, "", nil, map[string]any{"k": unrelated})
+		matched, err := (VarsMatcher{"k": []string{unrelated.Error()}}).MatchWithError(req)
+		if err != nil {
+			t.Fatalf("unrelated handler errors must not control request handling but got %v", err)
+		}
+		if !matched {
+			t.Error("expected a text match like before")
+		}
+	})
+
+	t.Run("vars regexp matcher matches unrelated errors on text like before", func(t *testing.T) {
+		req, _ := newVarsTestRequest(t, "", nil, map[string]any{"k": unrelated})
+		re := MatchVarsRE{"k": &MatchRegexp{Pattern: "^.*HTTP 500.*$"}}
+		if err := re.Provision(caddy.Context{}); err != nil {
+			t.Fatalf("provisioning the regexp: %v", err)
+		}
+		matched, err := re.MatchWithError(req)
+		if err != nil {
+			t.Fatalf("unrelated handler errors must not control request handling but got %v", err)
+		}
+		if !matched {
+			t.Error("expected the error text to match the regexp like before")
+		}
+	})
+
+	t.Run("body limit marker is the only propagated error", func(t *testing.T) {
+		req, _ := newVarsTestRequest(t, "", nil, map[string]any{"k": bodyLimit})
+
+		matched, err := (VarsMatcher{"k": []string{"x"}}).MatchWithError(req)
+		var marker RequestBodyLimitError
+		if err == nil || !errors.As(err, &marker) {
+			t.Fatalf("expected the body limit marker from the vars matcher but got %v", err)
+		}
+		handlerErr, ok := err.(HandlerError)
+		if !ok || handlerErr.StatusCode != http.StatusRequestEntityTooLarge {
+			t.Errorf("expected a 413 handler error carrying the marker but got %v", err)
+		}
+		if matched {
+			t.Error("no vars match should happen when the marker aborts")
+		}
+
+		re := MatchVarsRE{"k": &MatchRegexp{Pattern: ".*"}}
+		if err := re.Provision(caddy.Context{}); err != nil {
+			t.Fatalf("provisioning the regexp: %v", err)
+		}
+		matched, err = re.MatchWithError(req)
+		if err == nil || !errors.As(err, &marker) {
+			t.Fatalf("expected the body limit marker from the regexp matcher too but got %v", err)
+		}
+		handlerErr, ok = err.(HandlerError)
+		if !ok || handlerErr.StatusCode != http.StatusRequestEntityTooLarge {
+			t.Errorf("expected a 413 handler error carrying the marker but got %v", err)
+		}
+		if matched {
+			t.Error("no regexp match should happen when the marker aborts")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

fixes #7691

when a request body goes over the request_body max_size limit, the request_body handler turns the http.MaxBytesError into a caddyhttp handler error with status 413, but the {http.request.body} and {http.request.body_base64} placeholders read with io.Copy and ignored the error, so they returned the truncated prefix as if it was the whole body. the docs say a read past max_size returns 413, and a silently truncated body is a bad failure mode in templates and vars_regexp where code makes decisions from that value (i am following the narrower follow-up that was prescribed when #7692 was closed)

so now the placeholder path surfaces that 413 handler error instead, and the template placeholder func plus the vars matchers propagate only that status-carrying error, so the oversized request fails with 413 in both consumption sites. every other placeholder and every other error path stays unchanged

## Testing

- go test ./modules/caddyhttp/... -count=1 (14 packages ok)
- go test -race ./modules/caddyhttp/ ./modules/caddyhttp/templates/
- go test ./caddytest/integration/ -run TestRequestBodyPlaceholder (2/2 pass)
- go vet ./modules/caddyhttp/...
- golangci-lint run modules/caddyhttp/... (0 issues)
- gofmt clean

the two new integration tests fail before this change (they got 200 instead of 413) and pass after

## Assistance Disclosure

this change was written with the help of AI coding agents (GLM in my local harness), i reviewed and tested every line before submitting, and the implementation follows the maintainer-prescribed scope from the issue thread
