### PR TITLE
fileserver: reject invalid browse file_limit values

### DIFF
--- a/caddytest/integration/caddyfile_adapt/file_server_file_limit_duplicate.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/file_server_file_limit_duplicate.caddyfiletest
@@ -1,0 +1,10 @@
+:80
+
+file_server {
+	browse {
+		file_limit 10
+		file_limit 20
+	}
+}
+----------
+file_limit is already configured

--- a/caddytest/integration/caddyfile_adapt/file_server_file_limit_invalid.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/file_server_file_limit_invalid.caddyfiletest
@@ -1,0 +1,9 @@
+:80
+
+file_server {
+	browse {
+		file_limit notanint
+	}
+}
+----------
+file_limit must be an integer

--- a/caddytest/integration/caddyfile_adapt/file_server_file_limit_negative.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/file_server_file_limit_negative.caddyfiletest
@@ -1,0 +1,9 @@
+:80
+
+file_server {
+	browse {
+		file_limit -1
+	}
+}
+----------
+file_limit must be a positive integer

--- a/caddytest/integration/caddyfile_adapt/file_server_file_limit_partial.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/file_server_file_limit_partial.caddyfiletest
@@ -1,0 +1,9 @@
+:80
+
+file_server {
+	browse {
+		file_limit 12abc
+	}
+}
+----------
+file_limit must be an integer

--- a/caddytest/integration/caddyfile_adapt/file_server_file_limit_zero.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/file_server_file_limit_zero.caddyfiletest
@@ -1,0 +1,9 @@
+:80
+
+file_server {
+	browse {
+		file_limit 0
+	}
+}
+----------
+file_limit must be a positive integer

--- a/modules/caddyhttp/fileserver/browse.go
+++ b/modules/caddyhttp/fileserver/browse.go
@@ -67,7 +67,9 @@ type Browse struct {
 	// The first option must be `sort_by` and the second option must be `order` (if exists).
 	SortOptions []string `json:"sort,omitempty"`
 
-	// FileLimit limits the number of up to n DirEntry values in directory order.
+	// FileLimit limits the number of DirEntry values returned when
+	// browsing a directory. Must be a positive integer when set via
+	// the Caddyfile. When unset (0), defaultDirEntryLimit is used.
 	FileLimit int `json:"file_limit,omitempty"`
 }
 

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -56,11 +56,19 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 //	    root          <path>
 //	    hide          <files...>
 //	    index         <files...>
-//	    browse        [<template_file>]
+//	    browse        [<template_file>] {
+//	        reveal_symlinks
+//	        sort <sort_by> [<order>]
+//	        file_limit <positive_integer>
+//	    }
 //	    precompressed <formats...>
 //	    status        <status>
 //	    disable_canonical_uris
 //	}
+//
+// file_limit must be a positive integer. Non-integer or non-positive
+// values are rejected at parse time (rather than silently falling back
+// to the default directory entry limit).
 //
 // The FinalizeUnmarshalCaddyfile method should be called after this
 // to finalize setup of hidden Caddyfiles.
@@ -135,13 +143,19 @@ func (fsrv *FileServer) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 						}
 					}
 				case "file_limit":
+					if fsrv.Browse.FileLimit != 0 {
+						return d.Err("file_limit is already configured")
+					}
 					fileLimit := d.RemainingArgs()
 					if len(fileLimit) != 1 {
-						return d.Err("file_limit should have an integer value")
+						return d.Err("file_limit requires exactly one positive integer argument")
 					}
-					val, _ := strconv.Atoi(fileLimit[0])
-					if fsrv.Browse.FileLimit != 0 {
-						return d.Err("file_limit is already enabled")
+					val, err := strconv.Atoi(fileLimit[0])
+					if err != nil {
+						return d.Errf("file_limit must be an integer: %v", err)
+					}
+					if val <= 0 {
+						return d.Errf("file_limit must be a positive integer, got %d", val)
 					}
 					fsrv.Browse.FileLimit = val
 				default:

--- a/modules/caddyhttp/fileserver/caddyfile_test.go
+++ b/modules/caddyhttp/fileserver/caddyfile_test.go
@@ -1,0 +1,243 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileserver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+)
+
+func TestUnmarshalCaddyfileBrowseFileLimit(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantLimit int
+		wantErr   string
+	}{
+		{
+			name: "valid positive integer",
+			input: `file_server {
+	browse {
+		file_limit 4000
+	}
+}`,
+			wantLimit: 4000,
+		},
+		{
+			name: "valid with sort options",
+			input: `file_server {
+	browse {
+		sort time desc
+		file_limit 250
+	}
+}`,
+			wantLimit: 250,
+		},
+		{
+			name: "non-integer value",
+			input: `file_server {
+	browse {
+		file_limit notanint
+	}
+}`,
+			wantErr: "file_limit must be an integer",
+		},
+		{
+			name: "partially numeric value",
+			input: `file_server {
+	browse {
+		file_limit 12abc
+	}
+}`,
+			wantErr: "file_limit must be an integer",
+		},
+		{
+			name: "zero is rejected",
+			input: `file_server {
+	browse {
+		file_limit 0
+	}
+}`,
+			wantErr: "file_limit must be a positive integer",
+		},
+		{
+			name: "negative is rejected",
+			input: `file_server {
+	browse {
+		file_limit -5
+	}
+}`,
+			wantErr: "file_limit must be a positive integer",
+		},
+		{
+			name: "missing argument",
+			input: `file_server {
+	browse {
+		file_limit
+	}
+}`,
+			wantErr: "file_limit requires exactly one positive integer argument",
+		},
+		{
+			name: "too many arguments",
+			input: `file_server {
+	browse {
+		file_limit 10 20
+	}
+}`,
+			wantErr: "file_limit requires exactly one positive integer argument",
+		},
+		{
+			name: "duplicate file_limit",
+			input: `file_server {
+	browse {
+		file_limit 10
+		file_limit 20
+	}
+}`,
+			wantErr: "file_limit is already configured",
+		},
+		{
+			name: "empty string argument",
+			input: `file_server {
+	browse {
+		file_limit ""
+	}
+}`,
+			wantErr: "file_limit must be an integer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := caddyfile.NewTestDispenser(tt.input)
+			fsrv := new(FileServer)
+			err := fsrv.UnmarshalCaddyfile(d)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil (FileLimit=%d)", tt.wantErr, fsrv.Browse.FileLimit)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if fsrv.Browse == nil {
+				t.Fatal("expected Browse to be configured")
+			}
+			if fsrv.Browse.FileLimit != tt.wantLimit {
+				t.Fatalf("FileLimit = %d, want %d", fsrv.Browse.FileLimit, tt.wantLimit)
+			}
+		})
+	}
+}
+
+func TestUnmarshalCaddyfileBrowseBlock(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantSymlinks  bool
+		wantSort      []string
+		wantFileLimit int
+		wantErr       string
+	}{
+		{
+			name: "reveal_symlinks and sort",
+			input: `file_server {
+	browse {
+		reveal_symlinks
+		sort namedirfirst asc
+	}
+}`,
+			wantSymlinks: true,
+			wantSort:     []string{"namedirfirst", "asc"},
+		},
+		{
+			name: "unknown browse subdirective",
+			input: `file_server {
+	browse {
+		not_a_thing
+	}
+}`,
+			wantErr: "unknown subdirective",
+		},
+		{
+			name: "unknown sort option",
+			input: `file_server {
+	browse {
+		sort by_magic
+	}
+}`,
+			wantErr: "unknown sort option",
+		},
+		{
+			name: "full browse block",
+			input: `file_server {
+	browse {
+		reveal_symlinks
+		sort size desc
+		file_limit 100
+	}
+}`,
+			wantSymlinks:  true,
+			wantSort:      []string{"size", "desc"},
+			wantFileLimit: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := caddyfile.NewTestDispenser(tt.input)
+			fsrv := new(FileServer)
+			err := fsrv.UnmarshalCaddyfile(d)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if fsrv.Browse == nil {
+				t.Fatal("expected Browse to be configured")
+			}
+			if fsrv.Browse.RevealSymlinks != tt.wantSymlinks {
+				t.Fatalf("RevealSymlinks = %v, want %v", fsrv.Browse.RevealSymlinks, tt.wantSymlinks)
+			}
+			if len(tt.wantSort) > 0 {
+				if len(fsrv.Browse.SortOptions) != len(tt.wantSort) {
+					t.Fatalf("SortOptions = %#v, want %#v", fsrv.Browse.SortOptions, tt.wantSort)
+				}
+				for i := range tt.wantSort {
+					if fsrv.Browse.SortOptions[i] != tt.wantSort[i] {
+						t.Fatalf("SortOptions[%d] = %q, want %q", i, fsrv.Browse.SortOptions[i], tt.wantSort[i])
+					}
+				}
+			}
+			if fsrv.Browse.FileLimit != tt.wantFileLimit {
+				t.Fatalf("FileLimit = %d, want %d", fsrv.Browse.FileLimit, tt.wantFileLimit)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #7985

## Summary
`file_server browse file_limit` only checked argument count and discarded `strconv.Atoi` errors. Invalid values such as `notanint` adapted successfully, left `FileLimit` at 0, and silently fell back to the default directory entry limit (10000).

## Changes
- Require a positive integer for `file_limit`
- Reject non-integers, zero, negatives, missing/extra args, and duplicates
- Document browse block options in `UnmarshalCaddyfile`
- Add unit tests for browse/`file_limit` parsing
- Add caddyfile-adapt fixtures covering the failure modes

## Testing
- `go test ./modules/caddyhttp/fileserver/ -run TestUnmarshalCaddyfile`
- `go test ./caddytest/integration/ -run TestCaddyfileAdaptToJSON/file_server_file_limit`
