### PR TITLE
cmd: upgrade automemlimit to v1.0.0

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -482,7 +482,7 @@ func setResourceLimits(logger *zap.Logger) func() {
 
 	// Configure the maximum memory to use to match the Linux container quota (if any) or system memory
 	// See https://pkg.go.dev/runtime/debug#SetMemoryLimit
-	_, _ = memlimit.SetGoMemLimitWithOpts(
+	_, _ = memlimit.Set(
 		memlimit.WithLogger(
 			slog.New(zapslog.NewHandler(
 				logger.Core(),

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.1
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/DeRuina/timberjack v1.4.5
-	github.com/KimMachineGun/automemlimit v0.7.5
+	github.com/KimMachineGun/automemlimit v1.0.0
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/aryann/difflib v0.0.0-20210328193216-ff5ff6dc229b

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/DeRuina/timberjack v1.4.5 h1:F/kms5MPNAXUeWdOILt5ALC6iDHWNRPevaeIVH7tqYU=
 github.com/DeRuina/timberjack v1.4.5/go.mod h1:RLoeQrwrCGIEF8gO5nV5b/gMD0QIy7bzQhBUgpp1EqE=
-github.com/KimMachineGun/automemlimit v0.7.5 h1:RkbaC0MwhjL1ZuBKunGDjE/ggwAX43DwZrJqVwyveTk=
-github.com/KimMachineGun/automemlimit v0.7.5/go.mod h1:QZxpHaGOQoYvFhv/r4u3U0JTC2ZcOwbSr11UZF46UBM=
+github.com/KimMachineGun/automemlimit v1.0.0 h1:+MqlvDE/pkJNjk1rU+O14QsH8k10nJAD0frB0lsxyvw=
+github.com/KimMachineGun/automemlimit v1.0.0/go.mod h1:n+BSXxQWDFS1DKh67Rqo0lgTsowsg6x65ak5uyngML0=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=


### PR DESCRIPTION
`automemlimit` v1.0.0 renamed `SetGoMemLimitWithOpts` to `Set` and removed the other `Set*` helpers, so Caddy no longer compiles against it:

```
cmd/main.go:485:18: undefined: memlimit.SetGoMemLimitWithOpts
```

This keeps anyone building Caddy, or a module that depends on it, pinned to v0.7.5.

Behavior is unchanged. Every option the call passes (`WithLogger`, `WithProvider`, `ApplyFallback`, `FromCgroup`, `FromSystem`) survived v1.0.0 untouched, and so did the 0.9 default ratio and the `AUTOMEMLIMIT` handling, including `AUTOMEMLIMIT=off`.

v1.0.0 also drops `AUTOMEMLIMIT_DEBUG` (already deprecated in v0.7.5 in favor of `memlimit.WithLogger`, which is what this call uses) and `AUTOMEMLIMIT_EXPERIMENT`. Neither is referenced here, and the cgroup-version-specific providers that were removed (`FromCgroupV1`, `FromCgroupV2`, `FromCgroupHybrid`) are not used either.

`go build ./...` and `go test ./...` pass, and the memlimit path still logs as before:

```
{"level":"info","msg":"GOMEMLIMIT is updated","GOMEMLIMIT":46385646796,"previous":9223372036854775807}
```

## AI Disclosure

Done by Claude.