### PR TITLE
caddyhttp: remove unused QUICConfig from the HTTP/3 server

### DIFF
--- a/modules/caddyhttp/server.go
+++ b/modules/caddyhttp/server.go
@@ -32,9 +32,7 @@ import (
 	"time"
 
 	"github.com/caddyserver/certmagic"
-	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
-	h3qlog "github.com/quic-go/quic-go/http3/qlog"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -1036,11 +1034,10 @@ func (s *Server) serveHTTP3(addr caddy.NetworkAddress, tlsCfg *tls.Config) error
 			Handler:        s,
 			TLSConfig:      tlsCfg,
 			MaxHeaderBytes: s.MaxHeaderBytes,
-			QUICConfig: &quic.Config{
-				Versions:          []quic.Version{quic.Version1, quic.Version2},
-				InitialPacketSize: 1200,
-				Tracer:            h3qlog.DefaultConnectionTracer,
-			},
+			// QUICConfig is deliberately unset: http3.Server only reads it when it
+			// creates its own listener (ListenAndServe/Serve). We bring our own
+			// listener and call ServeListener, so anything set here is ignored.
+			// The QUIC settings that actually apply are in NetworkAddress.ListenQUIC.
 			IdleTimeout: time.Duration(s.IdleTimeout),
 		}
 	}


### PR DESCRIPTION
Found while looking into #7979.

`http3.Server` only reads `QUICConfig` when it creates its own listener. Caddy builds the listener itself and calls `ServeListener`, so this block is ignored. The settings that actually apply are already in `NetworkAddress.ListenQUIC`.

No behavior change. Left a comment in its place so the next person edits the right file.

Tested with `go test -race -short ./...`, lint, and `curl --http3` (still gets HTTP/3 200).

## Assistance Disclosure
No AI used