### PR TITLE
events: tell CertMagic which events are worth emitting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/aryann/difflib v0.0.0-20210328193216-ff5ff6dc229b
-	github.com/caddyserver/certmagic v0.25.4
+	github.com/caddyserver/certmagic v0.25.5-0.20260910014726-b7fe84888c0e
 	github.com/caddyserver/zerossl v0.1.5
 	github.com/cloudflare/circl v1.6.4
 	github.com/dunglas/go-urlpattern v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/caddyserver/certmagic v0.25.4 h1:8eIXh0HC3MsGnNo8One+BCxMGTbe5zb/oz+2KsxBFQg=
-github.com/caddyserver/certmagic v0.25.4/go.mod h1:YVs43D5+H/Dckt4bTga1KSO/xYfFBfVZainGDywYPAA=
+github.com/caddyserver/certmagic v0.25.5-0.20260910014726-b7fe84888c0e h1:x6EFcT1Sosa3s7tnLWUmY8Fqk9j6H9B9hCziaY9BnJY=
+github.com/caddyserver/certmagic v0.25.5-0.20260910014726-b7fe84888c0e/go.mod h1:YVs43D5+H/Dckt4bTga1KSO/xYfFBfVZainGDywYPAA=
 github.com/caddyserver/zerossl v0.1.5 h1:dkvOjBAEEtY6LIGAHei7sw2UgqSD6TrWweXpV7lvEvE=
 github.com/caddyserver/zerossl v0.1.5/go.mod h1:CxA0acn7oEGO6//4rtrRjYgEoa4MFw/XofZnrYwGqG4=
 github.com/ccoveille/go-safecast/v2 v2.0.0 h1:+5eyITXAUj3wMjad6cRVJKGnC7vDS55zk0INzJagub0=

--- a/modules/caddyevents/app.go
+++ b/modules/caddyevents/app.go
@@ -199,6 +199,17 @@ func (app *App) On(eventName string, handler Handler) error {
 	})
 }
 
+// ShouldEmit reports whether emitting the named event could be observed by
+// anything: a handler subscribed to it by name or to all events, or the debug
+// log that Emit writes for every event. Emitters that assemble event data
+// before calling Emit can use it to skip that work; it is the same question
+// Emit answers internally, exported so callers do not have to guess.
+func (app *App) ShouldEmit(eventName string) bool {
+	return app.subscriptions[eventName] != nil ||
+		app.subscriptions[""] != nil ||
+		app.logger.Core().Enabled(zapcore.DebugLevel)
+}
+
 // Emit creates and dispatches an event named eventName to all relevant handlers with
 // the metadata data. Events are emitted and propagated synchronously. The returned Event
 // value will have any additional information from the invoked handlers.
@@ -212,14 +223,11 @@ func (app *App) Emit(ctx caddy.Context, eventName string, data map[string]any) c
 			zap.String("name", eventName), zap.Error(err))
 	}
 
-	// A handler can only be reached through subscriptions to this event by
-	// name or to all events, so if neither is bound, nothing can observe
-	// this event and the only remaining output is the debug log below.
-	// Bail out before deriving loggers and registering replacer values:
-	// some events, such as tls_get_certificate, are emitted on every TLS
-	// handshake, where that work is significant and always wasted.
-	if app.subscriptions[eventName] == nil && app.subscriptions[""] == nil &&
-		!app.logger.Core().Enabled(zapcore.DebugLevel) {
+	// bail out before deriving loggers and registering replacer values if
+	// nothing can observe this event: some events, such as
+	// tls_get_certificate, are emitted on every TLS handshake, where that
+	// work is significant and always wasted
+	if !app.ShouldEmit(eventName) {
 		return e
 	}
 

--- a/modules/caddyevents/app_test.go
+++ b/modules/caddyevents/app_test.go
@@ -92,6 +92,54 @@ func TestEmitDispatchesToCatchAllSubscriber(t *testing.T) {
 	}
 }
 
+// Emit writes a debug line for every event, so with debug logging on an event
+// is observable even when nothing is subscribed. A predicate that answered
+// only about subscribers would silence that line.
+func TestShouldEmit(t *testing.T) {
+	app, _, cancel := testApp(t)
+	defer cancel()
+
+	if app.ShouldEmit("cert_obtained") {
+		t.Error("nothing is subscribed and debug is off; should not emit")
+	}
+
+	if err := app.On("cert_obtained", new(countingHandler)); err != nil {
+		t.Fatal(err)
+	}
+	if !app.ShouldEmit("cert_obtained") {
+		t.Error("a handler is bound by name; should emit")
+	}
+	if app.ShouldEmit("tls_get_certificate") {
+		t.Error("nothing is bound to this event; should not emit")
+	}
+}
+
+func TestShouldEmitWithCatchAllSubscriber(t *testing.T) {
+	app, _, cancel := testApp(t)
+	defer cancel()
+
+	if err := app.Subscribe(&Subscription{Handlers: []Handler{new(countingHandler)}}); err != nil {
+		t.Fatal(err)
+	}
+	if !app.ShouldEmit("tls_get_certificate") {
+		t.Error("a catch-all subscription observes every event; should emit")
+	}
+}
+
+func TestShouldEmitWithDebugLogging(t *testing.T) {
+	app, _, cancel := testApp(t)
+	defer cancel()
+	app.logger = zap.New(zapcore.NewCore(
+		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+		zapcore.AddSync(io.Discard),
+		zapcore.DebugLevel,
+	))
+
+	if !app.ShouldEmit("tls_get_certificate") {
+		t.Error("debug logging observes every event; should emit")
+	}
+}
+
 // Some events, such as tls_get_certificate, are emitted on every TLS
 // handshake, whether or not anything is subscribed to them.
 func BenchmarkEmitNoSubscribers(b *testing.B) {

--- a/modules/caddyevents/handshake_bench_test.go
+++ b/modules/caddyevents/handshake_bench_test.go
@@ -57,7 +57,7 @@ func benchCert(tb testing.TB) tls.Certificate {
 // benchmarkCertLookup measures CertMagic's GetCertificate, which Caddy calls
 // once per TLS handshake. CertMagic emits "tls_get_certificate" there, so this
 // shows what the events app costs a handshake when nothing is subscribed.
-func benchmarkCertLookup(b *testing.B, onEvent func(context.Context, string, map[string]any) error) {
+func benchmarkCertLookup(b *testing.B, onEvent func(context.Context, string, map[string]any) error, shouldEmit func(string) bool) {
 	b.Helper()
 
 	var cfg *certmagic.Config
@@ -68,9 +68,10 @@ func benchmarkCertLookup(b *testing.B, onEvent func(context.Context, string, map
 	b.Cleanup(cache.Stop)
 
 	cfg = certmagic.New(cache, certmagic.Config{
-		Storage: &certmagic.FileStorage{Path: b.TempDir()},
-		Logger:  zap.NewNop(),
-		OnEvent: onEvent,
+		Storage:        &certmagic.FileStorage{Path: b.TempDir()},
+		Logger:         zap.NewNop(),
+		OnEvent:        onEvent,
+		ShouldEmitFunc: shouldEmit,
 	})
 	if _, err := cfg.CacheUnmanagedTLSCertificate(context.Background(), benchCert(b), nil); err != nil {
 		b.Fatal(err)
@@ -107,5 +108,5 @@ func BenchmarkCertLookupWithEventsApp(b *testing.B) {
 
 	benchmarkCertLookup(b, func(_ context.Context, name string, data map[string]any) error {
 		return app.Emit(ctx, name, data).Aborted
-	})
+	}, app.ShouldEmit)
 }

--- a/modules/caddytls/automation.go
+++ b/modules/caddytls/automation.go
@@ -366,6 +366,7 @@ func (ap *AutomationPolicy) makeCertMagicConfig(tlsApp *TLS, issuers []certmagic
 		RenewalWindowRatio: ap.RenewalWindowRatio,
 		KeySource:          keySource,
 		OnEvent:            tlsApp.onEvent,
+		ShouldEmitFunc:     tlsApp.events.ShouldEmit,
 		OnDemand:           ond,
 		ReusePrivateKeys:   ap.ReusePrivateKeys,
 		OCSP: certmagic.OCSPConfig{

--- a/modules/caddytls/tls.go
+++ b/modules/caddytls/tls.go
@@ -255,9 +255,10 @@ func (t *TLS) Provision(ctx caddy.Context) error {
 	// commands like validate can be a better test
 	certCacheMu.RLock()
 	magic := certmagic.New(certCache, certmagic.Config{
-		Storage: ctx.Storage(),
-		Logger:  t.logger,
-		OnEvent: t.onEvent,
+		Storage:        ctx.Storage(),
+		Logger:         t.logger,
+		OnEvent:        t.onEvent,
+		ShouldEmitFunc: t.events.ShouldEmit,
 		OCSP: certmagic.OCSPConfig{
 			DisableStapling: t.DisableOCSPStapling,
 		},


### PR DESCRIPTION
Follow-up to #7997 and caddyserver/certmagic#406, and the last piece of #7996.

**Draft until CertMagic cuts a release.** `go.mod` currently points at a pseudo-version of the merged commit; it needs to become a tag before this can merge.

## Why

#7997 made dispatch cheap when nothing is subscribed, but it could not touch the data CertMagic had already built. `GetCertificateWithContext` emits `tls_get_certificate` as its first statement, and Go evaluates the argument before `emit` is entered, so the map and the `ClientHello` copy were assembled on every handshake regardless.

caddyserver/certmagic#406 added `Config.ShouldEmitFunc` for exactly this: an embedder answers whether an event is worth emitting, and CertMagic skips building the data when it is not.

## Change

`App.ShouldEmit` becomes exported and is passed alongside `OnEvent`:

```go
func (app *App) ShouldEmit(eventName string) bool {
	return app.subscriptions[eventName] != nil ||
		app.subscriptions[""] != nil ||
		app.logger.Core().Enabled(zapcore.DebugLevel)
}
```

The debug term matters. `Emit` writes a line for every event, so an event is observable whenever debug logging is on, even with nothing subscribed. A predicate that answered the literal "do I have subscribers?" question would silence that line — the trap @steadytao flagged when reviewing the CertMagic side. `Emit`'s own shortcut now calls this method rather than repeating the condition, so the two cannot drift apart.

## Benchmarks

`CertLookupWithEventsApp` is CertMagic's per-handshake certificate lookup, wired the way Caddy wires it. Not a full handshake — no TLS crypto, no I/O.

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| master | 1032 | 2480 | 15 |
| this branch | **540** | **1824** | **10** |

For the whole series, starting before #7997: 2045 → 540 ns/op, 5996 → 1824 B/op, 41 → 10 allocs/op.

`ShouldEmit` is covered for four states: nothing subscribed, a handler bound by name, a catch-all subscription, and debug logging on with nothing subscribed.

## Assistance Disclosure

I investigated this with Claude Code (Claude Opus 5). It read the code paths, wrote the patch, the benchmarks and the tests, and ran the test suite. I directed the investigation, reviewed the change, and vetted it for correctness.
