### PR TITLE
caddyhttp: fix randString sameCase dictionary to match its docs

### DIFF
--- a/modules/caddyhttp/errors.go
+++ b/modules/caddyhttp/errors.go
@@ -93,7 +93,7 @@ func randString(n int, sameCase bool) string {
 	}
 	dict := []byte("abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRTUVWXY23456789")
 	if sameCase {
-		dict = []byte("abcdefghijkmnpqrstuvwxyz0123456789")
+		dict = []byte("abcdefghijkmnpqrstuvwxyz123456789")
 	}
 	b := make([]byte, n)
 	for i := range b {

--- a/modules/caddyhttp/errors_randstring_test.go
+++ b/modules/caddyhttp/errors_randstring_test.go
@@ -1,0 +1,33 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddyhttp
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRandString_SameCaseExcludesZero is the regression test for the
+// randString(sameCase=true) dictionary bug where '0' was still emitted
+// despite being called out as a confusing character in the doc comment.
+func TestRandString_SameCaseExcludesZero(t *testing.T) {
+	// A sample of 5000 characters makes a leaked '0' extremely unlikely
+	// to go unnoticed: the dictionary is 33 characters, so the expected
+	// count for any single character would be ~151 if it were present.
+	s := randString(5000, true)
+	if strings.ContainsRune(s, '0') {
+		t.Errorf("randString(n, sameCase=true) must not emit '0'; got %q", s)
+	}
+}


### PR DESCRIPTION
The doc comment says `randString` excludes confusing characters like I, l, 1, 0, O. When `sameCase` is true, uppercase letters and the characters l and o should be excluded. But the `sameCase` dictionary still contained '0'. Drop it.


## Assistance Disclosure

Test was generated by copilot/Claude 4.7; fixed by the same.

Related to https://github.com/caddyserver/caddy/pull/7227