### PR TITLE
cmd: flush buffered error logs before exit

### DIFF
--- a/cmd/cobra.go
+++ b/cmd/cobra.go
@@ -154,6 +154,7 @@ func WrapCommandFuncForCobra(f CommandFunc) func(cmd *cobra.Command, _ []string)
 			// colored, structured formatting as INFO/WARN output, rather than
 			// cobra's plain "Error: ..." line which lacks any highlighting.
 			caddy.Log().Error(err.Error())
+			_ = caddy.Log().Sync()
 			cmd.SilenceErrors = true
 		}
 		if status > 1 {

--- a/internal/logbuffer.go
+++ b/internal/logbuffer.go
@@ -27,6 +27,7 @@ type LogBufferCore struct {
 	entries []zapcore.Entry
 	fields  [][]zapcore.Field
 	level   zapcore.LevelEnabler
+	logger  *zap.Logger
 }
 
 type LogBufferCoreInterface interface {
@@ -63,7 +64,16 @@ func (c *LogBufferCore) Write(entry zapcore.Entry, fields []zapcore.Field) error
 	return nil
 }
 
-func (c *LogBufferCore) Sync() error { return nil }
+func (c *LogBufferCore) Sync() error {
+	if c.logger != nil {
+		c.FlushTo(c.logger)
+	}
+	return nil
+}
+
+func (c *LogBufferCore) SetFlushLogger(logger *zap.Logger) {
+	c.logger = logger
+}
 
 // FlushTo flushes buffered logs to the given zap.Logger.
 func (c *LogBufferCore) FlushTo(logger *zap.Logger) {

--- a/internal/logbuffer_test.go
+++ b/internal/logbuffer_test.go
@@ -1,0 +1,29 @@
+package internal
+
+import (
+	"bytes"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestLogBufferCoreSync(t *testing.T) {
+	var output bytes.Buffer
+	encoder := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
+	logger := zap.New(zapcore.NewCore(encoder, zapcore.AddSync(&output), zap.InfoLevel))
+	buffer := NewLogBufferCore(zap.InfoLevel)
+	buffer.SetFlushLogger(logger)
+
+	zap.New(buffer).Error("startup failed")
+	if output.Len() != 0 {
+		t.Fatal("buffered log was written before sync")
+	}
+
+	if err := buffer.Sync(); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if !bytes.Contains(output.Bytes(), []byte("startup failed")) {
+		t.Fatal("sync did not flush buffered log")
+	}
+}

--- a/logging.go
+++ b/logging.go
@@ -793,6 +793,7 @@ func BufferedLog() (*zap.Logger, *zap.Logger, *internal.LogBufferCore) {
 	defer defaultLoggerMu.Unlock()
 	origLogger := defaultLogger.logger
 	bufferCore := internal.NewLogBufferCore(zap.InfoLevel)
+	bufferCore.SetFlushLogger(origLogger)
 	defaultLogger.logger = zap.New(bufferCore)
 	return defaultLogger.logger, origLogger, bufferCore
 }


### PR DESCRIPTION
## Summary\n\nFixes #7962 by making buffered startup logs flush when the Cobra command wrapper records an error. The buffer now retains its destination logger and implements Sync by flushing to it.\n\n## Validation\n\n- go test ./internal ./cmd\n- git diff --check\n\nCommit: 5a6c85be