### PR TITLE
fileserver: reject non-integer browse file_limit

### DIFF
--- a/caddytest/integration/caddyfile_adapt/file_server_file_limit_not_integer.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/file_server_file_limit_not_integer.caddyfiletest
@@ -1,0 +1,9 @@
+:80
+
+file_server {
+	browse {
+		file_limit notanint
+	}
+}
+----------
+file_limit should have an integer value

--- a/caddytest/integration/caddyfile_adapt/file_server_file_limit_partial.caddyfiletest
+++ b/caddytest/integration/caddyfile_adapt/file_server_file_limit_partial.caddyfiletest
@@ -1,0 +1,9 @@
+:80
+
+file_server {
+	browse {
+		file_limit 12abc
+	}
+}
+----------
+file_limit should have an integer value

--- a/modules/caddyhttp/fileserver/caddyfile.go
+++ b/modules/caddyhttp/fileserver/caddyfile.go
@@ -139,7 +139,10 @@ func (fsrv *FileServer) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					if len(fileLimit) != 1 {
 						return d.Err("file_limit should have an integer value")
 					}
-					val, _ := strconv.Atoi(fileLimit[0])
+					val, err := strconv.Atoi(fileLimit[0])
+					if err != nil {
+						return d.Err("file_limit should have an integer value")
+					}
 					if fsrv.Browse.FileLimit != 0 {
 						return d.Err("file_limit is already enabled")
 					}


### PR DESCRIPTION
Fixes #7985.

`browse file_limit` discarded the `strconv.Atoi` error, so `file_limit notanint` and `file_limit 12abc` adapted and fell through to the default 10000.

`strconv.Atoi` does not accept a numeric prefix. `Atoi("12abc")` returns 0 and an error (thanks @steadytao). Both cases now fail adapt with the existing "file_limit should have an integer value" message.

Adapt tests fail without the check and pass with it.

LLM disclosure: an assistant helped locate the discarded Atoi and draft the tests. I read the parse path, ran the red/green adapt tests, and the wording is mine.

Made with [Cursor](https://cursor.com)